### PR TITLE
release: bismark-io + bismark-dedup → 1.0.0-beta.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bismark-dedup"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-io"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "bstr",
  "noodles-bam",

--- a/rust/bismark-dedup/CHANGELOG.md
+++ b/rust/bismark-dedup/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to `bismark-dedup` will be documented in this file.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] — 2026-05-24
+## [1.0.0-beta.1] — 2026-05-24
+
+First **public pre-release** of `bismark-dedup`. Feature-complete and
+verified byte-identical to Bismark Perl v0.25.1 on real WGBS data;
+published as beta to allow a period of integration feedback before the
+immutable 1.0.0 lands on crates.io.
+
+The beta is intended to be **functionally identical** to what 1.0.0 will
+ship: no breaking changes are planned between 1.0.0-beta.N and 1.0.0.
 
 First stable release. Feature-complete Rust port of Bismark Perl v0.25.1's `deduplicate_bismark` script — **verified byte-identical** to Perl's output on the 10M PE WGBS audit dataset (7,969,632 retained qnames + 294-byte dedup report).
 

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-dedup"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 description = "Rust port of Bismark Perl's deduplicate_bismark script"
 edition.workspace = true
 rust-version.workspace = true
@@ -19,7 +19,7 @@ name = "deduplicate_bismark_rs"
 path = "src/main.rs"
 
 [dependencies]
-bismark-io = { version = "=1.0.0", path = "../bismark-io" }
+bismark-io = { version = "=1.0.0-beta.1", path = "../bismark-io" }
 # noodles-sam pinned to match bismark-io =1.0.0's transitive choice.
 # Needed directly for `Header` (returned by `bismark_io::open_reader`
 # via `AnyReader::header`) and for test-helper types.

