### PR TITLE
impl(noodles-io): BAM/SAM reader + BismarkRecord/Pair types

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,5 +3,864 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "bismark-io"
 version = "0.0.0"
+dependencies = [
+ "bstr",
+ "noodles-bam",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
+ "noodles-cram",
+ "noodles-csi 0.50.0",
+ "noodles-fasta",
+ "noodles-sam",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9ceaec84b54518262de7cf06b8b43e83c808349960f1610b21b0bfc9640f20"
+dependencies = [
+ "sha2",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "noodles-bam"
+version = "0.89.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c1872afd5963f751ae78ef04ab3fb050aefc615c05c04cda7c54120eedf9b0"
+dependencies = [
+ "bstr",
+ "indexmap",
+ "memchr",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
+ "noodles-csi 0.56.0",
+ "noodles-sam",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c1c3e3f19c4afd0c540104e596a9312074de9d0c01bedd5370ffba62ba3b439"
+dependencies = [
+ "bytes",
+ "crossbeam-channel",
+ "flate2",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d22589ec50582fa0c3e629d27e5263fc5ff5d436955648ba601b7ac4155fbf2"
+dependencies = [
+ "bytes",
+ "crossbeam-channel",
+ "zlib-rs",
+]
+
+[[package]]
+name = "noodles-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ebfc6396fb51059c98a35bb81b96422ac41ea1bc60b6c8e9c6b2550212e9493"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "noodles-core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8dbac7c5f9a7de9fe45590f198a09697df631cd13d2060b4742cc48144555b0"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "noodles-cram"
+version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae197edf3fbf530f6cbd4cf22dc36dba94b1a14d6ed1a925bd17e0eaecc40e8"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "bzip2",
+ "flate2",
+ "indexmap",
+ "lexical-core",
+ "lzma-rust2",
+ "md-5",
+ "noodles-bam",
+ "noodles-core 0.20.0",
+ "noodles-fasta",
+ "noodles-sam",
+]
+
+[[package]]
+name = "noodles-csi"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e055462495239a7e401d2c545c87731f9c5b909f95cea402d83149d353a69da9"
+dependencies = [
+ "bit-vec 0.8.0",
+ "bstr",
+ "byteorder",
+ "indexmap",
+ "noodles-bgzf 0.42.0",
+ "noodles-core 0.18.0",
+]
+
+[[package]]
+name = "noodles-csi"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6832254d731cb022d46927ce64403221b280b17140516cafa21e43ee4140d633"
+dependencies = [
+ "bit-vec 0.9.1",
+ "bstr",
+ "indexmap",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
+]
+
+[[package]]
+name = "noodles-fasta"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e6a772d7a5cb566196d1a1806c4471ad63bc6ffad5b2d549e9602708a9aaab"
+dependencies = [
+ "bstr",
+ "memchr",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
+]
+
+[[package]]
+name = "noodles-sam"
+version = "0.85.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbaf538bea4f886de8b3fb611784a13f82c9f8e08e942849e88ec44234674512"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "indexmap",
+ "lexical-core",
+ "memchr",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
+ "noodles-csi 0.56.0",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,7 +4,7 @@ members = ["bismark-io"]
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.89"
 license = "GPL-3.0-only"
 repository = "https://github.com/FelixKrueger/Bismark"
 authors = ["Felix Krueger"]

--- a/rust/bismark-io/Cargo.toml
+++ b/rust/bismark-io/Cargo.toml
@@ -12,5 +12,16 @@ authors.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
-# Dependencies (noodles-bam, noodles-sam, noodles-cram, noodles-fasta,
-# thiserror) will be added in the implementation PR per DESIGN.md.
+# noodles family — exact-pinned. See DESIGN.md and PLAN.md (rev 3) for rationale.
+noodles-bam = "=0.89.0"
+noodles-sam = "=0.85.0"
+noodles-cram = "=0.93.0"
+noodles-fasta = "=0.61.0"
+noodles-core = "=0.20.0"
+noodles-bgzf = "=0.47.0"
+noodles-csi = "=0.50.0"
+thiserror = "2"
+
+[dev-dependencies]
+tempfile = "3"
+bstr = "1"

--- a/rust/bismark-io/DESIGN.md
+++ b/rust/bismark-io/DESIGN.md
@@ -218,9 +218,6 @@ Closes user-facing request: [#788](https://github.com/FelixKrueger/Bismark/issue
 ```rust
 #[derive(Debug, thiserror::Error)]
 pub enum BismarkIoError {
-    #[error("malformed BAM/SAM record at offset {offset}: {reason}")]
-    MalformedRecord { offset: u64, reason: String },
-
     #[error("missing required Bismark tag: {tag}")]
     MissingTag { tag: &'static str },
 
@@ -233,10 +230,11 @@ pub enum BismarkIoError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("noodles BAM error: {0}")]
-    Bam(#[from] noodles::bam::io::reader::Error),
-
     // … additional variants as the surface area grows
+    // (MalformedTag, XmSeqLengthMismatch, MateMismatch, ReadIdentityMismatch,
+    // UnsortedInput, MissingCramReference). noodles' BAM/SAM/CRAM readers
+    // surface their errors as std::io::Error, so the single `Io` variant
+    // covers them — no per-format wrapper variants are needed.
 }
 ```
 

--- a/rust/bismark-io/src/cigar.rs
+++ b/rust/bismark-io/src/cigar.rs
@@ -1,0 +1,373 @@
+//! Bismark-flavoured CIGAR helpers as an extension trait on
+//! [`noodles_sam::alignment::record_buf::Cigar`].
+//!
+//! Centralises the off-by-one-prone CIGAR arithmetic in one place so every
+//! downstream binary inherits the same correct computation. In particular,
+//! [`CigarExt::reference_end`] is the direct prevention for the
+//! `pos.saturating_sub(1)` off-by-one that affected the prior-art Rust
+//! port (97-position drift in the 10M PE audit).
+
+use noodles_sam::alignment::record::cigar::op::Kind;
+use noodles_sam::alignment::record_buf::Cigar;
+
+/// Extension methods on [`noodles_sam::alignment::record_buf::Cigar`].
+///
+/// Bring into scope with `use bismark_io::CigarExt;`.
+pub trait CigarExt {
+    /// Number of reference bases consumed by the alignment.
+    ///
+    /// Sum of `Op::len()` for ops that consume reference: `M`, `D`, `N`,
+    /// `=`, `X`.
+    fn reference_span(&self) -> usize;
+
+    /// Number of read bases consumed by the alignment.
+    ///
+    /// Sum of `Op::len()` for ops that consume read: `M`, `I`, `S`, `=`,
+    /// `X`.
+    fn read_span(&self) -> usize;
+
+    /// 1-based inclusive last reference position covered by the alignment.
+    ///
+    /// Given a 1-based `start` position (as `noodles_sam::Record::alignment_start()`
+    /// returns), this is `start + reference_span() - 1`. Matches the SAM
+    /// spec convention and `noodles_sam::Record::alignment_end()` semantics.
+    ///
+    /// **Do not** roll your own `pos.saturating_sub(1)` arithmetic — that
+    /// shortcut collapses adjacent positions on reverse-strand reads and
+    /// caused a 97-position drift in the prior-art Rust port's dedup
+    /// report. Use this helper.
+    fn reference_end(&self, start: usize) -> usize;
+
+    /// Iterator over aligned positions, one item per read base.
+    ///
+    /// For each base in the read (read_pos goes 0..read_span), yields the
+    /// corresponding reference offset (if any) and the CIGAR op kind:
+    ///
+    /// - `M`, `=`, `X`: `ref_offset = Some(...)`, increments per base.
+    /// - `I`: `ref_offset = None`, read advances but reference does not.
+    /// - `S`: `ref_offset = None` (soft-clipped read base; not aligned).
+    /// - `D`, `N`: no item (those ops consume reference only, not read).
+    /// - `H`, `P`: skipped (consume neither read nor reference).
+    fn aligned_positions(&self) -> AlignedPositions<'_>;
+}
+
+/// One aligned position from [`CigarExt::aligned_positions`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlignedPosition {
+    /// 0-based position into the read sequence.
+    pub read_pos: usize,
+    /// 0-based offset from the alignment start on the reference, or `None`
+    /// if this read base is not aligned to a reference position (insertion
+    /// or soft-clip).
+    pub ref_offset: Option<usize>,
+    /// CIGAR op kind that produced this position.
+    pub op_kind: Kind,
+}
+
+/// Iterator returned by [`CigarExt::aligned_positions`].
+pub struct AlignedPositions<'a> {
+    ops: std::slice::Iter<'a, noodles_sam::alignment::record::cigar::Op>,
+    current_op: Option<(Kind, usize)>, // (op kind, remaining length in current op)
+    read_pos: usize,
+    ref_offset: usize,
+}
+
+impl<'a> AlignedPositions<'a> {
+    fn new(cigar: &'a Cigar) -> Self {
+        Self {
+            ops: cigar.as_ref().iter(),
+            current_op: None,
+            read_pos: 0,
+            ref_offset: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for AlignedPositions<'a> {
+    type Item = AlignedPosition;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // Refill `current_op` from the iterator if empty, skipping
+            // CIGAR ops that yield no items (D, N, H, P).
+            if self.current_op.is_none() {
+                let op = self.ops.next()?;
+                let kind = op.kind();
+                let len = op.len();
+                match kind {
+                    Kind::Deletion | Kind::Skip => {
+                        // Consumes reference only; no read positions.
+                        self.ref_offset += len;
+                        continue;
+                    }
+                    Kind::HardClip | Kind::Pad => {
+                        // Consumes neither read nor reference.
+                        continue;
+                    }
+                    _ => {
+                        if len == 0 {
+                            continue;
+                        }
+                        self.current_op = Some((kind, len));
+                    }
+                }
+            }
+
+            // Emit one item from the current op.
+            let (kind, remaining) = self.current_op.as_mut().expect("just filled");
+            let kind = *kind;
+
+            let item = match kind {
+                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+                    let item = AlignedPosition {
+                        read_pos: self.read_pos,
+                        ref_offset: Some(self.ref_offset),
+                        op_kind: kind,
+                    };
+                    self.read_pos += 1;
+                    self.ref_offset += 1;
+                    item
+                }
+                Kind::Insertion | Kind::SoftClip => {
+                    let item = AlignedPosition {
+                        read_pos: self.read_pos,
+                        ref_offset: None,
+                        op_kind: kind,
+                    };
+                    self.read_pos += 1;
+                    item
+                }
+                // Deletion, Skip, HardClip, Pad handled above; unreachable here.
+                Kind::Deletion | Kind::Skip | Kind::HardClip | Kind::Pad => unreachable!(),
+            };
+
+            *remaining -= 1;
+            if *remaining == 0 {
+                self.current_op = None;
+            }
+            return Some(item);
+        }
+    }
+}
+
+impl CigarExt for Cigar {
+    fn reference_span(&self) -> usize {
+        self.as_ref()
+            .iter()
+            .filter_map(|op| match op.kind() {
+                Kind::Match
+                | Kind::Deletion
+                | Kind::Skip
+                | Kind::SequenceMatch
+                | Kind::SequenceMismatch => Some(op.len()),
+                _ => None,
+            })
+            .sum()
+    }
+
+    fn read_span(&self) -> usize {
+        self.as_ref()
+            .iter()
+            .filter_map(|op| match op.kind() {
+                Kind::Match
+                | Kind::Insertion
+                | Kind::SoftClip
+                | Kind::SequenceMatch
+                | Kind::SequenceMismatch => Some(op.len()),
+                _ => None,
+            })
+            .sum()
+    }
+
+    fn reference_end(&self, start: usize) -> usize {
+        // 1-based inclusive end. For an alignment starting at `start` and
+        // covering `span` reference bases, the end is `start + span - 1`.
+        let span = self.reference_span();
+        if span == 0 { start } else { start + span - 1 }
+    }
+
+    fn aligned_positions(&self) -> AlignedPositions<'_> {
+        AlignedPositions::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noodles_sam::alignment::record::cigar::Op;
+
+    fn cigar_from_ops(ops: &[(Kind, usize)]) -> Cigar {
+        Cigar::from(ops.iter().map(|(k, n)| Op::new(*k, *n)).collect::<Vec<_>>())
+    }
+
+    #[test]
+    fn reference_span_simple_match() {
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        assert_eq!(c.reference_span(), 100);
+    }
+
+    #[test]
+    fn reference_span_with_indels() {
+        // 50M 5I 50M 5D 50M → ref consumes 50 + 0 + 50 + 5 + 50 = 155
+        let c = cigar_from_ops(&[
+            (Kind::Match, 50),
+            (Kind::Insertion, 5),
+            (Kind::Match, 50),
+            (Kind::Deletion, 5),
+            (Kind::Match, 50),
+        ]);
+        assert_eq!(c.reference_span(), 155);
+    }
+
+    #[test]
+    fn reference_span_with_soft_clips_only_match_counts() {
+        // 5S 100M 5S → ref consumes only 100
+        let c = cigar_from_ops(&[(Kind::SoftClip, 5), (Kind::Match, 100), (Kind::SoftClip, 5)]);
+        assert_eq!(c.reference_span(), 100);
+    }
+
+    #[test]
+    fn reference_span_with_ref_skip() {
+        // 50M 1000N 50M → ref consumes 50 + 1000 + 50 = 1100
+        let c = cigar_from_ops(&[(Kind::Match, 50), (Kind::Skip, 1000), (Kind::Match, 50)]);
+        assert_eq!(c.reference_span(), 1100);
+    }
+
+    #[test]
+    fn reference_span_empty_cigar_is_zero() {
+        let c = cigar_from_ops(&[]);
+        assert_eq!(c.reference_span(), 0);
+    }
+
+    #[test]
+    fn read_span_simple_match() {
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        assert_eq!(c.read_span(), 100);
+    }
+
+    #[test]
+    fn read_span_with_indels() {
+        // 50M 5I 50M 5D 50M → read consumes 50 + 5 + 50 + 0 + 50 = 155
+        let c = cigar_from_ops(&[
+            (Kind::Match, 50),
+            (Kind::Insertion, 5),
+            (Kind::Match, 50),
+            (Kind::Deletion, 5),
+            (Kind::Match, 50),
+        ]);
+        assert_eq!(c.read_span(), 155);
+    }
+
+    #[test]
+    fn read_span_includes_soft_clips() {
+        // 5S 100M 5S → read consumes 5 + 100 + 5 = 110
+        let c = cigar_from_ops(&[(Kind::SoftClip, 5), (Kind::Match, 100), (Kind::SoftClip, 5)]);
+        assert_eq!(c.read_span(), 110);
+    }
+
+    #[test]
+    fn reference_end_inclusive_1based() {
+        // Start at 100, span 50 → end at 149 (positions 100..149 inclusive = 50 bases)
+        let c = cigar_from_ops(&[(Kind::Match, 50)]);
+        assert_eq!(c.reference_end(100), 149);
+    }
+
+    #[test]
+    fn reference_end_with_empty_cigar_returns_start() {
+        let c = cigar_from_ops(&[]);
+        assert_eq!(c.reference_end(100), 100);
+    }
+
+    #[test]
+    fn reference_end_does_not_underflow_on_zero_start() {
+        // Defensive: even with span=0 and start=0 we don't panic.
+        let c = cigar_from_ops(&[]);
+        assert_eq!(c.reference_end(0), 0);
+    }
+
+    #[test]
+    fn aligned_positions_simple_match() {
+        let c = cigar_from_ops(&[(Kind::Match, 3)]);
+        let positions: Vec<_> = c.aligned_positions().collect();
+        assert_eq!(positions.len(), 3);
+        assert_eq!(
+            positions[0],
+            AlignedPosition {
+                read_pos: 0,
+                ref_offset: Some(0),
+                op_kind: Kind::Match
+            }
+        );
+        assert_eq!(
+            positions[1],
+            AlignedPosition {
+                read_pos: 1,
+                ref_offset: Some(1),
+                op_kind: Kind::Match
+            }
+        );
+        assert_eq!(
+            positions[2],
+            AlignedPosition {
+                read_pos: 2,
+                ref_offset: Some(2),
+                op_kind: Kind::Match
+            }
+        );
+    }
+
+    #[test]
+    fn aligned_positions_insertion_has_no_ref_offset() {
+        // 2M 1I 2M: read positions 0,1 → ref 0,1; pos 2 → I (no ref); pos 3,4 → ref 2,3
+        let c = cigar_from_ops(&[(Kind::Match, 2), (Kind::Insertion, 1), (Kind::Match, 2)]);
+        let positions: Vec<_> = c.aligned_positions().collect();
+        assert_eq!(positions.len(), 5);
+        assert_eq!(positions[0].ref_offset, Some(0));
+        assert_eq!(positions[1].ref_offset, Some(1));
+        assert_eq!(positions[2].ref_offset, None);
+        assert_eq!(positions[2].op_kind, Kind::Insertion);
+        assert_eq!(positions[3].ref_offset, Some(2));
+        assert_eq!(positions[4].ref_offset, Some(3));
+    }
+
+    #[test]
+    fn aligned_positions_deletion_skipped_ref_advances() {
+        // 2M 1D 2M: 4 read positions; ref offsets 0, 1, 3, 4
+        let c = cigar_from_ops(&[(Kind::Match, 2), (Kind::Deletion, 1), (Kind::Match, 2)]);
+        let positions: Vec<_> = c.aligned_positions().collect();
+        assert_eq!(positions.len(), 4);
+        assert_eq!(positions[0].ref_offset, Some(0));
+        assert_eq!(positions[1].ref_offset, Some(1));
+        assert_eq!(positions[2].ref_offset, Some(3));
+        assert_eq!(positions[3].ref_offset, Some(4));
+    }
+
+    #[test]
+    fn aligned_positions_soft_clip_has_no_ref_offset() {
+        // 2S 2M: read pos 0 → S (no ref), 1 → S (no ref), 2 → ref 0, 3 → ref 1
+        let c = cigar_from_ops(&[(Kind::SoftClip, 2), (Kind::Match, 2)]);
+        let positions: Vec<_> = c.aligned_positions().collect();
+        assert_eq!(positions.len(), 4);
+        assert_eq!(positions[0].ref_offset, None);
+        assert_eq!(positions[0].op_kind, Kind::SoftClip);
+        assert_eq!(positions[1].ref_offset, None);
+        assert_eq!(positions[2].ref_offset, Some(0));
+        assert_eq!(positions[3].ref_offset, Some(1));
+    }
+
+    #[test]
+    fn aligned_positions_hard_clip_skipped() {
+        // 2H 2M: hard-clip emits nothing; 2 items for the match
+        let c = cigar_from_ops(&[(Kind::HardClip, 2), (Kind::Match, 2)]);
+        let positions: Vec<_> = c.aligned_positions().collect();
+        assert_eq!(positions.len(), 2);
+        assert_eq!(positions[0].read_pos, 0);
+        assert_eq!(positions[0].ref_offset, Some(0));
+    }
+
+    #[test]
+    fn aligned_positions_empty_cigar() {
+        let c = cigar_from_ops(&[]);
+        assert_eq!(c.aligned_positions().count(), 0);
+    }
+}

--- a/rust/bismark-io/src/error.rs
+++ b/rust/bismark-io/src/error.rs
@@ -1,0 +1,94 @@
+//! Typed errors for `bismark-io`.
+//!
+//! See `DESIGN.md` Q4 and `PLAN.md` rev 3 for rationale. The crate uses
+//! [`thiserror`] for typed errors so callers can match on specific failure
+//! modes. Binary crates that consume `bismark-io` wrap these in
+//! [`anyhow::Error`] at the orchestration layer.
+
+use std::path::PathBuf;
+
+/// All errors raised by `bismark-io`.
+///
+/// Variants describe specific failure modes — callers can `match` on them to
+/// handle each appropriately (skip, abort, retry, etc.). The crate never
+/// panics on user input; all malformed-input paths return one of these
+/// variants.
+#[derive(Debug, thiserror::Error)]
+pub enum BismarkIoError {
+    /// A SAM/BAM record could not be parsed at all (noodles reported it
+    /// malformed, or our parsing layer found something irrecoverable).
+    #[error("malformed BAM/SAM record at offset {offset}: {reason}")]
+    MalformedRecord { offset: u64, reason: String },
+
+    /// A required Bismark optional tag is absent from the record.
+    ///
+    /// `XR:Z:` and `XG:Z:` are required by `BismarkRecord` construction.
+    #[error("missing required Bismark tag: {tag}")]
+    MissingTag { tag: &'static str },
+
+    /// A Bismark optional tag is present but cannot be decoded.
+    ///
+    /// For example: `XR:Z:` tag with non-UTF-8 bytes, or `NM:i:` with a
+    /// non-integer value.
+    #[error("malformed Bismark tag {tag}: {reason}")]
+    MalformedTag { tag: &'static str, reason: String },
+
+    /// The combination of XR/XG values is not one of the four valid
+    /// Bismark strand encodings.
+    ///
+    /// Valid combinations: `(CT, CT) → OT`, `(GA, CT) → CTOT`,
+    /// `(CT, GA) → OB`, `(GA, GA) → CTOB`.
+    #[error("invalid XR/XG combination: XR={xr:?}, XG={xg:?}")]
+    InvalidStrandTags { xr: Vec<u8>, xg: Vec<u8> },
+
+    /// The XM methylation-call string length does not match the read
+    /// sequence length.
+    ///
+    /// This is a data-integrity check. Corrupted BAMs or records re-edited
+    /// by external tools can produce length-mismatched XM tags that would
+    /// silently misalign methylation calls.
+    #[error("XM/seq length mismatch: XM={xm_len}, seq={seq_len}")]
+    XmSeqLengthMismatch { xm_len: usize, seq_len: usize },
+
+    /// Paired-end mate validation: R1 and R2 records have different qnames.
+    #[error("paired-end mate mismatch: r1 qname={r1_qname:?}, r2 qname={r2_qname:?}")]
+    MateMismatch {
+        r1_qname: Vec<u8>,
+        r2_qname: Vec<u8>,
+    },
+
+    /// Paired-end mate validation: the read identity of a supplied record
+    /// is not what was expected (e.g. caller passed two R1 records to
+    /// `BismarkPair::from_mates`).
+    ///
+    /// Stored as a string to keep the error module decoupled from the
+    /// `ReadIdentity` enum in `record.rs`.
+    #[error("read identity mismatch: {description}")]
+    ReadIdentityMismatch { description: String },
+
+    /// The input BAM is coordinate-sorted (`@HD SO:coordinate`). Bismark
+    /// downstream tools require name-grouped or unsorted input for
+    /// paired-end work. Use `BamReader::without_sort_check()` (or
+    /// equivalent) on SE-only callers to opt out.
+    #[error(
+        "input BAM is coordinate-sorted; Bismark downstream tools require name-grouped or unsorted input"
+    )]
+    UnsortedInput,
+
+    /// A CRAM operation was requested but no reference FASTA was supplied.
+    #[error("CRAM reference required for {0}")]
+    MissingCramReference(PathBuf),
+
+    /// The given file path does not have a recognised BAM/SAM/CRAM
+    /// extension.
+    #[error("unsupported file kind for path: {0}")]
+    UnsupportedKind(PathBuf),
+
+    /// Underlying I/O failure.
+    ///
+    /// noodles' BAM, SAM, and CRAM readers all surface their errors as
+    /// `std::io::Error`, so a single `From<std::io::Error>` variant
+    /// captures all of them.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/rust/bismark-io/src/error.rs
+++ b/rust/bismark-io/src/error.rs
@@ -15,11 +15,6 @@ use std::path::PathBuf;
 /// variants.
 #[derive(Debug, thiserror::Error)]
 pub enum BismarkIoError {
-    /// A SAM/BAM record could not be parsed at all (noodles reported it
-    /// malformed, or our parsing layer found something irrecoverable).
-    #[error("malformed BAM/SAM record at offset {offset}: {reason}")]
-    MalformedRecord { offset: u64, reason: String },
-
     /// A required Bismark optional tag is absent from the record.
     ///
     /// `XR:Z:` and `XG:Z:` are required by `BismarkRecord` construction.

--- a/rust/bismark-io/src/lib.rs
+++ b/rust/bismark-io/src/lib.rs
@@ -1,10 +1,29 @@
 //! `bismark-io` — Bismark-aware BAM/SAM/CRAM I/O on top of [`noodles`].
 //!
 //! This crate is the shared library for Bismark's Rust rewrite, exposing
-//! Bismark-flavoured wrappers around [`noodles`] record types — strand-classified,
-//! tag-decoded, CIGAR-aware.
+//! Bismark-flavoured wrappers around [`noodles`] record types — strand-
+//! classified, tag-decoded, CIGAR-aware.
 //!
-//! See `DESIGN.md` (in the crate root) for the design contract. Implementation
-//! lands incrementally via sub-issues of the parent epic.
+//! See `DESIGN.md` (in the crate root) for the design contract and
+//! `~/.claude/plans/05232026_bismark-io-v1/PLAN.md` for the implementation
+//! plan. The crate is sync-only for v1.0; pure-Rust with no `samtools`
+//! subprocess, no `htslib` C link, no `unsafe` blocks.
 //!
 //! [`noodles`]: https://github.com/zaeleus/noodles
+
+#![forbid(unsafe_code)]
+
+pub mod cigar;
+pub mod error;
+pub mod pair;
+pub mod read;
+pub mod record;
+pub mod strand;
+pub mod tags;
+
+pub use cigar::{AlignedPosition, AlignedPositions, CigarExt};
+pub use error::BismarkIoError;
+pub use pair::BismarkPair;
+pub use read::{AlignmentKind, BamReader, SamReader};
+pub use record::{BismarkRecord, ReadIdentity};
+pub use strand::BismarkStrand;

--- a/rust/bismark-io/src/pair.rs
+++ b/rust/bismark-io/src/pair.rs
@@ -51,6 +51,13 @@ impl BismarkPair {
 
         // Borrow-compare first; only allocate on the error path. At 27M+
         // pairs from a typical PE WGBS run the cheap-path matters.
+        //
+        // Both-None case: when neither record has a qname (unusual — Bismark
+        // always names reads), both sides become `b""` and compare equal.
+        // We treat this as "matching qnames" rather than an error; if upstream
+        // is feeding us nameless reads, surfacing a MateMismatch here would
+        // be misleading. Real corruption would manifest as one name set and
+        // the other missing, which still triggers MateMismatch correctly.
         let r1_name_opt = r1.inner().name();
         let r2_name_opt = r2.inner().name();
         let r1_bytes: &[u8] = r1_name_opt.as_ref().map_or(b"", |n| AsRef::as_ref(*n));

--- a/rust/bismark-io/src/pair.rs
+++ b/rust/bismark-io/src/pair.rs
@@ -1,0 +1,218 @@
+//! Paired-end Bismark records.
+//!
+//! [`BismarkPair`] is the structural-correctness scaffold that makes the
+//! per-record-strand-vs-pair-strand distinction explicit at the type level.
+//! Output-routing code for paired-end data uses `pair_strand()` — which is
+//! derived from R1 alone — rather than each mate's `record_strand()` (which
+//! differs between R1 and R2 of a directional pair).
+//!
+//! See `DESIGN.md` Q1 and `PLAN.md` rev 3 for the rationale, including
+//! why the prior-art Rust port's per-call strand re-derivation produced
+//! the strand-routing bug this type prevents.
+
+use crate::error::BismarkIoError;
+use crate::record::{BismarkRecord, ReadIdentity};
+use crate::strand::BismarkStrand;
+
+/// A paired-end alignment with its library-level strand classification.
+///
+/// `pair_strand` is decided by R1 (the SAM-spec rule for directional
+/// libraries). Both R1 and R2 calls should be routed to output files using
+/// `pair_strand()`, not each mate's own `record_strand()`.
+#[derive(Debug, Clone)]
+pub struct BismarkPair {
+    r1: BismarkRecord,
+    r2: BismarkRecord,
+    pair_strand: BismarkStrand,
+}
+
+impl BismarkPair {
+    /// Construct a pair from R1 and R2 records.
+    ///
+    /// Validates:
+    /// - `r1.read_identity()` is `R1` (else [`BismarkIoError::ReadIdentityMismatch`]).
+    /// - `r2.read_identity()` is `R2` (else [`BismarkIoError::ReadIdentityMismatch`]).
+    /// - The records share a qname (else [`BismarkIoError::MateMismatch`]).
+    ///
+    /// `pair_strand` is set to `r1.record_strand()`. Note that R2's
+    /// per-record strand will be the complement (e.g. for an OT-pair, R1
+    /// is OT and R2 is CTOT); this is expected and not an error.
+    pub fn from_mates(r1: BismarkRecord, r2: BismarkRecord) -> Result<Self, BismarkIoError> {
+        if r1.read_identity() != ReadIdentity::R1 {
+            return Err(BismarkIoError::ReadIdentityMismatch {
+                description: format!("expected R1 for first mate, got {:?}", r1.read_identity()),
+            });
+        }
+        if r2.read_identity() != ReadIdentity::R2 {
+            return Err(BismarkIoError::ReadIdentityMismatch {
+                description: format!("expected R2 for second mate, got {:?}", r2.read_identity()),
+            });
+        }
+
+        let r1_name: Vec<u8> = r1
+            .inner()
+            .name()
+            .map(|n| <_ as AsRef<[u8]>>::as_ref(n).to_vec())
+            .unwrap_or_default();
+        let r2_name: Vec<u8> = r2
+            .inner()
+            .name()
+            .map(|n| <_ as AsRef<[u8]>>::as_ref(n).to_vec())
+            .unwrap_or_default();
+        if r1_name != r2_name {
+            return Err(BismarkIoError::MateMismatch {
+                r1_qname: r1_name,
+                r2_qname: r2_name,
+            });
+        }
+
+        let pair_strand = r1.record_strand();
+        Ok(Self {
+            r1,
+            r2,
+            pair_strand,
+        })
+    }
+
+    /// Library-level strand classification, derived from R1.
+    ///
+    /// **Use this for output routing of both R1 AND R2 methylation calls
+    /// in paired-end mode.** Do NOT use each mate's `record_strand()`
+    /// (they differ for R1 vs R2 of the same pair in a directional
+    /// library).
+    pub fn pair_strand(&self) -> BismarkStrand {
+        self.pair_strand
+    }
+
+    /// R1 of the pair.
+    pub fn r1(&self) -> &BismarkRecord {
+        &self.r1
+    }
+
+    /// R2 of the pair.
+    pub fn r2(&self) -> &BismarkRecord {
+        &self.r2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bstr::BString;
+    use noodles_sam::alignment::RecordBuf;
+    use noodles_sam::alignment::record::data::field::Tag;
+    use noodles_sam::alignment::record_buf::Sequence;
+    use noodles_sam::alignment::record_buf::data::field::Value;
+
+    fn synth(name: &[u8], xr: &[u8], xg: &[u8], xm: &[u8], seq: &[u8], flags: u16) -> RecordBuf {
+        let mut record = RecordBuf::default();
+        *record.name_mut() = Some(BString::from(name.to_vec()));
+        *record.flags_mut() = noodles_sam::alignment::record::Flags::from(flags);
+        *record.sequence_mut() = Sequence::from(seq.to_vec());
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XR"), Value::String(BString::from(xr.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XM"), Value::String(BString::from(xm.to_vec())));
+        record
+    }
+
+    fn make_pair_records(
+        r1_xr_xg: (&[u8], &[u8]),
+        r2_xr_xg: (&[u8], &[u8]),
+    ) -> (BismarkRecord, BismarkRecord) {
+        let r1 = synth(b"qname1", r1_xr_xg.0, r1_xr_xg.1, b".....", b"ACGTC", 0x41);
+        let r2 = synth(b"qname1", r2_xr_xg.0, r2_xr_xg.1, b".....", b"ACGTC", 0x81);
+        (
+            BismarkRecord::from_noodles_record(r1).unwrap(),
+            BismarkRecord::from_noodles_record(r2).unwrap(),
+        )
+    }
+
+    #[test]
+    fn from_mates_ot_pair() {
+        // OT pair: R1 XR=CT XG=CT → OT, R2 XR=GA XG=CT → CTOT
+        let (r1, r2) = make_pair_records((b"CT", b"CT"), (b"GA", b"CT"));
+        assert_eq!(r1.record_strand(), BismarkStrand::OT);
+        assert_eq!(r2.record_strand(), BismarkStrand::CTOT);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(pair.pair_strand(), BismarkStrand::OT);
+    }
+
+    #[test]
+    fn from_mates_ob_pair() {
+        // OB pair: R1 XR=CT XG=GA → OB, R2 XR=GA XG=GA → CTOB
+        let (r1, r2) = make_pair_records((b"CT", b"GA"), (b"GA", b"GA"));
+        assert_eq!(r1.record_strand(), BismarkStrand::OB);
+        assert_eq!(r2.record_strand(), BismarkStrand::CTOB);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(pair.pair_strand(), BismarkStrand::OB);
+    }
+
+    #[test]
+    fn from_mates_ctot_pair_non_directional() {
+        // Non-directional CTOT-pair: R1 XR=GA XG=CT → CTOT, R2 XR=CT XG=CT → OT
+        let (r1, r2) = make_pair_records((b"GA", b"CT"), (b"CT", b"CT"));
+        assert_eq!(r1.record_strand(), BismarkStrand::CTOT);
+        assert_eq!(r2.record_strand(), BismarkStrand::OT);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(pair.pair_strand(), BismarkStrand::CTOT);
+    }
+
+    #[test]
+    fn from_mates_ctob_pair_non_directional() {
+        // Non-directional CTOB-pair: R1 XR=GA XG=GA → CTOB, R2 XR=CT XG=GA → OB
+        let (r1, r2) = make_pair_records((b"GA", b"GA"), (b"CT", b"GA"));
+        assert_eq!(r1.record_strand(), BismarkStrand::CTOB);
+        assert_eq!(r2.record_strand(), BismarkStrand::OB);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(pair.pair_strand(), BismarkStrand::CTOB);
+    }
+
+    #[test]
+    fn from_mates_wrong_r1_identity_errors() {
+        // Caller passes R2 + R2 (no R1)
+        let (_r1, r2a) = make_pair_records((b"CT", b"CT"), (b"GA", b"CT"));
+        let (_r1b, r2b) = make_pair_records((b"CT", b"CT"), (b"GA", b"CT"));
+        let err = BismarkPair::from_mates(r2a, r2b).unwrap_err();
+        assert!(matches!(err, BismarkIoError::ReadIdentityMismatch { .. }));
+    }
+
+    #[test]
+    fn from_mates_wrong_r2_identity_errors() {
+        // Caller passes R1 + R1 (no R2)
+        let (r1a, _r2) = make_pair_records((b"CT", b"CT"), (b"GA", b"CT"));
+        let (r1b, _r2b) = make_pair_records((b"CT", b"CT"), (b"GA", b"CT"));
+        let err = BismarkPair::from_mates(r1a, r1b).unwrap_err();
+        assert!(matches!(err, BismarkIoError::ReadIdentityMismatch { .. }));
+    }
+
+    #[test]
+    fn from_mates_qname_mismatch_errors() {
+        // R1 has qname1, R2 has qname2
+        let r1_raw = synth(b"qname1", b"CT", b"CT", b".....", b"ACGTC", 0x41);
+        let r2_raw = synth(b"qname2", b"GA", b"CT", b".....", b"ACGTC", 0x81);
+        let r1 = BismarkRecord::from_noodles_record(r1_raw).unwrap();
+        let r2 = BismarkRecord::from_noodles_record(r2_raw).unwrap();
+        let err = BismarkPair::from_mates(r1, r2).unwrap_err();
+        match err {
+            BismarkIoError::MateMismatch { r1_qname, r2_qname } => {
+                assert_eq!(r1_qname, b"qname1");
+                assert_eq!(r2_qname, b"qname2");
+            }
+            other => panic!("expected MateMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accessors_return_inner_records() {
+        let (r1, r2) = make_pair_records((b"CT", b"CT"), (b"GA", b"CT"));
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(pair.r1().record_strand(), BismarkStrand::OT);
+        assert_eq!(pair.r2().record_strand(), BismarkStrand::CTOT);
+    }
+}

--- a/rust/bismark-io/src/pair.rs
+++ b/rust/bismark-io/src/pair.rs
@@ -49,20 +49,16 @@ impl BismarkPair {
             });
         }
 
-        let r1_name: Vec<u8> = r1
-            .inner()
-            .name()
-            .map(|n| <_ as AsRef<[u8]>>::as_ref(n).to_vec())
-            .unwrap_or_default();
-        let r2_name: Vec<u8> = r2
-            .inner()
-            .name()
-            .map(|n| <_ as AsRef<[u8]>>::as_ref(n).to_vec())
-            .unwrap_or_default();
-        if r1_name != r2_name {
+        // Borrow-compare first; only allocate on the error path. At 27M+
+        // pairs from a typical PE WGBS run the cheap-path matters.
+        let r1_name_opt = r1.inner().name();
+        let r2_name_opt = r2.inner().name();
+        let r1_bytes: &[u8] = r1_name_opt.as_ref().map_or(b"", |n| AsRef::as_ref(*n));
+        let r2_bytes: &[u8] = r2_name_opt.as_ref().map_or(b"", |n| AsRef::as_ref(*n));
+        if r1_bytes != r2_bytes {
             return Err(BismarkIoError::MateMismatch {
-                r1_qname: r1_name,
-                r2_qname: r2_name,
+                r1_qname: r1_bytes.to_vec(),
+                r2_qname: r2_bytes.to_vec(),
             });
         }
 

--- a/rust/bismark-io/src/read.rs
+++ b/rust/bismark-io/src/read.rs
@@ -194,6 +194,21 @@ fn check_not_coordinate_sorted(header: &Header) -> Result<(), BismarkIoError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bstr::BString;
+    use noodles_sam::header::record::value::Map;
+    use noodles_sam::header::record::value::map::header::Version;
+    use std::io::Cursor;
+
+    /// Build a SAM header with the given SO value (or no SO if `so` is None).
+    fn header_with_sort_order(so: Option<&[u8]>) -> Header {
+        let mut hd =
+            Map::<noodles_sam::header::record::value::map::Header>::new(Version::new(1, 6));
+        if let Some(so_bytes) = so {
+            hd.other_fields_mut()
+                .insert(SORT_ORDER, BString::from(so_bytes.to_vec()));
+        }
+        noodles_sam::Header::builder().set_header(hd).build()
+    }
 
     #[test]
     fn alignment_kind_from_path_bam() {
@@ -233,5 +248,96 @@ mod tests {
     fn alignment_kind_from_path_no_extension_errors() {
         let err = AlignmentKind::from_path(Path::new("noext")).unwrap_err();
         assert!(matches!(err, BismarkIoError::UnsupportedKind(_)));
+    }
+
+    #[test]
+    fn check_not_coordinate_sorted_rejects_coordinate() {
+        let header = header_with_sort_order(Some(b"coordinate"));
+        let err = check_not_coordinate_sorted(&header).unwrap_err();
+        assert!(matches!(err, BismarkIoError::UnsortedInput));
+    }
+
+    #[test]
+    fn check_not_coordinate_sorted_allows_queryname() {
+        let header = header_with_sort_order(Some(b"queryname"));
+        assert!(check_not_coordinate_sorted(&header).is_ok());
+    }
+
+    #[test]
+    fn check_not_coordinate_sorted_allows_unsorted() {
+        let header = header_with_sort_order(Some(b"unsorted"));
+        assert!(check_not_coordinate_sorted(&header).is_ok());
+    }
+
+    #[test]
+    fn check_not_coordinate_sorted_allows_unknown() {
+        let header = header_with_sort_order(Some(b"unknown"));
+        assert!(check_not_coordinate_sorted(&header).is_ok());
+    }
+
+    #[test]
+    fn check_not_coordinate_sorted_allows_no_so_field() {
+        let header = header_with_sort_order(None);
+        assert!(check_not_coordinate_sorted(&header).is_ok());
+    }
+
+    #[test]
+    fn check_not_coordinate_sorted_allows_no_hd_at_all() {
+        // A header with no @HD record at all (Default header).
+        let header = noodles_sam::Header::default();
+        assert!(check_not_coordinate_sorted(&header).is_ok());
+    }
+
+    /// Minimal SAM bytes with a single mapped record carrying valid Bismark
+    /// tags. Useful for iterator-level integration tests.
+    const SAM_ONE_MAPPED: &[u8] = b"@HD\tVN:1.6\tSO:unsorted\n\
+@SQ\tSN:chr1\tLN:1000\n\
+read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTC\tIIIII\tXM:Z:.....\tXR:Z:CT\tXG:Z:CT\n";
+
+    /// SAM with one mapped + one unmapped record. Unmapped has FLAG 0x4.
+    const SAM_MAPPED_AND_UNMAPPED: &[u8] = b"@HD\tVN:1.6\tSO:unsorted\n\
+@SQ\tSN:chr1\tLN:1000\n\
+mapped_read\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTC\tIIIII\tXM:Z:.....\tXR:Z:CT\tXG:Z:CT\n\
+unmapped_read\t4\t*\t0\t0\t*\t*\t0\t0\tACGTC\tIIIII\n";
+
+    /// SAM with one record that is missing the XR tag entirely.
+    const SAM_MISSING_XR: &[u8] = b"@HD\tVN:1.6\tSO:unsorted\n\
+@SQ\tSN:chr1\tLN:1000\n\
+read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTC\tIIIII\tXM:Z:.....\tXG:Z:CT\n";
+
+    #[test]
+    fn sam_reader_yields_mapped_record() {
+        let mut reader = SamReader::new(Cursor::new(SAM_ONE_MAPPED)).unwrap();
+        let records: Vec<_> = reader.records().collect();
+        assert_eq!(records.len(), 1);
+        let rec = records.into_iter().next().unwrap().unwrap();
+        assert_eq!(rec.record_strand(), crate::BismarkStrand::OT);
+    }
+
+    #[test]
+    fn sam_reader_silently_drops_unmapped_records() {
+        let mut reader = SamReader::new(Cursor::new(SAM_MAPPED_AND_UNMAPPED)).unwrap();
+        let records: Vec<_> = reader.records().collect();
+        // Only the mapped record should appear; unmapped is silently filtered.
+        assert_eq!(
+            records.len(),
+            1,
+            "unmapped read (FLAG & 0x4) must be silently dropped, not surfaced"
+        );
+        let rec = records.into_iter().next().unwrap().unwrap();
+        // Verify it's the mapped one by checking we got a successful BismarkRecord.
+        let _ = rec.record_strand();
+    }
+
+    #[test]
+    fn sam_reader_propagates_missing_tag_error() {
+        let mut reader = SamReader::new(Cursor::new(SAM_MISSING_XR)).unwrap();
+        let records: Vec<_> = reader.records().collect();
+        assert_eq!(records.len(), 1);
+        let err = records.into_iter().next().unwrap().unwrap_err();
+        assert!(
+            matches!(err, BismarkIoError::MissingTag { tag: "XR" }),
+            "expected MissingTag {{ tag: \"XR\" }}, got {err:?}"
+        );
     }
 }

--- a/rust/bismark-io/src/read.rs
+++ b/rust/bismark-io/src/read.rs
@@ -1,0 +1,237 @@
+//! BAM and SAM readers that yield [`BismarkRecord`]s.
+//!
+//! Both readers wrap their underlying noodles reader and produce
+//! [`BismarkRecord`] via [`BismarkRecord::from_noodles_record`]. The
+//! iterator-level adapter:
+//!
+//! - **Silently filters unmapped reads** (SAM FLAG & 0x4). The
+//!   [`BismarkRecord`] constructor never sees them. Callers needing raw
+//!   access to unmapped reads should use the underlying noodles reader
+//!   directly.
+//! - **Detects coordinate-sorted input** by inspecting the SAM header's
+//!   `@HD SO:` field at construction time. Coordinate-sorted BAMs make
+//!   PE work meaningless (R1 and R2 are not adjacent); raises
+//!   [`BismarkIoError::UnsortedInput`]. SE-only callers can opt out by
+//!   calling [`BamReader::without_sort_check`].
+//!
+//! CRAM reader, BAM/SAM writers, and CRAM writer are delivered in
+//! subsequent sub-issues under epic #794.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use noodles_sam::Header;
+use noodles_sam::alignment::RecordBuf;
+use noodles_sam::header::record::value::map::header::sort_order::COORDINATE;
+use noodles_sam::header::record::value::map::header::tag::SORT_ORDER;
+
+use crate::error::BismarkIoError;
+use crate::record::BismarkRecord;
+
+/// Recognised input file kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlignmentKind {
+    /// Binary alignment map.
+    Bam,
+    /// Sequence alignment map (plain text).
+    Sam,
+    /// CRAM. (Reader landed in a follow-up sub-issue under #794.)
+    Cram,
+}
+
+impl AlignmentKind {
+    /// Infer from a file path's extension. Returns
+    /// [`BismarkIoError::UnsupportedKind`] if the extension is none of
+    /// `.bam`, `.sam`, `.cram`.
+    pub fn from_path(path: &Path) -> Result<Self, BismarkIoError> {
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase());
+        match ext.as_deref() {
+            Some("bam") => Ok(Self::Bam),
+            Some("sam") => Ok(Self::Sam),
+            Some("cram") => Ok(Self::Cram),
+            _ => Err(BismarkIoError::UnsupportedKind(path.to_path_buf())),
+        }
+    }
+}
+
+/// BAM reader producing [`BismarkRecord`]s.
+///
+/// Wraps `noodles_bam::io::Reader` which itself wraps a BGZF reader around
+/// the underlying byte stream.
+pub struct BamReader<R: BufRead> {
+    inner: noodles_bam::io::Reader<noodles_bgzf::io::Reader<R>>,
+    header: Header,
+}
+
+impl BamReader<BufReader<File>> {
+    /// Open a BAM file from a path. Reads the header eagerly and detects
+    /// coordinate sort.
+    pub fn from_path(path: &Path) -> Result<Self, BismarkIoError> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        Self::new(reader)
+    }
+}
+
+impl<R: BufRead> BamReader<R> {
+    /// Construct from any [`BufRead`] producing BAM bytes. Reads the
+    /// header eagerly and rejects coordinate-sorted input.
+    pub fn new(reader: R) -> Result<Self, BismarkIoError> {
+        let mut inner = noodles_bam::io::Reader::new(reader);
+        let header = inner.read_header()?;
+        check_not_coordinate_sorted(&header)?;
+        Ok(Self { inner, header })
+    }
+
+    /// Construct without rejecting coordinate-sorted input. For SE-only
+    /// callers (or callers that have other reasons to accept coordinate
+    /// sort).
+    pub fn without_sort_check(reader: R) -> Result<Self, BismarkIoError> {
+        let mut inner = noodles_bam::io::Reader::new(reader);
+        let header = inner.read_header()?;
+        Ok(Self { inner, header })
+    }
+
+    /// Header from the BAM file.
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
+    /// Iterator yielding one [`BismarkRecord`] per mapped alignment.
+    /// Unmapped reads (SAM FLAG & 0x4) are silently filtered.
+    pub fn records(&mut self) -> impl Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_ {
+        let header = &self.header;
+        self.inner
+            .record_bufs(header)
+            .filter_map(filter_unmapped_then_classify)
+    }
+}
+
+/// SAM reader producing [`BismarkRecord`]s.
+pub struct SamReader<R: BufRead> {
+    inner: noodles_sam::io::Reader<R>,
+    header: Header,
+}
+
+impl SamReader<BufReader<File>> {
+    /// Open a SAM file from a path.
+    pub fn from_path(path: &Path) -> Result<Self, BismarkIoError> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        Self::new(reader)
+    }
+}
+
+impl<R: BufRead> SamReader<R> {
+    /// Construct from any [`BufRead`] producing SAM bytes.
+    pub fn new(reader: R) -> Result<Self, BismarkIoError> {
+        let mut inner = noodles_sam::io::Reader::new(reader);
+        let header = inner.read_header()?;
+        check_not_coordinate_sorted(&header)?;
+        Ok(Self { inner, header })
+    }
+
+    /// Construct without rejecting coordinate-sorted input.
+    pub fn without_sort_check(reader: R) -> Result<Self, BismarkIoError> {
+        let mut inner = noodles_sam::io::Reader::new(reader);
+        let header = inner.read_header()?;
+        Ok(Self { inner, header })
+    }
+
+    /// Header from the SAM file.
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
+    /// Iterator yielding one [`BismarkRecord`] per mapped alignment.
+    pub fn records(&mut self) -> impl Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_ {
+        let header = &self.header;
+        self.inner
+            .record_bufs(header)
+            .filter_map(filter_unmapped_then_classify)
+    }
+}
+
+/// Filter out unmapped records (FLAG & 0x4) and classify the rest as
+/// [`BismarkRecord`]. Surfaces noodles I/O errors and `BismarkIoError`
+/// from classification.
+fn filter_unmapped_then_classify(
+    item: std::io::Result<RecordBuf>,
+) -> Option<Result<BismarkRecord, BismarkIoError>> {
+    match item {
+        Ok(rec) => {
+            let flags = u16::from(rec.flags());
+            if (flags & 0x4) != 0 {
+                None // unmapped — silently drop
+            } else {
+                Some(BismarkRecord::from_noodles_record(rec))
+            }
+        }
+        Err(e) => Some(Err(BismarkIoError::Io(e))),
+    }
+}
+
+/// Verify that the BAM/SAM header does not declare coordinate sort.
+///
+/// The SO sort-order field is in the HD map's `other_fields`. We compare
+/// against the canonical noodles byte constant `COORDINATE`.
+fn check_not_coordinate_sorted(header: &Header) -> Result<(), BismarkIoError> {
+    if let Some(hd) = header.header()
+        && let Some(so) = hd.other_fields().get(&SORT_ORDER)
+    {
+        let so_bytes: &[u8] = AsRef::as_ref(so);
+        if so_bytes == COORDINATE {
+            return Err(BismarkIoError::UnsortedInput);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alignment_kind_from_path_bam() {
+        assert_eq!(
+            AlignmentKind::from_path(Path::new("x.bam")).unwrap(),
+            AlignmentKind::Bam
+        );
+        assert_eq!(
+            AlignmentKind::from_path(Path::new("x.BAM")).unwrap(),
+            AlignmentKind::Bam
+        );
+    }
+
+    #[test]
+    fn alignment_kind_from_path_sam() {
+        assert_eq!(
+            AlignmentKind::from_path(Path::new("x.sam")).unwrap(),
+            AlignmentKind::Sam
+        );
+    }
+
+    #[test]
+    fn alignment_kind_from_path_cram() {
+        assert_eq!(
+            AlignmentKind::from_path(Path::new("x.cram")).unwrap(),
+            AlignmentKind::Cram
+        );
+    }
+
+    #[test]
+    fn alignment_kind_from_path_unknown_errors() {
+        let err = AlignmentKind::from_path(Path::new("x.txt")).unwrap_err();
+        assert!(matches!(err, BismarkIoError::UnsupportedKind(_)));
+    }
+
+    #[test]
+    fn alignment_kind_from_path_no_extension_errors() {
+        let err = AlignmentKind::from_path(Path::new("noext")).unwrap_err();
+        assert!(matches!(err, BismarkIoError::UnsupportedKind(_)));
+    }
+}

--- a/rust/bismark-io/src/record.rs
+++ b/rust/bismark-io/src/record.rs
@@ -1,0 +1,291 @@
+//! Bismark-aware record wrapper.
+//!
+//! [`BismarkRecord`] wraps [`noodles_sam::alignment::RecordBuf`] with eager
+//! strand classification at parse time. The per-record strand is derived
+//! once from the XR/XG tags and stored as a typed field — never recomputed.
+//!
+//! See `DESIGN.md` Q1 for the rationale: this is the structural
+//! prevention for the per-call strand-routing bug that affected the prior-
+//! art Rust port. Output routing for paired-end data should use
+//! [`crate::pair::BismarkPair`]'s `pair_strand()` rather than this
+//! `record_strand()` (they differ between R1 and R2 of a directional pair).
+
+use noodles_sam::alignment::RecordBuf;
+use noodles_sam::alignment::record_buf::Cigar;
+
+use crate::error::BismarkIoError;
+use crate::strand::BismarkStrand;
+use crate::tags;
+
+/// Read identity within a paired-end (or single-end) alignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReadIdentity {
+    /// Single-end read (FLAG has neither 0x40 nor 0x80 set).
+    Single,
+    /// First in pair (FLAG & 0x40).
+    R1,
+    /// Second in pair (FLAG & 0x80).
+    R2,
+}
+
+impl ReadIdentity {
+    /// Derive read identity from SAM flag bits.
+    pub fn from_flags(flags: u16) -> Self {
+        let is_first = (flags & 0x40) != 0;
+        let is_last = (flags & 0x80) != 0;
+        match (is_first, is_last) {
+            (true, false) => Self::R1,
+            (false, true) => Self::R2,
+            _ => Self::Single,
+        }
+    }
+
+    /// Canonical short label (`"R1"`, `"R2"`, or `"SE"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Single => "SE",
+            Self::R1 => "R1",
+            Self::R2 => "R2",
+        }
+    }
+}
+
+/// A Bismark-aware alignment record.
+///
+/// Wraps a [`RecordBuf`] with the per-record strand classification already
+/// computed (eagerly, at parse time) and the read identity decoded from
+/// the SAM flag.
+#[derive(Debug, Clone)]
+pub struct BismarkRecord {
+    inner: RecordBuf,
+    record_strand: BismarkStrand,
+    read_identity: ReadIdentity,
+}
+
+impl BismarkRecord {
+    /// Construct from a noodles record, performing eager strand
+    /// classification and data-integrity checks.
+    ///
+    /// Validates:
+    /// - `XR:Z:` and `XG:Z:` tags present, parseable, and forming a valid
+    ///   Bismark strand combination.
+    /// - `XM:Z:` tag length equals the read sequence length (no
+    ///   misalignment between methylation-call string and bases).
+    ///
+    /// Does NOT filter unmapped reads — that filtering happens at the
+    /// reader-iterator layer, before this constructor sees the record.
+    pub fn from_noodles_record(inner: RecordBuf) -> Result<Self, BismarkIoError> {
+        let data = inner.data();
+        let xr = tags::xr(data)?;
+        let xg = tags::xg(data)?;
+        let record_strand = BismarkStrand::from_xr_xg(xr, xg)?;
+
+        // XM/seq length parity check.
+        let xm = tags::xm(data)?;
+        let seq_len = inner.sequence().as_ref().len();
+        if xm.len() != seq_len {
+            return Err(BismarkIoError::XmSeqLengthMismatch {
+                xm_len: xm.len(),
+                seq_len,
+            });
+        }
+
+        let flag_bits = u16::from(inner.flags());
+        let read_identity = ReadIdentity::from_flags(flag_bits);
+
+        Ok(Self {
+            inner,
+            record_strand,
+            read_identity,
+        })
+    }
+
+    /// Strand derived from THIS record's own `XR:Z:`/`XG:Z:` tags.
+    ///
+    /// For R2 of a directional OT pair, this returns `CTOT` — which is
+    /// NOT the pair-level routing key. Output routing for paired-end work
+    /// should use [`crate::pair::BismarkPair::pair_strand`] instead.
+    pub fn record_strand(&self) -> BismarkStrand {
+        self.record_strand
+    }
+
+    /// Read identity (`Single`, `R1`, or `R2`) decoded from SAM flag bits.
+    pub fn read_identity(&self) -> ReadIdentity {
+        self.read_identity
+    }
+
+    /// Reference to the wrapped noodles record. Escape hatch for cases not
+    /// covered by the explicit Bismark-aware accessors.
+    pub fn inner(&self) -> &RecordBuf {
+        &self.inner
+    }
+
+    /// Methylation-call string from the `XM:Z:` tag.
+    ///
+    /// Length is guaranteed by construction to equal the read sequence
+    /// length.
+    pub fn xm(&self) -> &[u8] {
+        // Safe: `from_noodles_record` validated this tag's presence.
+        tags::xm(self.inner.data()).expect("XM presence validated at construction")
+    }
+
+    /// 1-based alignment start position on the reference, or `None` if the
+    /// record has no alignment position (unmapped — filtered upstream, but
+    /// defensive).
+    pub fn alignment_start(&self) -> Option<usize> {
+        self.inner.alignment_start().map(usize::from)
+    }
+
+    /// CIGAR string from the wrapped record. Use with [`crate::CigarExt`]
+    /// for reference-span, read-span, and aligned-position helpers.
+    pub fn cigar(&self) -> &Cigar {
+        self.inner.cigar()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bstr::BString;
+    use noodles_sam::alignment::record::data::field::Tag;
+    use noodles_sam::alignment::record_buf::Sequence;
+    use noodles_sam::alignment::record_buf::data::field::Value;
+
+    /// Build a synthetic RecordBuf with the given XR/XG/XM and sequence.
+    /// Caller can override flags via `flags_override` (default: 0).
+    fn synth(xr: &[u8], xg: &[u8], xm: &[u8], seq: &[u8], flags_override: u16) -> RecordBuf {
+        let mut record = RecordBuf::default();
+        *record.flags_mut() = noodles_sam::alignment::record::Flags::from(flags_override);
+        *record.sequence_mut() = Sequence::from(seq.to_vec());
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XR"), Value::String(BString::from(xr.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XM"), Value::String(BString::from(xm.to_vec())));
+        record
+    }
+
+    #[test]
+    fn from_noodles_record_classifies_ot() {
+        let r = synth(b"CT", b"CT", b".....", b"ACGTC", 0);
+        let bm = BismarkRecord::from_noodles_record(r).unwrap();
+        assert_eq!(bm.record_strand(), BismarkStrand::OT);
+        assert_eq!(bm.read_identity(), ReadIdentity::Single);
+    }
+
+    #[test]
+    fn from_noodles_record_classifies_ctot() {
+        let r = synth(b"GA", b"CT", b".....", b"ACGTC", 0);
+        let bm = BismarkRecord::from_noodles_record(r).unwrap();
+        assert_eq!(bm.record_strand(), BismarkStrand::CTOT);
+    }
+
+    #[test]
+    fn from_noodles_record_classifies_ob() {
+        let r = synth(b"CT", b"GA", b".....", b"ACGTC", 0);
+        let bm = BismarkRecord::from_noodles_record(r).unwrap();
+        assert_eq!(bm.record_strand(), BismarkStrand::OB);
+    }
+
+    #[test]
+    fn from_noodles_record_classifies_ctob() {
+        let r = synth(b"GA", b"GA", b".....", b"ACGTC", 0);
+        let bm = BismarkRecord::from_noodles_record(r).unwrap();
+        assert_eq!(bm.record_strand(), BismarkStrand::CTOB);
+    }
+
+    #[test]
+    fn from_noodles_record_decodes_r1() {
+        // FLAG 0x40 = first in pair, 0x01 = paired
+        let r = synth(b"CT", b"CT", b".....", b"ACGTC", 0x41);
+        let bm = BismarkRecord::from_noodles_record(r).unwrap();
+        assert_eq!(bm.read_identity(), ReadIdentity::R1);
+    }
+
+    #[test]
+    fn from_noodles_record_decodes_r2() {
+        // FLAG 0x80 = second in pair, 0x01 = paired
+        let r = synth(b"GA", b"CT", b".....", b"ACGTC", 0x81);
+        let bm = BismarkRecord::from_noodles_record(r).unwrap();
+        assert_eq!(bm.read_identity(), ReadIdentity::R2);
+    }
+
+    #[test]
+    fn from_noodles_record_missing_xr_errors() {
+        let mut r = synth(b"CT", b"CT", b".....", b"ACGTC", 0);
+        // Remove XR
+        r.data_mut().remove(&Tag::from(*b"XR"));
+        let err = BismarkRecord::from_noodles_record(r).unwrap_err();
+        assert!(matches!(err, BismarkIoError::MissingTag { tag: "XR" }));
+    }
+
+    #[test]
+    fn from_noodles_record_missing_xg_errors() {
+        let mut r = synth(b"CT", b"CT", b".....", b"ACGTC", 0);
+        r.data_mut().remove(&Tag::from(*b"XG"));
+        let err = BismarkRecord::from_noodles_record(r).unwrap_err();
+        assert!(matches!(err, BismarkIoError::MissingTag { tag: "XG" }));
+    }
+
+    #[test]
+    fn from_noodles_record_missing_xm_errors() {
+        let mut r = synth(b"CT", b"CT", b".....", b"ACGTC", 0);
+        r.data_mut().remove(&Tag::from(*b"XM"));
+        let err = BismarkRecord::from_noodles_record(r).unwrap_err();
+        assert!(matches!(err, BismarkIoError::MissingTag { tag: "XM" }));
+    }
+
+    #[test]
+    fn from_noodles_record_malformed_strand_tags_errors() {
+        let r = synth(b"XX", b"YY", b".....", b"ACGTC", 0);
+        let err = BismarkRecord::from_noodles_record(r).unwrap_err();
+        assert!(matches!(err, BismarkIoError::InvalidStrandTags { .. }));
+    }
+
+    #[test]
+    fn from_noodles_record_xm_seq_length_mismatch_errors() {
+        // XM is 5 chars, seq is 6 bases → mismatch
+        let r = synth(b"CT", b"CT", b".....", b"ACGTCA", 0);
+        let err = BismarkRecord::from_noodles_record(r).unwrap_err();
+        assert!(matches!(
+            err,
+            BismarkIoError::XmSeqLengthMismatch {
+                xm_len: 5,
+                seq_len: 6
+            }
+        ));
+    }
+
+    #[test]
+    fn from_noodles_record_accessors_work() {
+        let r = synth(b"CT", b"CT", b".z.h.", b"ACGTC", 0);
+        let bm = BismarkRecord::from_noodles_record(r).unwrap();
+        assert_eq!(bm.xm(), b".z.h.");
+        assert_eq!(bm.record_strand(), BismarkStrand::OT);
+        // inner() escape hatch returns a reference to the wrapped record.
+        let _ = bm.inner();
+    }
+
+    #[test]
+    fn read_identity_from_flags_table() {
+        assert_eq!(ReadIdentity::from_flags(0x00), ReadIdentity::Single);
+        assert_eq!(ReadIdentity::from_flags(0x04), ReadIdentity::Single); // unmapped, no R1/R2 bit
+        assert_eq!(ReadIdentity::from_flags(0x40), ReadIdentity::R1);
+        assert_eq!(ReadIdentity::from_flags(0x80), ReadIdentity::R2);
+        assert_eq!(ReadIdentity::from_flags(0x41), ReadIdentity::R1); // R1 + paired
+        assert_eq!(ReadIdentity::from_flags(0x81), ReadIdentity::R2); // R2 + paired
+        // Both R1 and R2 set is invalid in SAM spec; we treat as Single (defensive).
+        assert_eq!(ReadIdentity::from_flags(0xC0), ReadIdentity::Single);
+    }
+
+    #[test]
+    fn read_identity_as_str() {
+        assert_eq!(ReadIdentity::Single.as_str(), "SE");
+        assert_eq!(ReadIdentity::R1.as_str(), "R1");
+        assert_eq!(ReadIdentity::R2.as_str(), "R2");
+    }
+}

