### PR TITLE
impl(bismark-io): v1.0.0-beta.3 — magic-byte file-format detection

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bismark-dedup"
-version = "1.1.0-beta.1"
+version = "1.1.0-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-io"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "bstr",
  "noodles-bam",

--- a/rust/bismark-dedup/CHANGELOG.md
+++ b/rust/bismark-dedup/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `bismark-dedup` will be documented in this file.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0-beta.2] — 2026-05-25
+
+Inherits **magic-byte file-format detection** from `bismark-io`
+`1.0.0-beta.3`. Mis-named input files (`.bam` containing SAM,
+`.sam` containing CRAM, files with no extension at all) are now
+classified correctly by their actual content rather than rejected by
+extension. Matches Perl Bismark's behaviour.
+
+### Changed
+
+- **`bismark-io` pin bumped to `=1.0.0-beta.3`** for magic-byte
+  detection. No source-code changes in `bismark-dedup` — the
+  `AlignmentKind::from_path` signature is unchanged; new error
+  variants flow through `BismarkDedupError`'s `#[from] BismarkIoError`
+  transparently.
+- The `deduplicate_bismark_rs` binary now tolerates mis-named input
+  files via the inherited magic-byte sniff.
+
 ## [1.1.0-beta.1] — 2026-05-24
 
 First v1.1 pre-release. Adds **BGZF-threaded BAM I/O** behind `--parallel N`,

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-dedup"
-version = "1.1.0-beta.1"
+version = "1.1.0-beta.2"
 description = "Rust port of Bismark Perl's deduplicate_bismark script"
 edition.workspace = true
 rust-version.workspace = true
@@ -19,7 +19,7 @@ name = "deduplicate_bismark_rs"
 path = "src/main.rs"
 
 [dependencies]
-bismark-io = { version = "=1.0.0-beta.2", path = "../bismark-io" }
+bismark-io = { version = "=1.0.0-beta.3", path = "../bismark-io" }
 # noodles-sam pinned to match bismark-io =1.0.0's transitive choice.
 # Needed directly for `Header` (returned by `bismark_io::open_reader`
 # via `AnyReader::header`) and for test-helper types.

