### PR TITLE
Swapped zcat for gzcat, as zcat is very much broken on macos

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -83,7 +83,7 @@ when -o had been specified.
 coverage2cytosine
 =================
 
-Changed zcat for gunzip -c when reading a gzipped coverage file.
+Changed gunzip -c for gunzip -c when reading a gzipped coverage file.
 
 Changed the way in which the coverage input file is handed over from the methylation_extractor
 to coverage2cytosine (previously the path information might have been part of the filename, but

--- a/bismark
+++ b/bismark
@@ -116,7 +116,7 @@ sub subset_input_file_FastQ{
   my ($filename,$process_id,$offset) = @_;
 
   if ($filename =~ /gz$/){
-    open (OFFSET,"zcat $filename |") or die "Couldn't read from file '$filename': $!\n";
+    open (OFFSET,"gunzip -c $filename |") or die "Couldn't read from file '$filename': $!\n";
   }
   else{
     open (OFFSET,$filename) or die "Couldn't read from file '$filename': $!\n";
@@ -172,7 +172,7 @@ sub subset_input_file_FastA{
   my ($filename,$process_id,$offset) = @_;
 
   if ($filename =~ /gz$/){
-    open (OFFSET,"zcat $filename |") or die "Couldn't read from file '$filename': $!\n";
+    open (OFFSET,"gunzip -c $filename |") or die "Couldn't read from file '$filename': $!\n";
   }
   else{
     open (OFFSET,$filename) or die "Couldn't read from file '$filename': $!\n";
@@ -1176,7 +1176,7 @@ sub merge_individual_ambiguous_files{
   foreach my $temp(@$temp_ambiguous){
     warn "Merging from file >> $temp <<\n";
     if ($temp =~ /gz$/){
-      open (IN,"zcat ${output_dir}$temp |") or die "Failed to read from ambiguous temp file '${output_dir}$temp'\n";
+      open (IN,"gunzip -c ${output_dir}$temp |") or die "Failed to read from ambiguous temp file '${output_dir}$temp'\n";
     }
     else{
       open (IN,"${output_dir}$temp") or die "Failed to read from ambiguous temp file '${output_dir}$temp'\n";
@@ -1252,7 +1252,7 @@ sub merge_individual_unmapped_files{
   foreach my $temp(@$temp_unmapped){
     warn "Merging from file >> $temp <<\n";
     if ($temp =~ /gz$/){
-      open (IN,"zcat ${output_dir}${temp} |") or die "Failed to read from unmapped temp file '${output_dir}$temp'\n";
+      open (IN,"gunzip -c ${output_dir}${temp} |") or die "Failed to read from unmapped temp file '${output_dir}$temp'\n";
     }
     else{
       open (IN,"${output_dir}${temp}") or die "Failed to read from unmapped temp file '${output_dir}${temp}'\n";
@@ -2245,7 +2245,7 @@ sub process_single_end_fastA_file_for_methylation_call{
 
   ### gzipped version of the infile
   if ($sequence_file =~ /\.gz$/){
-    open (IN,"zcat $sequence_file |") or die $!;
+    open (IN,"gunzip -c $sequence_file |") or die $!;
   }
   else{
     open (IN,$sequence_file) or die $!;
@@ -2322,7 +2322,7 @@ sub process_single_end_fastQ_file_for_methylation_call{
 
   ### gzipped version of the infile
   if ($sequence_file =~ /\.gz$/){
-    open (IN,"zcat $sequence_file |") or die $!;
+    open (IN,"gunzip -c $sequence_file |") or die $!;
   }
   else{
     open (IN,$sequence_file) or die $!;
@@ -2407,8 +2407,8 @@ sub process_fastA_files_for_paired_end_methylation_calls{
 
   ### gzipped version of the infiles
   if ($sequence_file_1 =~ /\.gz$/ and $sequence_file_2 =~ /\.gz$/){
-    open (IN1,"zcat $sequence_file_1 |") or die "Failed to open zcat pipe to $sequence_file_1 $!\n";
-    open (IN2,"zcat $sequence_file_2 |") or die "Failed to open zcat pipe to $sequence_file_2 $!\n";
+    open (IN1,"gunzip -c $sequence_file_1 |") or die "Failed to open gunzip -c pipe to $sequence_file_1 $!\n";
+    open (IN2,"gunzip -c $sequence_file_2 |") or die "Failed to open gunzip -c pipe to $sequence_file_2 $!\n";
   }
   else{
     open (IN1,$sequence_file_1) or die $!;
@@ -2501,8 +2501,8 @@ sub process_fastQ_files_for_paired_end_methylation_calls{
 
   ### gzipped version of the infiles
   if ($sequence_file_1 =~ /\.gz$/ and $sequence_file_2 =~ /\.gz$/){
-    open (IN1,"zcat $sequence_file_1 |") or die "Failed to open zcat pipe to $sequence_file_1 $!\n";
-    open (IN2,"zcat $sequence_file_2 |") or die "Failed to open zcat pipe to $sequence_file_2 $!\n";
+    open (IN1,"gunzip -c $sequence_file_1 |") or die "Failed to open gunzip -c pipe to $sequence_file_1 $!\n";
+    open (IN2,"gunzip -c $sequence_file_2 |") or die "Failed to open gunzip -c pipe to $sequence_file_2 $!\n";
   }
   else{
     open (IN1,$sequence_file_1) or die $!;
@@ -5886,7 +5886,7 @@ sub biTransformFastAFiles {
 
   ### gzipped version of the infile
   if ($file =~ /\.gz$/){
-    open (IN,"zcat $file |") or die "Couldn't read from file $file: $!\n";
+    open (IN,"gunzip -c $file |") or die "Couldn't read from file $file: $!\n";
   }
   else{
     open (IN,$file) or die "Couldn't read from file $file: $!\n";
@@ -6006,7 +6006,7 @@ sub biTransformFastAFiles_paired_end {
 
   ### gzipped version of the infile
   if ($file =~ /\.gz$/){
-    open (IN,"zcat $file |") or die "Couldn't read from file $file: $!\n";
+    open (IN,"gunzip -c $file |") or die "Couldn't read from file $file: $!\n";
   }
   else{
     open (IN,$file) or die "Couldn't read from file $file: $!\n";
@@ -6158,7 +6158,7 @@ sub biTransformFastQFiles {
 
   ### gzipped version of the infile
   if ($file =~ /\.gz$/){
-    open (IN,"zcat $file |") or die "Couldn't read from file $file: $!\n";
+    open (IN,"gunzip -c $file |") or die "Couldn't read from file $file: $!\n";
   }
   else{
     open (IN,$file) or die "Couldn't read from file $file: $!\n";
@@ -6317,7 +6317,7 @@ sub biTransformFastQFiles_paired_end {
 
   ### gzipped version of the infile
   if ($file =~ /\.gz$/){
-    open (IN,"zcat $file |") or die "Couldn't read from file $file: $!\n";
+    open (IN,"gunzip -c $file |") or die "Couldn't read from file $file: $!\n";
   }
   else{
     open (IN,$file) or die "Couldn't read from file $file: $!\n";
@@ -6495,14 +6495,14 @@ sub biTransformFastQFiles_paired_end_bowtie1_gzip {
 
   ### gzipped version of infile 1
   if ($file_1 =~ /\.gz$/){
-    open (IN_1,"zcat $file_1 |") or die "Couldn't read from file $file_1: $!\n";
+    open (IN_1,"gunzip -c $file_1 |") or die "Couldn't read from file $file_1: $!\n";
   }
   else{
     open (IN_1,$file_1) or die "Couldn't read from file $file_1: $!\n";
   }
   ### gzipped version of infile 2
   if ($file_2 =~ /\.gz$/){
-    open (IN_2,"zcat $file_2 |") or die "Couldn't read from file $file_2: $!\n";
+    open (IN_2,"gunzip -c $file_2 |") or die "Couldn't read from file $file_2: $!\n";
   }
   else{
     open (IN_2,$file_2) or die "Couldn't read from file $file_2: $!\n";
@@ -7014,7 +7014,7 @@ sub paired_end_align_fragments_to_bisulfite_genome_fastQ {
 
     if ($gzip){
       warn "Now starting a Bowtie paired-end alignment for $fh->{name} (reading in sequences from ${temp_dir}$fh->{inputfile_1}, with the options: $bt_options)\n";
-      open ($fh->{fh},"zcat ${temp_dir}$fh->{inputfile_1} | $path_to_bowtie $bt_options $fh->{bisulfiteIndex} --12 - |") or die "Can't open pipe to bowtie: $!";
+      open ($fh->{fh},"gunzip -c ${temp_dir}$fh->{inputfile_1} | $path_to_bowtie $bt_options $fh->{bisulfiteIndex} --12 - |") or die "Can't open pipe to bowtie: $!";
     }
     else{
       warn "Now starting a Bowtie paired-end alignment for $fh->{name} (reading in sequences from ${temp_dir}$fh->{inputfile_1} and ${temp_dir}$fh->{inputfile_2}, with the options: $bt_options))\n";
@@ -7188,7 +7188,7 @@ sub single_end_align_fragments_to_bisulfite_genome_fastA {
 
     warn "Now starting the Bowtie aligner for $fh->{name} (reading in sequences from $temp_dir$fh->{inputfile} with options: $bt_options)\n";
     if ($gzip){
-      open ($fh->{fh},"zcat $temp_dir$fh->{inputfile} | $path_to_bowtie $bt_options $fh->{bisulfiteIndex} - |") or die "Can't open pipe to bowtie: $!";
+      open ($fh->{fh},"gunzip -c $temp_dir$fh->{inputfile} | $path_to_bowtie $bt_options $fh->{bisulfiteIndex} - |") or die "Can't open pipe to bowtie: $!";
     }
     else{
       open ($fh->{fh},"$path_to_bowtie $bt_options $fh->{bisulfiteIndex} $temp_dir$fh->{inputfile} |") or die "Can't open pipe to bowtie: $!"; # command for uncompressed data
@@ -7309,7 +7309,7 @@ sub single_end_align_fragments_to_bisulfite_genome_fastQ {
     sleep (5);
 
     if ($gzip){
-      open ($fh->{fh},"zcat $temp_dir$fh->{inputfile} | $path_to_bowtie $bowtie_options $fh->{bisulfiteIndex} - |") or die "Can't open pipe to bowtie: $!";
+      open ($fh->{fh},"gunzip -c $temp_dir$fh->{inputfile} | $path_to_bowtie $bowtie_options $fh->{bisulfiteIndex} - |") or die "Can't open pipe to bowtie: $!";
     }
     else{
       open ($fh->{fh},"$path_to_bowtie $bowtie_options $fh->{bisulfiteIndex} $temp_dir$fh->{inputfile} |") or die "Can't open pipe to bowtie: $!"; # command for uncompressed data

--- a/bismark2bedGraph
+++ b/bismark2bedGraph
@@ -164,7 +164,7 @@ foreach my $infile (@bedfiles) {
 	warn "Now replacing whitespaces in the sequence ID field of the Bismark methylation extractor output $infile prior to bedGraph conversion\n\n";
 	
 	if ($infile =~ /gz$/){
-	    open (READ,"zcat $infile |") or die $!;
+	    open (READ,"gunzip -c $infile |") or die $!;
 	}
 	else{
 	    open (READ,$infile) or die $!;
@@ -198,7 +198,7 @@ foreach my $infile (@bedfiles) {
     
     # opening infile
     if ($infile =~ /gz$/){
-	open (IN,"zcat $infile |") or die "Couldn't find file '$infile': $!\n";
+	open (IN,"gunzip -c $infile |") or die "Couldn't find file '$infile': $!\n";
     }
     else{
 	open (IN,$infile) or die "Couldn't find file '$infile': $!\n";
@@ -429,7 +429,7 @@ foreach my $in (@temp_files) {
     
     if ($gazillion){
 	if ($in =~ /gz$/){
-	    open $ifh, "zcat $in | sort -S $sort_size -T $sort_dir -k3,3V -k4,4n |" or die "Input file could not be sorted. $!\n";
+	    open $ifh, "gunzip -c $in | sort -S $sort_size -T $sort_dir -k3,3V -k4,4n |" or die "Input file could not be sorted. $!\n";
 	}
 	else{ 
 	    open $ifh, "sort -S $sort_size -T $sort_dir -k3,3V -k4,4n $in |" or die "Input file could not be sorted. $!\n";
@@ -441,7 +441,7 @@ foreach my $in (@temp_files) {
 	### this sort command was used previously and sorts according to chromosome in addition to position. Since the files are being sorted according to chromosomes anyway,
 	### we may drop the -k3,3V option. It has been reported that this will result in a dramatic speed increase
 	if ($in =~ /gz$/){
-	    open $ifh, "zcat $in | sort -S $sort_size -T $sort_dir -k4,4n |" or die "Input file could not be sorted. $!\n";
+	    open $ifh, "gunzip -c $in | sort -S $sort_size -T $sort_dir -k4,4n |" or die "Input file could not be sorted. $!\n";
 	}
 	else{
 	    open $ifh, "sort -S $sort_size -T $sort_dir -k4,4n $in |" or die "Input file could not be sorted. $!\n";

--- a/bismark_methylation_extractor
+++ b/bismark_methylation_extractor
@@ -569,7 +569,7 @@ sub delete_unused_files{
 
   while ($index <= $#sorting_files){
     if ($sorting_files[$index] =~ /gz$/){
-      open (USED,"zcat $sorting_files[$index] |") or die "Failed to read from methylation extractor output file $sorting_files[$index]: $!\n";
+      open (USED,"gunzip -c $sorting_files[$index] |") or die "Failed to read from methylation extractor output file $sorting_files[$index]: $!\n";
     }
     else{
       open (USED,$sorting_files[$index]) or die "Failed to read from methylation extractor output file $sorting_files[$index]: $!\n";
@@ -1074,7 +1074,7 @@ VERSION
 	
       ### if the user did not specify whether the alignment file was single-end or paired-end we are trying to get this information from the @PG header line in the SAM/BAM file
       if ($file =~ /\.gz$/){
-	open (DETERMINE,"zcat $file |") or die "Unable to read from gzipped file $file: $!\n";
+	open (DETERMINE,"gunzip -c $file |") or die "Unable to read from gzipped file $file: $!\n";
       }
       elsif ($file =~ /\.cram$/ || $file =~ /\.bam$/ || isBam($file) ){ ### this would allow to read BAM files that do not end in *.bam
 	open (DETERMINE,"samtools view -h $file |") or die "Unable to read from BAM/CRAM file $file: $!\n";
@@ -1289,7 +1289,7 @@ sub test_positional_sorting{
   sleep(1);
   
   if ($filename =~ /\.gz$/) {
-      open (TEST,"zcat $filename |") or die "Can't open gzipped file $filename: $!\n";
+      open (TEST,"gunzip -c $filename |") or die "Can't open gzipped file $filename: $!\n";
   }
   elsif ($filename =~ /bam$/ || $filename =~ /cram$/ || isBam($filename) ){ ### this would allow to read BAM files that do not end in *.bam
       if ($samtools_path){
@@ -1432,7 +1432,7 @@ sub process_Bismark_results_file{
   }
 
   if ($filename =~ /\.gz$/) {
-      open (IN,"zcat $filename |") or die "Can't open gzipped file $filename: $!\n";
+      open (IN,"gunzip -c $filename |") or die "Can't open gzipped file $filename: $!\n";
   }
   elsif ($filename =~ /bam$/ || $filename =~ /cram$/ || isBam($filename) ){ ### this would allow to read BAM files that do not end in *.bam
       if ($samtools_path){
@@ -5596,9 +5596,9 @@ sub isBam{
   my $filename = shift;
 
   # reading the first line of the input file to see if it is a BAM file in disguise (i.e. a BAM file that does not end in *.bam which may be produced by Galaxy)
-  open (DISGUISE,"zcat $filename |") or die "Failed to open filehandle DISGUISE for $filename\n\n";
+  open (DISGUISE,"gunzip -c $filename |") or die "Failed to open filehandle DISGUISE for $filename\n\n";
 
-  ### when BAM files read through a zcat stream they start with BAM...
+  ### when BAM files read through a gunzip -c stream they start with BAM...
   my $bam_in_disguise = <DISGUISE>;
   # warn "BAM in disguise: $bam_in_disguise\n\n";
 

--- a/coverage2cytosine
+++ b/coverage2cytosine
@@ -303,7 +303,7 @@ sub generate_genome_wide_cytosine_report {
   my $in = shift;
   # infiles handed over by the methylation extractor will be just the filename on their own. The directory should have been handed over with --dir
   if ($in =~ /gz$/){
-      open (IN,"gunzip -c $in |") or die "Failed to read from gzipped file $in: $!\n"; # changed from zcat to gunzip -c 08 04 16
+      open (IN,"gunzip -c $in |") or die "Failed to read from gzipped file $in: $!\n"; # changed from gunzip -c to gunzip -c 08 04 16
   }
   else{
       open (IN,"$in") or die "Failed to read from file $in: $!\n";
@@ -709,7 +709,7 @@ sub generate_GC_context_report {
 
   my $in = shift;
   if ($in =~ /gz$/){
-    open (IN,"zcat $in |") or die "Failed to read from gzipped file $in: $!\n";
+    open (IN,"gunzip -c $in |") or die "Failed to read from gzipped file $in: $!\n";
   }
   else{
     open (IN,"$in") or die "Failed to read from file $in: $!\n";

--- a/deduplicate_bismark
+++ b/deduplicate_bismark
@@ -202,7 +202,7 @@ foreach my $file (@filenames){
 
     ### if the user did not specify whether the alignment file was single-end or paired-end we are trying to get this information from the @PG header line in the SAM/BAM file
     if ($file =~ /\.gz$/){
-      open (DETERMINE,"zcat $file |") or die "Unable to read from gzipped file $file: $!\n";
+      open (DETERMINE,"gunzip -c $file |") or die "Unable to read from gzipped file $file: $!\n";
     }
     elsif ($file =~ /\.bam$/){
       open (DETERMINE,"$samtools_path view -h $file |") or die "Unable to read from BAM file $file: $!\n";
@@ -271,7 +271,7 @@ foreach my $file (@filenames){
     my %positions;
 
     if ($file =~ /\.gz$/){
-      open (IN,"zcat $file |") or die "Unable to read from gzipped file $file: $!\n";
+      open (IN,"gunzip -c $file |") or die "Unable to read from gzipped file $file: $!\n";
     }
     elsif ($file =~ /\.bam$/){
       open (IN,"$samtools_path view -h $file |") or die "Unable to read from BAM file $file: $!\n";
@@ -584,7 +584,7 @@ sub deduplicate_barcoded_rrbs{
   my %positions;
 
   if ($file =~ /\.gz$/){
-    open (IN,"zcat $file |") or die "Unable to read from gzipped file $file: $!\n";
+    open (IN,"gunzip -c $file |") or die "Unable to read from gzipped file $file: $!\n";
   }
   elsif ($file =~ /\.bam$/){
     open (IN,"$samtools_path view -h $file |") or die "Unable to read from BAM file $file: $!\n";
@@ -925,7 +925,7 @@ sub test_positional_sorting{
   sleep(1);
 
   if ($filename =~ /\.gz$/) {
-    open (TEST,"zcat $filename |") or die "Can't open gzipped file $filename: $!\n";
+    open (TEST,"gunzip -c $filename |") or die "Can't open gzipped file $filename: $!\n";
   }
   elsif ($filename =~ /bam$/ ||  isBam($filename) ){ ### this would allow to read BAM files that do not end in *.bam
     if ($samtools_path){
@@ -987,9 +987,9 @@ sub isBam{
   my $filename = shift;
 
   # reading the first line of the input file to see if it is a BAM file in disguise (i.e. a BAM file that does not end in *.bam which may be produced by Galaxy)
-  open (DISGUISE,"zcat $filename |") or die "Failed to open filehandle DISGUISE for $filename\n\n";
+  open (DISGUISE,"gunzip -c $filename |") or die "Failed to open filehandle DISGUISE for $filename\n\n";
 
-  ### when BAM files read through a zcat stream they start with BAM...
+  ### when BAM files read through a gunzip -c stream they start with BAM...
   my $bam_in_disguise = <DISGUISE>;
   # warn "BAM in disguise: $bam_in_disguise\n\n";
 
@@ -1032,7 +1032,7 @@ sub deduplicate_representative {
 
   ### going through the file first and storing all positions as well as their methylation call strings in a hash
   if ($file =~ /\.gz$/){
-    open (IN,"zcat $file |") or die "Unable to read from gzipped file $file: $!\n";
+    open (IN,"gunzip -c $file |") or die "Unable to read from gzipped file $file: $!\n";
   }
   elsif ($file =~ /\.bam$/){
     open (IN,"$samtools_path view -h $file |") or die "Unable to read from BAM file $file: $!\n";


### PR DESCRIPTION
Title says it all really. zcat on macos adds '.Z' to the file name automatically, meaning it can't see the file. Bismark, currently doesn't catch this error and carries on regardless.

Thanks

Nathan