### PR TITLE
Testing: Fix CI tests

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -25,7 +25,7 @@ jobs:
     #      sudo cpanm GD::Graph
 
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: 3.8

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -30,7 +30,8 @@ jobs:
           conda config --add channels defaults
           conda config --add channels bioconda
           conda config --add channels conda-forge
-          conda install bowtie2 hisat2 samtools
+          conda config --set channel_priority strict
+          conda install bowtie2>=2.4 hisat2 samtools
 
       - name: Bismark help message
         shell: bash -l {0}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -17,18 +17,11 @@ jobs:
       - name: Check out Bismark source-code repository
         uses: actions/checkout@v2
 
-    # Not sure I actually need those, was taken from FastQ Screen
-    #  - name: Install Perl dependencies
-    #    run: |
-    #      sudo apt-get install libgd-perl
-    #      sudo cpan App::cpanminus
-    #      sudo cpanm GD::Graph
-
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install conda dependencies
         shell: bash -l {0}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,7 +31,7 @@ jobs:
           conda config --add channels bioconda
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda install bowtie2>=2.4 hisat2 samtools
+          conda install "bowtie2>=2.4" hisat2 samtools
 
       - name: Bismark help message
         shell: bash -l {0}


### PR DESCRIPTION
These force the CI tests to use Python 3.9 and obtain a recent-ish version of bowtie2.

Tests still fail, but they fail a bit later on now. 😛  