### PR TITLE
release(bismark-dedup): tag v1.0.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bismark-dedup"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/rust/bismark-dedup/CHANGELOG.md
+++ b/rust/bismark-dedup/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to `bismark-dedup` will be documented in this file.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] — 2026-05-24
+
+First stable release. Feature-complete Rust port of Bismark Perl v0.25.1's `deduplicate_bismark` script — **verified byte-identical** to Perl's output on the 10M PE WGBS audit dataset (7,969,632 retained qnames + 294-byte dedup report).
+
+The binary installs as `deduplicate_bismark_rs` during the v0.26 → v1.0 coexistence period; the `_rs` suffix is dropped once the Perl scripts move to a `legacy/` directory.
+
+### Added
+
+- **Single-end and paired-end deduplication** via `pipeline::run_single`.
+  - SE key: `(strand, chr_id, key_pos)` where `key_pos = alignment_start` for forward strands (OT/CTOB) or `cigar.reference_end(start)` for reverse strands (CTOT/OB). Matches Perl lines 343–388.
+  - PE key: `(pair_strand, chr_id, start, end)` where `start`/`end` come from R1/R2 depending on pair-strand direction. Matches Perl lines 397–492.
+- **Multi-file mode** via `pipeline::run_multiple` (`--multiple` flag). All inputs accumulate into one shared dedup state; cross-file `@SQ` name-set consistency validated at startup.
+- **Auto-detection of SE vs PE mode** from the input BAM's `@PG ID:Bismark` line (matches Perl lines 90–116). Falls back to the explicit `-s`/`-p`/`--single`/`--paired` flags.
+- **Output format mirrors input**: CRAM in → CRAM out (with `--cram_ref`), BAM in → BAM out, SAM in → SAM out.
+- **clap-derive CLI** with the full Perl flag surface: `-s`/`-p`/`--bam`/`--sam`/`--cram_ref`/`-o`/`--output_dir`/`--multiple`/`-V`/`--help`. Compat-only flags (`--parallel`, `--samtools_path`) silently accepted.
+- **v1.0-deferred-flag stubs** for `--barcode`/`--umi`/`--bclconvert` (RRBS UMI mode) — exit non-zero with a clear "use Perl `deduplicate_bismark`" message. v1.1 will add UMI support.
+- **Perl-verbatim joke** for the long-deprecated `--representative` flag: `"Deduplication in '--representative' mode is no longer supported. Please stop wanting that."`
+- **DedupKey type** (`#[repr(C)]`, 16 bytes pinned by compile-time `const _: () = assert!(size_of::<DedupKey>() == 16);`). Shared between the `seen` hash-set and the `duplicate_positions` counter — **structurally eliminates the 97-position drift bug** present in the prior-art Rust port at `alanhoyle/Bismark@rust-port` (whose `pack_pos_pe(strand, chr, start)` dropped the `end` component when keying the positions counter).
+- **DedupReport** with `format()` producing Perl-byte-equal output (sprintf-style `%.2f` percentages; `N/A` on `count == 0`).
+- **Byte-identity test gate** (`tests/byte_identity_real_data.rs`, `#[ignore]`'d) running on the 10M PE WGBS dataset (`SRR24827378_10M_R1_val_1_bismark_bt2_pe.bam`, 8,592,524 records). Compares Rust output qname set vs Perl baseline and report bytes for exact equality.
+- **Twelve integration tests** (`tests/integration_dedup.rs`) covering SE/PE/CTOT (non-directional) dedup, R1-R2 adjacency invariant, report-byte snapshot vs Rust formatter, `--outfile` path-strip behaviour, `--multiple` cross-file dedup, `--multiple` empty-file1 ordering invariant, mixed-format rejection, `@SQ` mismatch detection, and the `removed = 0` no-duplicate report.
+- **Compile-time provenance** via `version_string()` — `deduplicate_bismark_rs 1.0.0 (<os>/<arch>)`. v1.1 will extend this with vergen-driven git-hash + ISO-8601 build timestamp.
+
+### Design contract
+
+- **No `samtools` subprocess**, no `htslib` C-link, no `unsafe` blocks. All BAM/SAM/CRAM I/O via `bismark-io` v1.0 (which uses pure-Rust [noodles](https://github.com/zaeleus/noodles)).
+- **Strand classification is eager** at parse time (per-record from XR/XG tags). Pair-strand is R1-derived and used for output routing; this is enforced at the type level via separate `BismarkRecord::record_strand()` and `BismarkPair::pair_strand()` methods.
+- **`BamWriter::finish()` consumes by value** — `#[must_use]` annotation ensures callers can't accidentally drop the writer with un-flushed data.
+- **`run_multiple` peeks file1 BEFORE opening the output writer** — empty-file1 errors leave no header-only BAM on disk (PLAN §10.9 invariant).
+
+### MSRV
+
+Rust **1.89.0**. Required by `bismark-io` v1.0 → `noodles-bam` 0.89.
+
+### Test coverage
+
+- **199 tests pass** workspace-wide (90+ unit tests in `bismark-dedup` + the entire `bismark-io` v1.0 suite).
+- **1 `#[ignore]`'d byte-identity gate** verified against real 10M PE WGBS data; not run by default to avoid the ~2-minute wall time per `cargo test`.
+- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
+- `cargo fmt --all -- --check`: clean.
+
+### Out of scope (deferred to v1.1+)
+
+- **RRBS UMI dedup mode** (`--barcode`/`--umi`/`--bclconvert`). v1.0 stubs these flags with a clear deferral error.
+- **Multi-threading** (`--parallel N > 1`). v1.0 silently accepts the flag for CLI compatibility but runs single-threaded.
+- **vergen-based provenance** (git hash + ISO-8601 build timestamp in `--version`).
+- **Sorted-input auto-renaming** — v1.0 errors on `SO:coordinate` BAMs with a clear "re-sort with `samtools sort -n` first" message.
+
+### Not yet published to crates.io
+
+By design — within the Bismark workspace, path-dep usage is the supported integration model. crates.io publication is deferred until the v1.0 → v1.1 stabilisation period.

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-dedup"
-version = "0.0.0"
+version = "1.0.0"
 description = "Rust port of Bismark Perl's deduplicate_bismark script"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-dedup/README.md
+++ b/rust/bismark-dedup/README.md
@@ -1,0 +1,147 @@
+# `bismark-dedup`
+
+Rust port of [Bismark](https://github.com/FelixKrueger/Bismark)'s `deduplicate_bismark` script — removes PCR-duplicate alignments from Bismark BAM/SAM/CRAM files.
+
+**Status:** v1.0.0 — feature-complete, byte-identical to Bismark Perl v0.25.1's output on real WGBS data. See [`CHANGELOG.md`](./CHANGELOG.md).
+
+## What it does
+
+Given a Bismark-aligned BAM/SAM/CRAM file, `bismark-dedup` removes duplicate alignments — typically arising from PCR amplification — and writes a deduplicated BAM/SAM/CRAM. Identification of duplicates uses Bismark's strand-aware key formula:
+
+| Mode | Dedup key |
+|------|-----------|
+| Single-end | `(strand, chromosome, key_position)` — key_position is the alignment start (forward strands OT/CTOB) or `reference_end` (reverse strands CTOT/OB) |
+| Paired-end | `(pair_strand, chromosome, fragment_start, fragment_end)` — pair_strand is R1-derived; fragment bounds come from R1's start + R2's reference_end (forward pairs) or R2's start + R1's reference_end (reverse pairs) |
+
+This matches Bismark Perl `deduplicate_bismark` v0.25.1 exactly.
+
+## Installation
+
+```sh
+# Within the Bismark workspace (path dependency):
+cd rust/
+cargo install --path bismark-dedup
+
+# After release on crates.io (not yet published):
+# cargo install bismark-dedup
+```
+
+During the Perl → Rust coexistence period, the binary installs as **`deduplicate_bismark_rs`** (with `_rs` suffix) so it can sit alongside the Perl `deduplicate_bismark` on `$PATH` without conflict.
+
+## Usage
+
+```sh
+# Single-end auto-detect (from Bismark's @PG line):
+deduplicate_bismark_rs sample_bismark_bt2.bam
+
+# Paired-end explicit:
+deduplicate_bismark_rs --paired sample_bismark_bt2_pe.bam
+
+# Output to a specific directory + custom basename:
+deduplicate_bismark_rs --paired --output_dir results/ --outfile my_sample sample.bam
+
+# Multiple inputs combined into one sample:
+deduplicate_bismark_rs --paired --multiple file1.bam file2.bam file3.bam
+
+# SAM output instead of BAM:
+deduplicate_bismark_rs --sam --paired sample.bam
+
+# CRAM input/output (mirrors input format):
+deduplicate_bismark_rs --paired --cram_ref genome.fa sample.cram
+```
+
+### Flag reference
+
+| Flag | Purpose |
+|------|---------|
+| `<files>...` | One or more Bismark BAM/SAM/CRAM input files (positional) |
+| `-s`, `--single` | Force single-end mode (auto-detected if neither `-s` nor `-p` is set) |
+| `-p`, `--paired` | Force paired-end mode |
+| `--bam` | Output BAM format (default) |
+| `--sam` | Output SAM format |
+| `--cram_ref <FASTA>` | Reference FASTA — required when input or output is CRAM |
+| `-o`, `--outfile <NAME>` | Custom output basename (path prefix stripped per Perl regex chain) |
+| `--output_dir <DIR>` | Output directory (created if missing) |
+| `--multiple` | Treat all positional inputs as one combined sample |
+| `--barcode`, `--umi` | **Not in v1.0** — errors with v1.1 deferral message |
+| `--bclconvert` | **Not in v1.0** — errors with v1.1 deferral message |
+| `--parallel <N>` | Accepted for compat, silently ignored (single-threaded in v1.0) |
+| `--samtools_path <PATH>` | Accepted for compat, silently ignored (`bismark-dedup` is pure-Rust) |
+| `--representative` | Errors with Perl-verbatim joke (deprecated upstream) |
+| `-V`, `--version` | Print provenance string and exit |
+| `-h`, `--help` | clap-generated help |
+
+## Output
+
+For input `sample.bam`:
+
+| File | Contents |
+|------|----------|
+| `sample.deduplicated.bam` | Deduplicated BAM (PE: R1-then-R2 adjacency preserved) |
+| `sample.deduplication_report.txt` | Byte-equal to Perl's report format |
+
+For `--multiple` mode: the `.multiple.` infix appears in both filenames (`sample.multiple.deduplicated.bam`, `sample.multiple.deduplication_report.txt`) — matches Perl's convention.
+
+## Byte-identity invariant
+
+v1.0 is verified byte-identical to Bismark Perl v0.25.1's output on:
+
+- **10M PE WGBS dataset** (`SRR24827378_10M_R1_val_1_bismark_bt2_pe.bam`, 8,592,524 records, GRCh38, directional): **7,969,632 retained qnames + 294-byte report — exact match.**
+
+Test it locally:
+
+```sh
+BISMARK_REAL_DATA_DIR=/path/to/dataset/ \
+  cargo test --release -- --ignored byte_identity_real_data
+```
+
+(Default: `~/Desktop/TrimG_Bismark_test/profiling/`. Skips with explicit reason if dataset absent.)
+
+## Out of scope for v1.0 (deferred to v1.1+)
+
+- **UMI / RRBS mode** (`--barcode`, `--umi`, `--bclconvert`) — use Bismark Perl `deduplicate_bismark` for these workflows.
+- **Multi-threading** (`--parallel N > 1`) — single-threaded in v1.0; rayon-based chunked dedup deferred to v1.1.
+- **Sorted-input auto-handling** — coordinate-sorted PE input is rejected with a clear "re-sort with `samtools sort -n` first" error message rather than auto-sorting.
+
+## How is this different from Bismark Perl's `deduplicate_bismark`?
+
+| | Perl `deduplicate_bismark` | `deduplicate_bismark_rs` (v1.0) |
+|---|----|----|
+| Runtime deps | `samtools` (subprocess) | None — pure Rust via [noodles](https://github.com/zaeleus/noodles) |
+| Input formats | `.bam` (via samtools), `.sam`, `.sam.gz` | `.bam`, `.sam`, `.cram` |
+| Output formats | `.bam` (via samtools), `.sam` | `.bam`, `.sam`, `.cram` |
+| Strand classification | Re-derived per record from XR/XG | Eager at parse time; per-record vs pair-strand distinction enforced by the type system |
+| `--multiple` `@SQ` validation | Implicit via samtools cat behaviour | Explicit equality check across inputs |
+| PE mate qname validation | Implicit; assumes R1/R2 adjacency | Explicit via `BismarkPair::from_mates` qname check |
+
+## Building from source
+
+Requires Rust 1.89 or later (set in workspace `Cargo.toml`).
+
+```sh
+cd rust/
+cargo build --release --package bismark-dedup
+./target/release/deduplicate_bismark_rs --version
+```
+
+## Workspace dependencies
+
+`bismark-dedup` depends on:
+
+- [`bismark-io`](../bismark-io/README.md) (path dep, version `=1.0.0`) — Bismark-aware BAM/SAM/CRAM I/O on top of noodles.
+- [`clap`](https://crates.io/crates/clap) `=4.5.30` — CLI parsing
+- [`rustc-hash`](https://crates.io/crates/rustc-hash) `=2.1.0` — `FxHashSet` for dedup-key storage
+- [`thiserror`](https://crates.io/crates/thiserror) `=2.0.0` — typed errors
+- [`anyhow`](https://crates.io/crates/anyhow) `=1.0.86` — binary-level error context (main only)
+
+All deps exact-pinned, matching `bismark-io` v1.0's noodles version choices.
+
+## License
+
+GPL-3.0-only. Matches the upstream Perl Bismark license.
+
+## See also
+
+- [Bismark project](https://github.com/FelixKrueger/Bismark)
+- [The Rust rewrite plan](../../../.claude/plans/05242026_bismark-dedup-v1/PLAN.md) (internal, not committed)
+- [bismark-io design contract](../bismark-io/DESIGN.md)


### PR DESCRIPTION
## 🎉 v1.0.0 release: bismark-dedup is feature-complete + byte-identical to Perl on real data

Marks the end of the bismark-dedup v1.0 epic. Verified byte-identical to Bismark Perl v0.25.1's output on the 10M PE WGBS audit dataset (8.6M alignments, GRCh38).

## What this PR contains

- \`rust/bismark-dedup/Cargo.toml\`: version bump \`0.0.0\` → \`1.0.0\`
- \`rust/bismark-dedup/README.md\` (NEW, 147 lines): crate-level docs — usage, flag reference, byte-identity invariant, Perl-vs-Rust comparison table
- \`rust/bismark-dedup/CHANGELOG.md\` (NEW, 80 lines): v1.0.0 release notes covering Phases A-F design contract + MSRV + test coverage + deferred items

## crates.io publication deferred

\`cargo publish --dry-run --package bismark-dedup\` fails (expected): bismark-dedup pins \`bismark-io = \"=1.0.0\"\` which isn't on crates.io yet (also workspace-only). Within the Bismark workspace, path-dep usage is the supported integration model per the v1.0 CHANGELOG.

## After merge

Annotated git tag \`bismark-dedup-v1.0.0\` will be created from the merge commit.

## Local gates

- \`cargo test --workspace\`: 199 tests pass + 1 ignored
- \`cargo clippy --workspace --all-targets -- -D warnings\`: clean
- \`cargo fmt --all -- --check\`: clean
- \`cargo test --release -- --ignored byte_identity_real_data\`: **PASSED** on real 10M PE WGBS dataset

Refs: #794. Closes the bismark-dedup v1.0 epic.