### PR TITLE
Fix for "C methylated in Unknown context..." in PE alignment and bismark2report alignment report processing

### DIFF
--- a/bismark
+++ b/bismark
@@ -2271,13 +2271,13 @@ sub print_final_analysis_report_paired_ends{
 	}
 
 	### printing methylated C percentage (Unknown C context) if applicable
-	if ($percent_meC_unknown){	
-		warn "C methylated in unknown context (CN or CHN):\t${percent_meC_unknown}%\n";
-		print REPORT "C methylated in unknown context (CN or CHN):\t${percent_meC_unknown}%\n";
+	if ($percent_meC_unknown){
+		warn "C methylated in Unknown context (CN or CHN):\t${percent_meC_unknown}%\n";
+		print REPORT "C methylated in Unknown context (CN or CHN):\t${percent_meC_unknown}%\n";
 	}
 	else{
-		warn "Can't determine percentage of methylated Cs in unknown context (CN or CHN) if value was 0\n";
-		print REPORT "Can't determine percentage of methylated Cs in unknown context (CN or CHN) if value was 0\n";
+		warn "Can't determine percentage of methylated Cs in Unknown context (CN or CHN) if value was 0\n";
+		print REPORT "Can't determine percentage of methylated Cs in Unknown context (CN or CHN) if value was 0\n";
 	}
 
 	print REPORT "\n\n";

--- a/bismark2report
+++ b/bismark2report
@@ -327,7 +327,7 @@ sub read_alignment_report{
       $perc_CHH =~ s/%//;
       print "percentage CHH >> $perc_CHH <<\n" if ($verbose);
     }
-    elsif($_ =~ /^C methylated in Unknown context:/ ){
+    elsif($_ =~ /^C methylated in Unknown context \(CN or CHN\):/ ){
       (undef,$perc_unknown) = split /\t/;
       $perc_unknown =~ s/%//;
       print "percentage Unknown >> $perc_unknown <<\n" if ($verbose);


### PR DESCRIPTION
bismark:
- SE/PE alignment outputs differed via a capitalization

bismark2report:
- regex didn't match either SE/PE alignment report output. (missing `\(CN or CHN\)`)