### PR TITLE
impl(bismark-dedup): Phase D — CLI + main wire-up

### DIFF
--- a/rust/bismark-dedup/src/cli.rs
+++ b/rust/bismark-dedup/src/cli.rs
@@ -1,0 +1,351 @@
+//! Command-line interface for `deduplicate_bismark_rs`.
+//!
+//! [`Cli`] is the clap-derived parser. [`Cli::validate`] resolves the
+//! parsed arguments into a [`ResolvedConfig`] and rejects unsupported /
+//! conflicting flag combinations:
+//!
+//! - `--barcode` / `--bclconvert` → [`BismarkDedupError::UnsupportedFlagV1`]
+//!   (v1.1 will add these).
+//! - `--representative` → [`BismarkDedupError::RepresentativeRemoved`]
+//!   (Bismark deprecated this upstream).
+//! - `--outfile` with multiple positional inputs but no `--multiple` →
+//!   [`BismarkDedupError::OutfileWithMultipleInputs`].
+//!
+//! Flags accepted for Perl compatibility but ignored:
+//! - `--parallel <N>` (silently — Perl is also silent on this flag).
+//! - `--samtools_path <PATH>` (silently — bismark-io is pure Rust).
+//!
+//! The `--version` / `-V` flag emits a TG-style provenance string via
+//! [`crate::version_string`]; clap's auto-version is disabled to allow
+//! the custom format.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use crate::error::BismarkDedupError;
+
+/// Parsed command-line arguments. Use [`Cli::validate`] to convert to a
+/// [`ResolvedConfig`] after parsing.
+#[derive(Parser, Debug)]
+#[command(
+    name = "deduplicate_bismark_rs",
+    about = "Remove PCR duplicate alignments from Bismark BAM/SAM/CRAM files",
+    long_about = None,
+    disable_version_flag = true
+)]
+pub struct Cli {
+    /// Bismark BAM/SAM/CRAM file(s) to deduplicate.
+    pub files: Vec<PathBuf>,
+
+    /// Force single-end mode (auto-detected from @PG if not specified).
+    #[arg(short = 's', long = "single", conflicts_with = "paired")]
+    pub single: bool,
+
+    /// Force paired-end mode (auto-detected from @PG if not specified).
+    #[arg(short = 'p', long = "paired")]
+    pub paired: bool,
+
+    /// Output in BAM format (default; accepted for Perl compatibility).
+    #[arg(long = "bam", conflicts_with = "sam")]
+    pub bam: bool,
+
+    /// Output in SAM format instead of BAM.
+    #[arg(long = "sam")]
+    pub sam: bool,
+
+    /// CRAM reference FASTA (required when input or output is CRAM).
+    #[arg(long = "cram_ref")]
+    pub cram_ref: Option<PathBuf>,
+
+    /// Custom output basename (any path prefix is stripped to basename).
+    #[arg(short = 'o', long = "outfile")]
+    pub outfile: Option<String>,
+
+    /// Output directory (created if it does not exist).
+    #[arg(long = "output_dir", default_value = ".")]
+    pub output_dir: PathBuf,
+
+    /// Treat all positional inputs as one combined sample (Perl `--multiple`).
+    #[arg(long = "multiple")]
+    pub multiple: bool,
+
+    /// **Not supported in v1.0** — use the Perl `deduplicate_bismark` for
+    /// UMI/RRBS mode.
+    #[arg(long = "barcode", visible_alias = "umi")]
+    pub barcode: bool,
+
+    /// **Not supported in v1.0** — use the Perl `deduplicate_bismark` for
+    /// bcl-convert-style internal UMIs.
+    #[arg(long = "bclconvert")]
+    pub bclconvert: bool,
+
+    /// Number of threads (accepted for Perl compatibility, **ignored** in
+    /// v1.0 — bismark-dedup is single-threaded; rayon support deferred to
+    /// v1.1).
+    #[arg(long = "parallel", default_value_t = 1u32)]
+    pub parallel: u32,
+
+    /// Removed in upstream Bismark; exits non-zero with a clear message.
+    #[arg(long = "representative")]
+    pub representative: bool,
+
+    /// Path to a `samtools` binary (accepted for Perl compatibility,
+    /// **ignored** — bismark-io is pure Rust, no subprocess).
+    #[arg(long = "samtools_path")]
+    pub samtools_path: Option<PathBuf>,
+
+    /// Print version information and exit.
+    #[arg(short = 'V', long = "version")]
+    pub version: bool,
+}
+
+/// The resolved, validated subset of CLI arguments passed to the
+/// pipeline. Constructed by [`Cli::validate`].
+#[derive(Debug, Clone)]
+pub struct ResolvedConfig {
+    /// Positional inputs.
+    pub files: Vec<PathBuf>,
+    /// `Some(true)` for PE, `Some(false)` for SE, `None` for auto-detect.
+    pub explicit_mode: Option<bool>,
+    /// `true` if `--sam` was passed, else BAM output.
+    pub sam_output: bool,
+    /// CRAM reference path, if `--cram_ref` was supplied.
+    pub cram_ref: Option<PathBuf>,
+    /// User-supplied output basename, if `--outfile` was supplied.
+    pub outfile: Option<String>,
+    /// Output directory (defaults to `.`).
+    pub output_dir: PathBuf,
+    /// `--multiple` mode flag.
+    pub multiple: bool,
+}
+
+impl Cli {
+    /// Reject unsupported / conflicting flag combinations; return a
+    /// [`ResolvedConfig`] on success.
+    ///
+    /// Reject (in priority order):
+    /// 1. `--representative` → [`BismarkDedupError::RepresentativeRemoved`]
+    /// 2. `--barcode` / `--bclconvert` → [`BismarkDedupError::UnsupportedFlagV1`]
+    /// 3. Empty `files` → [`BismarkDedupError::NoInputFiles`]
+    /// 4. `--outfile` with `>1` files and no `--multiple` →
+    ///    [`BismarkDedupError::OutfileWithMultipleInputs`]
+    ///
+    /// `--single` / `--paired` are mutually exclusive (enforced by clap
+    /// at parse time via `conflicts_with`). Neither set → `explicit_mode = None`
+    /// (caller must auto-detect from the BAM header).
+    pub fn validate(self) -> Result<ResolvedConfig, BismarkDedupError> {
+        if self.representative {
+            return Err(BismarkDedupError::RepresentativeRemoved);
+        }
+        if self.barcode {
+            return Err(BismarkDedupError::UnsupportedFlagV1 { flag: "barcode" });
+        }
+        if self.bclconvert {
+            return Err(BismarkDedupError::UnsupportedFlagV1 { flag: "bclconvert" });
+        }
+        if self.files.is_empty() {
+            return Err(BismarkDedupError::NoInputFiles);
+        }
+        if self.outfile.is_some() && self.files.len() > 1 && !self.multiple {
+            return Err(BismarkDedupError::OutfileWithMultipleInputs {
+                n_files: self.files.len(),
+            });
+        }
+
+        let explicit_mode = match (self.single, self.paired) {
+            (true, false) => Some(false),
+            (false, true) => Some(true),
+            (false, false) => None,
+            // clap rejects (true, true) at parse time via conflicts_with.
+            (true, true) => unreachable!("clap conflicts_with prevents this"),
+        };
+
+        // --parallel and --samtools_path are silently accepted and ignored
+        // (matches Perl's silence on --parallel). No warning needed.
+        let _ = self.parallel;
+        let _ = self.samtools_path;
+        let _ = self.bam; // implicit default; --sam overrides.
+
+        Ok(ResolvedConfig {
+            files: self.files,
+            explicit_mode,
+            sam_output: self.sam,
+            cram_ref: self.cram_ref,
+            outfile: self.outfile,
+            output_dir: self.output_dir,
+            multiple: self.multiple,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
+        let mut full = vec!["deduplicate_bismark_rs"];
+        full.extend(args.iter().copied());
+        Cli::try_parse_from(full)
+    }
+
+    #[test]
+    fn clap_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn parses_single_positional_input_default_mode() {
+        let cli = parse(&["sample.bam"]).unwrap();
+        assert_eq!(cli.files, vec![PathBuf::from("sample.bam")]);
+        assert!(!cli.single && !cli.paired);
+        assert!(!cli.bam && !cli.sam);
+        assert!(!cli.multiple);
+    }
+
+    #[test]
+    fn rejects_simultaneous_single_and_paired() {
+        // clap's conflicts_with kicks in here.
+        let err = parse(&["-s", "-p", "sample.bam"]).unwrap_err();
+        assert!(
+            err.to_string().contains("cannot be used with"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_simultaneous_bam_and_sam() {
+        let err = parse(&["--bam", "--sam", "sample.bam"]).unwrap_err();
+        assert!(
+            err.to_string().contains("cannot be used with"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_representative() {
+        let cli = parse(&["--representative", "sample.bam"]).unwrap();
+        let err = cli.validate().unwrap_err();
+        assert!(matches!(err, BismarkDedupError::RepresentativeRemoved));
+    }
+
+    #[test]
+    fn validate_rejects_barcode_with_v1_deferral() {
+        let cli = parse(&["--barcode", "sample.bam"]).unwrap();
+        let err = cli.validate().unwrap_err();
+        assert!(matches!(
+            err,
+            BismarkDedupError::UnsupportedFlagV1 { flag: "barcode" }
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_umi_alias_with_v1_deferral() {
+        // --umi is a visible_alias for --barcode.
+        let cli = parse(&["--umi", "sample.bam"]).unwrap();
+        let err = cli.validate().unwrap_err();
+        assert!(matches!(
+            err,
+            BismarkDedupError::UnsupportedFlagV1 { flag: "barcode" }
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_bclconvert_with_v1_deferral() {
+        let cli = parse(&["--bclconvert", "sample.bam"]).unwrap();
+        let err = cli.validate().unwrap_err();
+        assert!(matches!(
+            err,
+            BismarkDedupError::UnsupportedFlagV1 { flag: "bclconvert" }
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_no_positional_inputs() {
+        let cli = parse(&[]).unwrap();
+        let err = cli.validate().unwrap_err();
+        assert!(matches!(err, BismarkDedupError::NoInputFiles));
+    }
+
+    #[test]
+    fn validate_rejects_outfile_with_multiple_inputs_no_multiple_flag() {
+        let cli = parse(&["--outfile", "x.bam", "a.bam", "b.bam"]).unwrap();
+        let err = cli.validate().unwrap_err();
+        match err {
+            BismarkDedupError::OutfileWithMultipleInputs { n_files } => {
+                assert_eq!(n_files, 2);
+            }
+            other => panic!("expected OutfileWithMultipleInputs, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_accepts_outfile_with_multiple_inputs_when_multiple_set() {
+        let cli = parse(&["--multiple", "--outfile", "x.bam", "a.bam", "b.bam"]).unwrap();
+        let config = cli.validate().unwrap();
+        assert_eq!(config.files.len(), 2);
+        assert!(config.multiple);
+        assert_eq!(config.outfile.as_deref(), Some("x.bam"));
+    }
+
+    #[test]
+    fn validate_explicit_mode_single() {
+        let cli = parse(&["-s", "sample.bam"]).unwrap();
+        let config = cli.validate().unwrap();
+        assert_eq!(config.explicit_mode, Some(false));
+    }
+
+    #[test]
+    fn validate_explicit_mode_paired() {
+        let cli = parse(&["--paired", "sample.bam"]).unwrap();
+        let config = cli.validate().unwrap();
+        assert_eq!(config.explicit_mode, Some(true));
+    }
+
+    #[test]
+    fn validate_explicit_mode_none_when_neither_flag_set() {
+        let cli = parse(&["sample.bam"]).unwrap();
+        let config = cli.validate().unwrap();
+        assert_eq!(config.explicit_mode, None);
+    }
+
+    #[test]
+    fn parallel_and_samtools_path_silently_accepted() {
+        let cli = parse(&[
+            "--parallel",
+            "4",
+            "--samtools_path",
+            "/usr/bin/samtools",
+            "sample.bam",
+        ])
+        .unwrap();
+        assert_eq!(cli.parallel, 4);
+        assert_eq!(cli.samtools_path, Some(PathBuf::from("/usr/bin/samtools")));
+        let config = cli.validate().unwrap();
+        assert_eq!(config.files.len(), 1);
+    }
+
+    #[test]
+    fn output_dir_defaults_to_current_directory() {
+        let cli = parse(&["sample.bam"]).unwrap();
+        let config = cli.validate().unwrap();
+        assert_eq!(config.output_dir, PathBuf::from("."));
+    }
+
+    #[test]
+    fn cram_ref_passed_through_to_config() {
+        let cli = parse(&["--cram_ref", "/path/to/genome.fa", "sample.cram"]).unwrap();
+        let config = cli.validate().unwrap();
+        assert_eq!(config.cram_ref, Some(PathBuf::from("/path/to/genome.fa")));
+    }
+
+    #[test]
+    fn version_flag_parses_without_files() {
+        // `--version` is a soft check by the caller in main(); clap doesn't
+        // reject the absence of positional files at parse time.
+        let cli = parse(&["--version"]).unwrap();
+        assert!(cli.version);
+        assert!(cli.files.is_empty());
+    }
+}

--- a/rust/bismark-dedup/src/error.rs
+++ b/rust/bismark-dedup/src/error.rs
@@ -109,6 +109,22 @@ pub enum BismarkDedupError {
         qname: String,
     },
 
+    /// User passed no positional input files.
+    #[error("no input file(s) provided — pass one or more BAM/SAM/CRAM paths on the command line")]
+    NoInputFiles,
+
+    /// User specified neither `--single`/`--paired` AND the input BAM
+    /// header has no `@PG ID:Bismark` line with both `-1`/`--1` and
+    /// `-2`/`--2` args, so library mode cannot be inferred.
+    #[error(
+        "cannot auto-detect single-end vs paired-end mode from {input}'s @PG header; \
+         please pass --single or --paired explicitly"
+    )]
+    CannotAutoDetectMode {
+        /// Input file whose @PG header was inspected.
+        input: PathBuf,
+    },
+
     /// Direct `std::io::Error` from the orchestration layer (e.g. writing
     /// the report file).
     #[error("std I/O: {0}")]

--- a/rust/bismark-dedup/src/lib.rs
+++ b/rust/bismark-dedup/src/lib.rs
@@ -32,6 +32,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod cli;
 pub mod dedup;
 pub mod error;
 pub mod filename;

--- a/rust/bismark-dedup/src/main.rs
+++ b/rust/bismark-dedup/src/main.rs
@@ -116,7 +116,11 @@ fn resolve_paired_mode(input: &Path, config: &ResolvedConfig) -> Result<bool, Bi
     }
     // Auto-detect: open the reader briefly to inspect the header. The
     // file will be opened again by the pipeline; the redundant open is
-    // cheap (the header is small and decompressed once).
+    // cheap for BAM/SAM (microseconds) but **non-trivial for CRAM**
+    // (must build the FASTA reference repository twice). For v1.0,
+    // accepted as a known overhead; v1.1 will refactor auto-detect into
+    // the pipeline itself to share the reader. Users who care can pass
+    // `-s`/`-p` explicitly to skip auto-detect.
     let reader = bismark_io::open_reader(input, config.cram_ref.as_deref())?;
     match pipeline::detect_paired_from_header(reader.header()) {
         Some(is_paired) => {

--- a/rust/bismark-dedup/src/main.rs
+++ b/rust/bismark-dedup/src/main.rs
@@ -1,25 +1,156 @@
 //! Binary entry point for `deduplicate_bismark_rs`.
 //!
-//! Phase A scaffolding: parses `--version` and prints the provenance string.
-//! Any other invocation prints a "not yet implemented" notice and exits with a
-//! non-zero status. Actual dedup logic lands in Phases B through F per
-//! `~/.claude/plans/05242026_bismark-dedup-v1/PLAN.md`.
+//! Parses CLI via [`bismark_dedup::cli::Cli`], validates the flag
+//! combinations into a [`bismark_dedup::cli::ResolvedConfig`], then
+//! dispatches to [`bismark_dedup::pipeline::run_single`] (one file per
+//! invocation, the default) or [`bismark_dedup::pipeline::run_multiple`]
+//! (all positional inputs combined, `--multiple` flag).
+//!
+//! Exit codes:
+//! - `0` — success
+//! - `1` — any [`BismarkDedupError`]
+//! - `2` — clap parse error (clap convention for usage errors)
 
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::ExitCode;
 
+use clap::Parser;
+
+use bismark_dedup::cli::Cli;
+use bismark_dedup::cli::ResolvedConfig;
+use bismark_dedup::error::BismarkDedupError;
+use bismark_dedup::filename;
+use bismark_dedup::pipeline;
 use bismark_dedup::version_string;
 
 fn main() -> ExitCode {
-    let args: Vec<String> = std::env::args().collect();
+    let cli = Cli::parse();
 
-    if args.iter().any(|a| a == "--version" || a == "-V") {
+    // `--version` / `-V` is handled here (clap auto-version is disabled
+    // in src/cli.rs so we can emit our custom provenance string).
+    if cli.version {
         println!("{}", version_string());
         return ExitCode::SUCCESS;
     }
 
+    match run(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run(cli: Cli) -> Result<(), BismarkDedupError> {
+    let config = cli.validate()?;
+
+    // Ensure output directory exists. Matches Perl line 1248.
+    if !config.output_dir.as_os_str().is_empty() && config.output_dir != Path::new(".") {
+        std::fs::create_dir_all(&config.output_dir)?;
+    }
+
+    if config.multiple {
+        process_multiple(&config)?;
+    } else {
+        for input in &config.files {
+            process_one(input, &config)?;
+        }
+    }
+    Ok(())
+}
+
+/// Process a single positional input. Used for the default (non-`--multiple`)
+/// path: each file is deduplicated independently with its own report.
+fn process_one(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkDedupError> {
+    let is_paired = resolve_paired_mode(input, config)?;
+    let (out_path, report_path, file_label) = derive_output_paths(input, config, false)?;
+
+    eprintln!("Output file is: {}", out_path.display());
+
+    let report = pipeline::run_single(
+        input,
+        &out_path,
+        config.cram_ref.as_deref(),
+        is_paired,
+        file_label,
+    )?;
+    report.write_to(&report_path)?;
+    eprintln!("{}", report.format());
+    Ok(())
+}
+
+/// Process all positional inputs as one combined sample (`--multiple` mode).
+fn process_multiple(config: &ResolvedConfig) -> Result<(), BismarkDedupError> {
+    let primary = &config.files[0];
+    let is_paired = resolve_paired_mode(primary, config)?;
+    let (out_path, report_path, file_label) = derive_output_paths(primary, config, true)?;
+
     eprintln!(
-        "bismark-dedup: not yet implemented (Phase A scaffolding only). \
-         See https://github.com/FelixKrueger/Bismark/issues/794 for status."
+        "Multiple Input files for the same sample selected — all input files treated as one big single file."
     );
-    ExitCode::from(64)
+    for f in &config.files {
+        eprintln!("  {}", f.display());
+    }
+    eprintln!();
+    eprintln!("Output file is: {}", out_path.display());
+
+    let report = pipeline::run_multiple(
+        &config.files,
+        &out_path,
+        config.cram_ref.as_deref(),
+        is_paired,
+        file_label,
+    )?;
+    report.write_to(&report_path)?;
+    eprintln!("{}", report.format());
+    Ok(())
+}
+
+/// Resolve the SE/PE mode: explicit flag wins, else auto-detect from the
+/// input's `@PG ID:Bismark` header line.
+fn resolve_paired_mode(input: &Path, config: &ResolvedConfig) -> Result<bool, BismarkDedupError> {
+    if let Some(mode) = config.explicit_mode {
+        return Ok(mode);
+    }
+    // Auto-detect: open the reader briefly to inspect the header. The
+    // file will be opened again by the pipeline; the redundant open is
+    // cheap (the header is small and decompressed once).
+    let reader = bismark_io::open_reader(input, config.cram_ref.as_deref())?;
+    match pipeline::detect_paired_from_header(reader.header()) {
+        Some(is_paired) => {
+            eprintln!(
+                "Auto-detected library type from @PG line: {}",
+                if is_paired {
+                    "paired-end"
+                } else {
+                    "single-end"
+                }
+            );
+            Ok(is_paired)
+        }
+        None => Err(BismarkDedupError::CannotAutoDetectMode {
+            input: input.to_path_buf(),
+        }),
+    }
+}
+
+/// Derive the output BAM/SAM path, report path, and file_label string
+/// for the given input. The `multiple` flag selects the `.multiple.`
+/// infix on both filenames.
+fn derive_output_paths(
+    input: &Path,
+    config: &ResolvedConfig,
+    multiple: bool,
+) -> Result<(PathBuf, PathBuf, String), BismarkDedupError> {
+    let stem = filename::derive_output_stem(input, config.outfile.as_deref());
+    let out_name = filename::output_filename(&stem, multiple, config.sam_output);
+    let report_name = filename::report_filename(&stem, multiple);
+    let out_path = config.output_dir.join(out_name);
+    let report_path = config.output_dir.join(report_name);
+    // File label for the report content: Perl echoes $ARGV[i] verbatim,
+    // so use the input path as the user supplied it.
+    let file_label = input.to_string_lossy().into_owned();
+    Ok((out_path, report_path, file_label))
 }

--- a/rust/bismark-dedup/src/pipeline.rs
+++ b/rust/bismark-dedup/src/pipeline.rs
@@ -114,6 +114,74 @@ fn is_forward(strand: BismarkStrand) -> bool {
     matches!(strand, BismarkStrand::OT | BismarkStrand::CTOB)
 }
 
+/// Auto-detect library mode (single-end vs paired-end) from a Bismark
+/// BAM header.
+///
+/// Walks the `@PG` lines, finds the Bismark-aligner entry (ID starting
+/// with `Bismark`), and inspects its command line for `-1`/`--1` AND
+/// `-2`/`--2` arguments (which Bismark only passes in paired-end mode).
+///
+/// Returns:
+/// - `Some(true)` — PE (Bismark @PG found with both `-1`/`--1` and `-2`/`--2`)
+/// - `Some(false)` — SE (Bismark @PG found, missing one or both of those)
+/// - `None` — no Bismark @PG line in the header; caller must error out
+///   (CLI parse-stage forces the user to specify `--single`/`--paired`
+///   explicitly in that case).
+///
+/// Mirrors Perl `deduplicate_bismark` lines 90–116.
+#[must_use]
+pub fn detect_paired_from_header(header: &Header) -> Option<bool> {
+    // Serialize the header to its on-disk SAM text representation and
+    // search for the Bismark @PG line. This is robust to noodles API
+    // shape changes across versions (the SAM text format is the stable
+    // contract here, not the in-memory `Programs` type).
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = noodles_sam::io::Writer::new(&mut buf);
+        if writer.write_header(header).is_err() {
+            return None;
+        }
+    }
+    let text = String::from_utf8_lossy(&buf);
+    for line in text.lines() {
+        // SAM header @PG line format: `@PG\tID:<id>\t...\tCL:<args>...`
+        // The `ID:Bismark` substring identifies the Bismark @PG.
+        if !line.starts_with("@PG") || !line.contains("ID:Bismark") {
+            continue;
+        }
+        // Look for -1/--1 AND -2/--2 in the command-line args. Bismark's
+        // PE invocation always has both; SE has neither.
+        // We accept space-separated, tab-separated, or end-of-line
+        // boundaries to be robust to argument quoting differences.
+        let has_1 = arg_present(line, "-1") || arg_present(line, "--1");
+        let has_2 = arg_present(line, "-2") || arg_present(line, "--2");
+        return Some(has_1 && has_2);
+    }
+    None
+}
+
+/// True if `arg` appears as a standalone token in `text` (delimited by
+/// whitespace, tab, or end of string).
+fn arg_present(text: &str, arg: &str) -> bool {
+    // Build the patterns we'll search for: arg surrounded by whitespace/tab,
+    // or arg at end of line.
+    let arg_space = format!(" {arg} ");
+    let arg_tab_left = format!("\t{arg} ");
+    let arg_tab_right = format!(" {arg}\t");
+    let arg_tab_both = format!("\t{arg}\t");
+    let arg_end_space = format!(" {arg}");
+    let arg_end_tab = format!("\t{arg}");
+    if text.contains(&arg_space)
+        || text.contains(&arg_tab_left)
+        || text.contains(&arg_tab_right)
+        || text.contains(&arg_tab_both)
+    {
+        return true;
+    }
+    // At end of string: require the arg to be the trailing token.
+    text.ends_with(&arg_end_space) || text.ends_with(&arg_end_tab)
+}
+
 /// Compute the SE dedup key from a `BismarkRecord`.
 fn compute_se_key(
     record: &BismarkRecord,

--- a/rust/bismark-dedup/src/pipeline.rs
+++ b/rust/bismark-dedup/src/pipeline.rs
@@ -160,26 +160,23 @@ pub fn detect_paired_from_header(header: &Header) -> Option<bool> {
     None
 }
 
-/// True if `arg` appears as a standalone token in `text` (delimited by
-/// whitespace, tab, or end of string).
+/// True if `arg` appears as a standalone token in `text`, delimited by
+/// whitespace or tab on **both** sides.
+///
+/// Matches Perl's `/\s+--?1\s+/` semantics: a `-1` at the very end of the
+/// line (without trailing whitespace) is NOT considered present, even
+/// though Bismark in practice always appends a path after `-1`/`-2`.
+/// Being strict here matches Perl exactly — important for byte-identity
+/// when the same input is run through both implementations.
 fn arg_present(text: &str, arg: &str) -> bool {
-    // Build the patterns we'll search for: arg surrounded by whitespace/tab,
-    // or arg at end of line.
     let arg_space = format!(" {arg} ");
     let arg_tab_left = format!("\t{arg} ");
     let arg_tab_right = format!(" {arg}\t");
     let arg_tab_both = format!("\t{arg}\t");
-    let arg_end_space = format!(" {arg}");
-    let arg_end_tab = format!("\t{arg}");
-    if text.contains(&arg_space)
+    text.contains(&arg_space)
         || text.contains(&arg_tab_left)
         || text.contains(&arg_tab_right)
         || text.contains(&arg_tab_both)
-    {
-        return true;
-    }
-    // At end of string: require the arg to be the trailing token.
-    text.ends_with(&arg_end_space) || text.ends_with(&arg_end_tab)
 }
 
 /// Compute the SE dedup key from a `BismarkRecord`.

--- a/rust/bismark-dedup/tests/sanity.rs
+++ b/rust/bismark-dedup/tests/sanity.rs
@@ -27,9 +27,31 @@ fn short_version_flag_works_too() {
 }
 
 #[test]
-fn unknown_invocation_exits_nonzero_with_status_notice() {
+fn invocation_with_no_input_files_errors_with_clear_message() {
     let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
     cmd.assert()
         .failure()
-        .stderr(predicates::str::contains("not yet implemented"));
+        .stderr(predicates::str::contains("no input file"));
+}
+
+#[test]
+fn representative_flag_errors_with_perl_verbatim_joke() {
+    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    cmd.arg("--representative")
+        .arg("dummy.bam")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Please stop wanting that"));
+}
+
+#[test]
+fn barcode_flag_errors_with_v1_deferral_message() {
+    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    cmd.arg("--barcode")
+        .arg("dummy.bam")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "not supported in bismark-dedup v1.0",
+        ));
 }


### PR DESCRIPTION
## Summary

Phase D wires Phase C's \`run_single\`/\`run_multiple\` pipelines to a clap-derive CLI. **The binary is now functionally complete for the v1.0 happy path** — Phases E/F/G are validation + release-prep, not new functionality.

## New files

- \`src/cli.rs\` (351 lines): clap-derive \`Cli\` + \`Cli::validate() → ResolvedConfig\`. All flags from PLAN §4.7.

## Modified

- \`src/main.rs\` (rewritten, +149 -25): parse → validate → dispatch. Exit codes per PLAN §5 (clap=2, error=1, success=0).
- \`src/pipeline.rs\` (+68): adds \`detect_paired_from_header()\` — serializes header to SAM text, searches for \`@PG ID:Bismark\` with both \`-1\`/\`--1\` AND \`-2\`/\`--2\` args.
- \`src/error.rs\` (+16): adds \`NoInputFiles\` and \`CannotAutoDetectMode\` variants.
- \`tests/sanity.rs\` (+26 -3): replaces Phase A's stub test with three real CLI assertion tests.

## CLI flags wired up

| Flag | Behaviour |
|------|-----------|
| Positional | One or more BAM/SAM/CRAM paths |
| \`-s\`/\`--single\`, \`-p\`/\`--paired\` | Mutually exclusive (clap conflicts_with) |
| \`--bam\`/\`--sam\` | Mutually exclusive output format |
| \`--cram_ref <FASTA>\` | Required when input/output is CRAM |
| \`-o\`/\`--outfile\` | Custom stem; basename stripped per Perl regex chain |
| \`--output_dir <DIR>\` | Created if missing (matches Perl line 1248) |
| \`--multiple\` | All inputs treated as one combined sample |
| \`--barcode\`/\`--umi\` | **v1.0 stub: errors** with deferral message |
| \`--bclconvert\` | **v1.0 stub: errors** with deferral message |
| \`--parallel <N>\` | Silently accepted, ignored (matches Perl) |
| \`--samtools_path <PATH>\` | Silently accepted, ignored (pure-Rust) |
| \`--representative\` | Errors with Perl-verbatim joke |
| \`-V\`/\`--version\` | Custom provenance via \`version_string()\` |

## Library auto-detection

\`detect_paired_from_header\` serializes the header to SAM text and searches \`@PG\` lines for \`ID:Bismark\` + \`-1\`/\`--1\` AND \`-2\`/\`--2\`. Returns \`Some(true)\`/\`Some(false)\`/\`None\` (None → \`CannotAutoDetectMode\` error). Matches Perl lines 90-116.

## Local gates

- \`cargo test --workspace\`: **186 tests pass** (72 lib + 5 sanity + 109 bismark-io; +22 from Phase C)
- \`cargo clippy --workspace --all-targets -- -D warnings\`: clean
- \`cargo fmt --all -- --check\`: clean

## Test coverage

- **18 new lib tests in cli.rs**: every \`Cli::validate()\` error path, all flag conflict combinations, happy paths for explicit-mode resolution + outfile pass-through + cram_ref pass-through.
- **3 new tests in tests/sanity.rs**: end-to-end binary spawns asserting exit code + stderr contains the right error message for empty-input, --representative, and --barcode.
- **0 new tests for the auto-detect helper itself** — it operates on noodles \`Header\` objects that are awkward to construct in unit tests; Phase E will exercise it through real BAM fixtures.

## Out of scope (remaining phases)

| Phase | Adds |
|-------|------|
| E | Integration tests on seeded-dup fixtures (PE/SE/CTOT) using real Bismark BAMs end-to-end through the binary |
| F | 10M PE WGBS byte-identity CI gate against Perl output |
| G | README, CHANGELOG, v1.0 tag |

## Test plan

- [ ] Rust CI matrix passes (test, clippy, fmt)
- [ ] Dual code-review (A + B) on the PR diff
- [ ] Plan-manager coverage audit on Phase D acceptance criteria

Refs: #794. Depends on PR #820 (Phase C, merged).