--- a/rust/bismark-dedup/src/error.rs
+++ b/rust/bismark-dedup/src/error.rs
@@ -139,3 +139,28 @@ pub enum BismarkDedupError {
     #[error("std I/O: {0}")]
     StdIo(#[from] std::io::Error),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// v1.0.0-beta.3 magic-byte detection adds new variants to
+    /// `BismarkIoError`. Verify they propagate through
+    /// `BismarkDedupError`'s `#[from] BismarkIoError` and that the
+    /// Display impl carries the inner variant's information.
+    #[test]
+    fn bismark_dedup_error_from_propagates_unrecognized_bgzf_payload() {
+        let io_err = BismarkIoError::UnrecognizedBgzfPayload {
+            path: PathBuf::from("/tmp/x.bam"),
+            payload_head: [b'V', b'C', b'F', 0x02],
+        };
+        let dedup_err: BismarkDedupError = io_err.into();
+        let s = dedup_err.to_string();
+        assert!(s.contains("/tmp/x.bam"), "Display omits inner path: {s}");
+        assert!(
+            s.contains("bgzipped"),
+            "Display omits 'bgzipped' marker: {s}"
+        );
+    }
+}

--- a/rust/bismark-io/CHANGELOG.md
+++ b/rust/bismark-io/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to `bismark-io` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.3] — 2026-05-25
+
+Magic-byte file-format detection for reader-side dispatch. Tolerates
+mis-named files (`.bam` containing SAM bytes, `.sam` containing CRAM
+bytes, files with no extension at all) — matches Perl Bismark's
+behaviour. Writers continue to use extension-based dispatch (the file
+doesn't exist yet at writer-call time).
+
+### Added
+
+- **`AlignmentKind::from_extension(&Path)`** — pure extension dispatch,
+  I/O-free. Preserves the pre-`1.0.0-beta.3` behaviour of `from_path`.
+  Used by `open_writer` and any caller that explicitly wants
+  extension-only.
+- Three new `BismarkIoError` variants emitted by the new `from_path`:
+  `TooShortToDetect { path, bytes_read }`, `UnrecognizedFormat
+  { path, magic_first_byte }`, `UnrecognizedBgzfPayload { path,
+  payload_head }`.
+
+### Changed (behaviour)
+
+- **`AlignmentKind::from_path(&Path)` now opens the file**, reads + (for
+  BGZF) decompresses the first block, and dispatches based on actual
+  file content rather than file extension. A SAM file with a `.bam`
+  extension is now correctly classified as SAM (previously it would
+  have errored at parse time with a BAM-decoder error).
+- `open_reader` uses the new sniff behaviour; `open_writer` is migrated
+  to `from_extension` so its semantics are unchanged.
+- The `UnsupportedKind` variant's doc-comment is narrowed: it's now
+  emitted only by `from_extension` (writer-side). Reader-side dispatch
+  emits the new variants above instead.
+
+### Changed (error variants)
+
+- Downstream consumers that **exhaustive-match** on `BismarkIoError`
+  need a new arm for each new variant. Consumers using `#[from]`
+  propagation are unaffected.
+
+### Performance
+
+- `from_path` is no longer I/O-free. Per-call cost is ~100-700 µs
+  (dominated by the ~200-500 µs BGZF inflate of one block). For
+  hot-path callers iterating over many input files, consider caching
+  the result.
+- `from_extension` is unchanged: ~0.2 µs per call.
+
+### Pinning
+
+Downstream consumers pinning `=1.0.0-beta.2` should bump to
+`=1.0.0-beta.3` when they want magic-byte detection. `bismark-dedup
+v1.1.0-beta.2` requires `=1.0.0-beta.3`.
+
 ## [1.0.0-beta.2] — 2026-05-24
 
 Additive release adding parallel BGZF reader/writer support, used by

--- a/rust/bismark-io/Cargo.toml
+++ b/rust/bismark-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-io"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 description = "Bismark-aware BAM/SAM/CRAM I/O on top of noodles"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-io/README.md
+++ b/rust/bismark-io/README.md
@@ -57,6 +57,26 @@ use bismark_io::{
 
 Module-level docs explain each type's contract. See `cargo doc --open --package bismark-io`.
 
+### `AlignmentKind`: format detection
+
+`AlignmentKind` exposes two dispatch functions with different I/O contracts:
+
+- **`from_extension(&Path) → Result<Self>`** — pure extension dispatch.
+  I/O-free. Used by `open_writer` (the output file doesn't exist yet,
+  so content sniffing is impossible). Errors with `UnsupportedKind`
+  for non-`.bam`/`.sam`/`.cram` extensions.
+- **`from_path(&Path) → Result<Self>`** — magic-byte sniff (added in
+  v1.0.0-beta.3). Opens the file; for BGZF, decompresses the first
+  block and verifies the `BAM\x01` payload magic. Used by `open_reader`
+  and any caller that needs tolerance for mis-named files. Errors with
+  `UnrecognizedFormat`, `UnrecognizedBgzfPayload`, or `TooShortToDetect`
+  depending on what was found.
+
+Magic-byte detection matches Perl Bismark's behaviour: a SAM file named
+`foo.bam` is classified as SAM, a `.vcf.gz` mis-routed to a BAM-expecting
+caller errors with a clear "looks like a non-BAM BGZF file" message
+rather than a confusing BAM-decoder error.
+
 ## Quick example
 
 ```rust
@@ -209,11 +229,11 @@ The pin policy: noodles releases frequently and occasionally bumps MSRV. Exact-p
 
 ## Stability
 
-This is **v1.0.0-beta.2** — the public API is stable; no breaking changes are planned between `1.0.0-beta.N` and `1.0.0`. The v1.0.0-beta.2 release is additive: it adds `ThreadedBamReader` / `ThreadedBamWriter` for parallel BGZF (de)compression but leaves every v1.0.0-beta.1 type/function signature unchanged. The `DESIGN.md` document is the canonical contract; if a future change to `bismark-io` contradicts `DESIGN.md`, the design doc gets updated in lockstep.
+This is **v1.0.0-beta.3** — the public API is stable; no breaking changes are planned between `1.0.0-beta.N` and `1.0.0`. The v1.0.0-beta.3 release adds **magic-byte file-format detection** for reader-side dispatch (matching Perl Bismark's behaviour); writer-side dispatch and every other type/function signature are unchanged from v1.0.0-beta.2. The `DESIGN.md` document is the canonical contract; if a future change to `bismark-io` contradicts `DESIGN.md`, the design doc gets updated in lockstep.
 
 ## crates.io
 
-`bismark-io = "=1.0.0-beta.1"` (the v1.0 single-threaded line, Phase A of the rayon epic) is **published to crates.io**. `bismark-io = "=1.0.0-beta.2"` (the v1.1 BGZF-threaded line, Phase D of the rayon epic) is **queued for the next publish window** — within the Bismark workspace, `bismark-dedup` already path-deps `=1.0.0-beta.2` for the threaded BAM I/O. Once published, external consumers can pin either depending on whether they need threaded readers/writers.
+`bismark-io = "=1.0.0-beta.1"` (the v1.0 single-threaded line) is **published to crates.io**. `bismark-io = "=1.0.0-beta.2"` (BGZF-threaded readers/writers) and `bismark-io = "=1.0.0-beta.3"` (magic-byte detection) are **queued for the next publish window** — within the Bismark workspace, `bismark-dedup` already path-deps `=1.0.0-beta.3`. Once published, external consumers can pin to whichever beta matches the features they need.
 
 ## License
 

--- a/rust/bismark-io/src/error.rs
+++ b/rust/bismark-io/src/error.rs
@@ -119,8 +119,65 @@ pub enum BismarkIoError {
 
     /// The given file path does not have a recognised BAM/SAM/CRAM
     /// extension.
+    ///
+    /// As of `bismark-io v1.0.0-beta.3`, this variant is emitted only by
+    /// [`crate::AlignmentKind::from_extension`] (writer-side dispatch — the
+    /// output file doesn't exist yet, so content sniffing is impossible).
+    /// Reader-side dispatch via [`crate::AlignmentKind::from_path`] sniffs
+    /// magic bytes and emits [`Self::UnrecognizedFormat`] or
+    /// [`Self::UnrecognizedBgzfPayload`] instead.
     #[error("unsupported file kind for path: {0}")]
     UnsupportedKind(PathBuf),
+
+    /// File was shorter than the minimum bytes needed for magic-byte
+    /// format detection.
+    ///
+    /// Emitted by [`crate::AlignmentKind::from_path`] when the file is
+    /// truncated below the 4 bytes needed to identify BAM/SAM/CRAM
+    /// signatures.
+    #[error("file {path} is too short to detect format ({bytes_read} bytes; need at least 4)")]
+    TooShortToDetect {
+        /// Path the caller tried to detect.
+        path: PathBuf,
+        /// Number of bytes successfully read before the file ended.
+        bytes_read: usize,
+    },
+
+    /// File's first byte matched none of `1f` (BGZF/BAM), `@` (SAM
+    /// header), or `C` (CRAM).
+    ///
+    /// Emitted by [`crate::AlignmentKind::from_path`]. Common causes:
+    /// truly unrelated file types, or headerless SAM (records only, no
+    /// `@HD`/`@SQ`/`@PG` lines).
+    #[error(
+        "file format not recognised at {path} — first byte is 0x{magic_first_byte:02x}; \
+         expected BAM (`1f 8b`), SAM (starts with `@`), or CRAM (`CRAM`). \
+         If this is a headerless SAM file (no `@HD`/`@SQ`/`@PG` line), \
+         bismark-dedup needs the standard SAM header — try `samtools view -h` first."
+    )]
+    UnrecognizedFormat {
+        /// Path the caller tried to detect.
+        path: PathBuf,
+        /// The first byte read from the file (helps the user identify the format).
+        magic_first_byte: u8,
+    },
+
+    /// File starts with BGZF magic but the decompressed payload doesn't
+    /// begin with `BAM\x01`. Common case: `.vcf.gz` or `.bcf` or any
+    /// other bgzipped non-BAM file mis-routed to a BAM-expecting caller.
+    ///
+    /// Emitted by [`crate::AlignmentKind::from_path`].
+    #[error(
+        "file {path} is bgzipped but the decompressed payload starts with \
+         {payload_head:02x?}, not `BAM\\x01` — looks like a non-BAM \
+         BGZF file (VCF, BCF, BED, …?)"
+    )]
+    UnrecognizedBgzfPayload {
+        /// Path the caller tried to detect.
+        path: PathBuf,
+        /// The first 4 bytes of the decompressed payload.
+        payload_head: [u8; 4],
+    },
 
     /// Underlying I/O failure.
     ///

--- a/rust/bismark-io/src/read.rs
+++ b/rust/bismark-io/src/read.rs
@@ -110,9 +110,12 @@ impl AlignmentKind {
     /// the file doesn't exist yet) prefer [`Self::from_extension`].
     pub fn from_path(path: &Path) -> Result<Self, BismarkIoError> {
         let mut file = std::fs::File::open(path)?;
-        let mut first_byte = [0u8; 1];
-        let n = std::io::Read::read(&mut file, &mut first_byte)?;
-        if n == 0 {
+        // `Read::read` is permitted to return short even when more data
+        // is available, so use the take+read_to_end loop pattern that
+        // either fills the buffer or hits real EOF.
+        let mut first_byte = Vec::with_capacity(1);
+        (&mut file).take(1).read_to_end(&mut first_byte)?;
+        if first_byte.is_empty() {
             return Err(BismarkIoError::TooShortToDetect {
                 path: path.to_path_buf(),
                 bytes_read: 0,
@@ -151,15 +154,23 @@ impl AlignmentKind {
 /// inflate cost. Cleaner code wins.
 fn detect_bgzf_payload(path: &Path) -> Result<AlignmentKind, BismarkIoError> {
     let file = std::fs::File::open(path)?;
-    let mut bgzf = noodles_bgzf::io::Reader::new(file);
-    let mut payload_head = [0u8; 4];
-    let n = std::io::Read::read(&mut bgzf, &mut payload_head)?;
-    if n < 4 {
+    let bgzf = noodles_bgzf::io::Reader::new(file);
+    // `noodles_bgzf::Reader::read` returns one BGZF block at a time per
+    // the `Read` contract — a single `read()` call may legally return
+    // fewer than 4 bytes even when more data is available. Use
+    // take+read_to_end so we loop until we have 4 bytes OR genuine EOF.
+    let mut payload_head_buf = Vec::with_capacity(4);
+    bgzf.take(4).read_to_end(&mut payload_head_buf)?;
+    if payload_head_buf.len() < 4 {
         return Err(BismarkIoError::TooShortToDetect {
             path: path.to_path_buf(),
-            bytes_read: n,
+            bytes_read: payload_head_buf.len(),
         });
     }
+    let payload_head: [u8; 4] = payload_head_buf
+        .as_slice()
+        .try_into()
+        .expect("we just checked len == 4");
     if &payload_head == b"BAM\x01" {
         Ok(AlignmentKind::Bam)
     } else {
@@ -177,16 +188,18 @@ fn detect_cram_magic(
     file: &mut std::fs::File,
     path: &Path,
 ) -> Result<AlignmentKind, BismarkIoError> {
-    let mut rest = [0u8; 3];
-    let n = std::io::Read::read(file, &mut rest)?;
-    if n < 3 {
+    // `Read::read` may return short even with more data available; use
+    // take+read_to_end to loop until 3 bytes OR genuine EOF.
+    let mut rest_buf = Vec::with_capacity(3);
+    file.take(3).read_to_end(&mut rest_buf)?;
+    if rest_buf.len() < 3 {
         return Err(BismarkIoError::TooShortToDetect {
             path: path.to_path_buf(),
             // First-byte peek (1) + however many we got here.
-            bytes_read: 1 + n,
+            bytes_read: 1 + rest_buf.len(),
         });
     }
-    if &rest == b"RAM" {
+    if rest_buf.as_slice() == b"RAM" {
         Ok(AlignmentKind::Cram)
     } else {
         Err(BismarkIoError::UnrecognizedFormat {
@@ -662,6 +675,35 @@ mod tests {
         match AlignmentKind::from_path(tmp.path()).unwrap_err() {
             BismarkIoError::TooShortToDetect { bytes_read: 2, .. } => {}
             other => panic!("expected TooShortToDetect with bytes_read=2, got {other:?}"),
+        }
+    }
+
+    /// End-to-end test for the load-bearing case: a real BGZF stream
+    /// whose decompressed payload starts with non-BAM bytes (e.g. a
+    /// `.vcf.gz` mis-routed to a BAM-expecting caller). Synthesizes the
+    /// BGZF wrapper via `noodles_bgzf::io::Writer` so the BGZF block
+    /// structure is spec-valid.
+    #[test]
+    fn from_path_rejects_bgzf_non_bam_payload() {
+        use std::io::Write;
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        // Build a valid BGZF stream whose payload starts with VCF magic.
+        {
+            let file = std::fs::File::create(tmp.path()).unwrap();
+            let mut bgzf = noodles_bgzf::io::Writer::new(file);
+            bgzf.write_all(b"##fileformat=VCFv4.2\n").unwrap();
+            bgzf.finish().unwrap();
+        }
+        match AlignmentKind::from_path(tmp.path()).unwrap_err() {
+            BismarkIoError::UnrecognizedBgzfPayload { payload_head, .. } => {
+                // The first 4 decompressed bytes are `##fi`.
+                assert_eq!(
+                    &payload_head, b"##fi",
+                    "payload_head should reflect the first 4 inflated bytes"
+                );
+            }
+            other => panic!("expected UnrecognizedBgzfPayload, got {other:?}"),
         }
     }
 

