### PR TITLE
Fix for #494: Multicore Bismark corrupts result files if one of child process fails

### DIFF
--- a/bismark
+++ b/bismark
@@ -569,13 +569,21 @@ foreach my $filename (@filenames){
 			# warn "here are the child IDs: @pids\n";
 			# warn "Looping through the child process IDs:\n";
 
+			my $all_children_succeeded = 1;
 			foreach my $id (@pids){
 				# print "$id\t";
 				my $kid = waitpid ($id,0);
 				# print "Returned: $kid\nExit status: $?\n";
 				unless ($? == 0){
+					$all_children_succeeded = 0;
 					warn "\nChild process terminated with exit signal: '$?'\n\n";
 				}
+			}
+			if ($all_children_succeeded) {
+				print "All child process successfully finished.";
+			}
+			else {
+				die "\nTerminating. Not all child processes successfully finished.";
 			}
 
 			# regenerating names for temporary files

--- a/bismark_methylation_extractor
+++ b/bismark_methylation_extractor
@@ -273,13 +273,21 @@ foreach my $filename (@filenames){
 		# warn "here are the child IDs: @$pids\n";
 		# warn "Looping through the child process IDs:\n";
 
+		my $all_children_succeeded = 1;
 		foreach my $id (@$pids){
 			# print "$id\t";
 			my $kid = waitpid ($id,0);
 			# print "Returned: $kid\nExit status: $?\n";
 			unless ($? == 0){
+				$all_children_succeeded = 0;
 				warn "\nChild process terminated with exit signal: '$?'\n\n";
 			}
+		}
+		if ($all_children_succeeded) {
+			print "All child process successfully finished.";
+		}
+		else {
+			die "\nTerminating. Not all child processes successfully finished.";
 		}
 	}
 


### PR DESCRIPTION
The suggested fix for #494: Just stop execution if not all cores have finished successfully 