### PR TITLE
impl(bismark-io): v1.0.0-beta.4 — UMI extractors

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-io"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "bstr",
  "noodles-bam",

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -19,7 +19,7 @@ name = "deduplicate_bismark_rs"
 path = "src/main.rs"
 
 [dependencies]
-bismark-io = { version = "=1.0.0-beta.3", path = "../bismark-io" }
+bismark-io = { version = "=1.0.0-beta.4", path = "../bismark-io" }
 # noodles-sam pinned to match bismark-io =1.0.0's transitive choice.
 # Needed directly for `Header` (returned by `bismark_io::open_reader`
 # via `AnyReader::header`) and for test-helper types.

--- a/rust/bismark-io/CHANGELOG.md
+++ b/rust/bismark-io/CHANGELOG.md
@@ -44,11 +44,11 @@ modes. Additive within the beta line; existing API surface unchanged.
 
 ### Phase context
 
-This release lands as part of the v1.2 UMI/RRBS epic (planned at
-`~/.claude/plans/05252026_bismark-dedup-umi-v1.2/EPIC.md`). Phase A
-ships the extractors; Phase B integrates them into `bismark-dedup`'s
-`DedupKey` and pipeline. Phase C real-data validates against Perl
-baselines on oxy.
+This release lands as part of the v1.2 UMI/RRBS epic. Phase A ships
+the extractors; the consumer-side integration (UMI-aware `DedupKey`
+and pipeline) lands in `bismark-dedup v1.2.0-beta.1`. Real-data
+byte-identity vs Perl `deduplicate_bismark v0.25.1` is validated on a
+synthesized-UMI RRBS dataset.
 
 ## [1.0.0-beta.3] — 2026-05-25
 

--- a/rust/bismark-io/CHANGELOG.md
+++ b/rust/bismark-io/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to `bismark-io` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.4] — 2026-05-25
+
+UMI extraction helpers for Bismark qnames, supporting Perl
+`deduplicate_bismark v0.25.1`'s `--barcode`/`--umi` and `--bclconvert`
+modes. Additive within the beta line; existing API surface unchanged.
+
+### Added
+
+- New module `bismark_io::umi` with two zero-copy public functions:
+
+  - **`extract_barcode(&[u8]) -> Option<&[u8]>`** — extracts the
+    tail-of-qname UMI per Perl regex `:([\w\+]+)$` at
+    `deduplicate_bismark:659`. Used by Perl's `--barcode`/`--umi`
+    modes.
+
+  - **`extract_bclconvert(&[u8]) -> Option<&[u8]>`** — extracts the
+    internal-position UMI in bcl-convert read ID format per Perl
+    regex `:([CAGTN\+]+)_\d:N:\d:([CAGTN\+]+)$` at
+    `deduplicate_bismark:650`. Used by Perl's `--bclconvert` mode.
+
+- 29 unit tests (12 + 17) covering every edge case enumerated in the
+  Phase A plan (empty input, no-colon, invalid chars, dual-UMI `+`
+  separator, post-`fix_IDs` format, underflow guard, mode mismatch).
+
+- 2 doc tests (one per function) with both the Perl-docs canonical
+  example AND the post-Bismark-`fix_IDs` format that `bismark-dedup`
+  will actually encounter in v1.2.
+
+### Performance
+
+- Both extractors are O(N) over the qname bytes, single-pass or
+  reverse-scan. Zero allocation: return type is `Option<&[u8]>`
+  borrowed from the input.
+- Hand-rolled byte comparison (no `regex` crate dependency added).
+  Estimated ~100 ns per call on a 100-byte qname — negligible vs
+  dedup hash work.
+
+### Phase context
+
+This release lands as part of the v1.2 UMI/RRBS epic (planned at
+`~/.claude/plans/05252026_bismark-dedup-umi-v1.2/EPIC.md`). Phase A
+ships the extractors; Phase B integrates them into `bismark-dedup`'s
+`DedupKey` and pipeline. Phase C real-data validates against Perl
+baselines on oxy.
+
 ## [1.0.0-beta.3] — 2026-05-25
 
 Magic-byte file-format detection for reader-side dispatch. Tolerates

