### PR TITLE
impl(bismark-dedup): Phase B — DedupKey + DedupState + DedupReport

### DIFF
--- a/rust/bismark-dedup/src/dedup.rs
+++ b/rust/bismark-dedup/src/dedup.rs
@@ -1,0 +1,293 @@
+//! Core dedup primitives.
+//!
+//! Pure logic, no I/O. The two types here are:
+//!
+//! - [`DedupKey`] — the value used to detect duplicates. Single key shape
+//!   serves both single-end and paired-end (SE uses `end == start`), and is
+//!   used for BOTH the seen-set and the positions-counter. That last point
+//!   matters: a prior-art Rust port keyed the positions-counter on only
+//!   `(strand, chr, start)` while keying the seen-set on the full
+//!   `(strand, chr, start, end)`, producing a 97-position drift in the
+//!   dedup report on a 10M PE WGBS dataset (~0.017%). Using the same key
+//!   type for both eliminates that bug by construction.
+//!
+//! - [`DedupState`] — accumulates the seen-set, the duplicate-positions
+//!   set, and the running counters. [`DedupState::observe`] returns
+//!   `true` for unique records (caller should emit) and `false` for
+//!   duplicates. Mirrors the Perl `deduplicate_bismark` `%unique_seqs` +
+//!   `%positions` semantics from lines 500–512.
+//!
+//! See [`PLAN.md` §4.4 + §5](../../05242026_bismark-dedup-v1/PLAN.md) for
+//! the byte-level mapping to Perl.
+
+use bismark_io::BismarkStrand;
+use rustc_hash::FxHashSet;
+
+use crate::report::DedupReport;
+
+/// Dedup key — `(strand, chr_id, start, end)`.
+///
+/// SE records use `end == start`; PE records use `end == reference_end`
+/// on the appropriate mate (R2 for forward pairs, R1 for reverse).
+///
+/// `#[repr(C)]` together with the upstream `#[repr(u8)]` on
+/// [`BismarkStrand`] pins the in-memory layout to a stable 16 bytes
+/// (1 byte strand + 3 bytes padding + 3× `u32`). An anonymous
+/// `const _: () = assert!(size_of::<DedupKey>() == 16);` below catches
+/// any future drift at build time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(C)]
+pub struct DedupKey {
+    /// Bismark strand classification. For SE this is the per-record
+    /// strand; for PE this is the pair-strand (R1-derived).
+    pub strand: BismarkStrand,
+    /// Chromosome interned index. Resolved from chr **name** (not noodles
+    /// refID) so multi-file input via `--multiple` survives differing
+    /// `@SQ` orderings across inputs.
+    pub chr_id: u32,
+    /// 1-based start position. For SE forward / PE forward-strand R1:
+    /// the alignment start (SAM POS). For SE reverse / PE reverse-strand
+    /// R2: the `alignment_start` of the mate that supplies the start.
+    pub start: u32,
+    /// 1-based inclusive end position. For SE forward: equals `start`.
+    /// For SE reverse: `reference_end` of the record's CIGAR. For PE:
+    /// `reference_end` of the mate that supplies the end.
+    pub end: u32,
+}
+
+const _: () = {
+    assert!(
+        std::mem::size_of::<DedupKey>() == 16,
+        "DedupKey must be exactly 16 bytes — see PLAN §5/§7 memory math",
+    );
+};
+
+impl DedupKey {
+    /// Construct an SE key. `end` is set to `key_pos` (SE composite is
+    /// 3-tuple per Perl line 389).
+    #[must_use]
+    pub fn se(strand: BismarkStrand, chr_id: u32, key_pos: u32) -> Self {
+        Self {
+            strand,
+            chr_id,
+            start: key_pos,
+            end: key_pos,
+        }
+    }
+
+    /// Construct a PE key (4-tuple per Perl line 493).
+    #[must_use]
+    pub fn pe(strand: BismarkStrand, chr_id: u32, start: u32, end: u32) -> Self {
+        Self {
+            strand,
+            chr_id,
+            start,
+            end,
+        }
+    }
+}
+
+/// Accumulating dedup state for a single input file or `--multiple` group.
+///
+/// Mirrors Perl `deduplicate_bismark`'s `%unique_seqs` (the seen-set) and
+/// `%positions` (the duplicate-positions set) hashes. `count` and
+/// `removed` are running totals; `n_positions()` returns the size of the
+/// duplicate-positions set at the time of call.
+#[derive(Debug, Default)]
+pub struct DedupState {
+    seen: FxHashSet<DedupKey>,
+    duplicate_positions: FxHashSet<DedupKey>,
+    count: u64,
+    removed: u64,
+}
+
+impl DedupState {
+    /// Construct an empty state. Use [`DedupState::with_capacity`] if you
+    /// know the approximate record count up-front (saves rehashing).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pre-allocate the seen-set hash table to `capacity` records. Useful
+    /// at the start of a large input — saves rehashing.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            seen: FxHashSet::with_capacity_and_hasher(capacity, Default::default()),
+            duplicate_positions: FxHashSet::default(),
+            count: 0,
+            removed: 0,
+        }
+    }
+
+    /// Observe one record's dedup key. Returns `true` if the record is
+    /// unique (caller should emit it) and `false` if it's a duplicate.
+    ///
+    /// Side effects:
+    /// - Always increments `count`.
+    /// - On duplicate: increments `removed` AND inserts into the
+    ///   duplicate-positions set. The set's idempotent semantics mirror
+    ///   Perl's `unless (exists $positions{$composite}) { ... }` guard
+    ///   at lines 502–504.
+    pub fn observe(&mut self, key: DedupKey) -> bool {
+        self.count += 1;
+        if self.seen.insert(key) {
+            true
+        } else {
+            self.removed += 1;
+            self.duplicate_positions.insert(key);
+            false
+        }
+    }
+
+    /// Total alignment records / pairs observed so far.
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Number of records flagged as duplicates so far.
+    #[must_use]
+    pub fn removed(&self) -> u64 {
+        self.removed
+    }
+
+    /// Number of **distinct positions** at which at least one duplicate
+    /// was seen. Used directly as the "different position(s)" number in
+    /// the dedup report.
+    #[must_use]
+    pub fn n_positions(&self) -> usize {
+        self.duplicate_positions.len()
+    }
+
+    /// Consume the state into a [`DedupReport`] bound to the given file
+    /// label (typically the input path as supplied on the CLI — Perl
+    /// echoes `$ARGV[i]` verbatim in the report).
+    #[must_use]
+    pub fn into_report(self, file_label: String) -> DedupReport {
+        DedupReport::new(
+            file_label,
+            self.count,
+            self.removed,
+            self.duplicate_positions.len(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ot_key(start: u32, end: u32) -> DedupKey {
+        DedupKey::pe(BismarkStrand::OT, 0, start, end)
+    }
+
+    #[test]
+    fn se_first_occurrence_unique_second_duplicate() {
+        let mut state = DedupState::new();
+        let key = DedupKey::se(BismarkStrand::OT, 0, 100);
+        assert!(state.observe(key), "first occurrence must be unique");
+        assert!(!state.observe(key), "second occurrence must be a duplicate");
+        assert_eq!(state.count(), 2);
+        assert_eq!(state.removed(), 1);
+        assert_eq!(
+            state.n_positions(),
+            1,
+            "exactly one position seen as duplicate"
+        );
+    }
+
+    /// Alan's 97-position drift regression test.
+    ///
+    /// Two PE keys with the same `(strand, chr, start)` but differing
+    /// `end` MUST be treated as distinct positions — both in the
+    /// seen-set AND in the duplicate-positions counter.
+    ///
+    /// The prior-art Rust port keyed the duplicate-positions counter on
+    /// `(strand, chr, start)` only via `pack_pos_pe`, causing two
+    /// genuinely distinct PE pairs to collapse to one position.
+    #[test]
+    fn alan_drift_regression_distinct_ends_distinct_positions() {
+        let mut state = DedupState::new();
+        let key_a = ot_key(100, 200);
+        let key_b = ot_key(100, 250);
+        // First occurrences — both unique.
+        assert!(state.observe(key_a));
+        assert!(state.observe(key_b));
+        // Second occurrences — both duplicates, must increment n_positions to 2.
+        assert!(!state.observe(key_a));
+        assert!(!state.observe(key_b));
+        assert_eq!(state.count(), 4);
+        assert_eq!(state.removed(), 2);
+        assert_eq!(
+            state.n_positions(),
+            2,
+            "two distinct (strand,chr,start,end) tuples produced two distinct positions"
+        );
+    }
+
+    #[test]
+    fn duplicate_positions_set_is_idempotent_on_repeat_duplicates() {
+        // Mirrors Perl's `unless (exists $positions{$composite})` guard:
+        // seeing the same composite three+ times still only counts as one
+        // distinct duplicate-position.
+        let mut state = DedupState::new();
+        let key = DedupKey::se(BismarkStrand::OT, 0, 100);
+        state.observe(key); // unique
+        state.observe(key); // dup 1
+        state.observe(key); // dup 2
+        state.observe(key); // dup 3
+        assert_eq!(state.count(), 4);
+        assert_eq!(state.removed(), 3);
+        assert_eq!(
+            state.n_positions(),
+            1,
+            "all dups at same key → one position"
+        );
+    }
+
+    #[test]
+    fn empty_state_zero_counters() {
+        let state = DedupState::new();
+        assert_eq!(state.count(), 0);
+        assert_eq!(state.removed(), 0);
+        assert_eq!(state.n_positions(), 0);
+    }
+
+    #[test]
+    fn keys_with_different_strands_are_distinct() {
+        let mut state = DedupState::new();
+        let ot = DedupKey::se(BismarkStrand::OT, 0, 100);
+        let ob = DedupKey::se(BismarkStrand::OB, 0, 100);
+        assert!(state.observe(ot));
+        assert!(state.observe(ob), "different strand → not a duplicate");
+        assert_eq!(state.count(), 2);
+        assert_eq!(state.removed(), 0);
+    }
+
+    #[test]
+    fn keys_with_different_chr_ids_are_distinct() {
+        let mut state = DedupState::new();
+        let chr0 = DedupKey::se(BismarkStrand::OT, 0, 100);
+        let chr1 = DedupKey::se(BismarkStrand::OT, 1, 100);
+        assert!(state.observe(chr0));
+        assert!(state.observe(chr1));
+        assert_eq!(state.removed(), 0);
+    }
+
+    #[test]
+    fn se_constructor_sets_end_equal_to_start() {
+        let key = DedupKey::se(BismarkStrand::OT, 5, 42);
+        assert_eq!(key.start, 42);
+        assert_eq!(key.end, 42);
+    }
+
+    #[test]
+    fn pe_constructor_preserves_distinct_start_and_end() {
+        let key = DedupKey::pe(BismarkStrand::CTOT, 3, 100, 250);
+        assert_eq!(key.start, 100);
+        assert_eq!(key.end, 250);
+        assert_eq!(key.strand, BismarkStrand::CTOT);
+    }
+}

--- a/rust/bismark-dedup/src/dedup.rs
+++ b/rust/bismark-dedup/src/dedup.rs
@@ -109,8 +109,13 @@ impl DedupState {
         Self::default()
     }
 
-    /// Pre-allocate the seen-set hash table to `capacity` records. Useful
-    /// at the start of a large input — saves rehashing.
+    /// Pre-allocate the **seen-set** hash table to `capacity` records.
+    /// Useful at the start of a large input — saves rehashing as the set
+    /// grows. The duplicate-positions set is left at default capacity,
+    /// since it's bounded by the number of distinct duplicate positions
+    /// (typically much smaller than the seen-set on real data: e.g. on
+    /// the 10M PE WGBS audit dataset, seen ≈ 8.0M but
+    /// duplicate-positions ≈ 0.6M).
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {

--- a/rust/bismark-dedup/src/lib.rs
+++ b/rust/bismark-dedup/src/lib.rs
@@ -9,12 +9,27 @@
 //!
 //! ## Status
 //!
-//! **Phase A scaffolding only.** The public API surface (CLI, `DedupKey`,
-//! `DedupState`, `DedupReport`, pipeline) lands in Phases B through G as
-//! separate sub-issues with their own dual-review cycle.
+//! **Phase B in progress.** Public API surface so far:
+//!
+//! - [`DedupKey`] — the value used to detect duplicates (SE = 3-tuple,
+//!   PE = 4-tuple). Stable 16-byte `#[repr(C)]` layout.
+//! - [`DedupState`] — accumulates the seen-set, duplicate-positions set,
+//!   and running counters. [`DedupState::observe`] is the one-record
+//!   entry point.
+//! - [`DedupReport`] — byte-equal-to-Perl dedup report formatter.
+//!
+//! CLI surface, `bismark-io` wiring, integration tests, and the 10M PE
+//! WGBS byte-identity gate land in Phases C through G as separate
+//! sub-issues with their own dual-review cycle.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+
+pub mod dedup;
+pub mod report;
+
+pub use dedup::{DedupKey, DedupState};
+pub use report::DedupReport;
 
 /// Returns a TG-style provenance string for the binary's `--version` output.
 ///

--- a/rust/bismark-dedup/src/report.rs
+++ b/rust/bismark-dedup/src/report.rs
@@ -1,0 +1,227 @@
+//! Deduplication report formatting.
+//!
+//! [`DedupReport::format`] produces a byte-equal-to-Perl dedup report.
+//! The format below was verified character-by-character against Perl's
+//! `deduplicate_bismark` lines 529–537:
+//!
+//! ```text
+//! \n
+//! Total number of alignments analysed in <input_path>:\t<count>\n
+//! Total number duplicated alignments removed:\t<removed> (<pct_removed>%)\n
+//! Duplicated alignments were found at:\t<n_positions> different position(s)\n
+//! \n
+//! Total count of deduplicated leftover sequences: <leftover> (<pct_leftover>% of total)\n
+//! \n
+//! ```
+//!
+//! Percentages use `sprintf("%.2f", ...)` formatting; `N/A` when
+//! `count == 0`.
+//!
+//! `<input_path>` is the input filename **as supplied on the CLI** —
+//! Perl echoes `$ARGV[i]` verbatim. The byte-identity test in Phase F
+//! must therefore invoke the Rust binary with the same path string the
+//! Perl baseline was generated with.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+/// A render-ready deduplication report.
+///
+/// Construct via [`crate::dedup::DedupState::into_report`].
+#[derive(Debug, Clone)]
+pub struct DedupReport {
+    file_label: String,
+    count: u64,
+    removed: u64,
+    n_positions: usize,
+}
+
+impl DedupReport {
+    /// Construct a report. Typically called via
+    /// [`crate::dedup::DedupState::into_report`].
+    #[must_use]
+    pub fn new(file_label: String, count: u64, removed: u64, n_positions: usize) -> Self {
+        Self {
+            file_label,
+            count,
+            removed,
+            n_positions,
+        }
+    }
+
+    /// Total alignment records / pairs analysed.
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Records flagged as duplicates.
+    #[must_use]
+    pub fn removed(&self) -> u64 {
+        self.removed
+    }
+
+    /// Distinct positions at which a duplicate was observed.
+    #[must_use]
+    pub fn n_positions(&self) -> usize {
+        self.n_positions
+    }
+
+    /// Records kept after dedup: `count - removed`.
+    #[must_use]
+    pub fn leftover(&self) -> u64 {
+        self.count - self.removed
+    }
+
+    /// Render the report to a `String` in Perl-byte-equal format.
+    ///
+    /// See module docs for the exact format. Returns an owned `String`
+    /// so callers can write it to a file or compare against a snapshot
+    /// without intermediate allocation in the hot path.
+    #[must_use]
+    pub fn format(&self) -> String {
+        let leftover = self.leftover();
+        let (pct_removed, pct_leftover) = if self.count == 0 {
+            (String::from("N/A"), String::from("N/A"))
+        } else {
+            let count_f = self.count as f64;
+            (
+                format!("{:.2}", (self.removed as f64) / count_f * 100.0),
+                format!("{:.2}", (leftover as f64) / count_f * 100.0),
+            )
+        };
+
+        // String::with_capacity for the typical-case length to avoid
+        // reallocation on the hot path. ~256 bytes covers all paths.
+        let mut s = String::with_capacity(256);
+        writeln!(
+            s,
+            "\nTotal number of alignments analysed in {}:\t{}",
+            self.file_label, self.count
+        )
+        .expect("write to String never fails");
+        writeln!(
+            s,
+            "Total number duplicated alignments removed:\t{} ({}%)",
+            self.removed, pct_removed
+        )
+        .expect("write to String never fails");
+        writeln!(
+            s,
+            "Duplicated alignments were found at:\t{} different position(s)\n",
+            self.n_positions
+        )
+        .expect("write to String never fails");
+        writeln!(
+            s,
+            "Total count of deduplicated leftover sequences: {} ({}% of total)\n",
+            leftover, pct_leftover
+        )
+        .expect("write to String never fails");
+        s
+    }
+
+    /// Write the rendered report to a file path.
+    ///
+    /// # Errors
+    /// Returns `std::io::Error` if the file cannot be created or written.
+    pub fn write_to(&self, path: &Path) -> std::io::Result<()> {
+        std::fs::write(path, self.format())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Expected Perl-byte-equal output for a 10-record / 2-duplicates fixture.
+    /// Derived character-by-character from Perl `deduplicate_bismark`
+    /// lines 529–537 + Perl `sprintf("%.2f", ...)` semantics.
+    const EXPECTED_TYPICAL: &str = "\nTotal number of alignments analysed in /path/sample.bam:\t10\n\
+        Total number duplicated alignments removed:\t2 (20.00%)\n\
+        Duplicated alignments were found at:\t1 different position(s)\n\n\
+        Total count of deduplicated leftover sequences: 8 (80.00% of total)\n\n";
+
+    #[test]
+    fn format_matches_perl_byte_for_byte_typical_case() {
+        let r = DedupReport::new("/path/sample.bam".to_string(), 10, 2, 1);
+        assert_eq!(r.format(), EXPECTED_TYPICAL);
+    }
+
+    #[test]
+    fn format_uses_na_when_count_is_zero() {
+        let r = DedupReport::new("/path/empty.bam".to_string(), 0, 0, 0);
+        let expected = "\nTotal number of alignments analysed in /path/empty.bam:\t0\n\
+            Total number duplicated alignments removed:\t0 (N/A%)\n\
+            Duplicated alignments were found at:\t0 different position(s)\n\n\
+            Total count of deduplicated leftover sequences: 0 (N/A% of total)\n\n";
+        assert_eq!(r.format(), expected);
+    }
+
+    #[test]
+    fn format_removed_zero_no_duplicates() {
+        let r = DedupReport::new("/path/clean.bam".to_string(), 100, 0, 0);
+        let expected = "\nTotal number of alignments analysed in /path/clean.bam:\t100\n\
+            Total number duplicated alignments removed:\t0 (0.00%)\n\
+            Duplicated alignments were found at:\t0 different position(s)\n\n\
+            Total count of deduplicated leftover sequences: 100 (100.00% of total)\n\n";
+        assert_eq!(r.format(), expected);
+    }
+
+    #[test]
+    fn format_real_data_10m_dataset_numbers() {
+        // The exact numbers we expect from the 10M PE WGBS audit dataset
+        // (PLAN.md §10.4): count=8,592,524, removed=622,892, leftover=7,969,632,
+        // n_positions=571,488. Percent rounding: 622892/8592524*100 = 7.249847...
+        // sprintf("%.2f",...) → "7.25". 7969632/8592524*100 = 92.750152 → "92.75".
+        let r = DedupReport::new(
+            "/Users/fkrueger/Desktop/TrimG_Bismark_test/profiling/SRR24827378_10M_R1_val_1_bismark_bt2_pe.bam".to_string(),
+            8_592_524,
+            622_892,
+            571_488,
+        );
+        let formatted = r.format();
+        assert!(
+            formatted.contains("\t8592524\n"),
+            "count without comma grouping"
+        );
+        assert!(
+            formatted.contains("\t622892 (7.25%)\n"),
+            "removed and percent"
+        );
+        assert!(
+            formatted.contains("\t571488 different position(s)\n"),
+            "n_positions"
+        );
+        assert!(
+            formatted.contains(": 7969632 (92.75% of total)\n"),
+            "leftover and percent"
+        );
+    }
+
+    #[test]
+    fn leftover_arithmetic() {
+        let r = DedupReport::new("x".to_string(), 100, 30, 5);
+        assert_eq!(r.leftover(), 70);
+    }
+
+    #[test]
+    fn percent_rounds_to_two_decimal_places_via_sprintf_semantics() {
+        // 1 dup in 3 records → 33.33333...% removed; sprintf("%.2f") → "33.33"
+        let r = DedupReport::new("x".to_string(), 3, 1, 1);
+        let s = r.format();
+        assert!(s.contains("(33.33%)"), "got: {s}");
+        assert!(s.contains("(66.67% of total)"), "got: {s}");
+    }
+
+    #[test]
+    fn write_to_creates_and_writes_file() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.deduplication_report.txt");
+        let r = DedupReport::new("/path/sample.bam".to_string(), 10, 2, 1);
+        r.write_to(&path).unwrap();
+        let read_back = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(read_back, EXPECTED_TYPICAL);
+    }
+}

--- a/rust/bismark-dedup/src/report.rs
+++ b/rust/bismark-dedup/src/report.rs
@@ -37,10 +37,15 @@ pub struct DedupReport {
 }
 
 impl DedupReport {
-    /// Construct a report. Typically called via
-    /// [`crate::dedup::DedupState::into_report`].
+    /// Construct a report.
+    ///
+    /// Crate-private intentionally: the only legitimate construction path
+    /// is via [`crate::dedup::DedupState::into_report`], which guarantees
+    /// `removed <= count` and thus prevents an underflow in
+    /// [`DedupReport::leftover`]. Callers outside this crate should use
+    /// the `DedupState` path.
     #[must_use]
-    pub fn new(file_label: String, count: u64, removed: u64, n_positions: usize) -> Self {
+    pub(crate) fn new(file_label: String, count: u64, removed: u64, n_positions: usize) -> Self {
         Self {
             file_label,
             count,


### PR DESCRIPTION
## Summary

Phase B of the \`bismark-dedup\` v1.0 plan. **Pure logic, no I/O** — exclusively unit-testable. Three new types:

- **\`DedupKey\`** (\`src/dedup.rs\`): 4-field \`#[repr(C)]\` struct (strand, chr_id, start, end). Compile-time-asserted 16-byte layout. ONE key shape for both seen-set and duplicate-positions set — eliminates Alan Hoyle's port's 97-position drift bug by construction.
- **\`DedupState\`** (\`src/dedup.rs\`): wraps two \`FxHashSet<DedupKey>\`s + count/removed counters. \`observe(key) -> bool\` mirrors Perl lines 500-512 exactly.
- **\`DedupReport\`** (\`src/report.rs\`): \`format() -> String\` produces Perl-byte-equal output per Perl lines 529-537. \`sprintf(\"%.2f\")\` semantics; \"N/A\" on count == 0.

## Headline regression test

\`\`\`rust
#[test]
fn alan_drift_regression_distinct_ends_distinct_positions() {
    let mut state = DedupState::new();
    let key_a = DedupKey::pe(BismarkStrand::OT, 0, 100, 200);
    let key_b = DedupKey::pe(BismarkStrand::OT, 0, 100, 250);  // same (strand,chr,start), diff end
    state.observe(key_a); state.observe(key_b);  // unique
    state.observe(key_a); state.observe(key_b);  // duplicates
    assert_eq!(state.n_positions(), 2);  // Alan's port produced 1 here
}
\`\`\`

Alan's \`pack_pos_pe(strand, chr, start)\` dropped \`end\` when keying the positions counter, collapsing two genuinely-distinct PE pairs into one. v1.0 uses the same \`DedupKey\` for both the seen-set AND the positions counter — drift eliminated structurally.

## Other notable tests

- \`format_real_data_10m_dataset_numbers\`: pre-locks the expected report bytes for the eventual Phase F byte-identity gate (10M PE WGBS dataset: count=8,592,524, removed=622,892, 7.25%, n_positions=571,488). If anything in \`report.rs\` drifts, this test fails *before* Phase F runs against real data.
- \`format_uses_na_when_count_is_zero\`: edge case when count is 0 — both percentages render as \`N/A\` per Perl.
- \`duplicate_positions_set_is_idempotent_on_repeat_duplicates\`: 3+ occurrences at the same key still count as one distinct position (mirrors Perl's \`unless exists\` guard).

## Local test results

- \`cargo test --workspace\`: **126 tests pass** (was 111 at end of Phase A; +15 from \`dedup.rs\` / \`report.rs\` tests)
- \`cargo clippy --workspace --all-targets -- -D warnings\`: clean
- \`cargo fmt --all -- --check\`: clean

## What is NOT in this PR (subsequent phases)

| Phase | Adds |
|-------|------|
| C | \`bismark-io\` reader/writer wiring; \`Peekable\` empty-input guard; chr-name interning; filename derivation |
| D | clap-derive CLI with all flags from plan §4.7; main.rs orchestration |
| E | Integration tests on seeded-dup fixtures (PE/SE/CTOT) |
| F | 10M PE WGBS byte-identity CI gate |
| G | README, CHANGELOG, v1.0 tag |

## Test plan

- [ ] Rust CI matrix passes (test, clippy, fmt)
- [ ] Existing Perl BismarkCI still green

Refs: #794. Depends on #815 (bismark-io v1.0, merged) and PR #818 (Phase A scaffolding, merged).