--- a/rust/bismark-io/src/strand.rs
+++ b/rust/bismark-io/src/strand.rs
@@ -1,0 +1,185 @@
+//! Bismark strand classification.
+//!
+//! Bismark encodes the strand across two SAM optional tags rather than a
+//! single field:
+//!
+//! | Tag      | Meaning                                       | Values       |
+//! |----------|-----------------------------------------------|--------------|
+//! | `XR:Z:`  | Read conversion (how this record was sequenced) | `CT` or `GA` |
+//! | `XG:Z:`  | Genome conversion (which converted reference)  | `CT` or `GA` |
+//!
+//! The four-way strand is derived from the 2×2 combination:
+//!
+//! | XR | XG | → Strand                  |
+//! |----|----|---------------------------|
+//! | CT | CT | OT (Original Top)         |
+//! | GA | CT | CTOT (Complementary to OT)|
+//! | CT | GA | OB (Original Bottom)      |
+//! | GA | GA | CTOB (Complementary to OB)|
+//!
+//! See `DESIGN.md` Q1 for the API rationale, in particular the distinction
+//! between **per-record** and **per-pair** strand classification: this enum
+//! represents the per-record value derived from XR/XG. The pair-level
+//! classification is in [`crate::pair::BismarkPair`].
+
+use crate::error::BismarkIoError;
+
+/// Bismark four-way strand classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BismarkStrand {
+    /// Original Top (XR=CT, XG=CT).
+    OT,
+    /// Complementary to Original Top (XR=GA, XG=CT).
+    CTOT,
+    /// Original Bottom (XR=CT, XG=GA).
+    OB,
+    /// Complementary to Original Bottom (XR=GA, XG=GA).
+    CTOB,
+}
+
+impl BismarkStrand {
+    /// Derive the strand from raw `XR:Z:` and `XG:Z:` tag byte slices.
+    ///
+    /// Returns [`BismarkIoError::InvalidStrandTags`] if either slice is not
+    /// the literal `b"CT"` or `b"GA"`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bismark_io::BismarkStrand;
+    ///
+    /// assert_eq!(BismarkStrand::from_xr_xg(b"CT", b"CT").unwrap(), BismarkStrand::OT);
+    /// assert_eq!(BismarkStrand::from_xr_xg(b"GA", b"CT").unwrap(), BismarkStrand::CTOT);
+    /// assert_eq!(BismarkStrand::from_xr_xg(b"CT", b"GA").unwrap(), BismarkStrand::OB);
+    /// assert_eq!(BismarkStrand::from_xr_xg(b"GA", b"GA").unwrap(), BismarkStrand::CTOB);
+    /// ```
+    pub fn from_xr_xg(xr: &[u8], xg: &[u8]) -> Result<Self, BismarkIoError> {
+        match (xr, xg) {
+            (b"CT", b"CT") => Ok(Self::OT),
+            (b"GA", b"CT") => Ok(Self::CTOT),
+            (b"CT", b"GA") => Ok(Self::OB),
+            (b"GA", b"GA") => Ok(Self::CTOB),
+            _ => Err(BismarkIoError::InvalidStrandTags {
+                xr: xr.to_vec(),
+                xg: xg.to_vec(),
+            }),
+        }
+    }
+
+    /// Canonical Bismark string representation, used in output filenames
+    /// (`CpG_OT_*.txt`, `CHG_CTOT_*.txt`, etc.) and reports.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::OT => "OT",
+            Self::CTOT => "CTOT",
+            Self::OB => "OB",
+            Self::CTOB => "CTOB",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_xr_xg_all_four_valid_combinations() {
+        assert_eq!(
+            BismarkStrand::from_xr_xg(b"CT", b"CT").unwrap(),
+            BismarkStrand::OT
+        );
+        assert_eq!(
+            BismarkStrand::from_xr_xg(b"GA", b"CT").unwrap(),
+            BismarkStrand::CTOT
+        );
+        assert_eq!(
+            BismarkStrand::from_xr_xg(b"CT", b"GA").unwrap(),
+            BismarkStrand::OB
+        );
+        assert_eq!(
+            BismarkStrand::from_xr_xg(b"GA", b"GA").unwrap(),
+            BismarkStrand::CTOB
+        );
+    }
+
+    #[test]
+    fn from_xr_xg_rejects_lowercase() {
+        // Bismark spec requires uppercase; we do not normalise.
+        assert!(matches!(
+            BismarkStrand::from_xr_xg(b"ct", b"CT"),
+            Err(BismarkIoError::InvalidStrandTags { .. })
+        ));
+        assert!(matches!(
+            BismarkStrand::from_xr_xg(b"CT", b"ga"),
+            Err(BismarkIoError::InvalidStrandTags { .. })
+        ));
+    }
+
+    #[test]
+    fn from_xr_xg_rejects_empty() {
+        assert!(matches!(
+            BismarkStrand::from_xr_xg(b"", b""),
+            Err(BismarkIoError::InvalidStrandTags { .. })
+        ));
+        assert!(matches!(
+            BismarkStrand::from_xr_xg(b"", b"CT"),
+            Err(BismarkIoError::InvalidStrandTags { .. })
+        ));
+    }
+
+    #[test]
+    fn from_xr_xg_rejects_wrong_length() {
+        assert!(matches!(
+            BismarkStrand::from_xr_xg(b"C", b"CT"),
+            Err(BismarkIoError::InvalidStrandTags { .. })
+        ));
+        assert!(matches!(
+            BismarkStrand::from_xr_xg(b"CTT", b"CT"),
+            Err(BismarkIoError::InvalidStrandTags { .. })
+        ));
+    }
+
+    #[test]
+    fn from_xr_xg_rejects_unrelated_bytes() {
+        assert!(matches!(
+            BismarkStrand::from_xr_xg(b"AA", b"TT"),
+            Err(BismarkIoError::InvalidStrandTags { .. })
+        ));
+        assert!(matches!(
+            BismarkStrand::from_xr_xg(b"\x00\x01", b"CT"),
+            Err(BismarkIoError::InvalidStrandTags { .. })
+        ));
+    }
+
+    #[test]
+    fn from_xr_xg_error_preserves_input_bytes() {
+        let err = BismarkStrand::from_xr_xg(b"XX", b"YY").unwrap_err();
+        match err {
+            BismarkIoError::InvalidStrandTags { xr, xg } => {
+                assert_eq!(xr, b"XX");
+                assert_eq!(xg, b"YY");
+            }
+            other => panic!("expected InvalidStrandTags, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn as_str_matches_bismark_canonical_names() {
+        assert_eq!(BismarkStrand::OT.as_str(), "OT");
+        assert_eq!(BismarkStrand::CTOT.as_str(), "CTOT");
+        assert_eq!(BismarkStrand::OB.as_str(), "OB");
+        assert_eq!(BismarkStrand::CTOB.as_str(), "CTOB");
+    }
+
+    #[test]
+    fn enum_is_copy_and_hashable() {
+        use std::collections::HashSet;
+        let s = BismarkStrand::OT;
+        let _t = s; // Copy works (s still usable below)
+        let mut set: HashSet<BismarkStrand> = HashSet::new();
+        set.insert(s);
+        set.insert(BismarkStrand::CTOT);
+        set.insert(BismarkStrand::OT); // duplicate of the first insert
+        assert_eq!(set.len(), 2, "duplicate OT should not be re-counted");
+    }
+}

--- a/rust/bismark-io/src/tags.rs
+++ b/rust/bismark-io/src/tags.rs
@@ -1,0 +1,199 @@
+//! Typed accessors for Bismark-relevant SAM optional tags.
+//!
+//! Free functions over [`noodles_sam::alignment::record_buf::data::Data`]
+//! that pull out tags by name and return typed slices/values. Missing
+//! required tags surface as [`BismarkIoError::MissingTag`]; malformed
+//! values surface as [`BismarkIoError::MalformedTag`].
+
+use noodles_sam::alignment::record_buf::Data;
+use noodles_sam::alignment::record_buf::data::field::Value;
+
+use crate::error::BismarkIoError;
+
+const TAG_XM: [u8; 2] = *b"XM";
+const TAG_XR: [u8; 2] = *b"XR";
+const TAG_XG: [u8; 2] = *b"XG";
+const TAG_MD: [u8; 2] = *b"MD";
+const TAG_NM: [u8; 2] = *b"NM";
+
+/// Extract the `XM:Z:` methylation-call string from a record's data.
+pub fn xm(data: &Data) -> Result<&[u8], BismarkIoError> {
+    string_tag(data, &TAG_XM, "XM")
+}
+
+/// Extract the `XR:Z:` read-conversion tag.
+pub fn xr(data: &Data) -> Result<&[u8], BismarkIoError> {
+    string_tag(data, &TAG_XR, "XR")
+}
+
+/// Extract the `XG:Z:` genome-conversion tag.
+pub fn xg(data: &Data) -> Result<&[u8], BismarkIoError> {
+    string_tag(data, &TAG_XG, "XG")
+}
+
+/// Extract the optional `MD:Z:` mismatching-positions tag.
+///
+/// Returns `Ok(None)` if the tag is absent. Returns
+/// [`BismarkIoError::MalformedTag`] if present but not a string.
+pub fn md(data: &Data) -> Result<Option<&[u8]>, BismarkIoError> {
+    optional_string_tag(data, &TAG_MD, "MD")
+}
+
+/// Extract the optional `NM:i:` edit-distance tag.
+///
+/// Returns `Ok(None)` if the tag is absent. Returns
+/// [`BismarkIoError::MalformedTag`] if present but not a non-negative
+/// integer that fits in u32.
+pub fn nm(data: &Data) -> Result<Option<u32>, BismarkIoError> {
+    let tag = noodles_sam::alignment::record::data::field::Tag::from(TAG_NM);
+    match data.get(&tag) {
+        None => Ok(None),
+        Some(Value::Int8(v)) => to_u32_nonneg(*v as i64, "NM"),
+        Some(Value::UInt8(v)) => Ok(Some(u32::from(*v))),
+        Some(Value::Int16(v)) => to_u32_nonneg(*v as i64, "NM"),
+        Some(Value::UInt16(v)) => Ok(Some(u32::from(*v))),
+        Some(Value::Int32(v)) => to_u32_nonneg(*v as i64, "NM"),
+        Some(Value::UInt32(v)) => Ok(Some(*v)),
+        Some(other) => Err(BismarkIoError::MalformedTag {
+            tag: "NM",
+            reason: format!("expected integer, got {other:?}"),
+        }),
+    }
+}
+
+fn string_tag<'a>(
+    data: &'a Data,
+    tag_bytes: &[u8; 2],
+    tag_name: &'static str,
+) -> Result<&'a [u8], BismarkIoError> {
+    let tag = noodles_sam::alignment::record::data::field::Tag::from(*tag_bytes);
+    match data.get(&tag) {
+        None => Err(BismarkIoError::MissingTag { tag: tag_name }),
+        Some(Value::String(s)) => Ok(s.as_ref()),
+        Some(other) => Err(BismarkIoError::MalformedTag {
+            tag: tag_name,
+            reason: format!("expected Z (string), got {other:?}"),
+        }),
+    }
+}
+
+fn optional_string_tag<'a>(
+    data: &'a Data,
+    tag_bytes: &[u8; 2],
+    tag_name: &'static str,
+) -> Result<Option<&'a [u8]>, BismarkIoError> {
+    let tag = noodles_sam::alignment::record::data::field::Tag::from(*tag_bytes);
+    match data.get(&tag) {
+        None => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.as_ref())),
+        Some(other) => Err(BismarkIoError::MalformedTag {
+            tag: tag_name,
+            reason: format!("expected Z (string), got {other:?}"),
+        }),
+    }
+}
+
+fn to_u32_nonneg(v: i64, tag: &'static str) -> Result<Option<u32>, BismarkIoError> {
+    if v < 0 {
+        return Err(BismarkIoError::MalformedTag {
+            tag,
+            reason: format!("expected non-negative integer, got {v}"),
+        });
+    }
+    u32::try_from(v)
+        .map(Some)
+        .map_err(|_| BismarkIoError::MalformedTag {
+            tag,
+            reason: format!("value {v} does not fit in u32"),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bstr::BString;
+    use noodles_sam::alignment::record::data::field::Tag;
+
+    fn make_data() -> Data {
+        Data::default()
+    }
+
+    #[test]
+    fn xm_missing_returns_missing_tag_error() {
+        let data = make_data();
+        let err = xm(&data).unwrap_err();
+        assert!(matches!(err, BismarkIoError::MissingTag { tag: "XM" }));
+    }
+
+    #[test]
+    fn xm_present_returns_bytes() {
+        let mut data = make_data();
+        data.insert(Tag::from(TAG_XM), Value::String(BString::from("z.h.x.")));
+        let xm_bytes = xm(&data).unwrap();
+        assert_eq!(xm_bytes, b"z.h.x.");
+    }
+
+    #[test]
+    fn xr_xg_present_returns_bytes() {
+        let mut data = make_data();
+        data.insert(Tag::from(TAG_XR), Value::String(BString::from("CT")));
+        data.insert(Tag::from(TAG_XG), Value::String(BString::from("GA")));
+        assert_eq!(xr(&data).unwrap(), b"CT");
+        assert_eq!(xg(&data).unwrap(), b"GA");
+    }
+
+    #[test]
+    fn md_absent_returns_none() {
+        let data = make_data();
+        assert_eq!(md(&data).unwrap(), None);
+    }
+
+    #[test]
+    fn md_present_returns_some_bytes() {
+        let mut data = make_data();
+        data.insert(Tag::from(TAG_MD), Value::String(BString::from("10A5")));
+        assert_eq!(md(&data).unwrap(), Some(b"10A5".as_ref()));
+    }
+
+    #[test]
+    fn nm_absent_returns_none() {
+        let data = make_data();
+        assert_eq!(nm(&data).unwrap(), None);
+    }
+
+    #[test]
+    fn nm_present_as_int32_returns_value() {
+        let mut data = make_data();
+        data.insert(Tag::from(TAG_NM), Value::Int32(7));
+        assert_eq!(nm(&data).unwrap(), Some(7));
+    }
+
+    #[test]
+    fn nm_present_as_uint8_returns_value() {
+        let mut data = make_data();
+        data.insert(Tag::from(TAG_NM), Value::UInt8(3));
+        assert_eq!(nm(&data).unwrap(), Some(3));
+    }
+
+    #[test]
+    fn nm_negative_returns_malformed_tag_error() {
+        let mut data = make_data();
+        data.insert(Tag::from(TAG_NM), Value::Int32(-1));
+        let err = nm(&data).unwrap_err();
+        assert!(matches!(
+            err,
+            BismarkIoError::MalformedTag { tag: "NM", .. }
+        ));
+    }
+
+    #[test]
+    fn xr_wrong_type_returns_malformed_tag() {
+        let mut data = make_data();
+        data.insert(Tag::from(TAG_XR), Value::Int32(42));
+        let err = xr(&data).unwrap_err();
+        assert!(matches!(
+            err,
+            BismarkIoError::MalformedTag { tag: "XR", .. }
+        ));
+    }
+}


### PR DESCRIPTION
Closes #805. Part of epic #794.

## What this PR delivers

Phase A + B + C1-C2 of the `bismark-io` v1.0 implementation plan: the foundational types, traits, and BAM/SAM readers that downstream Phase 1 binary crates (`bismark-dedup`, `bismark-bedgraph`, `bismark-extractor`) will consume.

### Phase A — foundations
- **A1**: Bump workspace MSRV from 1.85 to 1.89 (required by noodles-bam 0.89).
- **A2**: Add noodles family deps, exact-pinned: `noodles-bam=0.89`, `noodles-sam=0.85`, `noodles-cram=0.93`, `noodles-fasta=0.61`, `noodles-core=0.20`, `noodles-bgzf=0.47`, `noodles-csi=0.50`, plus `thiserror=2`.
- **A3**: `BismarkIoError` typed error enum. No fake noodles-specific error variants — noodles 0.89/0.85/0.93 all use `std::io::Error` directly, covered by the single `Io(#[from] std::io::Error)` variant.
- **A4**: `BismarkStrand` enum (OT/CTOT/OB/CTOB) + `from_xr_xg` + `as_str`.
- **A5**: `CigarExt` extension trait — `reference_span`, `read_span`, `reference_end(start)` (1-based inclusive end matching SAM/noodles convention; direct prevention for the `pos.saturating_sub(1)` off-by-one), and `aligned_positions()` per-base iterator.
- **A6**: Free-function tag accessors for `XM:Z:`, `XR:Z:`, `XG:Z:`, `MD:Z:`, `NM:i:`.

### Phase B — record + pair types
- **B1**: `BismarkRecord` wraps `noodles_sam::alignment::RecordBuf` with eager strand classification at parse time. Validates XM/seq length parity. `ReadIdentity` (Single/R1/R2) derived from SAM flag bits.
- **B2**: `BismarkPair` with R1-derived `pair_strand`. The structural-correctness scaffold: per-record strand and pair strand are separate fields on separate types, so output-routing code cannot accidentally use per-record XR/XG. This is the direct type-system prevention for the prior-art port's strand-routing bug.

### Phase C1+C2 — readers
- `BamReader` and `SamReader` producing `BismarkRecord`. Iterator-level silent filtering of unmapped reads (FLAG & 0x4). Coordinate-sort detection via `@HD SO:` with `without_sort_check()` opt-out for SE-only callers.
- `AlignmentKind` enum + `from_path` for extension-based dispatch.

## Quality gates (all pass)

| Gate | Result |
|---|---|
| `cargo build --release` | clean |
| `cargo clippy --all-targets --release -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo test` | **62 unit tests + 1 doctest, all pass** |

## Crate invariants

- `#![forbid(unsafe_code)]` at crate root — no unsafe blocks anywhere.
- No `samtools` subprocess. No `rust-htslib`. No external runtime deps beyond standard noodles transitive deps.
- All malformed-input paths return `BismarkIoError`; never panic on user input.

## Out of scope (separate sub-issues under #794)

- CRAM reader + reference-reconstitution helper.
- BAM/SAM/CRAM writers.
- Integration tests on committed fixture BAM.
- Crate-level rustdoc + examples (`#![warn(missing_docs)]` not yet enabled).

These will land as follow-up sub-issues per the plan; opening them after this PR merges.