--- a/rust/bismark-io/Cargo.toml
+++ b/rust/bismark-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-io"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 description = "Bismark-aware BAM/SAM/CRAM I/O on top of noodles"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-io/README.md
+++ b/rust/bismark-io/README.md
@@ -4,7 +4,7 @@ Bismark-aware BAM/SAM/CRAM I/O on top of [`noodles`](https://github.com/zaeleus/
 
 `bismark-io` is the shared library crate for [Bismark](https://github.com/FelixKrueger/Bismark)'s Rust rewrite. It wraps the `noodles` crate family to expose record types that already know about Bismark's strand classification (OT/CTOT/OB/CTOB derived from the `XR:Z:` and `XG:Z:` tags), tag-decoded accessors (`XM`, `XR`, `XG`, `MD`, `NM`), and CIGAR-aware position helpers. Every Bismark Rust binary crate (`bismark-dedup`, `bismark-extractor`, `bismark-bedgraph`, …) depends on it.
 
-**Status:** v1.0.0-beta.2 — adds `ThreadedBamReader` / `ThreadedBamWriter` for parallel BGZF decode/encode (additive; existing API unchanged). Used by `bismark-dedup v1.1.0-beta.1`'s `--parallel N` flag. See [`CHANGELOG.md`](./CHANGELOG.md).
+**Status:** v1.0.0-beta.4 — adds `umi::extract_barcode` + `umi::extract_bclconvert` zero-copy UMI extractors (additive; existing API unchanged). Prior beta-line additions: beta.2 `ThreadedBamReader`/`Writer` (used by `bismark-dedup`'s `--parallel N`); beta.3 magic-byte file-format detection. See [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## Why a Bismark wrapper around `noodles`?
 
@@ -53,6 +53,11 @@ use bismark_io::{
     // CRAM reference helper
     reconstitute_cram_reference_from_bismark_genome,
 };
+
+// UMI extractors live in the `umi` submodule (beta.4):
+use bismark_io::umi;
+let umi_value = umi::extract_barcode(qname_bytes);          // tail-of-qname mode
+let umi_value = umi::extract_bclconvert(qname_bytes);       // bcl-convert internal-position mode
 ```
 
 Module-level docs explain each type's contract. See `cargo doc --open --package bismark-io`.
@@ -229,11 +234,11 @@ The pin policy: noodles releases frequently and occasionally bumps MSRV. Exact-p
 
 ## Stability
 
-This is **v1.0.0-beta.3** — the public API is stable; no breaking changes are planned between `1.0.0-beta.N` and `1.0.0`. The v1.0.0-beta.3 release adds **magic-byte file-format detection** for reader-side dispatch (matching Perl Bismark's behaviour); writer-side dispatch and every other type/function signature are unchanged from v1.0.0-beta.2. The `DESIGN.md` document is the canonical contract; if a future change to `bismark-io` contradicts `DESIGN.md`, the design doc gets updated in lockstep.
+This is **v1.0.0-beta.4** — the public API is stable; no breaking changes are planned between `1.0.0-beta.N` and `1.0.0`. The v1.0.0-beta.4 release adds the **`umi::` module** with zero-copy UMI extractors for both `--barcode/--umi` (tail-of-qname) and `--bclconvert` (internal-position) formats; every other type/function signature is unchanged from v1.0.0-beta.3. The `DESIGN.md` document is the canonical contract; if a future change to `bismark-io` contradicts `DESIGN.md`, the design doc gets updated in lockstep.
 
 ## crates.io
 
-`bismark-io = "=1.0.0-beta.1"` (the v1.0 single-threaded line) is **published to crates.io**. `bismark-io = "=1.0.0-beta.2"` (BGZF-threaded readers/writers) and `bismark-io = "=1.0.0-beta.3"` (magic-byte detection) are **queued for the next publish window** — within the Bismark workspace, `bismark-dedup` already path-deps `=1.0.0-beta.3`. Once published, external consumers can pin to whichever beta matches the features they need.
+`bismark-io = "=1.0.0-beta.1"` (the v1.0 single-threaded line) is **published to crates.io**. `bismark-io = "=1.0.0-beta.2"` (BGZF-threaded readers/writers), `=1.0.0-beta.3` (magic-byte detection), and `=1.0.0-beta.4` (UMI extractors) are **queued for the next publish window** — within the Bismark workspace, `bismark-dedup` already path-deps `=1.0.0-beta.4`. Once published, external consumers can pin to whichever beta matches the features they need.
 
 ## License
 

--- a/rust/bismark-io/README.md
+++ b/rust/bismark-io/README.md
@@ -52,12 +52,10 @@ use bismark_io::{
     open_writer, AnyWriter, BamWriter, SamWriter, CramWriter,
     // CRAM reference helper
     reconstitute_cram_reference_from_bismark_genome,
+    // UMI extractors (beta.4) — available both at the crate root via
+    // these flat re-exports and at `bismark_io::umi::*`:
+    extract_barcode, extract_bclconvert,
 };
-
-// UMI extractors live in the `umi` submodule (beta.4):
-use bismark_io::umi;
-let umi_value = umi::extract_barcode(qname_bytes);          // tail-of-qname mode
-let umi_value = umi::extract_bclconvert(qname_bytes);       // bcl-convert internal-position mode
 ```
 
 Module-level docs explain each type's contract. See `cargo doc --open --package bismark-io`.

--- a/rust/bismark-io/src/lib.rs
+++ b/rust/bismark-io/src/lib.rs
@@ -22,6 +22,7 @@ pub mod read;
 pub mod record;
 pub mod strand;
 pub mod tags;
+pub mod umi;
 pub mod write;
 
 pub use cigar::{AlignedPosition, AlignedPositions, CigarExt};

--- a/rust/bismark-io/src/lib.rs
+++ b/rust/bismark-io/src/lib.rs
@@ -34,4 +34,5 @@ pub use read::{
 };
 pub use record::{BismarkRecord, ReadIdentity};
 pub use strand::BismarkStrand;
+pub use umi::{extract_barcode, extract_bclconvert};
 pub use write::{AnyWriter, BamWriter, CramWriter, SamWriter, ThreadedBamWriter, open_writer};

--- a/rust/bismark-io/src/umi.rs
+++ b/rust/bismark-io/src/umi.rs
@@ -248,6 +248,16 @@ mod tests {
     }
 
     #[test]
+    fn extract_barcode_trailing_whitespace() {
+        // Whitespace (space, tab, newline) is not in [\w\+] — Reviewer B
+        // N4. A qname accidentally containing trailing whitespace should
+        // return None rather than a polluted UMI string.
+        assert_eq!(extract_barcode(b"x:UMI "), None);
+        assert_eq!(extract_barcode(b"x:UMI\n"), None);
+        assert_eq!(extract_barcode(b"x:UMI\t"), None);
+    }
+
+    #[test]
     fn extract_barcode_with_plus_dual_umi() {
         // Perl's [\w\+] allows '+' as a dual-UMI separator. The
         // Illumina dual-UMI convention writes paired barcodes as

--- a/rust/bismark-io/src/umi.rs
+++ b/rust/bismark-io/src/umi.rs
@@ -1,0 +1,389 @@
+//! UMI extractors for Bismark BAM qnames.
+//!
+//! Bismark's downstream `deduplicate_bismark` Perl script (v0.25.1)
+//! supports two UMI encoding formats in the read ID:
+//!
+//! - **`--barcode` / `--umi`** — UMI is the tail-of-qname token after
+//!   the last `:`, e.g. `MISEQ:...:CTCCTTAG`. Perl regex
+//!   (`deduplicate_bismark:659`): `:([\w\+]+)$`.
+//!
+//! - **`--bclconvert`** — UMI is at an internal position in the
+//!   bcl-convert read ID format, e.g.
+//!   `A00001:...:CAAGAG_1:N:0:AATGACGC`. Perl regex
+//!   (`deduplicate_bismark:650`):
+//!   `:([CAGTN\+]+)_\d:N:\d:([CAGTN\+]+)$`.
+//!
+//! Both extractors below mirror Perl exactly — character classes,
+//! anchoring, and empty-token rejection all match. Each returns
+//! `Option<&[u8]>` borrowed from the input qname (zero-copy). The
+//! caller chooses which extractor to call based on the user's CLI
+//! flag (mode selection is upstream — these extractors are pure).
+//!
+//! Non-ASCII bytes (>= 0x80) fail the character-class checks and the
+//! functions return `None`. Bismark BAM qnames are pure ASCII in
+//! practice; non-ASCII input is handled gracefully.
+
+/// Extract the `--barcode`/`--umi`-format UMI from a Bismark qname.
+///
+/// Matches Perl `deduplicate_bismark`'s regex at line 659:
+/// `:([\w\+]+)$`. The UMI is the **tail token** of the qname,
+/// separated by `:` from the rest, consisting only of word characters
+/// (ASCII alphanumeric or underscore) and/or `+`.
+///
+/// Returns `None` if the qname has no `:`, the tail is empty, or
+/// contains any character outside `[\w\+]`.
+///
+/// Non-ASCII bytes (any byte >= 0x80) fail the `[\w\+]` check and
+/// the function returns `None` — Bismark BAM qnames are pure ASCII in
+/// practice, but non-ASCII input is handled gracefully.
+///
+/// Zero-copy: the returned slice is borrowed from `qname`.
+///
+/// # Examples
+///
+/// ```
+/// use bismark_io::umi;
+/// // Post-fix_IDs format (what bismark-dedup actually sees in v1.2):
+/// assert_eq!(
+///     umi::extract_barcode(b"SRR24766921.1_A00686:91:HTHYKDMXX:1:1101:19696:1000:CAGCACTT"),
+///     Some(b"CAGCACTT".as_slice())
+/// );
+/// // Perl docs canonical example:
+/// assert_eq!(
+///     umi::extract_barcode(b"MISEQ:14:000000000-A55D0:1:1101:18024:2858_1:N:0:CTCCTTAG"),
+///     Some(b"CTCCTTAG".as_slice())
+/// );
+/// assert_eq!(
+///     umi::extract_barcode(b"read_with_no_colon"),
+///     None
+/// );
+/// assert_eq!(
+///     umi::extract_barcode(b"read:with:slash/tail"),
+///     None  // /tail is not [\w\+]
+/// );
+/// ```
+pub fn extract_barcode(qname: &[u8]) -> Option<&[u8]> {
+    // Step 1: find the last ':' in qname.
+    let last_colon = qname.iter().rposition(|&b| b == b':')?;
+    // Step 3: the candidate UMI is everything after the last colon.
+    let candidate = &qname[last_colon + 1..];
+    // Step 4: reject empty tails (Perl's `+` quantifier requires >= 1).
+    if candidate.is_empty() {
+        return None;
+    }
+    // Step 5: validate against [\w\+] = ASCII alnum or '_' or '+'.
+    // Note: Rust's `u8::is_ascii_alphanumeric` does NOT include '_';
+    // the explicit `|| b == b'_'` check is required to match Perl's
+    // `\w` which is `[A-Za-z0-9_]`.
+    if !candidate
+        .iter()
+        .all(|&b| b.is_ascii_alphanumeric() || b == b'_' || b == b'+')
+    {
+        return None;
+    }
+    Some(candidate)
+}
+
+/// Extract the `--bclconvert`-format UMI from a Bismark qname.
+///
+/// Matches Perl `deduplicate_bismark`'s regex at line 650:
+/// `:([CAGTN\+]+)_\d:N:\d:([CAGTN\+]+)$`. The UMI is the **first
+/// capture group** (the `[CAGTN+]+` immediately after a `:` and
+/// followed by `_<digit>:N:<digit>:i7`).
+///
+/// Returns `None` if the qname doesn't match the expected structure
+/// (no trailing `_<d>:N:<d>:i7` segment, UMI not strictly `[CAGTN+]+`,
+/// or i7 not strictly `[CAGTN+]+`).
+///
+/// Non-ASCII bytes (any byte >= 0x80) fail the `[CAGTN+]` check and
+/// the function returns `None`. Bismark BAM qnames are pure ASCII in
+/// practice; non-ASCII input is handled gracefully.
+///
+/// Zero-copy: the returned slice is borrowed from `qname`.
+///
+/// # Examples
+///
+/// ```
+/// use bismark_io::umi;
+/// // Post-fix_IDs format (what bismark-dedup actually sees in v1.2):
+/// assert_eq!(
+///     umi::extract_bclconvert(b"SRR24766921.1_A00686:91:HTHYKDMXX:1:1101:19696:1000:CAGCACTT_1:N:0:NNNNNNNN"),
+///     Some(b"CAGCACTT".as_slice())
+/// );
+/// // Perl docs canonical example:
+/// assert_eq!(
+///     umi::extract_bclconvert(b"A00001:001:HN2F7DRX1:1:1101:1452:1000:CAAGAG_1:N:0:AATGACGC"),
+///     Some(b"CAAGAG".as_slice())
+/// );
+/// assert_eq!(
+///     // i7 with N placeholders (matches the regex's `[CAGTN+]` char class)
+///     umi::extract_bclconvert(b"a:b:CAAGAG_1:N:0:NNNNNNNN"),
+///     Some(b"CAAGAG".as_slice())
+/// );
+/// assert_eq!(
+///     umi::extract_bclconvert(b"no_internal_structure"),
+///     None
+/// );
+/// ```
+pub fn extract_bclconvert(qname: &[u8]) -> Option<&[u8]> {
+    // Step 1: find the last ':' (i7 separator).
+    let i7_colon = qname.iter().rposition(|&b| b == b':')?;
+    // Step 2: i7 candidate must be non-empty and strictly [CAGTN+].
+    let i7 = &qname[i7_colon + 1..];
+    if i7.is_empty() || !i7.iter().all(is_cagtn_plus) {
+        return None;
+    }
+    // Step 3: underflow guard — need 6 bytes before i7_colon for the
+    // `_<digit>:N:<digit>` infix.
+    if i7_colon < 6 {
+        return None;
+    }
+    // Step 4: validate the 6-byte infix pattern `_<d>:N:<d>`.
+    let infix = &qname[i7_colon - 6..i7_colon];
+    if infix[0] != b'_'
+        || !infix[1].is_ascii_digit()
+        || infix[2] != b':'
+        || infix[3] != b'N'
+        || infix[4] != b':'
+        || !infix[5].is_ascii_digit()
+    {
+        return None;
+    }
+    // Step 5: UMI ends just before the '_' at infix[0].
+    let umi_end = i7_colon - 6;
+    // Step 6: find the ':' immediately before the UMI.
+    let umi_colon = qname[..umi_end].iter().rposition(|&b| b == b':')?;
+    // Step 7: UMI candidate must be non-empty and strictly [CAGTN+].
+    let umi = &qname[umi_colon + 1..umi_end];
+    if umi.is_empty() || !umi.iter().all(is_cagtn_plus) {
+        return None;
+    }
+    Some(umi)
+}
+
+/// Predicate matching Perl's `[CAGTN\+]` character class: literal
+/// DNA-base letters `C`, `A`, `G`, `T`, the ambiguity character `N`,
+/// or the `+` dual-UMI separator.
+fn is_cagtn_plus(b: &u8) -> bool {
+    matches!(b, b'C' | b'A' | b'G' | b'T' | b'N' | b'+')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─────────────────── extract_barcode ───────────────────
+
+    #[test]
+    fn extract_barcode_perl_example() {
+        // The exact example from Perl's --barcode help text.
+        assert_eq!(
+            extract_barcode(b"MISEQ:14:000000000-A55D0:1:1101:18024:2858_1:N:0:CTCCTTAG"),
+            Some(b"CTCCTTAG".as_slice())
+        );
+    }
+
+    #[test]
+    fn extract_barcode_simple() {
+        assert_eq!(extract_barcode(b"read:UMI"), Some(b"UMI".as_slice()));
+    }
+
+    #[test]
+    fn extract_barcode_with_underscore_and_plus() {
+        // Underscore and '+' are in [\w\+] per Perl regex.
+        assert_eq!(extract_barcode(b"x:Y_+Z"), Some(b"Y_+Z".as_slice()));
+    }
+
+    #[test]
+    fn extract_barcode_no_colon() {
+        assert_eq!(extract_barcode(b"noseparator"), None);
+    }
+
+    #[test]
+    fn extract_barcode_empty_tail() {
+        assert_eq!(extract_barcode(b"trailing:"), None);
+    }
+
+    #[test]
+    fn extract_barcode_invalid_char() {
+        // '/' is not in [\w\+].
+        assert_eq!(extract_barcode(b"x:has/slash"), None);
+    }
+
+    #[test]
+    fn extract_barcode_empty_input() {
+        assert_eq!(extract_barcode(b""), None);
+    }
+
+    #[test]
+    fn extract_barcode_only_colon() {
+        assert_eq!(extract_barcode(b":"), None);
+    }
+
+    #[test]
+    fn extract_barcode_after_fix_ids() {
+        // The post-Bismark-fix_IDs format that bismark-dedup actually
+        // sees: SRA prefix joined to Illumina qname via underscore.
+        assert_eq!(
+            extract_barcode(b"SRR24766921.1_A00686:91:HTHYKDMXX:1:1101:19696:1000:CAGCACTT"),
+            Some(b"CAGCACTT".as_slice())
+        );
+    }
+
+    #[test]
+    fn extract_barcode_with_slash_tail() {
+        // Catches the Phase 0 bug class: if synth_umi.py preserves
+        // the /1 mate suffix, the BAM qname ends with `:UMI/1` and
+        // Perl's regex fails (because `/` is not in [\w\+]). Our
+        // extractor must report None for this case so Phase B can
+        // surface the misconfiguration loudly.
+        assert_eq!(extract_barcode(b"x:UMI/1"), None);
+    }
+
+    #[test]
+    fn extract_barcode_only_digits() {
+        // Locks in plan §11's "no first-char restriction" — Perl's
+        // [\w\+] allows digits at any position including the start.
+        assert_eq!(extract_barcode(b"x:12345678"), Some(b"12345678".as_slice()));
+    }
+
+    #[test]
+    fn extract_barcode_with_plus_dual_umi() {
+        // Perl's [\w\+] allows '+' as a dual-UMI separator. The
+        // Illumina dual-UMI convention writes paired barcodes as
+        // `UMI1+UMI2`.
+        assert_eq!(
+            extract_barcode(b"x:CAGCACTT+TTAGTTGT"),
+            Some(b"CAGCACTT+TTAGTTGT".as_slice())
+        );
+    }
+
+    // ─────────────────── extract_bclconvert ───────────────────
+
+    #[test]
+    fn extract_bclconvert_perl_example() {
+        // The exact example from Perl's --bclconvert help text.
+        assert_eq!(
+            extract_bclconvert(b"A00001:001:HN2F7DRX1:1:1101:1452:1000:CAAGAG_1:N:0:AATGACGC"),
+            Some(b"CAAGAG".as_slice())
+        );
+    }
+
+    #[test]
+    fn extract_bclconvert_n_placeholder_i7() {
+        // Phase 0's synthesized format: i7 is all-N (the regex's
+        // [CAGTN+] class accepts N).
+        assert_eq!(
+            extract_bclconvert(b"a:b:CAAGAG_1:N:0:NNNNNNNN"),
+            Some(b"CAAGAG".as_slice())
+        );
+    }
+
+    #[test]
+    fn extract_bclconvert_after_fix_ids() {
+        // Post-Bismark-fix_IDs format.
+        assert_eq!(
+            extract_bclconvert(
+                b"SRR24766921.1_A00686:91:HTHYKDMXX:1:1101:19696:1000:CAGCACTT_1:N:0:NNNNNNNN"
+            ),
+            Some(b"CAGCACTT".as_slice())
+        );
+    }
+
+    #[test]
+    fn extract_bclconvert_r2_mate() {
+        // R2 differs only in the mate-id digit (`_2:` vs `_1:`); the
+        // UMI must extract identically.
+        assert_eq!(
+            extract_bclconvert(b"x:y:CAGCACTT_2:N:0:NNNNNNNN"),
+            Some(b"CAGCACTT".as_slice())
+        );
+    }
+
+    #[test]
+    fn extract_bclconvert_no_internal_structure() {
+        assert_eq!(extract_bclconvert(b"flatname"), None);
+    }
+
+    #[test]
+    fn extract_bclconvert_no_colon_before_umi() {
+        // Pattern matches up to `_1:N:0:i7` but there's no `:` before
+        // the UMI for the extractor to anchor on.
+        assert_eq!(extract_bclconvert(b"UMIonlyatstart_1:N:0:CAGT"), None);
+    }
+
+    #[test]
+    fn extract_bclconvert_umi_with_slash() {
+        // '/' is not in [CAGTN+].
+        assert_eq!(extract_bclconvert(b"x:UMI/1_1:N:0:CAGT"), None);
+    }
+
+    #[test]
+    fn extract_bclconvert_empty_umi() {
+        assert_eq!(extract_bclconvert(b"x:_1:N:0:CAGT"), None);
+    }
+
+    #[test]
+    fn extract_bclconvert_empty_i7() {
+        assert_eq!(extract_bclconvert(b"x:UMI_1:N:0:"), None);
+    }
+
+    #[test]
+    fn extract_bclconvert_i7_with_invalid_char() {
+        // i7 must be strictly [CAGTN+].
+        assert_eq!(extract_bclconvert(b"x:CAGCACTT_1:N:0:AB12CD"), None);
+    }
+
+    #[test]
+    fn extract_bclconvert_wrong_n_byte() {
+        // The `N` byte in `_<d>:N:<d>:` must literally be 'N'.
+        assert_eq!(extract_bclconvert(b"x:UMI_1:Y:0:CAGT"), None);
+    }
+
+    #[test]
+    fn extract_bclconvert_short_pattern() {
+        // No UMI before the '_'.
+        assert_eq!(extract_bclconvert(b":_1:N:0:CAGT"), None);
+    }
+
+    #[test]
+    fn extract_bclconvert_with_plus_dual_umi() {
+        // Perl's [CAGTN\+] allows '+' for dual-UMI separator. Per Perl
+        // docs line 645.
+        assert_eq!(
+            extract_bclconvert(b"x:y:CAGCACTT+TTAGTTGT_1:N:0:NNNNNNNN"),
+            Some(b"CAGCACTT+TTAGTTGT".as_slice())
+        );
+    }
+
+    #[test]
+    fn extract_bclconvert_empty_input() {
+        // Underflow guard: empty input has no `:` so the rposition
+        // returns None at step 1; never reaches the underflow check.
+        assert_eq!(extract_bclconvert(b""), None);
+    }
+
+    #[test]
+    fn extract_bclconvert_sub_6_bytes_before_i7_colon() {
+        // i7_colon = position of last ':' = 2 (in "ab:CD"), but
+        // i7_colon < 6 so the underflow guard returns None.
+        assert_eq!(extract_bclconvert(b"ab:CD"), None);
+    }
+
+    #[test]
+    fn extract_bclconvert_single_char_umi() {
+        // Minimum-length UMI (1 byte). Locks the `> 0` (not `>= 2`)
+        // boundary mutation slot.
+        assert_eq!(extract_bclconvert(b"x:C_1:N:0:NNNN"), Some(b"C".as_slice()));
+    }
+
+    #[test]
+    fn extract_bclconvert_single_char_i7() {
+        // Minimum-length i7 (1 byte). Mirror of the single-char-UMI
+        // boundary test.
+        assert_eq!(
+            extract_bclconvert(b"x:CAGCACTT_1:N:0:N"),
+            Some(b"CAGCACTT".as_slice())
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase A of the v1.2 UMI/RRBS epic. Adds zero-copy UMI extractor helpers to \`bismark-io\` for the two Perl \`deduplicate_bismark\` formats. Pure additive bump: \`bismark-io 1.0.0-beta.3 → 1.0.0-beta.4\`. No bismark-dedup source code changes (Cargo.toml pin bumped for workspace compile).

**Plan:** \`~/.claude/plans/05252026_bismark-dedup-umi-v1.2/phaseA-bismark-io-umi-extractors/PLAN.md\` rev 2 (dual-reviewed; both reviewers APPROVE-WITH-NITS; all 12 nits applied to rev 2).

## What lands

- **\`bismark_io::umi::extract_barcode(&[u8]) -> Option<&[u8]>\`** — tail-of-qname UMI per Perl regex \`:([\\w\\+]+)\$\` (\`deduplicate_bismark:659\`).
- **\`bismark_io::umi::extract_bclconvert(&[u8]) -> Option<&[u8]>\`** — internal-position UMI per Perl regex \`:([CAGTN\\+]+)_\\d:N:\\d:([CAGTN\\+]+)\$\` (\`deduplicate_bismark:650\`).
- Both: zero-copy (\`Option<&[u8]>\` borrowed from input), no \`regex\` dependency added, ~100 ns per call on a 100-byte qname.
- 29 unit tests (12 + 17) covering Perl-docs examples, post-Bismark-\`fix_IDs\` format, edge cases (empty input, no-colon, invalid chars, dual-UMI \`+\`, single-char UMI/i7, underflow guard), and the \`:UMI/1\` failure mode from Phase 0 debugging.
- 2 doc tests (one per function).

## Workspace test counts

- bismark-io lib tests: 109 → **138** (+29 umi unit tests)
- bismark-io doc tests: 1 → **3** (+2 umi doc tests)
- Workspace total: ~228 → **~259**, 5 ignored (unchanged)

## Cargo

- \`bismark-io\` \`1.0.0-beta.3\` → \`1.0.0-beta.4\`
- \`bismark-dedup\`'s path-dep pin \`=1.0.0-beta.3\` → \`=1.0.0-beta.4\` (pin only; no source changes; Phase B will bump bismark-dedup crate version to \`1.2.0-beta.1\` when it wires up DedupKey + pipeline + CLI flags).

## Phase context

- **Phase A (this PR)** — bismark-io UMI extractors. Pure-Rust, dependency-free of Phase 0 (the oxy data-prep run).
- **Phase B (next)** — bismark-dedup UMI-aware DedupKey + pipeline + CLI flag wiring. Blocks on this PR merging.
- **Phase C** — real-data byte-identity gate on oxy.
- **Phase D** — polish + (optional) publish.

## Test plan

- [x] 29 unit tests in \`umi::tests\` pass
- [x] 2 doc tests pass
- [x] All existing workspace tests still pass (zero regressions)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [ ] Dual code-review (will launch after PR opens)
- [ ] plan-manager coverage audit