--- a/rust/bismark-dedup/README.md
+++ b/rust/bismark-dedup/README.md
@@ -2,7 +2,7 @@
 
 Rust port of [Bismark](https://github.com/FelixKrueger/Bismark)'s `deduplicate_bismark` script — removes PCR-duplicate alignments from Bismark BAM/SAM/CRAM files.
 
-**Status:** v1.0.0 — feature-complete, byte-identical to Bismark Perl v0.25.1's output on real WGBS data. See [`CHANGELOG.md`](./CHANGELOG.md).
+**Status:** v1.0.0-beta.1 — feature-complete, byte-identical to Bismark Perl v0.25.1's output on real WGBS data; first public pre-release on crates.io. The beta is functionally identical to what 1.0.0 will ship; published as beta to allow integration feedback before the immutable 1.0.0 lands. See [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## What it does
 
@@ -128,7 +128,7 @@ cargo build --release --package bismark-dedup
 
 `bismark-dedup` depends on:
 
-- [`bismark-io`](../bismark-io/README.md) (path dep, version `=1.0.0`) — Bismark-aware BAM/SAM/CRAM I/O on top of noodles.
+- [`bismark-io`](../bismark-io/README.md) (path dep, version `=1.0.0-beta.1`) — Bismark-aware BAM/SAM/CRAM I/O on top of noodles.
 - [`clap`](https://crates.io/crates/clap) `=4.5.30` — CLI parsing
 - [`rustc-hash`](https://crates.io/crates/rustc-hash) `=2.1.0` — `FxHashSet` for dedup-key storage
 - [`thiserror`](https://crates.io/crates/thiserror) `=2.0.0` — typed errors

--- a/rust/bismark-dedup/tests/sanity.rs
+++ b/rust/bismark-dedup/tests/sanity.rs
@@ -13,8 +13,11 @@ fn version_output_matches_provenance_regex() {
     cmd.arg("--version")
         .assert()
         .success()
-        // `deduplicate_bismark_rs <semver> (<os>/<arch>)`
-        .stdout(is_match(r"^deduplicate_bismark_rs \d+\.\d+\.\d+ \(\S+/\S+\)\n$").unwrap());
+        // `deduplicate_bismark_rs <semver> (<os>/<arch>)` where <semver>
+        // may include a pre-release suffix (e.g. `1.0.0-beta.1`).
+        .stdout(
+            is_match(r"^deduplicate_bismark_rs \d+\.\d+\.\d+(-[\w.]+)? \(\S+/\S+\)\n$").unwrap(),
+        );
 }
 
 #[test]

--- a/rust/bismark-io/CHANGELOG.md
+++ b/rust/bismark-io/CHANGELOG.md
@@ -5,16 +5,26 @@ All notable changes to `bismark-io` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] — 2026-05-24
+## [1.0.0-beta.1] — 2026-05-24
 
-First stable release of `bismark-io`, the shared library crate for Bismark's
-Rust rewrite. Wraps the [`noodles`](https://github.com/zaeleus/noodles) family
-to provide Bismark-aware BAM/SAM/CRAM I/O: strand-classified record types,
+First **public pre-release** of `bismark-io` on crates.io. Feature-complete
+and test-passing per the v1.0 contract; published as beta to allow a
+period of integration feedback before the immutable 1.0.0 lands.
+
+The beta is intended to be **functionally identical** to what 1.0.0 will
+ship — no breaking changes are planned between `1.0.0-beta.N` and `1.0.0`.
+Downstream consumers pinning `=1.0.0-beta.1` and `=1.0.0` should observe
+the same behaviour.
+
+`bismark-io` is the shared library crate for Bismark's Rust rewrite.
+Wraps the [`noodles`](https://github.com/zaeleus/noodles) family to
+provide Bismark-aware BAM/SAM/CRAM I/O: strand-classified record types,
 tag-decoded accessors, CIGAR-aware position helpers.
 
 This release is feature-complete for the v1.0 scope defined in `DESIGN.md`.
 Downstream binary crates (`bismark-dedup`, `bismark-bedgraph`,
-`bismark-extractor`, `bismark-coverage2cytosine`) will pin to `=1.0.0`.
+`bismark-extractor`, `bismark-coverage2cytosine`) will pin to `=1.0.0-beta.1`
+during the beta period, then bump to `=1.0.0` at final release.
 
 ### Added
 

--- a/rust/bismark-io/Cargo.toml
+++ b/rust/bismark-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-io"
-version = "1.0.0"
+version = "1.0.0-beta.1"
 description = "Bismark-aware BAM/SAM/CRAM I/O on top of noodles"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-io/README.md
+++ b/rust/bismark-io/README.md
@@ -4,7 +4,7 @@ Bismark-aware BAM/SAM/CRAM I/O on top of [`noodles`](https://github.com/zaeleus/
 
 `bismark-io` is the shared library crate for [Bismark](https://github.com/FelixKrueger/Bismark)'s Rust rewrite. It wraps the `noodles` crate family to expose record types that already know about Bismark's strand classification (OT/CTOT/OB/CTOB derived from the `XR:Z:` and `XG:Z:` tags), tag-decoded accessors (`XM`, `XR`, `XG`, `MD`, `NM`), and CIGAR-aware position helpers. Every Bismark Rust binary crate (`bismark-dedup`, `bismark-extractor`, `bismark-bedgraph`, …) depends on it.
 
-**Status:** v1.0.0 — feature-complete; first stable release. See [`CHANGELOG.md`](./CHANGELOG.md).
+**Status:** v1.0.0-beta.1 — feature-complete; first public pre-release on crates.io. The beta is functionally identical to what 1.0.0 will ship; published as beta to allow integration feedback before the immutable 1.0.0 lands. See [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## Why a Bismark wrapper around `noodles`?
 
@@ -112,7 +112,7 @@ The pin policy: noodles releases frequently and occasionally bumps MSRV. Exact-p
 
 ## Stability
 
-This is **v1.0.0** — the public API is stable; breaking changes will bump the major version. The `DESIGN.md` document is the canonical contract; if a future change to `bismark-io` contradicts `DESIGN.md`, the design doc gets updated in lockstep.
+This is **v1.0.0-beta.1** — the public API is stable; no breaking changes are planned between `1.0.0-beta.N` and `1.0.0`. The `DESIGN.md` document is the canonical contract; if a future change to `bismark-io` contradicts `DESIGN.md`, the design doc gets updated in lockstep.
 
 ## crates.io
 


### PR DESCRIPTION
## Why beta

Trim-Galore lesson learned — don't publish a full \`1.0.0\` to crates.io as the very first public release. Once on crates.io the version is **immutable**; any post-publish bug fix requires a \`1.0.1\`, even for trivial issues. A beta period gives external consumers time to integrate against the API before \`1.0.0\` locks.

## What this PR contains

3 commits:

1. **\`release: bump bismark-io + bismark-dedup to 1.0.0-beta.1\`**
   - \`rust/bismark-io/Cargo.toml\`: version \`1.0.0\` → \`1.0.0-beta.1\`
   - \`rust/bismark-dedup/Cargo.toml\`: version \`1.0.0\` → \`1.0.0-beta.1\`
   - \`rust/bismark-dedup/Cargo.toml\`: bismark-io pin \`=1.0.0\` → \`=1.0.0-beta.1\`
   - Both CHANGELOGs: section headers + beta-strategy paragraph
   - \`tests/sanity.rs\`: version-output regex updated to accept pre-release suffixes

2. **\`docs: update crate README version refs from 1.0.0 to 1.0.0-beta.1\`** (bismark-dedup)
3. **\`docs(bismark-io): sync README version refs to 1.0.0-beta.1\`**

## Semver semantics

- \`1.0.0-beta.1\` is **functionally identical** to what \`1.0.0\` will ship — no breaking changes planned between \`1.0.0-beta.N\` and \`1.0.0\`
- Cargo + crates.io support semver pre-release identifiers natively
- Downstream consumers can pin \`=1.0.0-beta.1\` (strict), \`1.0.0-beta\` (any beta in the 1.0 series), or wait for \`1.0.0\`

## Existing git tags

The \`bismark-io-v1.0.0\` and \`bismark-dedup-v1.0.0\` tags from earlier PRs remain as **internal milestone markers** (\"v1.0 epic complete locally\"). After this PR merges, new tags \`bismark-io-v1.0.0-beta.1\` and \`bismark-dedup-v1.0.0-beta.1\` will mark the actual crates.io publish events.

## Local gates

- \`cargo test --workspace\`: 199 tests pass + 1 ignored
- \`cargo clippy --workspace --all-targets -- -D warnings\`: clean
- \`cargo fmt --all -- --check\`: clean
- \`cargo publish --package bismark-io --dry-run\`: succeeds at \`1.0.0-beta.1\`
- \`cargo publish --package bismark-dedup --dry-run\`: fails (expected — bismark-io not yet on crates.io)

## Crates.io publish (after merge)

Once user refreshes the crates.io token, the publish sequence is:

\`\`\`bash
cargo publish --package bismark-io      # 1.0.0-beta.1
# wait ~10s for crates.io index to refresh
cargo publish --package bismark-dedup   # 1.0.0-beta.1
\`\`\`

Then the new git tags \`bismark-io-v1.0.0-beta.1\` and \`bismark-dedup-v1.0.0-beta.1\` mark the publication events.

Refs: #794