### PR TITLE
release(noodles-io): tag bismark-io v1.0.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bismark-io"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "bstr",
  "noodles-bam",

--- a/rust/bismark-io/CHANGELOG.md
+++ b/rust/bismark-io/CHANGELOG.md
@@ -1,0 +1,111 @@
+# Changelog
+
+All notable changes to `bismark-io` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] — 2026-05-24
+
+First stable release of `bismark-io`, the shared library crate for Bismark's
+Rust rewrite. Wraps the [`noodles`](https://github.com/zaeleus/noodles) family
+to provide Bismark-aware BAM/SAM/CRAM I/O: strand-classified record types,
+tag-decoded accessors, CIGAR-aware position helpers.
+
+This release is feature-complete for the v1.0 scope defined in `DESIGN.md`.
+Downstream binary crates (`bismark-dedup`, `bismark-bedgraph`,
+`bismark-extractor`, `bismark-coverage2cytosine`) will pin to `=1.0.0`.
+
+### Added
+
+- **Strand classification** (`BismarkStrand`, `BismarkStrand::from_xr_xg`).
+  Eager classification at parse time; per-record strand vs pair-strand
+  distinction enforced at the type level via separate `BismarkRecord` and
+  `BismarkPair` types. `#[repr(u8)]` pins the discriminant layout (PR #816).
+  Sub-issue #805, PR #806.
+
+- **Typed errors** (`BismarkIoError` with `thiserror`). Variants:
+  `MissingTag`, `MalformedTag`, `InvalidStrandTags`, `XmSeqLengthMismatch`,
+  `MateMismatch`, `ReadIdentityMismatch`, `UnsortedInput`,
+  `MissingCramReference`, `MissingFastaIndex`, `DuplicateChromosomeName`,
+  `UnsupportedKind`, `Io`. Sub-issue #805, PR #806.
+
+- **CIGAR extension trait** (`CigarExt`). `reference_span`, `read_span`,
+  `reference_end`, `aligned_positions`. Property-tested for spec drift via
+  an independent ground-truth table derived from SAM spec §1.4.6. Sub-issue
+  #805 + #811, PR #806 + #812.
+
+- **Tag accessors** (`tags::xm`, `tags::xr`, `tags::xg`, `tags::md`,
+  `tags::nm`). Sub-issue #805, PR #806.
+
+- **Record types** (`BismarkRecord`, `BismarkPair`, `ReadIdentity`).
+  `BismarkRecord::from_noodles_record` performs eager strand classification +
+  XM/seq length parity check. `BismarkPair::from_mates` validates qname
+  equality + R1/R2 read-identity. Sub-issue #805, PR #806.
+
+- **BAM + SAM readers** (`BamReader`, `SamReader`). Iterator-level
+  unmapped-record filter + coordinate-sort detection via `@HD SO:`. Opt-out
+  via `without_sort_check`. Sub-issue #805, PR #806.
+
+- **CRAM reader** (`CramReader`) + **reference reconstitution helper**
+  (`reconstitute_cram_reference_from_bismark_genome`). Atomic write, byte-fidelity
+  chromosome names, `.fa.gz` support, duplicate-chromosome detection.
+  Sub-issue #807, PR #808.
+
+- **Path-dispatching reader** (`open_reader` + `AnyReader` enum). Routes to
+  `BamReader` / `SamReader` / `CramReader` based on file extension. Sub-issue
+  #807, PR #808.
+
+- **BAM + SAM + CRAM writers** (`BamWriter`, `SamWriter`, `CramWriter`).
+  `#[must_use]` on writer types; `finish()` consumes by value and is required
+  before drop. Sub-issue #809, PR #810.
+
+- **Path-dispatching writer** (`open_writer` + `AnyWriter` enum). Same
+  enum-dispatch pattern as `AnyReader`, chosen over `Box<dyn Trait>` because
+  `noodles-cram 0.93` exposes records via a borrowed iterator. Sub-issue
+  #809, PR #810.
+
+- **CRAM round-trip** end-to-end. Synthetic-record `cram_writer_roundtrip_via_tempfile`
+  test exercises reference-based decoding through the full read-write cycle.
+  Sub-issue #813, PR #814.
+
+- **Test fixtures + property tests** (`tests/integration_fixture_bam.rs`,
+  `tests/property.rs`). 22 KB Bismark-Perl-generated PE BAM (`tiny_pe_bismark.bam`)
+  pinned to Bismark Perl v0.25.1; 6 proptest properties covering strand
+  derivation + CIGAR span/end consistency. Sub-issue #811, PR #812.
+
+- **`#![forbid(unsafe_code)]`** and **`#![warn(missing_docs)]`** at the crate
+  root. All public items have rustdoc.
+
+### Design contract
+
+See [`DESIGN.md`](./DESIGN.md) for the design contract. Notable decisions:
+
+- No `samtools` subprocess, no `rust-htslib` C-link, no `unsafe` blocks.
+- Strand classification is eager (computed once at parse time, stored as a
+  typed field). Output routing for paired-end data uses `BismarkPair::pair_strand()`
+  (R1-derived), NOT each mate's `record_strand()`.
+- CRAM support is read **and** write — strictly stronger than Perl Bismark's
+  current behaviour (Perl pipes BAM through `samtools view -h -C` for CRAM).
+- Public API surface is sync-only for v1.0. Async support is a future decision.
+
+### MSRV
+
+Rust **1.89.0**. Required by `noodles-bam` 0.89.
+
+### Test coverage
+
+- **108 tests total** (96 lib + 5 integration + 6 property + 1 doctest); 0 ignored.
+- `cargo clippy --all-targets -- -D warnings` clean.
+- `cargo fmt --check` clean.
+
+### Notes for v1.0 consumers
+
+- `Cargo.toml`: pin with `bismark-io = "=1.0.0"` if you want a strict
+  match, or `bismark-io = "1"` for caret-compatible. The crate follows
+  semver — breaking changes will bump the major version.
+- This release is **not yet published to crates.io**. Path-dep usage from
+  within the Bismark workspace is the supported integration model until at
+  least one downstream binary crate (`bismark-dedup` first) lands. crates.io
+  publication is deferred to keep the publish-bump cycle in lockstep with
+  binary crates.

--- a/rust/bismark-io/Cargo.toml
+++ b/rust/bismark-io/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "bismark-io"
-version = "0.0.0"
+version = "1.0.0"
 description = "Bismark-aware BAM/SAM/CRAM I/O on top of noodles"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+readme = "README.md"
+keywords = ["bisulfite", "methylation", "bismark", "bioinformatics", "noodles"]
+categories = ["science::bioinformatics"]
 
 [lib]
 path = "src/lib.rs"

--- a/rust/bismark-io/README.md
+++ b/rust/bismark-io/README.md
@@ -1,0 +1,123 @@
+# `bismark-io`
+
+Bismark-aware BAM/SAM/CRAM I/O on top of [`noodles`](https://github.com/zaeleus/noodles).
+
+`bismark-io` is the shared library crate for [Bismark](https://github.com/FelixKrueger/Bismark)'s Rust rewrite. It wraps the `noodles` crate family to expose record types that already know about Bismark's strand classification (OT/CTOT/OB/CTOB derived from the `XR:Z:` and `XG:Z:` tags), tag-decoded accessors (`XM`, `XR`, `XG`, `MD`, `NM`), and CIGAR-aware position helpers. Every Bismark Rust binary crate (`bismark-dedup`, `bismark-extractor`, `bismark-bedgraph`, …) depends on it.
+
+**Status:** v1.0.0 — feature-complete; first stable release. See [`CHANGELOG.md`](./CHANGELOG.md).
+
+## Why a Bismark wrapper around `noodles`?
+
+`noodles` is an excellent pure-Rust BAM/SAM/CRAM library, but it's deliberately generic — it doesn't know anything about Bismark-specific tags or strand classification. Without a wrapper, every downstream binary would have to re-derive strand from `XR`/`XG` on every call site. That's exactly where the Bismark-flavoured Rust rewrites that came before this one introduced bugs (silently routing per-record strand to per-pair output files, see [audit](https://github.com/FelixKrueger/Bismark/issues/794)).
+
+`bismark-io` makes strand classification **structurally impossible to get wrong**:
+
+- `BismarkStrand::from_xr_xg` decodes the four-way OT/CTOT/OB/CTOB enum from the raw tag bytes.
+- `BismarkRecord` performs the classification **eagerly at parse time** and stores the result as a typed field. The per-record strand is computed once and never re-derived per call.
+- `BismarkPair` exposes a separate `pair_strand()` method that is **always R1-derived**. Output routing for paired-end data uses `pair_strand()`, NOT each mate's `record_strand()` (they differ for R1 vs R2 of a directional pair).
+
+## Design priorities
+
+In order:
+
+1. **Structural correctness over ergonomic shortcuts.** Strand is a property of a read (or pair), not of a position-on-a-read. Make the latter impossible to express.
+2. **Zero external runtime deps.** No `samtools` subprocess, no `htslib` C-link, no `unsafe` blocks.
+3. **Byte-equal output to Perl Bismark v0.25.1.** A CI invariant for downstream binaries.
+4. **Testable without I/O.** Pure functions (CIGAR span, strand derivation, tag decoding) live behind interfaces that take byte slices, not `File`s.
+
+Full design contract: [`DESIGN.md`](./DESIGN.md).
+
+## Supported formats
+
+| Format     | Read   | Write   | Notes                                                  |
+|------------|--------|---------|--------------------------------------------------------|
+| BAM        | ✅     | ✅      | Via `noodles-bam`                                      |
+| SAM        | ✅     | ✅      | Via `noodles-sam`                                      |
+| CRAM 3.0   | ✅     | ✅      | Via `noodles-cram`; requires reference FASTA           |
+
+For CRAM, the reference is required for both read **and** write. A helper, `reconstitute_cram_reference_from_bismark_genome`, builds a multi-FASTA reference from a Bismark genome directory (matching Perl Bismark's behaviour at `bismark:5131`).
+
+## Public API surface
+
+```rust
+use bismark_io::{
+    // Records and strand
+    BismarkRecord, BismarkPair, BismarkStrand, ReadIdentity,
+    // Errors
+    BismarkIoError,
+    // CIGAR helpers (extension trait on noodles' Cigar)
+    CigarExt, AlignedPosition, AlignedPositions,
+    // I/O
+    open_reader, AnyReader, BamReader, SamReader, CramReader, AlignmentKind,
+    open_writer, AnyWriter, BamWriter, SamWriter, CramWriter,
+    // CRAM reference helper
+    reconstitute_cram_reference_from_bismark_genome,
+};
+```
+
+Module-level docs explain each type's contract. See `cargo doc --open --package bismark-io`.
+
+## Quick example
+
+```rust
+use bismark_io::{open_reader, BismarkStrand};
+use std::path::Path;
+
+fn main() -> anyhow::Result<()> {
+    let mut reader = open_reader(Path::new("aligned.bam"), None)?;
+    let header = reader.header().clone();
+
+    for result in reader.records(&header) {
+        let record = result?;
+        match record.record_strand() {
+            BismarkStrand::OT   => { /* original top */ }
+            BismarkStrand::CTOT => { /* complementary to OT */ }
+            BismarkStrand::OB   => { /* original bottom */ }
+            BismarkStrand::CTOB => { /* complementary to OB */ }
+        }
+    }
+    Ok(())
+}
+```
+
+For paired-end work, pair adjacent records with `BismarkPair::from_mates(r1, r2)?` and use `pair.pair_strand()` for output routing.
+
+## MSRV
+
+Rust **1.89.0**. Required by `noodles-bam` 0.89.
+
+## Dependencies
+
+The `noodles` family is **exact-pinned** in `Cargo.toml`:
+
+| Crate          | Version  | Why exact-pin                                              |
+|----------------|----------|------------------------------------------------------------|
+| noodles-bam    | =0.89.0  | Sets the MSRV; defines `Record` shape we wrap              |
+| noodles-sam    | =0.85.0  | Mutually-resolvable with bam 0.89                          |
+| noodles-cram   | =0.93.0  | Mutually-resolvable; CRAM 3.0 + DataSeries::QualityScores  |
+| noodles-fasta  | =0.61.0  | Required by cram 0.93                                      |
+| noodles-core   | =0.20.0  | Common types (`Position`)                                  |
+| noodles-bgzf   | =0.47.0  | BGZF block boundaries                                      |
+| noodles-csi    | =0.50.0  | CRAM container indexing                                    |
+
+The pin policy: noodles releases frequently and occasionally bumps MSRV. Exact-pinning lets us upgrade as a deliberate workspace-wide decision rather than getting silently dragged along.
+
+## Testing
+
+- **108 tests total**: 96 lib unit tests + 5 integration tests + 6 proptest properties + 1 doctest.
+- `cargo test --workspace` runs everything.
+- `cargo clippy --all-targets -- -D warnings` is clean.
+- `cargo fmt --check` is clean.
+- The test fixture `test_files/tiny_pe_bismark.bam` is Bismark Perl v0.25.1-generated; see [`test_files/README.md`](./test_files/README.md) for provenance.
+
+## Stability
+
+This is **v1.0.0** — the public API is stable; breaking changes will bump the major version. The `DESIGN.md` document is the canonical contract; if a future change to `bismark-io` contradicts `DESIGN.md`, the design doc gets updated in lockstep.
+
+## crates.io
+
+This release is **not yet published to crates.io**. Within the Bismark workspace, path-dep usage is the supported integration model. Publication is deferred until at least one downstream binary crate lands, to keep the publish-bump cycle in lockstep with binary crates.
+
+## License
+
+GPL-3.0-only. Matches the upstream Perl Bismark license.


### PR DESCRIPTION
## Summary

Marks \`bismark-io\` as feature-complete and stable for downstream binary crates to depend on. First stable release.

- **Cargo.toml:** bump version \`0.0.0\` → \`1.0.0\`; add \`readme\`, \`keywords\`, \`categories\` for crates.io metadata
- **CHANGELOG.md:** new file. Documents the v1.0 entry summarising all Phase A-F work + PRs #806/#808/#810/#812/#814/#816
- **README.md:** new file. Feature-complete (not a "skeleton rewrite" as planned — there was no skeleton; created fresh)

## Test plan

- [x] All 108 tests pass (96 lib + 5 integration + 6 property + 1 doctest)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo publish --package bismark-io --dry-run --allow-dirty\` packages 21 files (201.4 KiB → 72.6 KiB gzipped) and verifies cleanly inside the isolated \`target/package/bismark-io-1.0.0\` extraction

## Not published to crates.io yet

By design — publication is deferred until at least one downstream binary crate (\`bismark-dedup\` first) lands, to keep the publish-bump cycle in lockstep with binary crates.

## After merge

A \`bismark-io-v1.0.0\` annotated git tag will be created from the merge commit so \`bismark-dedup\` (and future binary crates) can pin against a real version reference in their Cargo metadata.

Closes #815