--- a/rust/bismark-io/src/read.rs
+++ b/rust/bismark-io/src/read.rs
@@ -61,10 +61,20 @@ pub enum AlignmentKind {
 }
 
 impl AlignmentKind {
-    /// Infer from a file path's extension. Returns
-    /// [`BismarkIoError::UnsupportedKind`] if the extension is none of
-    /// `.bam`, `.sam`, `.cram`.
-    pub fn from_path(path: &Path) -> Result<Self, BismarkIoError> {
+    /// Infer from a file path's **extension**. I/O-free.
+    ///
+    /// Returns [`BismarkIoError::UnsupportedKind`] if the extension is
+    /// none of `.bam`, `.sam`, `.cram` (case-insensitive).
+    ///
+    /// Used by [`crate::open_writer`] (where the file doesn't exist yet,
+    /// so content sniffing is impossible) and by any caller that wants
+    /// explicit extension-only dispatch. Reader-side dispatch should
+    /// prefer [`Self::from_path`] (magic-byte sniff).
+    ///
+    /// This function preserves the pre-`v1.0.0-beta.3` behaviour of
+    /// `AlignmentKind::from_path` byte-for-byte; the relocation allows
+    /// the magic-byte variant below to take the more general name.
+    pub fn from_extension(path: &Path) -> Result<Self, BismarkIoError> {
         let ext = path
             .extension()
             .and_then(|e| e.to_str())
@@ -75,6 +85,114 @@ impl AlignmentKind {
             Some("cram") => Ok(Self::Cram),
             _ => Err(BismarkIoError::UnsupportedKind(path.to_path_buf())),
         }
+    }
+
+    /// Detect the file format by reading + (for BGZF) decompressing
+    /// enough bytes to authoritatively identify BAM/SAM/CRAM. Opens the
+    /// file; for the BGZF/BAM case, decompresses the first block
+    /// (~100-700 µs, dominated by the inflate of a 32-64 KiB BGZF block)
+    /// and verifies the BAM-specific `BAM\x01` magic in the
+    /// decompressed payload.
+    ///
+    /// Returns:
+    /// - [`AlignmentKind::Bam`] if the file starts with BGZF magic AND the
+    ///   decompressed first block starts with `BAM\x01`.
+    /// - [`AlignmentKind::Sam`] if the first byte is `@` (SAM header).
+    /// - [`AlignmentKind::Cram`] if the first 4 bytes are `CRAM`.
+    /// - [`BismarkIoError::UnrecognizedFormat`] if no magic matches.
+    /// - [`BismarkIoError::UnrecognizedBgzfPayload`] if BGZF magic
+    ///   matched but the inflated payload isn't `BAM\x01`.
+    /// - [`BismarkIoError::TooShortToDetect`] if the file is too small.
+    /// - [`BismarkIoError::Io`] on a system I/O error.
+    ///
+    /// Used by [`crate::open_reader`] and any caller that wants
+    /// tolerance for mis-named files. For writer-side dispatch (where
+    /// the file doesn't exist yet) prefer [`Self::from_extension`].
+    pub fn from_path(path: &Path) -> Result<Self, BismarkIoError> {
+        let mut file = std::fs::File::open(path)?;
+        let mut first_byte = [0u8; 1];
+        let n = std::io::Read::read(&mut file, &mut first_byte)?;
+        if n == 0 {
+            return Err(BismarkIoError::TooShortToDetect {
+                path: path.to_path_buf(),
+                bytes_read: 0,
+            });
+        }
+        match first_byte[0] {
+            // BGZF/BAM: gzip magic byte 1. Re-open the file fresh and
+            // let `noodles_bgzf::Reader` validate the full block, then
+            // check the payload for `BAM\x01`.
+            0x1f => detect_bgzf_payload(path),
+            // SAM header line marker.
+            b'@' => Ok(Self::Sam),
+            // CRAM file definition starts with the ASCII string `CRAM`.
+            b'C' => detect_cram_magic(&mut file, path),
+            // No recognised magic.
+            other => Err(BismarkIoError::UnrecognizedFormat {
+                path: path.to_path_buf(),
+                magic_first_byte: other,
+            }),
+        }
+    }
+}
+
+/// Open the path as a BGZF stream and read 4 bytes from the
+/// decompressed payload. If those bytes are `BAM\x01` it's a BAM file;
+/// otherwise it's some other BGZF-wrapped format (VCF, BCF, etc.) and we
+/// return [`BismarkIoError::UnrecognizedBgzfPayload`].
+///
+/// Implementation note: this helper re-opens the file fresh rather than
+/// seeking the caller's existing `File` handle back to offset 0 and
+/// wrapping it. Two reasons: (1) `noodles_bgzf::Reader::new` expects a
+/// `Read` source positioned at the start of a BGZF stream — passing a
+/// `File` whose cursor we've already advanced (even after `seek(0)`)
+/// couples error semantics across the two read attempts; (2) the second
+/// `open(2)` syscall is ~1 µs on a warm page cache, dwarfed by the
+/// inflate cost. Cleaner code wins.
+fn detect_bgzf_payload(path: &Path) -> Result<AlignmentKind, BismarkIoError> {
+    let file = std::fs::File::open(path)?;
+    let mut bgzf = noodles_bgzf::io::Reader::new(file);
+    let mut payload_head = [0u8; 4];
+    let n = std::io::Read::read(&mut bgzf, &mut payload_head)?;
+    if n < 4 {
+        return Err(BismarkIoError::TooShortToDetect {
+            path: path.to_path_buf(),
+            bytes_read: n,
+        });
+    }
+    if &payload_head == b"BAM\x01" {
+        Ok(AlignmentKind::Bam)
+    } else {
+        Err(BismarkIoError::UnrecognizedBgzfPayload {
+            path: path.to_path_buf(),
+            payload_head,
+        })
+    }
+}
+
+/// Verify that a file whose first byte is `C` is actually CRAM (full
+/// magic `CRAM`). The caller has already consumed the first byte from
+/// `file`; this helper reads the remaining 3 bytes.
+fn detect_cram_magic(
+    file: &mut std::fs::File,
+    path: &Path,
+) -> Result<AlignmentKind, BismarkIoError> {
+    let mut rest = [0u8; 3];
+    let n = std::io::Read::read(file, &mut rest)?;
+    if n < 3 {
+        return Err(BismarkIoError::TooShortToDetect {
+            path: path.to_path_buf(),
+            // First-byte peek (1) + however many we got here.
+            bytes_read: 1 + n,
+        });
+    }
+    if &rest == b"RAM" {
+        Ok(AlignmentKind::Cram)
+    } else {
+        Err(BismarkIoError::UnrecognizedFormat {
+            path: path.to_path_buf(),
+            magic_first_byte: b'C',
+        })
     }
 }
 
@@ -412,6 +530,7 @@ mod tests {
     use noodles_sam::header::record::value::Map;
     use noodles_sam::header::record::value::map::header::Version;
     use std::io::Cursor;
+    use std::path::PathBuf;
 
     /// Build a SAM header with the given SO value (or no SO if `so` is None).
     fn header_with_sort_order(so: Option<&[u8]>) -> Header {
@@ -424,44 +543,155 @@ mod tests {
         noodles_sam::Header::builder().set_header(hd).build()
     }
 
+    // ─────────────── from_extension (legacy extension dispatch) ───────────────
+
     #[test]
-    fn alignment_kind_from_path_bam() {
+    fn alignment_kind_from_extension_bam() {
         assert_eq!(
-            AlignmentKind::from_path(Path::new("x.bam")).unwrap(),
+            AlignmentKind::from_extension(Path::new("x.bam")).unwrap(),
             AlignmentKind::Bam
         );
         assert_eq!(
-            AlignmentKind::from_path(Path::new("x.BAM")).unwrap(),
+            AlignmentKind::from_extension(Path::new("x.BAM")).unwrap(),
             AlignmentKind::Bam
         );
     }
 
     #[test]
-    fn alignment_kind_from_path_sam() {
+    fn alignment_kind_from_extension_sam() {
         assert_eq!(
-            AlignmentKind::from_path(Path::new("x.sam")).unwrap(),
+            AlignmentKind::from_extension(Path::new("x.sam")).unwrap(),
             AlignmentKind::Sam
         );
     }
 
     #[test]
-    fn alignment_kind_from_path_cram() {
+    fn alignment_kind_from_extension_cram() {
         assert_eq!(
-            AlignmentKind::from_path(Path::new("x.cram")).unwrap(),
+            AlignmentKind::from_extension(Path::new("x.cram")).unwrap(),
             AlignmentKind::Cram
         );
     }
 
     #[test]
-    fn alignment_kind_from_path_unknown_errors() {
-        let err = AlignmentKind::from_path(Path::new("x.txt")).unwrap_err();
+    fn alignment_kind_from_extension_unknown_errors() {
+        let err = AlignmentKind::from_extension(Path::new("x.txt")).unwrap_err();
         assert!(matches!(err, BismarkIoError::UnsupportedKind(_)));
     }
 
     #[test]
-    fn alignment_kind_from_path_no_extension_errors() {
-        let err = AlignmentKind::from_path(Path::new("noext")).unwrap_err();
+    fn alignment_kind_from_extension_no_extension_errors() {
+        let err = AlignmentKind::from_extension(Path::new("noext")).unwrap_err();
         assert!(matches!(err, BismarkIoError::UnsupportedKind(_)));
+    }
+
+    // ─────────────── from_path (new magic-byte sniff) ───────────────
+
+    /// The fixture BAM produced by Perl Bismark is the canonical
+    /// real-data BAM for sniff verification.
+    #[test]
+    fn from_path_detects_bam_via_bgzf_payload_on_fixture() {
+        let fixture = Path::new("test_files/tiny_pe_bismark.bam");
+        assert_eq!(
+            AlignmentKind::from_path(fixture).unwrap(),
+            AlignmentKind::Bam
+        );
+    }
+
+    /// SAM bytes in a file: classification follows content, not extension.
+    /// The temp file has no specific extension (NamedTempFile gives it a
+    /// random one), but `from_path` should ignore extension and classify
+    /// by the `@HD` first-byte content.
+    #[test]
+    fn from_path_detects_sam_by_at_sign_first_byte() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"@HD\tVN:1.6\n").unwrap();
+        assert_eq!(
+            AlignmentKind::from_path(tmp.path()).unwrap(),
+            AlignmentKind::Sam
+        );
+    }
+
+    /// CRAM magic in a file with no extension at all.
+    #[test]
+    fn from_path_detects_cram_by_magic() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"CRAM\x03\x00").unwrap();
+        assert_eq!(
+            AlignmentKind::from_path(tmp.path()).unwrap(),
+            AlignmentKind::Cram
+        );
+    }
+
+    #[test]
+    fn from_path_errors_on_empty_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        // Empty file (NamedTempFile::new is empty by default).
+        match AlignmentKind::from_path(tmp.path()).unwrap_err() {
+            BismarkIoError::TooShortToDetect { bytes_read: 0, .. } => {}
+            other => panic!("expected TooShortToDetect, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_path_errors_on_unrecognized_first_byte() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"XXXX").unwrap();
+        match AlignmentKind::from_path(tmp.path()).unwrap_err() {
+            BismarkIoError::UnrecognizedFormat {
+                magic_first_byte: b'X',
+                ..
+            } => {}
+            other => panic!("expected UnrecognizedFormat with byte=0x58, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_path_errors_on_missing_file() {
+        let err = AlignmentKind::from_path(Path::new("/nonexistent/path/should-not-exist.bam"))
+            .unwrap_err();
+        assert!(matches!(err, BismarkIoError::Io(_)));
+    }
+
+    #[test]
+    fn from_path_errors_on_partial_cram_magic() {
+        // 2 bytes: matches `C` first-byte dispatch, then reads 1 of the
+        // expected 3 trailing bytes before EOF. Total bytes read = 1 + 1 = 2.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"CR").unwrap();
+        match AlignmentKind::from_path(tmp.path()).unwrap_err() {
+            BismarkIoError::TooShortToDetect { bytes_read: 2, .. } => {}
+            other => panic!("expected TooShortToDetect with bytes_read=2, got {other:?}"),
+        }
+    }
+
+    /// New `UnrecognizedBgzfPayload` Display: includes path + hex head.
+    #[test]
+    fn unrecognized_bgzf_payload_display_includes_path_and_head() {
+        let err = BismarkIoError::UnrecognizedBgzfPayload {
+            path: PathBuf::from("/tmp/x.bam"),
+            payload_head: [b'V', b'C', b'F', 0x02],
+        };
+        let s = err.to_string();
+        assert!(s.contains("/tmp/x.bam"), "Display omits path: {s}");
+        assert!(s.contains("bgzipped"), "Display omits 'bgzipped': {s}");
+        assert!(s.contains("BAM"), "Display omits 'BAM' reference: {s}");
+    }
+
+    /// `UnrecognizedFormat` Display: includes the `samtools view -h` hint
+    /// so users with headerless SAM get an actionable next step.
+    #[test]
+    fn unrecognized_format_display_includes_samtools_hint() {
+        let err = BismarkIoError::UnrecognizedFormat {
+            path: PathBuf::from("/tmp/y"),
+            magic_first_byte: b'X',
+        };
+        let s = err.to_string();
+        assert!(
+            s.contains("samtools view -h"),
+            "Display omits samtools-view-h hint: {s}"
+        );
+        assert!(s.contains("0x58"), "Display omits hex first-byte: {s}");
     }
 
     #[test]
@@ -568,10 +798,13 @@ read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTC\tIIIII\tXM:Z:.....\tXG:Z:CT\n";
 
     #[test]
     fn open_reader_cram_without_cram_ref_errors() {
-        // A .cram path with no cram_ref should fail with MissingCramReference,
-        // even before any file I/O is attempted (we check the missing-ref
-        // condition before opening the CRAM).
-        let err = expect_err(open_reader(Path::new("nonexistent.cram"), None));
+        // A CRAM-magic file with no cram_ref should fail with
+        // MissingCramReference. Since v1.0.0-beta.3 `open_reader` uses
+        // magic-byte sniff (not extension), the file must exist for the
+        // sniff to detect CRAM before the cram_ref check fires.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"CRAM\x03\x00").unwrap();
+        let err = expect_err(open_reader(tmp.path(), None));
         assert!(
             matches!(err, BismarkIoError::MissingCramReference(_)),
             "expected MissingCramReference, got {err:?}"
@@ -579,15 +812,35 @@ read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTC\tIIIII\tXM:Z:.....\tXG:Z:CT\n";
     }
 
     #[test]
-    fn open_reader_unsupported_extension_errors() {
-        let err = expect_err(open_reader(Path::new("foo.txt"), None));
-        assert!(matches!(err, BismarkIoError::UnsupportedKind(_)));
+    fn open_reader_unrecognized_format_errors() {
+        // A file whose contents match no recognised magic byte:
+        // post-beta.3 this is `UnrecognizedFormat`, regardless of
+        // extension (which is no longer consulted).
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"XXXX").unwrap();
+        let err = expect_err(open_reader(tmp.path(), None));
+        assert!(
+            matches!(
+                err,
+                BismarkIoError::UnrecognizedFormat {
+                    magic_first_byte: b'X',
+                    ..
+                }
+            ),
+            "expected UnrecognizedFormat with byte=0x58, got {err:?}"
+        );
     }
 
     #[test]
-    fn open_reader_no_extension_errors() {
-        let err = expect_err(open_reader(Path::new("noext"), None));
-        assert!(matches!(err, BismarkIoError::UnsupportedKind(_)));
+    fn open_reader_too_short_to_detect_errors() {
+        // Empty file: too short for any magic. Post-beta.3 this is
+        // TooShortToDetect.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let err = expect_err(open_reader(tmp.path(), None));
+        assert!(
+            matches!(err, BismarkIoError::TooShortToDetect { bytes_read: 0, .. }),
+            "expected TooShortToDetect with bytes_read=0, got {err:?}"
+        );
     }
 
     #[test]

--- a/rust/bismark-io/src/write.rs
+++ b/rust/bismark-io/src/write.rs
@@ -347,7 +347,11 @@ pub fn open_writer(
     header: Header,
     cram_ref: Option<&Path>,
 ) -> Result<AnyWriter<BufWriter<File>, File>, BismarkIoError> {
-    match AlignmentKind::from_path(path)? {
+    // Writers can't sniff bytes (the file doesn't exist yet), so they
+    // dispatch on the file's extension via `from_extension`. Reader-side
+    // dispatch (via `AlignmentKind::from_path`) is the magic-byte-sniff
+    // path added in `bismark-io v1.0.0-beta.3`.
+    match AlignmentKind::from_extension(path)? {
         AlignmentKind::Bam => Ok(AnyWriter::Bam(BamWriter::from_path(path, header)?)),
         AlignmentKind::Sam => Ok(AnyWriter::Sam(SamWriter::from_path(path, header)?)),
         AlignmentKind::Cram => {

--- a/rust/bismark-io/tests/integration_fixture_bam.rs
+++ b/rust/bismark-io/tests/integration_fixture_bam.rs
@@ -322,3 +322,24 @@ fn threaded_bam_reader_parallel_1_is_valid_but_overhead() {
     let count = reader.records().count();
     assert_eq!(count, 203);
 }
+
+/// v1.0.0-beta.3 integration: `open_reader` dispatches via magic-byte
+/// sniff, NOT extension. Copy the fixture BAM to a path with no
+/// extension at all and verify the records still decode correctly.
+#[test]
+fn open_reader_dispatches_via_sniff_on_extensionless_path() {
+    use bismark_io::open_reader;
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    // Overwrite the temp file (which already has some random-suffix
+    // extension) with our fixture BAM contents.
+    std::fs::copy(fixture_path(), tmp.path()).unwrap();
+
+    let mut reader = open_reader(tmp.path(), None)
+        .expect("open_reader should succeed via magic-byte sniff regardless of extension");
+    let count = reader.records().filter_map(Result::ok).count();
+    assert_eq!(
+        count, 203,
+        "extensionless fixture BAM should decode same as the .bam-named one"
+    );
+}


### PR DESCRIPTION
## Summary

Adds magic-byte file-format detection to `bismark-io`, matching Perl Bismark's behaviour: input files are classified by their actual content, not their filename extension. A SAM file named `foo.bam` is now correctly identified as SAM (previously it errored at parse time with a confusing BAM-decoder error); a `.vcf.gz` mis-routed to a BAM-expecting caller now errors with a clear "looks like a non-BAM BGZF file" message.

**Plan:** \`~/.claude/plans/05252026_magic-byte-format-detection/PLAN.md\` rev 2.1, dual plan-reviewed in two rounds (both reviewers ended at APPROVE-WITH-NITS; all critical findings from round 1 closed in rev 2; round-2 nits applied in rev 2.1).

## What lands

- **\`AlignmentKind::from_extension(&Path)\`** — pure extension dispatch, I/O-free. Preserves the pre-beta.3 \`from_path\` behaviour. Used by \`open_writer\` (the output file doesn't exist yet, so content sniffing is impossible).
- **\`AlignmentKind::from_path(&Path)\`** — magic-byte sniff (new). Opens the file; for BGZF, decompresses the first block via \`noodles_bgzf::Reader\` and verifies the \`BAM\\x01\` payload magic. Used by \`open_reader\`.
- **Three new \`BismarkIoError\` variants** emitted by the sniff path: \`TooShortToDetect\`, \`UnrecognizedFormat\` (with samtools-view-h hint for headerless SAM), \`UnrecognizedBgzfPayload\` (distinguishes \`.vcf.gz\`/\`.bcf\` from BAM).

## Versions

- \`bismark-io\`: \`1.0.0-beta.2\` → \`1.0.0-beta.3\`
- \`bismark-dedup\`: \`1.1.0-beta.1\` → \`1.1.0-beta.2\` (pin bump only; no source changes — the \`from_path\` signature is unchanged, new error variants flow through \`BismarkDedupError\`'s \`#[from] BismarkIoError\` transparently)

## Test plan

- [x] 5 \`from_extension\` tests (legacy extension dispatch preserved)
- [x] 9 \`from_path\` tests (BAM via fixture, SAM via mis-named, CRAM via no-extension, empty file, unknown bytes, missing file, partial CRAM, two Display tests for new variants)
- [x] 3 \`open_reader\` tests migrated to post-beta.3 semantics
- [x] 1 new integration test in \`tests/integration_fixture_bam.rs\`: extensionless fixture BAM still decodes 203 records
- [x] 1 new \`bismark-dedup\` test: new \`BismarkIoError\` variants propagate through \`BismarkDedupError\` correctly
- [x] All existing tests pass (225 + 5 ignored, up from 214 + 5)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

## Post-merge (user-gated)

Per PHASE_D_PLAN's publish gate (also applies to this beta.3):
1. \`cargo publish bismark-io 1.0.0-beta.3\` (optional; depends on Phase D's beta.2 publish state — see plan §13).
2. Tag \`bismark-io-v1.0.0-beta.3\` + \`bismark-dedup-v1.1.0-beta.2\` at the merge SHA.

The Phase D rayon work-item (queued task #62 → this PR) is now done; closing task #62 after merge.