### PR TITLE
Update coverage2cytosine

### DIFF
--- a/coverage2cytosine
+++ b/coverage2cytosine
@@ -1627,6 +1627,7 @@ VERSION
     $CpG_only = 1;
   }
   
+  chdir $parent_dir or die "Failed to move back to current working directory\n";
   ### GENOME folder
   if (defined $genome_folder){
       


### PR DESCRIPTION
Bug fix: If `$genome_folder` is a relative path and `$output_dir` is given, `coverage2cytosine` will fail because it `chdir` to `$output_dir` before `chdir` to `$genome_folder`. To fix this, `coverage2cytosine` need to return back to '$parent_dir' before `chdir` to '$genome_folder'. 

The error message is shown as below:

Failed to move to '../../data/ref/bismark_index/'. Make sure the path to the genome folder is correct, and respecify!