### PR TITLE
docs: add 'Using as a library' sections to crate READMEs

### DIFF
--- a/rust/bismark-dedup/README.md
+++ b/rust/bismark-dedup/README.md
@@ -103,6 +103,80 @@ BISMARK_REAL_DATA_DIR=/path/to/dataset/ \
 - **Multi-threading** (`--parallel N > 1`) — single-threaded in v1.0; rayon-based chunked dedup deferred to v1.1.
 - **Sorted-input auto-handling** — coordinate-sorted PE input is rejected with a clear "re-sort with `samtools sort -n` first" error message rather than auto-sorting.
 
+## Using as a library in other tools
+
+`bismark-dedup` ships as both a binary (`deduplicate_bismark_rs`) AND a Rust library. Other tools can embed the dedup pipeline as a direct function call rather than spawning the binary — matching the [Trim Galore ↔ fastqc-rust](https://github.com/FelixKrueger/TrimGalore) integration model.
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+bismark-dedup = "=1.0.0-beta.1"
+```
+
+End-to-end example — dedup a Bismark BAM from within your own Rust pipeline:
+
+```rust
+use bismark_dedup::pipeline::run_single;
+use std::path::Path;
+
+fn dedup_bam(input: &Path, output: &Path) -> anyhow::Result<()> {
+    // is_paired: true for PE, false for SE. Auto-detection is in `detect_paired_from_header`.
+    let report = run_single(
+        input,
+        output,
+        None,                                // cram_ref — None for BAM/SAM input
+        /* is_paired = */ true,
+        input.display().to_string(),         // file_label echoed in the report
+    )?;
+
+    // Report can be written to a file OR consumed in-memory:
+    println!("dedup complete: {} records analysed, {} removed ({:.2}%)",
+             report.count(), report.removed(),
+             100.0 * report.removed() as f64 / report.count() as f64);
+    Ok(())
+}
+```
+
+Multi-file mode (one combined sample across N input BAMs):
+
+```rust
+use bismark_dedup::pipeline::run_multiple;
+
+fn dedup_combined(inputs: &[std::path::PathBuf], output: &std::path::Path) -> anyhow::Result<()> {
+    let report = run_multiple(
+        inputs,
+        output,
+        None,
+        true,  // is_paired
+        inputs[0].display().to_string(),
+    )?;
+    report.write_to(&output.with_extension("deduplication_report.txt"))?;
+    Ok(())
+}
+```
+
+Lower-level primitives — if you want to drive the dedup loop yourself (e.g., on records already in memory, or with a custom input source):
+
+```rust
+use bismark_dedup::{DedupKey, DedupState};
+use bismark_io::BismarkStrand;
+
+let mut state = DedupState::new();
+let key = DedupKey::pe(BismarkStrand::OT, /* chr_id */ 0, /* start */ 100, /* end */ 200);
+
+if state.observe(key) {
+    // record is unique — emit it to your output
+} else {
+    // record is a duplicate — drop it
+}
+
+let report = state.into_report("my_sample.bam".to_string());
+// report.format() returns the Perl-byte-equal report string.
+```
+
+See `cargo doc --open --package bismark-dedup` for the full library API. The same algorithm that powers the `deduplicate_bismark_rs` binary is available to your code with zero subprocess overhead.
+
 ## How is this different from Bismark Perl's `deduplicate_bismark`?
 
 | | Perl `deduplicate_bismark` | `deduplicate_bismark_rs` (v1.0) |

--- a/rust/bismark-io/README.md
+++ b/rust/bismark-io/README.md
@@ -82,6 +82,74 @@ fn main() -> anyhow::Result<()> {
 
 For paired-end work, pair adjacent records with `BismarkPair::from_mates(r1, r2)?` and use `pair.pair_strand()` for output routing.
 
+## Using as a library in other tools
+
+`bismark-io` is designed to be the I/O foundation for Bismark-aware Rust tools — both the binary crates in this workspace (`bismark-dedup`, future `bismark-extractor` / `bismark-bedgraph` / etc.) and external consumers (pipeline frameworks, custom analysis scripts, methylation orchestrators).
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+bismark-io = "=1.0.0-beta.1"
+```
+
+End-to-end example — count records per strand:
+
+```rust
+use bismark_io::{open_reader, BismarkStrand};
+use std::path::Path;
+
+fn count_records_by_strand(bam_path: &Path) -> anyhow::Result<[u64; 4]> {
+    let mut reader = open_reader(bam_path, None)?;
+    let mut counts = [0u64; 4]; // OT, CTOT, OB, CTOB
+
+    for result in reader.records() {
+        let record = result?;
+        let idx = match record.record_strand() {
+            BismarkStrand::OT   => 0,
+            BismarkStrand::CTOT => 1,
+            BismarkStrand::OB   => 2,
+            BismarkStrand::CTOB => 3,
+        };
+        counts[idx] += 1;
+    }
+    Ok(counts)
+}
+```
+
+Pair-strand example (paired-end with R1-derived routing):
+
+```rust
+use bismark_io::{open_reader, BismarkPair};
+
+fn pair_strands(bam_path: &std::path::Path) -> anyhow::Result<Vec<bismark_io::BismarkStrand>> {
+    let mut reader = open_reader(bam_path, None)?;
+    let mut records = reader.records();
+    let mut pair_strands = Vec::new();
+    loop {
+        let Some(r1) = records.next().transpose()? else { break };
+        let Some(r2) = records.next().transpose()? else {
+            anyhow::bail!("PE input ended with unpaired R1");
+        };
+        let pair = BismarkPair::from_mates(r1, r2)?;  // validates qname + R1/R2 ordering
+        pair_strands.push(pair.pair_strand());
+    }
+    Ok(pair_strands)
+}
+```
+
+CIGAR-aware position helpers (the dedup key formula uses these):
+
+```rust
+use bismark_io::CigarExt;
+
+// reference_end(start) = start + reference_span - 1
+// (or `start` for empty CIGAR — see CigarExt docs for the edge case).
+let end = record.cigar().reference_end(record.alignment_start().unwrap());
+```
+
+See `cargo doc --open --package bismark-io` for the full API surface, including `BismarkRecord`, `BismarkPair`, `CigarExt`, `tags::{xm, xr, xg, md, nm}`, and the `reconstitute_cram_reference_from_bismark_genome` helper.
+
 ## MSRV
 
 Rust **1.89.0**. Required by `noodles-bam` 0.89.


### PR DESCRIPTION
## Why

Both \`bismark-io\` and \`bismark-dedup\` are designed as **library + binary crates** (each crate has \`lib.rs\` + \`main.rs\`). External Rust consumers can integrate them as direct function calls rather than spawning the binaries — matching the [Trim Galore ↔ fastqc-rust](https://github.com/FelixKrueger/TrimGalore) integration model.

Before this PR the crate READMEs focused on CLI usage. This PR documents the library API as an intentional public surface from v1.0.0-beta.1 onwards.

## What's added

### \`rust/bismark-io/README.md\` (+68 lines)

End-to-end examples:
- Count records per strand (BismarkStrand classification iteration)
- Pair iteration + qname/R1/R2 validation via \`BismarkPair::from_mates\`
- CigarExt::reference_end for dedup-key-style position arithmetic
- Pointer to \`cargo doc --open\` for the full API

### \`rust/bismark-dedup/README.md\` (+74 lines)

End-to-end examples:
- \`pipeline::run_single\`: dedup a Bismark BAM from within your own Rust pipeline
- \`pipeline::run_multiple\`: combined-sample dedup across N inputs
- Lower-level \`DedupKey\` + \`DedupState\` primitives for custom dedup loops
- Pointer to \`cargo doc --open\` for the full API

## Why this matters before crates.io publish

The library API is stable from 1.0.0-beta.1 onwards. Documenting it as an intentional public surface now (rather than letting users discover it via docs.rs) sets the expectation that future tools (\`bismark-extractor\`, \`bismark-bedgraph\`, future \`bismark-pipeline\` orchestrators) compose by **direct Rust calls into each tool's lib**, not by subprocess invocation.

## Local gates

Docs-only change. \`cargo build --workspace\` succeeds. \`cargo fmt --all -- --check\` clean. No new tests needed.

Refs: #794