### PR TITLE
feat(bismark-dedup): Phase B — UMI/RRBS dedup mode (v1.2.0-beta.1)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bismark-dedup"
-version = "1.1.0-beta.2"
+version = "1.2.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -108,13 +108,14 @@ dependencies = [
  "noodles-sam",
  "predicates",
  "rustc-hash",
+ "smallvec",
  "tempfile",
  "thiserror",
 ]
 
 [[package]]
 name = "bismark-io"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "bstr",
  "noodles-bam",
@@ -125,6 +126,7 @@ dependencies = [
  "noodles-fasta",
  "noodles-sam",
  "proptest",
+ "smallvec",
  "tempfile",
  "thiserror",
 ]
@@ -903,6 +905,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "strsim"

--- a/rust/bismark-dedup/CHANGELOG.md
+++ b/rust/bismark-dedup/CHANGELOG.md
@@ -4,6 +4,78 @@ All notable changes to `bismark-dedup` will be documented in this file.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0-beta.1] — 2026-05-25
+
+**UMI/RRBS dedup mode** (`--barcode` / `--umi` / `--bclconvert`)
+arrives. Phase B of the v1.2 UMI epic. Position-only dedup workflows
+(v1.0/v1.1) are byte-for-byte unchanged; UMI workflows engage the new
+`UmiDedupKey` + `UmiDedupState` types.
+
+### Added
+
+- CLI flags `--barcode` / `--umi` / `--bclconvert` are now real (no
+  longer return `UnsupportedFlagV1`). They engage UMI-aware dedup
+  byte-for-byte against Perl `deduplicate_bismark v0.25.1`'s
+  `deduplicate_barcoded_rrbs` codepath.
+- `UmiMode` enum (`Barcode`, `Bclconvert`) on `ResolvedConfig::umi_mode`.
+  Both flags set → `Bclconvert` wins (matches Perl's
+  `$rrbs = 1` auto-coupling at `deduplicate_bismark:1377`).
+- `UmiDedupKey` — `(strand, chr_id, start, end, umi)`. UMI storage via
+  `SmallVec<[u8; 16]>`: stack-allocated for ≤16-byte UMIs, heap
+  fallback for longer (e.g. 17-byte dual-UMI). Compile-time
+  `const _: () = assert!(size_of::<UmiDedupKey>() <= 64)` guards
+  inline-key memory growth. **Measured: `size_of::<UmiDedupKey>() = 48`
+  bytes** on aarch64-apple-darwin (4-byte fields + SmallVec header +
+  16-byte inline buffer + alignment padding). Plan §11 V3.5 satisfied.
+- `UmiDedupState` — sibling of `DedupState` with `observe()` / `count()`
+  / `removed()` / `n_positions()` / `into_report()` semantics matching
+  the position-only path 1-to-1. Reports carry the `(UMI mode)` banner
+  suffix at Perl `deduplicate_bismark:908` byte-precision.
+- Pipeline sibling functions: `pipeline::run_single_umi`,
+  `pipeline::run_multiple_umi`, `pipeline::run_single_parallel_umi`,
+  `pipeline::run_multiple_parallel_umi`. **API-evolution decision**:
+  no signature changes to v1.1's `run_*` functions; external callers
+  continue to compile against v1.2 unchanged.
+- Error variant `UmiExtractionFailed { flag, qname }` — emitted at the
+  first record whose qname does not match the chosen UMI extractor's
+  pattern. Matches Perl `deduplicate_bismark:662-663`.
+- Startup STDERR banner `\nProcessing paired-end Bismark output
+  file(s) (UMI-mode)\n` when UMI mode is engaged (hyphen-form, matches
+  Perl `deduplicate_bismark:903`). Report-file banner uses the
+  space-form `(UMI mode)` at line 908.
+- 7 new integration tests on the 10K CI fixtures (`tests/data/`)
+  committed in Phase 0-bis: byte-identity vs Perl on both
+  `synth_barcode_10k` and `synth_bclconvert_10k`, the
+  position-only-vs-UMI-mode diagnostic property,
+  `--parallel 4` × UMI byte-identity vs `--parallel 1`,
+  `--bclconvert + --barcode` precedence, `--multiple` UMI accumulation,
+  and `UmiExtractionFailed` end-to-end.
+- 9 new unit tests for `UmiDedupKey` / `UmiDedupState` /
+  `DedupReport::format` UMI banner / dual-UMI heap-fallback /
+  `Cli::validate` UMI-mode resolution.
+
+### Changed
+
+- `bismark-io` pinned to `=1.0.0-beta.5` (UMI plumbing on `BismarkRecord`).
+- `DedupReport::new()` gains a trailing `umi_mode: bool` parameter
+  (crate-private — only `*DedupState::into_report()` constructs reports).
+- `--barcode` / `--bclconvert` removed from the `UnsupportedFlagV1`
+  rejection list. The variant remains in the error enum for any future
+  deferral need.
+
+### Known limitations (deferred)
+
+- **No bcl-convert auto-detect.** v1.2 trusts the user's UMI flag
+  choice. Running `--barcode` on bcl-convert qnames silently extracts
+  the wrong tail (the i7 tail, not the UMI) and produces nonsense
+  dedup keys. Match the flag to your data. v1.3 plans a
+  sniff-first-record auto-detect equivalent to Perl's
+  `test_readIDs_for_bclconvert` at `deduplicate_bismark:164`.
+
+### Dependencies
+
+- New: `smallvec = "=1.13.2"`. Matches `bismark-io`'s pin.
+
 ## [1.1.0-beta.2] — 2026-05-25
 
 Inherits **magic-byte file-format detection** from `bismark-io`

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-dedup"
-version = "1.1.0-beta.2"
+version = "1.2.0-beta.1"
 description = "Rust port of Bismark Perl's deduplicate_bismark script"
 edition.workspace = true
 rust-version.workspace = true
@@ -19,7 +19,7 @@ name = "deduplicate_bismark_rs"
 path = "src/main.rs"
 
 [dependencies]
-bismark-io = { version = "=1.0.0-beta.4", path = "../bismark-io" }
+bismark-io = { version = "=1.0.0-beta.5", path = "../bismark-io" }
 # noodles-sam pinned to match bismark-io =1.0.0's transitive choice.
 # Needed directly for `Header` (returned by `bismark_io::open_reader`
 # via `AnyReader::header`) and for test-helper types.
@@ -29,6 +29,9 @@ rustc-hash = "=2.1.0"
 thiserror = "=2.0.0"
 anyhow = "=1.0.86"
 bstr = "=1.10.0"
+# Phase B (v1.2 UMI epic): UmiDedupKey carries the per-record UMI as a
+# stack-allocated SmallVec for ≤16-byte UMIs. Matches bismark-io's pin.
+smallvec = "=1.13.2"
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"

--- a/rust/bismark-dedup/README.md
+++ b/rust/bismark-dedup/README.md
@@ -83,8 +83,8 @@ single-threaded path is preserved.
 | `-o`, `--outfile <NAME>` | Custom output basename (path prefix stripped per Perl regex chain) |
 | `--output_dir <DIR>` | Output directory (created if missing) |
 | `--multiple` | Treat all positional inputs as one combined sample |
-| `--barcode`, `--umi` | **Not in v1.0** — errors with v1.1 deferral message |
-| `--bclconvert` | **Not in v1.0** — errors with v1.1 deferral message |
+| `--barcode`, `--umi` | **v1.2+**: engages UMI-aware dedup. UMI is the tail-of-qname token after the last `:` (Perl `deduplicate_bismark:659`). **Warning**: do NOT pass this on bcl-convert reads — pass `--bclconvert` instead. v1.3 will add auto-detect. |
+| `--bclconvert` | **v1.2+**: engages UMI-aware dedup with bcl-convert internal UMI format (Perl `deduplicate_bismark:650`). Wins over `--barcode/--umi` if both flags are set. |
 | `--parallel <N>` | v1.1: parallel BGZF (de)compression workers for BAM I/O (`N ≥ 1`). CRAM falls back to single-threaded with a warning. `N > 4` emits a soft "diminishing returns" warning — measured saturation at N=4 on 10M PE WGBS. |
 | `--samtools_path <PATH>` | Accepted for compat, silently ignored (`bismark-dedup` is pure-Rust) |
 | `--representative` | Errors with Perl-verbatim joke (deprecated upstream) |
@@ -131,8 +131,8 @@ single-threaded path, not merely byte-identical to itself.
 
 ## Out of scope (still deferred)
 
-- **UMI / RRBS mode** (`--barcode`, `--umi`, `--bclconvert`) — use Bismark Perl `deduplicate_bismark` for these workflows. Scheduled for a later v1.x.
-- **CRAM parallelism** — `--parallel N` is BAM-only in v1.1; CRAM input or output falls back to single-threaded with a warning.
+- **bcl-convert auto-detect** — v1.2 trusts the user's `--barcode` / `--bclconvert` choice. Running `--barcode` on bcl-convert qnames silently extracts the wrong tail (the i7 tail, not the UMI). Match the flag to your data. v1.3 plans a sniff-first-record auto-detect equivalent to Perl's `test_readIDs_for_bclconvert` (`deduplicate_bismark:164`).
+- **CRAM parallelism** — `--parallel N` is BAM-only in v1.1/v1.2; CRAM input or output falls back to single-threaded with a warning.
 - **Sorted-input auto-handling** — coordinate-sorted PE input is rejected with a clear "re-sort with `samtools sort -n` first" error message rather than auto-sorting.
 
 ## Using as a library in other tools

--- a/rust/bismark-dedup/src/cli.rs
+++ b/rust/bismark-dedup/src/cli.rs
@@ -4,12 +4,24 @@
 //! parsed arguments into a [`ResolvedConfig`] and rejects unsupported /
 //! conflicting flag combinations:
 //!
-//! - `--barcode` / `--bclconvert` → [`BismarkDedupError::UnsupportedFlagV1`]
-//!   (v1.1 will add these).
+//! - `--barcode` / `--umi` → engages UMI-aware dedup (v1.2+; tail-of-qname
+//!   format).
+//! - `--bclconvert` → engages UMI-aware dedup with bcl-convert internal
+//!   UMI format. Implies `--barcode` semantically (matches Perl's
+//!   `$rrbs = 1` auto-coupling at deduplicate_bismark:1377).
 //! - `--representative` → [`BismarkDedupError::RepresentativeRemoved`]
 //!   (Bismark deprecated this upstream).
 //! - `--outfile` with multiple positional inputs but no `--multiple` →
 //!   [`BismarkDedupError::OutfileWithMultipleInputs`].
+//!
+//! ## UMI mode caveat
+//!
+//! `bismark-dedup` v1.2 trusts the user's UMI flag choice — it does NOT
+//! auto-detect qname format. Running `--barcode` on bcl-convert qnames
+//! silently extracts the wrong tail (the i7 tail, not the UMI),
+//! producing nonsense dedup keys. Match the flag to your data: if your
+//! reads come from bcl-convert, you MUST pass `--bclconvert`. (v1.3
+//! plans a sniff-first-record auto-detect; tracked.)
 //!
 //! Flags accepted for Perl compatibility but ignored:
 //! - `--parallel <N>` (silently — Perl is also silent on this flag).
@@ -70,13 +82,21 @@ pub struct Cli {
     #[arg(long = "multiple")]
     pub multiple: bool,
 
-    /// **Not supported in v1.0** — use the Perl `deduplicate_bismark` for
-    /// UMI/RRBS mode.
+    /// UMI/RRBS dedup mode: the UMI is the tail-of-qname token after the
+    /// last `:`, e.g. `MISEQ:...:CTCCTTAG` (8-mer ACGT). New in v1.2;
+    /// matches Perl `deduplicate_bismark --barcode` (line 659).
+    ///
+    /// **Warning**: this trusts the user's flag — running `--barcode` on
+    /// bcl-convert qnames silently extracts the i7 tail, NOT the UMI. If
+    /// your reads come from bcl-convert, pass `--bclconvert` instead.
     #[arg(long = "barcode", visible_alias = "umi")]
     pub barcode: bool,
 
-    /// **Not supported in v1.0** — use the Perl `deduplicate_bismark` for
-    /// bcl-convert-style internal UMIs.
+    /// bcl-convert UMI dedup mode: the UMI is at an internal position in
+    /// the qname, e.g. `A00001:...:CAAGAG_1:N:0:AATGACGC`. New in v1.2;
+    /// matches Perl `deduplicate_bismark --bclconvert` (line 650).
+    /// Engages UMI mode unconditionally (the Rust port does NOT have the
+    /// v0.25.1 released-Perl `--bclconvert`-alone-falls-through bug).
     #[arg(long = "bclconvert")]
     pub bclconvert: bool,
 
@@ -105,6 +125,20 @@ pub struct Cli {
     pub version: bool,
 }
 
+/// UMI dedup mode selected at the CLI. New in v1.2 for the v1.2 UMI/RRBS
+/// epic. `None` (in the `umi_mode` field) = position-only dedup
+/// (the v1.0/v1.1 default).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UmiMode {
+    /// `--barcode` / `--umi`: UMI is the tail-of-qname token after the
+    /// last `:`. Bismark-io extractor: [`bismark_io::umi::extract_barcode`].
+    Barcode,
+    /// `--bclconvert`: UMI is at an internal position in the qname.
+    /// Bismark-io extractor: [`bismark_io::umi::extract_bclconvert`].
+    /// Wins over `--barcode` if both flags are passed.
+    Bclconvert,
+}
+
 /// The resolved, validated subset of CLI arguments passed to the
 /// pipeline. Constructed by [`Cli::validate`].
 #[derive(Debug, Clone)]
@@ -131,6 +165,9 @@ pub struct ResolvedConfig {
     /// container decode isn't BGZF-based; v1.1 falls back to
     /// single-threaded + emits a one-line stderr warning).
     pub parallel: usize,
+    /// UMI dedup mode (v1.2+). `None` = position-only (v1.0/v1.1
+    /// behaviour, no behaviour change for non-UMI callers).
+    pub umi_mode: Option<UmiMode>,
 }
 
 impl Cli {
@@ -139,12 +176,16 @@ impl Cli {
     ///
     /// Reject (in priority order):
     /// 1. `--representative` → [`BismarkDedupError::RepresentativeRemoved`]
-    /// 2. `--barcode` / `--bclconvert` → [`BismarkDedupError::UnsupportedFlagV1`]
-    /// 3. `--parallel 0` → [`BismarkDedupError::InvalidParallelValue`]
+    /// 2. `--parallel 0` → [`BismarkDedupError::InvalidParallelValue`]
     ///    (clap's `u32` parser accepts 0; explicit check needed here)
-    /// 4. Empty `files` → [`BismarkDedupError::NoInputFiles`]
-    /// 5. `--outfile` with `>1` files and no `--multiple` →
+    /// 3. Empty `files` → [`BismarkDedupError::NoInputFiles`]
+    /// 4. `--outfile` with `>1` files and no `--multiple` →
     ///    [`BismarkDedupError::OutfileWithMultipleInputs`]
+    ///
+    /// `--barcode` / `--umi` / `--bclconvert` are accepted in v1.2+ and
+    /// engage UMI-aware dedup. If both `--barcode` and `--bclconvert` are
+    /// set, `--bclconvert` wins (matches Perl's precedence at
+    /// `deduplicate_bismark:1377`).
     ///
     /// `--single` / `--paired` are mutually exclusive (enforced by clap
     /// at parse time via `conflicts_with`). Neither set → `explicit_mode = None`
@@ -152,12 +193,6 @@ impl Cli {
     pub fn validate(self) -> Result<ResolvedConfig, BismarkDedupError> {
         if self.representative {
             return Err(BismarkDedupError::RepresentativeRemoved);
-        }
-        if self.barcode {
-            return Err(BismarkDedupError::UnsupportedFlagV1 { flag: "barcode" });
-        }
-        if self.bclconvert {
-            return Err(BismarkDedupError::UnsupportedFlagV1 { flag: "bclconvert" });
         }
         if self.parallel == 0 {
             return Err(BismarkDedupError::InvalidParallelValue { value: 0 });
@@ -170,6 +205,17 @@ impl Cli {
                 n_files: self.files.len(),
             });
         }
+
+        // Resolve UMI mode (Phase B of v1.2 UMI epic):
+        //   --bclconvert wins over --barcode if both are set (matches
+        //   Perl's auto-coupling at deduplicate_bismark:1377).
+        let umi_mode = if self.bclconvert {
+            Some(UmiMode::Bclconvert)
+        } else if self.barcode {
+            Some(UmiMode::Barcode)
+        } else {
+            None
+        };
 
         let explicit_mode = match (self.single, self.paired) {
             (true, false) => Some(false),
@@ -193,6 +239,7 @@ impl Cli {
             output_dir: self.output_dir,
             multiple: self.multiple,
             parallel: self.parallel as usize,
+            umi_mode,
         })
     }
 }
@@ -248,35 +295,45 @@ mod tests {
         assert!(matches!(err, BismarkDedupError::RepresentativeRemoved));
     }
 
+    // ─── Phase B (v1.2): --barcode / --umi / --bclconvert now resolve to
+    // UmiMode rather than rejecting with UnsupportedFlagV1.
+
     #[test]
-    fn validate_rejects_barcode_with_v1_deferral() {
+    fn validate_barcode_resolves_to_umi_mode_barcode() {
         let cli = parse(&["--barcode", "sample.bam"]).unwrap();
-        let err = cli.validate().unwrap_err();
-        assert!(matches!(
-            err,
-            BismarkDedupError::UnsupportedFlagV1 { flag: "barcode" }
-        ));
+        let config = cli.validate().unwrap();
+        assert_eq!(config.umi_mode, Some(UmiMode::Barcode));
     }
 
     #[test]
-    fn validate_rejects_umi_alias_with_v1_deferral() {
+    fn validate_umi_alias_resolves_to_umi_mode_barcode() {
         // --umi is a visible_alias for --barcode.
         let cli = parse(&["--umi", "sample.bam"]).unwrap();
-        let err = cli.validate().unwrap_err();
-        assert!(matches!(
-            err,
-            BismarkDedupError::UnsupportedFlagV1 { flag: "barcode" }
-        ));
+        let config = cli.validate().unwrap();
+        assert_eq!(config.umi_mode, Some(UmiMode::Barcode));
     }
 
     #[test]
-    fn validate_rejects_bclconvert_with_v1_deferral() {
+    fn validate_bclconvert_resolves_to_umi_mode_bclconvert() {
         let cli = parse(&["--bclconvert", "sample.bam"]).unwrap();
-        let err = cli.validate().unwrap_err();
-        assert!(matches!(
-            err,
-            BismarkDedupError::UnsupportedFlagV1 { flag: "bclconvert" }
-        ));
+        let config = cli.validate().unwrap();
+        assert_eq!(config.umi_mode, Some(UmiMode::Bclconvert));
+    }
+
+    #[test]
+    fn validate_bclconvert_plus_barcode_bclconvert_wins() {
+        // Both flags set → bclconvert wins (matches Perl's auto-coupling
+        // precedence at deduplicate_bismark:1377).
+        let cli = parse(&["--bclconvert", "--barcode", "sample.bam"]).unwrap();
+        let config = cli.validate().unwrap();
+        assert_eq!(config.umi_mode, Some(UmiMode::Bclconvert));
+    }
+
+    #[test]
+    fn validate_no_umi_flag_yields_none() {
+        let cli = parse(&["sample.bam"]).unwrap();
+        let config = cli.validate().unwrap();
+        assert_eq!(config.umi_mode, None);
     }
 
     #[test]

--- a/rust/bismark-dedup/src/dedup.rs
+++ b/rust/bismark-dedup/src/dedup.rs
@@ -22,6 +22,7 @@
 
 use bismark_io::BismarkStrand;
 use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
 
 use crate::report::DedupReport;
 
@@ -176,6 +177,173 @@ impl DedupState {
             self.count,
             self.removed,
             self.duplicate_positions.len(),
+            false, // non-UMI mode
+        )
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Phase B (v1.2 UMI epic): UMI-aware dedup key + state.
+//
+// UmiDedupKey is the UMI-mode sibling of DedupKey. The position-only
+// dedup path (DedupKey + DedupState above) is unchanged — non-UMI
+// workflows continue to use 16-byte keys with the existing
+// compile-time-asserted layout. UMI workflows use the wider UmiDedupKey
+// below. The pipeline picks the appropriate state container based on
+// CLI `--barcode` / `--bclconvert` flags.
+//
+// See PLAN.md Phase B §3.2-3.3 for the two-HashSets rationale.
+// ────────────────────────────────────────────────────────────────────────
+
+/// UMI-aware dedup key — `(strand, chr_id, start, end, umi)`.
+///
+/// Mirrors Perl `deduplicate_bismark`'s `deduplicate_barcoded_rrbs` key
+/// formula: position + UMI bytes. Two records at the same position with
+/// different UMIs are distinct (correct UMI extraction prevents
+/// over-dedup of independent template molecules that happened to land
+/// at the same chromosome coordinates).
+///
+/// UMI storage uses [`SmallVec<[u8; 16]>`] — stack-allocated for ≤16-byte
+/// UMIs (all known Bismark workflows; covers single 8-mer ACGT, 6-mer,
+/// 10-mer, and 8+8-mer dual-UMI without the `+`) with transparent heap
+/// fallback for longer UMIs (e.g. dual-UMI `XXXXXXXX+YYYYYYYY` at 17
+/// bytes).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UmiDedupKey {
+    /// Bismark strand classification. Same semantics as [`DedupKey::strand`].
+    pub strand: BismarkStrand,
+    /// Chromosome interned index. Same semantics as [`DedupKey::chr_id`].
+    pub chr_id: u32,
+    /// 1-based start position. Same semantics as [`DedupKey::start`].
+    pub start: u32,
+    /// 1-based inclusive end position. Same semantics as [`DedupKey::end`].
+    pub end: u32,
+    /// Extracted UMI bytes (from qname via the user-selected extractor).
+    /// Never empty for records that survive the dedup pipeline's UMI
+    /// extraction step — empty UMIs are caught upstream as
+    /// `UmiExtractionFailed`.
+    pub umi: SmallVec<[u8; 16]>,
+}
+
+// Cap UmiDedupKey at 64 bytes inline. Reviewer B flagged a 24-vs-32 disagreement
+// on the SmallVec size; this assertion lets the compiler enforce the
+// upper bound. If it ever fires, the size_of has crept past expectations
+// and the storage strategy needs revisiting.
+const _: () = {
+    assert!(
+        std::mem::size_of::<UmiDedupKey>() <= 64,
+        "UmiDedupKey grew past 64 bytes — review the SmallVec inline capacity \
+         and per-key memory budget in PLAN §8 before relaxing this bound",
+    );
+};
+
+impl UmiDedupKey {
+    /// Construct an SE UMI key (mirrors [`DedupKey::se`]).
+    #[must_use]
+    pub fn se(strand: BismarkStrand, chr_id: u32, key_pos: u32, umi: SmallVec<[u8; 16]>) -> Self {
+        Self {
+            strand,
+            chr_id,
+            start: key_pos,
+            end: key_pos,
+            umi,
+        }
+    }
+
+    /// Construct a PE UMI key (mirrors [`DedupKey::pe`]).
+    #[must_use]
+    pub fn pe(
+        strand: BismarkStrand,
+        chr_id: u32,
+        start: u32,
+        end: u32,
+        umi: SmallVec<[u8; 16]>,
+    ) -> Self {
+        Self {
+            strand,
+            chr_id,
+            start,
+            end,
+            umi,
+        }
+    }
+}
+
+/// UMI-aware dedup state — sibling of [`DedupState`] for UMI mode.
+///
+/// Same `observe()` semantics: returns `true` for unique records (caller
+/// should emit), `false` for duplicates. Same report shape via
+/// [`UmiDedupState::into_report`] — the only difference vs the
+/// position-only path is the `(UMI mode)` banner suffix in the report.
+#[derive(Debug, Default)]
+pub struct UmiDedupState {
+    seen: FxHashSet<UmiDedupKey>,
+    duplicate_positions: FxHashSet<UmiDedupKey>,
+    count: u64,
+    removed: u64,
+}
+
+impl UmiDedupState {
+    /// Construct an empty UMI dedup state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pre-allocate the seen-set to `capacity` records.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            seen: FxHashSet::with_capacity_and_hasher(capacity, Default::default()),
+            duplicate_positions: FxHashSet::default(),
+            count: 0,
+            removed: 0,
+        }
+    }
+
+    /// Observe one record's UMI dedup key. Returns `true` if unique (caller
+    /// should emit), `false` if duplicate. Same Perl-`%unique_seqs` +
+    /// `%positions` semantics as [`DedupState::observe`].
+    pub fn observe(&mut self, key: UmiDedupKey) -> bool {
+        self.count += 1;
+        if self.seen.insert(key.clone()) {
+            true
+        } else {
+            self.removed += 1;
+            self.duplicate_positions.insert(key);
+            false
+        }
+    }
+
+    /// Total alignment records / pairs observed so far.
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Number of records flagged as duplicates so far.
+    #[must_use]
+    pub fn removed(&self) -> u64 {
+        self.removed
+    }
+
+    /// Number of distinct positions (UMI-aware) at which at least one
+    /// duplicate was seen.
+    #[must_use]
+    pub fn n_positions(&self) -> usize {
+        self.duplicate_positions.len()
+    }
+
+    /// Consume into a [`DedupReport`] with `umi_mode = true` (emits the
+    /// `(UMI mode)` banner suffix per `deduplicate_bismark:908`).
+    #[must_use]
+    pub fn into_report(self, file_label: String) -> DedupReport {
+        DedupReport::new(
+            file_label,
+            self.count,
+            self.removed,
+            self.duplicate_positions.len(),
+            true,
         )
     }
 }
@@ -294,5 +462,106 @@ mod tests {
         assert_eq!(key.start, 100);
         assert_eq!(key.end, 250);
         assert_eq!(key.strand, BismarkStrand::CTOT);
+    }
+
+    // ─── Phase B (v1.2 UMI epic): UmiDedupKey / UmiDedupState tests ────
+
+    fn umi(bytes: &[u8]) -> SmallVec<[u8; 16]> {
+        SmallVec::from_slice(bytes)
+    }
+
+    #[test]
+    fn umi_dedup_key_same_position_different_umi_are_distinct() {
+        // Two records at the same (strand, chr, start, end) but with
+        // different UMIs MUST be treated as unique by the seen-set. This
+        // is the entire point of UMI mode — independent template
+        // molecules that happen to land at the same coordinates should
+        // not collapse to one.
+        let mut state = UmiDedupState::new();
+        let k1 = UmiDedupKey::pe(BismarkStrand::OT, 0, 100, 200, umi(b"AAAAAAAA"));
+        let k2 = UmiDedupKey::pe(BismarkStrand::OT, 0, 100, 200, umi(b"TTTTTTTT"));
+        assert!(state.observe(k1));
+        assert!(state.observe(k2));
+        assert_eq!(state.count(), 2);
+        assert_eq!(state.removed(), 0, "different UMIs → not duplicates");
+    }
+
+    #[test]
+    fn umi_dedup_key_same_position_same_umi_is_duplicate() {
+        let mut state = UmiDedupState::new();
+        let k1 = UmiDedupKey::pe(BismarkStrand::OT, 0, 100, 200, umi(b"AAAAAAAA"));
+        let k2 = UmiDedupKey::pe(BismarkStrand::OT, 0, 100, 200, umi(b"AAAAAAAA"));
+        assert!(state.observe(k1));
+        assert!(
+            !state.observe(k2),
+            "identical UMIs at same position → duplicate"
+        );
+        assert_eq!(state.count(), 2);
+        assert_eq!(state.removed(), 1);
+        assert_eq!(state.n_positions(), 1);
+    }
+
+    #[test]
+    fn umi_dedup_state_reports_with_umi_mode_banner() {
+        // UmiDedupState::into_report() must set the umi_mode flag so the
+        // report's banner gets the `(UMI mode)` suffix (matches Perl
+        // line 908).
+        let mut state = UmiDedupState::new();
+        state.observe(UmiDedupKey::pe(
+            BismarkStrand::OT,
+            0,
+            100,
+            200,
+            umi(b"AAAAAAAA"),
+        ));
+        let report = state.into_report("/path/sample.bam".to_string());
+        let formatted = report.format();
+        assert!(
+            formatted.contains("(UMI mode):"),
+            "report must contain `(UMI mode)` banner, got: {formatted:?}"
+        );
+    }
+
+    #[test]
+    fn umi_dedup_key_dual_umi_with_plus_uses_heap_path_correctly() {
+        // Dual-UMI `XXXXXXXX+YYYYYYYY` is 17 bytes — exceeds the
+        // SmallVec inline capacity. The heap fallback must still hash +
+        // compare correctly.
+        let dual_umi: SmallVec<[u8; 16]> = SmallVec::from_slice(b"AAAAAAAA+TTTTTTTT");
+        assert_eq!(dual_umi.len(), 17);
+        assert!(dual_umi.spilled(), "17-byte UMI must spill to heap");
+        let mut state = UmiDedupState::new();
+        let k1 = UmiDedupKey::pe(BismarkStrand::OT, 0, 100, 200, dual_umi.clone());
+        let k2 = UmiDedupKey::pe(BismarkStrand::OT, 0, 100, 200, dual_umi);
+        assert!(state.observe(k1));
+        assert!(!state.observe(k2), "same dual-UMI must be a duplicate");
+    }
+
+    #[test]
+    fn umi_dedup_key_size_under_64_bytes() {
+        // The compile-time `const _` assertion guarantees this at build
+        // time. The runtime check below mostly documents the actual size
+        // for the CHANGELOG note.
+        let actual = std::mem::size_of::<UmiDedupKey>();
+        assert!(
+            actual <= 64,
+            "UmiDedupKey size {actual} > 64; the const-assert should have caught this"
+        );
+    }
+
+    #[test]
+    fn umi_dedup_state_empty_zero_counters() {
+        let state = UmiDedupState::new();
+        assert_eq!(state.count(), 0);
+        assert_eq!(state.removed(), 0);
+        assert_eq!(state.n_positions(), 0);
+    }
+
+    #[test]
+    fn umi_se_constructor_sets_end_equal_to_start() {
+        let key = UmiDedupKey::se(BismarkStrand::OT, 5, 42, umi(b"BARCODE"));
+        assert_eq!(key.start, 42);
+        assert_eq!(key.end, 42);
+        assert_eq!(key.umi.as_slice(), b"BARCODE");
     }
 }

--- a/rust/bismark-dedup/src/error.rs
+++ b/rust/bismark-dedup/src/error.rs
@@ -30,16 +30,6 @@ pub enum BismarkDedupError {
         qname: String,
     },
 
-    /// CLI flag deferred to v1.1; v1.0 stub for explicit error rather than
-    /// silent acceptance.
-    #[error(
-        "--{flag} is not supported in bismark-dedup v1.0; use the Perl `deduplicate_bismark` for this mode"
-    )]
-    UnsupportedFlagV1 {
-        /// Name of the flag (e.g. `"barcode"`, `"bclconvert"`).
-        flag: &'static str,
-    },
-
     /// `--outfile` specified with multiple positional inputs but no
     /// `--multiple` flag.
     #[error("--outfile requires a single input file unless --multiple is set (got {n_files})")]
@@ -138,6 +128,24 @@ pub enum BismarkDedupError {
     /// the report file).
     #[error("std I/O: {0}")]
     StdIo(#[from] std::io::Error),
+
+    /// UMI mode (`--barcode` / `--umi` / `--bclconvert`) was requested but a
+    /// record's qname did not match the extractor's pattern.
+    ///
+    /// Mirrors Perl `deduplicate_bismark`'s "Failed to extract a barcode
+    /// from the read ID" error at line 662-663. Errors at the first
+    /// failed record; no partial output left on disk.
+    #[error(
+        "--{flag} mode requires UMI in qname; failed to extract from qname={qname:?}. \
+         Check that the input was generated with the matching UMI flag — see `--help` \
+         for which qname format each flag expects."
+    )]
+    UmiExtractionFailed {
+        /// CLI flag name driving extraction: `"barcode"` or `"bclconvert"`.
+        flag: &'static str,
+        /// The offending qname (lossy UTF-8).
+        qname: String,
+    },
 }
 
 #[cfg(test)]

--- a/rust/bismark-dedup/src/lib.rs
+++ b/rust/bismark-dedup/src/lib.rs
@@ -39,7 +39,8 @@ pub mod filename;
 pub mod pipeline;
 pub mod report;
 
-pub use dedup::{DedupKey, DedupState};
+pub use cli::UmiMode;
+pub use dedup::{DedupKey, DedupState, UmiDedupKey, UmiDedupState};
 pub use error::BismarkDedupError;
 pub use report::DedupReport;
 

--- a/rust/bismark-dedup/src/main.rs
+++ b/rust/bismark-dedup/src/main.rs
@@ -51,6 +51,23 @@ fn run(cli: Cli) -> Result<(), BismarkDedupError> {
         std::fs::create_dir_all(&config.output_dir)?;
     }
 
+    // Phase B (v1.2): UMI-mode startup banner. Two distinct strings in
+    // Perl `deduplicate_bismark`:
+    //   line 167: warn "Deduplicating data in UMI mode\n";
+    //   line 172: warn "Deduplicating data in bcl-convert UMI mode\n";
+    // Perl picks based on `test_readIDs_for_bclconvert` auto-detect; the
+    // Rust port skips that (deferred to v1.3) and uses the user's flag.
+    // No leading `\n` — Perl's `warn` writes the string verbatim.
+    match config.umi_mode {
+        Some(bismark_dedup::cli::UmiMode::Barcode) => {
+            eprintln!("Deduplicating data in UMI mode");
+        }
+        Some(bismark_dedup::cli::UmiMode::Bclconvert) => {
+            eprintln!("Deduplicating data in bcl-convert UMI mode");
+        }
+        None => {}
+    }
+
     // Soft warning for --parallel values past the measured saturation
     // point. The Phase D oxy benchmark on 10M PE WGBS showed N=8 gave
     // zero additional speedup over N=4 (both at ~4.88× vs N=1) — the
@@ -102,22 +119,39 @@ fn process_one(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkDedup
         );
     }
 
-    let report = if use_parallel {
-        let parallel =
-            std::num::NonZero::new(config.parallel).expect("Cli::validate rejects parallel == 0");
-        eprintln!("BGZF threading: {} worker(s) per reader/writer", parallel);
-        pipeline::run_single_parallel(input, &out_path, is_paired, file_label, parallel)?
-    } else {
-        pipeline::run_single(
+    let report = match (use_parallel, config.umi_mode) {
+        (true, Some(umi_mode)) => {
+            let parallel = std::num::NonZero::new(config.parallel)
+                .expect("Cli::validate rejects parallel == 0");
+            eprintln!("BGZF threading: {} worker(s) per reader/writer", parallel);
+            pipeline::run_single_parallel_umi(
+                input, &out_path, is_paired, file_label, parallel, umi_mode,
+            )?
+        }
+        (true, None) => {
+            let parallel = std::num::NonZero::new(config.parallel)
+                .expect("Cli::validate rejects parallel == 0");
+            eprintln!("BGZF threading: {} worker(s) per reader/writer", parallel);
+            pipeline::run_single_parallel(input, &out_path, is_paired, file_label, parallel)?
+        }
+        (false, Some(umi_mode)) => pipeline::run_single_umi(
             input,
             &out_path,
             config.cram_ref.as_deref(),
             is_paired,
             file_label,
-        )?
+            umi_mode,
+        )?,
+        (false, None) => pipeline::run_single(
+            input,
+            &out_path,
+            config.cram_ref.as_deref(),
+            is_paired,
+            file_label,
+        )?,
     };
     report.write_to(&report_path)?;
-    eprintln!("{}", report.format());
+    eprintln!("{}", report.format_stderr());
     Ok(())
 }
 
@@ -158,22 +192,50 @@ fn process_multiple(config: &ResolvedConfig) -> Result<(), BismarkDedupError> {
         );
     }
 
-    let report = if use_parallel {
-        let parallel =
-            std::num::NonZero::new(config.parallel).expect("Cli::validate rejects parallel == 0");
-        eprintln!("BGZF threading: {} worker(s) per reader/writer", parallel);
-        pipeline::run_multiple_parallel(&config.files, &out_path, is_paired, file_label, parallel)?
-    } else {
-        pipeline::run_multiple(
+    let report = match (use_parallel, config.umi_mode) {
+        (true, Some(umi_mode)) => {
+            let parallel = std::num::NonZero::new(config.parallel)
+                .expect("Cli::validate rejects parallel == 0");
+            eprintln!("BGZF threading: {} worker(s) per reader/writer", parallel);
+            pipeline::run_multiple_parallel_umi(
+                &config.files,
+                &out_path,
+                is_paired,
+                file_label,
+                parallel,
+                umi_mode,
+            )?
+        }
+        (true, None) => {
+            let parallel = std::num::NonZero::new(config.parallel)
+                .expect("Cli::validate rejects parallel == 0");
+            eprintln!("BGZF threading: {} worker(s) per reader/writer", parallel);
+            pipeline::run_multiple_parallel(
+                &config.files,
+                &out_path,
+                is_paired,
+                file_label,
+                parallel,
+            )?
+        }
+        (false, Some(umi_mode)) => pipeline::run_multiple_umi(
             &config.files,
             &out_path,
             config.cram_ref.as_deref(),
             is_paired,
             file_label,
-        )?
+            umi_mode,
+        )?,
+        (false, None) => pipeline::run_multiple(
+            &config.files,
+            &out_path,
+            config.cram_ref.as_deref(),
+            is_paired,
+            file_label,
+        )?,
     };
     report.write_to(&report_path)?;
-    eprintln!("{}", report.format());
+    eprintln!("{}", report.format_stderr());
     Ok(())
 }
 

--- a/rust/bismark-dedup/src/pipeline.rs
+++ b/rust/bismark-dedup/src/pipeline.rs
@@ -32,7 +32,11 @@ use rustc_hash::FxHashMap;
 use crate::DedupKey;
 use crate::DedupReport;
 use crate::DedupState;
+use crate::UmiDedupKey;
+use crate::UmiDedupState;
+use crate::cli::UmiMode;
 use crate::error::BismarkDedupError;
+use smallvec::SmallVec;
 
 /// Concrete writer type returned by `bismark_io::open_writer`.
 type Writer = AnyWriter<BufWriter<File>, File>;
@@ -647,6 +651,496 @@ pub fn run_multiple_parallel(
 
     writer.finish()?;
     Ok(state.into_report(file_label))
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// v1.2 Phase B: UMI-aware dedup (`--barcode` / `--umi` / `--bclconvert`).
+//
+// The functions below are siblings of `compute_*_key`, `stream_*`, and
+// `run_*`. They:
+//
+// - Take an additional `umi_mode: UmiMode` parameter (or, for the
+//   per-record-key helpers, derive the UMI from `BismarkRecord::umi()`
+//   which the reader pre-extracted at parse time).
+// - Build [`UmiDedupKey`]s instead of [`DedupKey`]s.
+// - Accumulate into [`UmiDedupState`] instead of [`DedupState`].
+// - Produce reports with the `(UMI mode)` banner suffix.
+//
+// API-evolution note (PLAN §4.2): these are NEW `pub fn`s, not modified
+// signatures. External v1.1 callers that imported `run_single`,
+// `run_single_parallel`, `run_multiple`, `run_multiple_parallel`
+// continue to compile against v1.2 without source changes.
+// ──────────────────────────────────────────────────────────────────────
+
+/// On error, best-effort unlink `output` so callers don't see a partial
+/// output file. Phase B fix (code-review C1) for the
+/// `UmiExtractionFailed`-mid-stream case: the writer is opened during
+/// streaming so a record-N failure leaves a header-only BAM on disk.
+/// Plan §4.3 and `error.rs` doc-comment both promise "no partial output";
+/// this helper makes good on that.
+fn cleanup_partial_output_on_err<T>(
+    output: &Path,
+    result: Result<T, BismarkDedupError>,
+) -> Result<T, BismarkDedupError> {
+    if result.is_err() {
+        let _ = std::fs::remove_file(output);
+    }
+    result
+}
+
+/// Map a [`UmiMode`] to the corresponding [`bismark_io::umi`] extractor
+/// function. Internal: callers feed the result into reader
+/// `records_with_umi(...)` constructors.
+fn umi_extractor_for(mode: UmiMode) -> fn(&[u8]) -> Option<&[u8]> {
+    match mode {
+        UmiMode::Barcode => bismark_io::extract_barcode,
+        UmiMode::Bclconvert => bismark_io::extract_bclconvert,
+    }
+}
+
+/// Short label for the CLI flag corresponding to a UMI mode. Used to
+/// populate `UmiExtractionFailed::flag` so the error message tells the
+/// user which flag drove the failed extraction.
+fn umi_mode_flag_label(mode: UmiMode) -> &'static str {
+    match mode {
+        UmiMode::Barcode => "barcode",
+        UmiMode::Bclconvert => "bclconvert",
+    }
+}
+
+/// Borrow the record's pre-extracted UMI, or return `UmiExtractionFailed`.
+fn require_umi(
+    record: &BismarkRecord,
+    mode: UmiMode,
+) -> Result<SmallVec<[u8; 16]>, BismarkDedupError> {
+    record
+        .umi()
+        .cloned()
+        .ok_or_else(|| BismarkDedupError::UmiExtractionFailed {
+            flag: umi_mode_flag_label(mode),
+            qname: qname_lossy(record),
+        })
+}
+
+/// Compute the UMI-aware SE dedup key. Mirrors [`compute_se_key`] but
+/// adds the pre-extracted UMI to the resulting key. Errors with
+/// `UmiExtractionFailed` if the record has no UMI (faithful to Perl
+/// `deduplicate_bismark:662-663`).
+fn compute_se_umi_key(
+    record: &BismarkRecord,
+    refid_table: &[u32],
+    umi_mode: UmiMode,
+) -> Result<UmiDedupKey, BismarkDedupError> {
+    let inner = record.inner();
+    let refid =
+        inner
+            .reference_sequence_id()
+            .ok_or_else(|| BismarkDedupError::MissingReferenceId {
+                qname: qname_lossy(record),
+            })?;
+    let chr_id = *refid_table
+        .get(refid)
+        .ok_or(BismarkDedupError::MissingChrInIntern { refid })?;
+    let start = u32::try_from(record.alignment_start().ok_or_else(|| {
+        BismarkDedupError::MissingAlignmentStart {
+            qname: qname_lossy(record),
+        }
+    })?)
+    .expect("alignment_start fits in u32 per BAM spec");
+    let key_pos = if is_forward(record.record_strand()) {
+        start
+    } else {
+        u32::try_from(record.cigar().reference_end(start as usize))
+            .expect("reference_end fits in u32 per BAM spec")
+    };
+    let umi = require_umi(record, umi_mode)?;
+    Ok(UmiDedupKey::se(
+        record.record_strand(),
+        chr_id,
+        key_pos,
+        umi,
+    ))
+}
+
+/// Compute the UMI-aware PE dedup key. Mirrors [`compute_pe_key`] but
+/// adds R1's pre-extracted UMI. Per Perl
+/// `deduplicate_bismark:642-660` (`deduplicate_barcoded_rrbs`), R1's UMI
+/// is the one used for paired-end dedup — R2's qname is read after the
+/// extraction step in Perl and only contributes start/end.
+fn compute_pe_umi_key(
+    pair: &BismarkPair,
+    refid_table: &[u32],
+    umi_mode: UmiMode,
+) -> Result<UmiDedupKey, BismarkDedupError> {
+    let r1 = pair.r1();
+    let r2 = pair.r2();
+    let refid = r1.inner().reference_sequence_id().ok_or_else(|| {
+        BismarkDedupError::MissingReferenceId {
+            qname: qname_lossy(r1),
+        }
+    })?;
+    let chr_id = *refid_table
+        .get(refid)
+        .ok_or(BismarkDedupError::MissingChrInIntern { refid })?;
+    let r1_start = u32::try_from(r1.alignment_start().ok_or_else(|| {
+        BismarkDedupError::MissingAlignmentStart {
+            qname: qname_lossy(r1),
+        }
+    })?)
+    .expect("alignment_start fits in u32 per BAM spec");
+    let r2_start = u32::try_from(r2.alignment_start().ok_or_else(|| {
+        BismarkDedupError::MissingAlignmentStart {
+            qname: qname_lossy(r2),
+        }
+    })?)
+    .expect("alignment_start fits in u32 per BAM spec");
+
+    let (start, end) = if is_forward(pair.pair_strand()) {
+        let end = u32::try_from(r2.cigar().reference_end(r2_start as usize))
+            .expect("reference_end fits in u32 per BAM spec");
+        (r1_start, end)
+    } else {
+        let end = u32::try_from(r1.cigar().reference_end(r1_start as usize))
+            .expect("reference_end fits in u32 per BAM spec");
+        (r2_start, end)
+    };
+    let umi = require_umi(r1, umi_mode)?;
+    Ok(UmiDedupKey::pe(pair.pair_strand(), chr_id, start, end, umi))
+}
+
+/// Stream SE records with UMI-aware keys. Sibling of [`stream_se`].
+fn stream_se_umi<W: WriteBismark>(
+    records: impl Iterator<Item = Result<BismarkRecord, bismark_io::BismarkIoError>>,
+    refid_table: &[u32],
+    umi_mode: UmiMode,
+    state: &mut UmiDedupState,
+    writer: &mut W,
+) -> Result<(), BismarkDedupError> {
+    for record_result in records {
+        let record = record_result?;
+        let key = compute_se_umi_key(&record, refid_table, umi_mode)?;
+        if state.observe(key) {
+            writer.write_one(&record)?;
+        }
+    }
+    Ok(())
+}
+
+/// Stream PE records with UMI-aware keys. Sibling of [`stream_pe`].
+fn stream_pe_umi<W: WriteBismark>(
+    records: impl Iterator<Item = Result<BismarkRecord, bismark_io::BismarkIoError>>,
+    refid_table: &[u32],
+    umi_mode: UmiMode,
+    state: &mut UmiDedupState,
+    writer: &mut W,
+) -> Result<(), BismarkDedupError> {
+    let mut iter = records;
+    loop {
+        let r1 = match iter.next() {
+            Some(Ok(r)) => r,
+            Some(Err(e)) => return Err(e.into()),
+            None => break,
+        };
+        let r2 = match iter.next() {
+            Some(Ok(r)) => r,
+            Some(Err(e)) => return Err(e.into()),
+            None => {
+                return Err(BismarkDedupError::UnpairedFinalRecord {
+                    qname: qname_lossy(&r1),
+                });
+            }
+        };
+        let pair = BismarkPair::from_mates(r1, r2)?;
+        let key = compute_pe_umi_key(&pair, refid_table, umi_mode)?;
+        if state.observe(key) {
+            writer.write_one(pair.r1())?;
+            writer.write_one(pair.r2())?;
+        }
+    }
+    Ok(())
+}
+
+/// UMI-aware sibling of [`run_single`]. Reader is constructed via
+/// `records_with_umi(...)` so each record's UMI is pre-extracted at
+/// parse time; dedup keys are UMI-aware via [`UmiDedupKey`].
+///
+/// New in `bismark-dedup` v1.2.0-beta.1. Position-only callers continue
+/// to use [`run_single`] unchanged.
+pub fn run_single_umi(
+    input: &Path,
+    output: &Path,
+    cram_ref: Option<&Path>,
+    is_paired: bool,
+    file_label: String,
+    umi_mode: UmiMode,
+) -> Result<DedupReport, BismarkDedupError> {
+    let extractor = umi_extractor_for(umi_mode);
+    let mut reader = bismark_io::open_reader(input, cram_ref)?;
+    let header = reader.header().clone();
+
+    let mut records = reader.records_with_umi(extractor).peekable();
+    if records.peek().is_none() {
+        return Err(BismarkDedupError::EmptyInput(input.to_path_buf()));
+    }
+
+    let intern = build_chr_intern(&header);
+    let refid_table = build_refid_table(&header, &intern);
+
+    let mut writer = bismark_io::open_writer(output, header, cram_ref)?;
+    let mut state = UmiDedupState::new();
+
+    let stream_result = if is_paired {
+        stream_pe_umi(records, &refid_table, umi_mode, &mut state, &mut writer)
+    } else {
+        stream_se_umi(records, &refid_table, umi_mode, &mut state, &mut writer)
+    };
+    let finish_result = writer.finish();
+    let final_result = match (stream_result, finish_result) {
+        (Ok(()), Ok(())) => Ok(state.into_report(file_label)),
+        (Err(e), _) => Err(e),
+        (Ok(()), Err(e)) => Err(e.into()),
+    };
+    cleanup_partial_output_on_err(output, final_result)
+}
+
+/// UMI-aware sibling of [`run_multiple`]. New in v1.2.0-beta.1.
+pub fn run_multiple_umi(
+    inputs: &[PathBuf],
+    output: &Path,
+    cram_ref: Option<&Path>,
+    is_paired: bool,
+    file_label: String,
+    umi_mode: UmiMode,
+) -> Result<DedupReport, BismarkDedupError> {
+    if inputs.is_empty() {
+        return Err(BismarkDedupError::EmptyInput(PathBuf::new()));
+    }
+    if inputs.len() == 1 {
+        return run_single_umi(
+            &inputs[0], output, cram_ref, is_paired, file_label, umi_mode,
+        );
+    }
+
+    let first_kind = bismark_io::AlignmentKind::from_path(&inputs[0])?;
+    for path in &inputs[1..] {
+        if bismark_io::AlignmentKind::from_path(path)? != first_kind {
+            return Err(BismarkDedupError::MultipleMixedFormat);
+        }
+    }
+
+    let extractor = umi_extractor_for(umi_mode);
+
+    let readers: Vec<_> = inputs
+        .iter()
+        .map(|p| bismark_io::open_reader(p, cram_ref))
+        .collect::<Result<Vec<_>, _>>()?;
+    let headers: Vec<Header> = readers.iter().map(|r| r.header().clone()).collect();
+
+    let intern = build_chr_intern(&headers[0]);
+    for (i, header) in headers.iter().enumerate().skip(1) {
+        validate_chr_consistency(&inputs[i], header, &intern)?;
+    }
+
+    let refid_tables: Vec<Vec<u32>> = headers
+        .iter()
+        .map(|h| build_refid_table(h, &intern))
+        .collect();
+
+    let mut readers_iter = readers.into_iter();
+    let mut first_reader = readers_iter
+        .next()
+        .expect("inputs.is_empty() checked above; readers has ≥1 element");
+    let first_record: BismarkRecord = {
+        let mut peek_iter = first_reader.records_with_umi(extractor);
+        match peek_iter.next() {
+            Some(Ok(r)) => r,
+            Some(Err(e)) => return Err(e.into()),
+            None => return Err(BismarkDedupError::EmptyInput(inputs[0].clone())),
+        }
+    };
+
+    let mut writer = bismark_io::open_writer(output, headers[0].clone(), cram_ref)?;
+    let mut state = UmiDedupState::new();
+
+    // Stream all inputs into a single inner block so a single `?`
+    // controls early-exit on any per-file error.
+    let stream_result: Result<(), BismarkDedupError> = (|| {
+        let combined = std::iter::once(Ok::<_, bismark_io::BismarkIoError>(first_record))
+            .chain(first_reader.records_with_umi(extractor));
+        if is_paired {
+            stream_pe_umi(
+                combined,
+                &refid_tables[0],
+                umi_mode,
+                &mut state,
+                &mut writer,
+            )?;
+        } else {
+            stream_se_umi(
+                combined,
+                &refid_tables[0],
+                umi_mode,
+                &mut state,
+                &mut writer,
+            )?;
+        }
+        for (i_zero_based, mut reader) in readers_iter.enumerate() {
+            let i = i_zero_based + 1;
+            let records = reader.records_with_umi(extractor);
+            if is_paired {
+                stream_pe_umi(records, &refid_tables[i], umi_mode, &mut state, &mut writer)?;
+            } else {
+                stream_se_umi(records, &refid_tables[i], umi_mode, &mut state, &mut writer)?;
+            }
+        }
+        Ok(())
+    })();
+    let finish_result = writer.finish();
+    let final_result = match (stream_result, finish_result) {
+        (Ok(()), Ok(())) => Ok(state.into_report(file_label)),
+        (Err(e), _) => Err(e),
+        (Ok(()), Err(e)) => Err(e.into()),
+    };
+    cleanup_partial_output_on_err(output, final_result)
+}
+
+/// UMI-aware sibling of [`run_single_parallel`]. BAM input + BAM output only.
+/// New in v1.2.0-beta.1.
+pub fn run_single_parallel_umi(
+    input: &Path,
+    output: &Path,
+    is_paired: bool,
+    file_label: String,
+    parallel: std::num::NonZero<usize>,
+    umi_mode: UmiMode,
+) -> Result<DedupReport, BismarkDedupError> {
+    let extractor = umi_extractor_for(umi_mode);
+    let mut reader = bismark_io::ThreadedBamReader::from_path(input, parallel)?;
+    let header = reader.header().clone();
+
+    let mut records = reader.records_with_umi(extractor).peekable();
+    if records.peek().is_none() {
+        return Err(BismarkDedupError::EmptyInput(input.to_path_buf()));
+    }
+
+    let intern = build_chr_intern(&header);
+    let refid_table = build_refid_table(&header, &intern);
+
+    let mut writer = bismark_io::ThreadedBamWriter::from_path(output, header, parallel)?;
+    let mut state = UmiDedupState::new();
+
+    let stream_result = if is_paired {
+        stream_pe_umi(records, &refid_table, umi_mode, &mut state, &mut writer)
+    } else {
+        stream_se_umi(records, &refid_table, umi_mode, &mut state, &mut writer)
+    };
+    let finish_result = writer.finish();
+    let final_result = match (stream_result, finish_result) {
+        (Ok(()), Ok(())) => Ok(state.into_report(file_label)),
+        (Err(e), _) => Err(e),
+        (Ok(()), Err(e)) => Err(e.into()),
+    };
+    cleanup_partial_output_on_err(output, final_result)
+}
+
+/// UMI-aware sibling of [`run_multiple_parallel`]. BAM input + BAM output only.
+/// New in v1.2.0-beta.1.
+pub fn run_multiple_parallel_umi(
+    inputs: &[PathBuf],
+    output: &Path,
+    is_paired: bool,
+    file_label: String,
+    parallel: std::num::NonZero<usize>,
+    umi_mode: UmiMode,
+) -> Result<DedupReport, BismarkDedupError> {
+    if inputs.is_empty() {
+        return Err(BismarkDedupError::EmptyInput(PathBuf::new()));
+    }
+    if inputs.len() == 1 {
+        return run_single_parallel_umi(
+            &inputs[0], output, is_paired, file_label, parallel, umi_mode,
+        );
+    }
+
+    for path in inputs {
+        if bismark_io::AlignmentKind::from_path(path)? != bismark_io::AlignmentKind::Bam {
+            return Err(BismarkDedupError::MultipleMixedFormat);
+        }
+    }
+
+    let extractor = umi_extractor_for(umi_mode);
+
+    let mut readers: Vec<bismark_io::ThreadedBamReader> = inputs
+        .iter()
+        .map(|p| bismark_io::ThreadedBamReader::from_path(p, parallel))
+        .collect::<Result<Vec<_>, _>>()?;
+    let headers: Vec<Header> = readers.iter().map(|r| r.header().clone()).collect();
+
+    let intern = build_chr_intern(&headers[0]);
+    for (i, header) in headers.iter().enumerate().skip(1) {
+        validate_chr_consistency(&inputs[i], header, &intern)?;
+    }
+
+    let refid_tables: Vec<Vec<u32>> = headers
+        .iter()
+        .map(|h| build_refid_table(h, &intern))
+        .collect();
+
+    let mut readers_iter = readers.drain(..);
+    let mut first_reader = readers_iter
+        .next()
+        .expect("inputs.is_empty() checked above; readers has ≥1 element");
+    let first_record: BismarkRecord = {
+        let mut peek_iter = first_reader.records_with_umi(extractor);
+        match peek_iter.next() {
+            Some(Ok(r)) => r,
+            Some(Err(e)) => return Err(e.into()),
+            None => return Err(BismarkDedupError::EmptyInput(inputs[0].clone())),
+        }
+    };
+
+    let mut writer =
+        bismark_io::ThreadedBamWriter::from_path(output, headers[0].clone(), parallel)?;
+    let mut state = UmiDedupState::new();
+
+    let stream_result: Result<(), BismarkDedupError> = (|| {
+        let combined = std::iter::once(Ok::<_, bismark_io::BismarkIoError>(first_record))
+            .chain(first_reader.records_with_umi(extractor));
+        if is_paired {
+            stream_pe_umi(
+                combined,
+                &refid_tables[0],
+                umi_mode,
+                &mut state,
+                &mut writer,
+            )?;
+        } else {
+            stream_se_umi(
+                combined,
+                &refid_tables[0],
+                umi_mode,
+                &mut state,
+                &mut writer,
+            )?;
+        }
+        for (i_zero_based, mut reader) in readers_iter.enumerate() {
+            let i = i_zero_based + 1;
+            let records = reader.records_with_umi(extractor);
+            if is_paired {
+                stream_pe_umi(records, &refid_tables[i], umi_mode, &mut state, &mut writer)?;
+            } else {
+                stream_se_umi(records, &refid_tables[i], umi_mode, &mut state, &mut writer)?;
+            }
+        }
+        Ok(())
+    })();
+    let finish_result = writer.finish();
+    let final_result = match (stream_result, finish_result) {
+        (Ok(()), Ok(())) => Ok(state.into_report(file_label)),
+        (Err(e), _) => Err(e),
+        (Ok(()), Err(e)) => Err(e.into()),
+    };
+    cleanup_partial_output_on_err(output, final_result)
 }
 
 #[cfg(test)]

--- a/rust/bismark-dedup/src/report.rs
+++ b/rust/bismark-dedup/src/report.rs
@@ -34,23 +34,37 @@ pub struct DedupReport {
     count: u64,
     removed: u64,
     n_positions: usize,
+    umi_mode: bool,
 }
 
 impl DedupReport {
     /// Construct a report.
     ///
     /// Crate-private intentionally: the only legitimate construction path
-    /// is via [`crate::dedup::DedupState::into_report`], which guarantees
-    /// `removed <= count` and thus prevents an underflow in
-    /// [`DedupReport::leftover`]. Callers outside this crate should use
-    /// the `DedupState` path.
+    /// is via [`crate::dedup::DedupState::into_report`] or
+    /// [`crate::dedup::UmiDedupState::into_report`], both of which
+    /// guarantee `removed <= count` (preventing an underflow in
+    /// [`DedupReport::leftover`]). Callers outside this crate should use
+    /// the `*DedupState` paths.
+    ///
+    /// `umi_mode = true` appends Perl's ` (UMI mode)` banner suffix
+    /// after the input filename in the first analysed-alignments line
+    /// (matches `deduplicate_bismark:908`). Position-only callers pass
+    /// `false`.
     #[must_use]
-    pub(crate) fn new(file_label: String, count: u64, removed: u64, n_positions: usize) -> Self {
+    pub(crate) fn new(
+        file_label: String,
+        count: u64,
+        removed: u64,
+        n_positions: usize,
+        umi_mode: bool,
+    ) -> Self {
         Self {
             file_label,
             count,
             removed,
             n_positions,
+            umi_mode,
         }
     }
 
@@ -78,11 +92,15 @@ impl DedupReport {
         self.count - self.removed
     }
 
-    /// Render the report to a `String` in Perl-byte-equal format.
+    /// Render the report to a `String` in Perl-byte-equal **report file**
+    /// format (line 908 of `deduplicate_bismark`). In UMI mode this
+    /// emits the space-form banner ` (UMI mode)`. For the STDERR
+    /// echo (which Perl emits at line 903 with the hyphen-form
+    /// `(UMI-mode)`) use [`Self::format_stderr`] instead.
     ///
-    /// See module docs for the exact format. Returns an owned `String`
-    /// so callers can write it to a file or compare against a snapshot
-    /// without intermediate allocation in the hot path.
+    /// Returns an owned `String` so callers can write it to a file or
+    /// compare against a snapshot without intermediate allocation in
+    /// the hot path.
     #[must_use]
     pub fn format(&self) -> String {
         let leftover = self.leftover();
@@ -99,10 +117,15 @@ impl DedupReport {
         // String::with_capacity for the typical-case length to avoid
         // reallocation on the hot path. ~256 bytes covers all paths.
         let mut s = String::with_capacity(256);
+        // Perl `deduplicate_bismark:908` emits the banner as:
+        //   "\nTotal number of alignments analysed in $file (UMI mode):\t$count\n"
+        // The ` (UMI mode)` suffix (space-form) is appended after the
+        // filename when UMI mode is engaged. Position-only emits no suffix.
+        let umi_suffix = if self.umi_mode { " (UMI mode)" } else { "" };
         writeln!(
             s,
-            "\nTotal number of alignments analysed in {}:\t{}",
-            self.file_label, self.count
+            "\nTotal number of alignments analysed in {}{}:\t{}",
+            self.file_label, umi_suffix, self.count
         )
         .expect("write to String never fails");
         writeln!(
@@ -124,6 +147,27 @@ impl DedupReport {
         )
         .expect("write to String never fails");
         s
+    }
+
+    /// Render the report in Perl-byte-equal **STDERR** format (line 903
+    /// of `deduplicate_bismark`). In UMI mode this emits the
+    /// **hyphen-form** banner ` (UMI-mode)` — distinct from the
+    /// space-form ` (UMI mode)` used in the report file. In non-UMI
+    /// mode it produces the same bytes as [`Self::format`].
+    ///
+    /// Per Reviewer A's C2-B finding: Perl emits the per-file summary
+    /// to STDERR with hyphen and to the report file with space; the
+    /// existing `format()` was being echoed to BOTH, so STDERR got
+    /// the wrong form.
+    #[must_use]
+    pub fn format_stderr(&self) -> String {
+        if self.umi_mode {
+            // Substitute the report-file space banner for the STDERR
+            // hyphen banner. Cheaper than re-implementing the formatter.
+            self.format().replace(" (UMI mode):", " (UMI-mode):")
+        } else {
+            self.format()
+        }
     }
 
     /// Write the rendered report to a file path.
@@ -149,13 +193,13 @@ mod tests {
 
     #[test]
     fn format_matches_perl_byte_for_byte_typical_case() {
-        let r = DedupReport::new("/path/sample.bam".to_string(), 10, 2, 1);
+        let r = DedupReport::new("/path/sample.bam".to_string(), 10, 2, 1, false);
         assert_eq!(r.format(), EXPECTED_TYPICAL);
     }
 
     #[test]
     fn format_uses_na_when_count_is_zero() {
-        let r = DedupReport::new("/path/empty.bam".to_string(), 0, 0, 0);
+        let r = DedupReport::new("/path/empty.bam".to_string(), 0, 0, 0, false);
         let expected = "\nTotal number of alignments analysed in /path/empty.bam:\t0\n\
             Total number duplicated alignments removed:\t0 (N/A%)\n\
             Duplicated alignments were found at:\t0 different position(s)\n\n\
@@ -165,7 +209,7 @@ mod tests {
 
     #[test]
     fn format_removed_zero_no_duplicates() {
-        let r = DedupReport::new("/path/clean.bam".to_string(), 100, 0, 0);
+        let r = DedupReport::new("/path/clean.bam".to_string(), 100, 0, 0, false);
         let expected = "\nTotal number of alignments analysed in /path/clean.bam:\t100\n\
             Total number duplicated alignments removed:\t0 (0.00%)\n\
             Duplicated alignments were found at:\t0 different position(s)\n\n\
@@ -184,6 +228,7 @@ mod tests {
             8_592_524,
             622_892,
             571_488,
+            false,
         );
         let formatted = r.format();
         assert!(
@@ -206,17 +251,61 @@ mod tests {
 
     #[test]
     fn leftover_arithmetic() {
-        let r = DedupReport::new("x".to_string(), 100, 30, 5);
+        let r = DedupReport::new("x".to_string(), 100, 30, 5, false);
         assert_eq!(r.leftover(), 70);
     }
 
     #[test]
     fn percent_rounds_to_two_decimal_places_via_sprintf_semantics() {
         // 1 dup in 3 records → 33.33333...% removed; sprintf("%.2f") → "33.33"
-        let r = DedupReport::new("x".to_string(), 3, 1, 1);
+        let r = DedupReport::new("x".to_string(), 3, 1, 1, false);
         let s = r.format();
         assert!(s.contains("(33.33%)"), "got: {s}");
         assert!(s.contains("(66.67% of total)"), "got: {s}");
+    }
+
+    /// Phase B (v1.2 UMI): byte-precision check vs Perl `(UMI mode)` banner.
+    /// Pins the EXACT bytes (space-form, line 908 of deduplicate_bismark)
+    /// so any drift fails the build.
+    #[test]
+    fn format_with_umi_mode_emits_byte_precise_banner_at_line_908() {
+        let r = DedupReport::new("/path/sample.bam".to_string(), 10, 2, 1, true);
+        let expected = "\nTotal number of alignments analysed in /path/sample.bam (UMI mode):\t10\n\
+            Total number duplicated alignments removed:\t2 (20.00%)\n\
+            Duplicated alignments were found at:\t1 different position(s)\n\n\
+            Total count of deduplicated leftover sequences: 8 (80.00% of total)\n\n";
+        assert_eq!(r.format(), expected);
+    }
+
+    /// Per Reviewer A C2-B / Reviewer B H1: `format_stderr` in UMI mode
+    /// emits the HYPHEN-form `(UMI-mode)` banner — distinct from the
+    /// space-form used in the report file. Locks Perl line 903 vs 908.
+    #[test]
+    fn format_stderr_with_umi_mode_emits_hyphen_form_banner_at_line_903() {
+        let r = DedupReport::new("/path/sample.bam".to_string(), 10, 2, 1, true);
+        let expected = "\nTotal number of alignments analysed in /path/sample.bam (UMI-mode):\t10\n\
+            Total number duplicated alignments removed:\t2 (20.00%)\n\
+            Duplicated alignments were found at:\t1 different position(s)\n\n\
+            Total count of deduplicated leftover sequences: 8 (80.00% of total)\n\n";
+        assert_eq!(r.format_stderr(), expected);
+    }
+
+    #[test]
+    fn format_stderr_non_umi_mode_identical_to_format() {
+        let r = DedupReport::new("/path/sample.bam".to_string(), 10, 2, 1, false);
+        assert_eq!(r.format_stderr(), r.format());
+    }
+
+    #[test]
+    fn format_without_umi_mode_omits_banner() {
+        // Position-only path must NOT contain `(UMI mode)` — regression
+        // guard against accidentally enabling the suffix in non-UMI workflows.
+        let r = DedupReport::new("/path/sample.bam".to_string(), 10, 2, 1, false);
+        let out = r.format();
+        assert!(
+            !out.contains("UMI mode"),
+            "non-UMI dedup report must not contain `UMI mode`, got: {out}"
+        );
     }
 
     #[test]
@@ -224,7 +313,7 @@ mod tests {
         use tempfile::tempdir;
         let dir = tempdir().unwrap();
         let path = dir.path().join("test.deduplication_report.txt");
-        let r = DedupReport::new("/path/sample.bam".to_string(), 10, 2, 1);
+        let r = DedupReport::new("/path/sample.bam".to_string(), 10, 2, 1, false);
         r.write_to(&path).unwrap();
         let read_back = std::fs::read_to_string(&path).unwrap();
         assert_eq!(read_back, EXPECTED_TYPICAL);

--- a/rust/bismark-dedup/tests/integration_dedup.rs
+++ b/rust/bismark-dedup/tests/integration_dedup.rs
@@ -1321,3 +1321,398 @@ fn parallel_4_multiple_mode_output_ends_with_bgzf_eof_marker() {
          BGZF EOF marker; got trailer: {trailer:?}"
     );
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// Phase B (v1.2): UMI-aware dedup integration tests against the 10K CI
+// fixtures committed in PR #836 (Phase 0-bis).
+//
+// Each test runs `deduplicate_bismark_rs --paired --<umi_flag>` against
+// a real-Bismark-aligned 10K-pair PE BAM whose qnames carry synthesized
+// 8-mer ACGT UMIs, and compares against the Perl
+// `deduplicate_bismark --paired --<flag>` baseline that ships alongside
+// the input. Validates V4 / V5 of PLAN §11 (the headline byte-identity
+// gates) on the small, CI-fast fixtures.
+// ──────────────────────────────────────────────────────────────────────
+
+/// Path to the Phase 0-bis 10K UMI fixtures directory.
+fn umi_fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("data")
+}
+
+/// Read the bytes of a fixture's Perl-baseline deduplication report.
+fn read_perl_report(stem: &str) -> Vec<u8> {
+    let p = umi_fixtures_dir().join(format!("{stem}.deduplication_report.txt"));
+    std::fs::read(&p).unwrap_or_else(|e| panic!("read perl report {p:?}: {e}"))
+}
+
+/// Read the retained-qname set from the Perl-baseline deduplicated BAM.
+fn read_perl_baseline_qnames(stem: &str) -> HashSet<String> {
+    let p = umi_fixtures_dir().join(format!("{stem}.deduplicated.bam"));
+    read_qnames(&p).into_iter().collect()
+}
+
+/// Stems of the two 10K fixtures (matching the file prefixes in `tests/data/`).
+const BARCODE_STEM: &str = "synth_barcode_10k_R1_val_1_bismark_bt2_pe";
+const BCLCONVERT_STEM: &str = "synth_bclconvert_10k_R1_val_1_bismark_bt2_pe";
+
+/// V4 headline test: byte-identity vs Perl on the `--barcode` 10K fixture.
+#[test]
+fn umi_barcode_dedup_matches_perl_baseline_byte_for_byte() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BARCODE_STEM}.bam"));
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--barcode")
+        .arg("--output_dir")
+        .arg(dir.path())
+        .arg(&input)
+        .assert()
+        .success();
+
+    let rust_out = dir.path().join(format!("{BARCODE_STEM}.deduplicated.bam"));
+    let rust_qnames: HashSet<String> = read_qnames(&rust_out).into_iter().collect();
+    let perl_qnames = read_perl_baseline_qnames(BARCODE_STEM);
+    assert_eq!(
+        rust_qnames,
+        perl_qnames,
+        "Rust --barcode retained-qname set diverges from Perl baseline \
+         on synth_barcode_10k (Phase 0-bis fixture); Rust dropped {}, Rust extra {}",
+        perl_qnames.difference(&rust_qnames).count(),
+        rust_qnames.difference(&perl_qnames).count(),
+    );
+
+    // Report byte-identity. Perl echoes `$ARGV` verbatim while Rust
+    // echoes the user-supplied path, so the two differ in the path
+    // segment of the analysed-alignments line ONLY. Reviewer B M1: the
+    // earlier strip-helper went too far and dropped the ` (UMI mode):`
+    // banner from BOTH sides, so a `(WRONG mode)` regression would
+    // still pass. This normaliser replaces the path with `<FILE>` and
+    // KEEPS the banner verbatim.
+    let rust_report = std::fs::read(
+        dir.path()
+            .join(format!("{BARCODE_STEM}.deduplication_report.txt")),
+    )
+    .unwrap();
+    let perl_report = read_perl_report(BARCODE_STEM);
+    let normalise_path_only = |bytes: &[u8]| -> String {
+        let s = String::from_utf8_lossy(bytes);
+        s.lines()
+            .map(|line| {
+                if !line.contains("alignments analysed in") {
+                    return line.to_string();
+                }
+                let in_pos = match line.find(" in ") {
+                    Some(p) => p,
+                    None => return line.to_string(),
+                };
+                // Find the banner; if missing, fall back to plain
+                // `:\t` for non-UMI lines. UMI report always has the
+                // banner, so this branch wins.
+                let banner_pos = line.find(" (UMI mode):").or_else(|| line.find(":\t"));
+                let banner_pos = match banner_pos {
+                    Some(p) => p,
+                    None => return line.to_string(),
+                };
+                let prefix = &line[..in_pos]; // "Total number of alignments analysed"
+                let suffix = &line[banner_pos..]; // " (UMI mode):\t<count>" — banner KEPT
+                format!("{prefix} in <FILE>{suffix}")
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let rust_normalised = normalise_path_only(&rust_report);
+    let perl_normalised = normalise_path_only(&perl_report);
+    assert_eq!(
+        rust_normalised, perl_normalised,
+        "Rust --barcode report bytes diverge from Perl baseline (path-normalised, \
+         banner kept); Rust:\n{rust_normalised}\nPerl:\n{perl_normalised}"
+    );
+    // Defense-in-depth: assert the SPACE-form banner literally appears
+    // in both reports. Guards against the normaliser ever falling
+    // through and accidentally masking a banner regression.
+    assert!(
+        rust_normalised.contains(" (UMI mode):"),
+        "Rust report missing space-form (UMI mode) banner: {rust_normalised}"
+    );
+    assert!(
+        perl_normalised.contains(" (UMI mode):"),
+        "Perl baseline missing space-form (UMI mode) banner: {perl_normalised}"
+    );
+}
+
+/// V5 headline test: byte-identity vs Perl on the `--bclconvert` 10K fixture.
+#[test]
+fn umi_bclconvert_dedup_matches_perl_baseline_byte_for_byte() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BCLCONVERT_STEM}.bam"));
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--bclconvert")
+        .arg("--output_dir")
+        .arg(dir.path())
+        .arg(&input)
+        .assert()
+        .success();
+
+    let rust_out = dir
+        .path()
+        .join(format!("{BCLCONVERT_STEM}.deduplicated.bam"));
+    let rust_qnames: HashSet<String> = read_qnames(&rust_out).into_iter().collect();
+    let perl_qnames = read_perl_baseline_qnames(BCLCONVERT_STEM);
+    assert_eq!(
+        rust_qnames,
+        perl_qnames,
+        "Rust --bclconvert retained-qname set diverges from Perl baseline \
+         on synth_bclconvert_10k; Rust dropped {}, Rust extra {}",
+        perl_qnames.difference(&rust_qnames).count(),
+        rust_qnames.difference(&perl_qnames).count(),
+    );
+}
+
+/// V6: diagnostic property — `--barcode` retains more reads than the
+/// position-only dedup path on the same input. Per Phase 0-bis the delta
+/// is 148 reads on `synth_barcode_10k`. Engaging UMI mode must therefore
+/// produce a strictly larger retained-qname set than the no-UMI run.
+#[test]
+fn umi_barcode_engages_mode_retains_more_reads_than_position_only() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BARCODE_STEM}.bam"));
+    let dir_umi = dir.path().join("umi");
+    let dir_pos = dir.path().join("pos");
+    std::fs::create_dir_all(&dir_umi).unwrap();
+    std::fs::create_dir_all(&dir_pos).unwrap();
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--barcode")
+        .arg("--output_dir")
+        .arg(&dir_umi)
+        .arg(&input)
+        .assert()
+        .success();
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--output_dir")
+        .arg(&dir_pos)
+        .arg(&input)
+        .assert()
+        .success();
+
+    let umi_q: HashSet<String> =
+        read_qnames(&dir_umi.join(format!("{BARCODE_STEM}.deduplicated.bam")))
+            .into_iter()
+            .collect();
+    let pos_q: HashSet<String> =
+        read_qnames(&dir_pos.join(format!("{BARCODE_STEM}.deduplicated.bam")))
+            .into_iter()
+            .collect();
+
+    assert!(
+        umi_q.len() > pos_q.len(),
+        "UMI-mode should retain strictly more reads than position-only on the \
+         Phase 0-bis 10K barcode fixture (UMI: {}, position-only: {})",
+        umi_q.len(),
+        pos_q.len(),
+    );
+    // The position-only path should be a subset of the UMI-mode path:
+    // anything position-only kept, UMI-mode also keeps (UMI mode only adds
+    // discrimination, never removes).
+    let extra_in_pos: Vec<&String> = pos_q.difference(&umi_q).collect();
+    assert!(
+        extra_in_pos.is_empty(),
+        "position-only dedup must be a subset of UMI-mode dedup; found {} \
+         reads in position-only but NOT in UMI mode",
+        extra_in_pos.len(),
+    );
+}
+
+/// V9: `--parallel 4 --barcode` produces the same retained-qname set as
+/// `--parallel 1 --barcode` on the 10K barcode fixture. Parallelism must
+/// not change UMI dedup outcomes.
+#[test]
+fn umi_mode_with_parallel_4_produces_same_qname_set_as_parallel_1() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BARCODE_STEM}.bam"));
+    let dir1 = dir.path().join("p1");
+    let dir4 = dir.path().join("p4");
+    std::fs::create_dir_all(&dir1).unwrap();
+    std::fs::create_dir_all(&dir4).unwrap();
+
+    for (parallel, out_dir) in [(1, &dir1), (4, &dir4)] {
+        Command::cargo_bin("deduplicate_bismark_rs")
+            .unwrap()
+            .arg("--paired")
+            .arg("--barcode")
+            .arg("--parallel")
+            .arg(parallel.to_string())
+            .arg("--output_dir")
+            .arg(out_dir)
+            .arg(&input)
+            .assert()
+            .success();
+    }
+
+    let q1: HashSet<String> = read_qnames(&dir1.join(format!("{BARCODE_STEM}.deduplicated.bam")))
+        .into_iter()
+        .collect();
+    let q4: HashSet<String> = read_qnames(&dir4.join(format!("{BARCODE_STEM}.deduplicated.bam")))
+        .into_iter()
+        .collect();
+    assert_eq!(
+        q1,
+        q4,
+        "--parallel 1 vs --parallel 4 retained-qname sets diverged under \
+         --barcode UMI mode (set diff size: {})",
+        q1.symmetric_difference(&q4).count(),
+    );
+}
+
+/// Per Reviewer A nit 5 / PLAN §6.3: passing both `--bclconvert` and
+/// `--barcode` should produce byte-identical output to passing
+/// `--bclconvert` alone (the "bclconvert wins" precedence at
+/// `cli.rs::Cli::validate`).
+#[test]
+fn umi_bclconvert_and_barcode_together_bclconvert_wins() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BCLCONVERT_STEM}.bam"));
+    let dir_bclonly = dir.path().join("bclonly");
+    let dir_both = dir.path().join("both");
+    std::fs::create_dir_all(&dir_bclonly).unwrap();
+    std::fs::create_dir_all(&dir_both).unwrap();
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--bclconvert")
+        .arg("--output_dir")
+        .arg(&dir_bclonly)
+        .arg(&input)
+        .assert()
+        .success();
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--bclconvert")
+        .arg("--barcode")
+        .arg("--output_dir")
+        .arg(&dir_both)
+        .arg(&input)
+        .assert()
+        .success();
+
+    let q_bclonly: HashSet<String> =
+        read_qnames(&dir_bclonly.join(format!("{BCLCONVERT_STEM}.deduplicated.bam")))
+            .into_iter()
+            .collect();
+    let q_both: HashSet<String> =
+        read_qnames(&dir_both.join(format!("{BCLCONVERT_STEM}.deduplicated.bam")))
+            .into_iter()
+            .collect();
+    assert_eq!(
+        q_bclonly, q_both,
+        "--bclconvert alone vs --bclconvert --barcode together produced \
+         divergent retained-qname sets; --bclconvert precedence broken"
+    );
+}
+
+/// Per Reviewer A nit 4 / PLAN §6.3: `--multiple` × UMI accumulates state
+/// across input files. Concatenating the same 10K input twice via
+/// `--multiple` should produce a retained-qname set whose size is between
+/// `len(single)` (perfect dedup) and `2 * len(single)` (no cross-file
+/// dedup), AND the size must match what Perl produces.
+///
+/// We can't easily run Perl in CI, so this test asserts the structural
+/// invariant: `--multiple` over [A, A] must produce the same set as
+/// `--multiple` over [A] alone (perfect cross-file dedup since the
+/// inputs are identical).
+#[test]
+fn umi_barcode_with_multiple_input_files_accumulates_state() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BARCODE_STEM}.bam"));
+    let dir_single = dir.path().join("single");
+    let dir_double = dir.path().join("double");
+    std::fs::create_dir_all(&dir_single).unwrap();
+    std::fs::create_dir_all(&dir_double).unwrap();
+
+    // Single input via --multiple (degenerate; should match the single-file path).
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--multiple")
+        .arg("--paired")
+        .arg("--barcode")
+        .arg("--output_dir")
+        .arg(&dir_single)
+        .arg(&input)
+        .assert()
+        .success();
+
+    // Same input passed twice — cross-file UMI dedup state should
+    // collapse all duplicates from the second file against the first.
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--multiple")
+        .arg("--paired")
+        .arg("--barcode")
+        .arg("--output_dir")
+        .arg(&dir_double)
+        .arg(&input)
+        .arg(&input)
+        .assert()
+        .success();
+
+    // The output filenames under `--multiple` use the first input's stem.
+    let out_name = format!("{BARCODE_STEM}.multiple.deduplicated.bam");
+    let q_single: HashSet<String> = read_qnames(&dir_single.join(&out_name))
+        .into_iter()
+        .collect();
+    let q_double: HashSet<String> = read_qnames(&dir_double.join(&out_name))
+        .into_iter()
+        .collect();
+    assert_eq!(
+        q_single, q_double,
+        "--multiple with [A, A] should retain the same qname set as --multiple [A] \
+         (cross-file UMI dedup state collapses the second copy entirely)"
+    );
+}
+
+/// V7: a `--barcode`-mode invocation against a BAM with qnames that
+/// have no `:` (no UMI tail) must error with `UmiExtractionFailed`,
+/// matching Perl's `Failed to extract a barcode from the read ID` at
+/// `deduplicate_bismark:662-663`.
+#[test]
+fn umi_barcode_on_record_without_umi_errors_with_extraction_failed() {
+    let dir = TempDir::new().unwrap();
+    // Build a tiny PE BAM whose qnames are plain (no `:`, no UMI).
+    let input = dir.path().join("noumis.bam");
+    let mut pairs: Vec<RecordBuf> = Vec::new();
+    for i in 0..3u64 {
+        let qname = format!("read{i}");
+        // OT pair: R1 forward, R2 same chr.
+        let r1 = build_record(&qname, b"CT", b"CT", 0x41, 0, 100 + i as usize, 50);
+        let r2 = build_record(&qname, b"GA", b"CT", 0x81, 0, 200 + i as usize, 50);
+        pairs.push(r1);
+        pairs.push(r2);
+    }
+    write_bam(&input, &pairs);
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--barcode")
+        .arg("--output_dir")
+        .arg(dir.path())
+        .arg(&input)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("UMI in qname"));
+}

--- a/rust/bismark-dedup/tests/sanity.rs
+++ b/rust/bismark-dedup/tests/sanity.rs
@@ -5,6 +5,7 @@
 //! Phase A: the binary builds, runs, and emits a recognisable identity string.
 
 use assert_cmd::Command;
+use predicates::prelude::*; // PredicateBooleanExt for `.not()` + `.and()`
 use predicates::str::is_match;
 
 #[test]
@@ -47,14 +48,42 @@ fn representative_flag_errors_with_perl_verbatim_joke() {
         .stderr(predicates::str::contains("Please stop wanting that"));
 }
 
+/// Phase B (v1.2): `--barcode` engages UMI mode. The startup banner
+/// matches Perl `deduplicate_bismark:167` byte-for-byte. (The previous
+/// banner string was fabricated; dual code review C2/H1 caught it.)
 #[test]
-fn barcode_flag_errors_with_v1_deferral_message() {
+fn barcode_flag_emits_perl_line_167_startup_banner() {
     let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
     cmd.arg("--barcode")
         .arg("dummy.bam")
         .assert()
         .failure()
+        .stderr(predicates::str::contains("Deduplicating data in UMI mode"));
+}
+
+/// Phase B (v1.2): `--bclconvert` engages UMI mode with the bcl-convert
+/// extractor. The startup banner matches Perl
+/// `deduplicate_bismark:172` byte-for-byte.
+#[test]
+fn bclconvert_flag_emits_perl_line_172_startup_banner() {
+    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    cmd.arg("--bclconvert")
+        .arg("dummy.bam")
+        .assert()
+        .failure()
         .stderr(predicates::str::contains(
-            "not supported in bismark-dedup v1.0",
+            "Deduplicating data in bcl-convert UMI mode",
         ));
+}
+
+/// Negative case (Reviewer B M3): a non-UMI invocation must NOT emit
+/// either UMI startup banner. Locks the conditional emission in `main.rs`.
+#[test]
+fn non_umi_invocation_does_not_emit_umi_startup_banner() {
+    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    cmd.arg("dummy.bam").assert().failure().stderr(
+        predicates::str::contains("Deduplicating data in UMI mode")
+            .not()
+            .and(predicates::str::contains("Deduplicating data in bcl-convert UMI mode").not()),
+    );
 }

--- a/rust/bismark-io/CHANGELOG.md
+++ b/rust/bismark-io/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to `bismark-io` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.5] — 2026-05-25
+
+UMI plumbing on `BismarkRecord` for Phase B of the v1.2 UMI/RRBS epic.
+Additive only; non-UMI workflows are byte-for-byte unchanged.
+
+### Added
+
+- `BismarkRecord::umi() -> Option<&Umi>` accessor and
+  `BismarkRecord::set_umi(Option<Umi>)` setter.
+- `BismarkRecord::from_noodles_record_with_umi(inner, extractor)` —
+  constructs a record AND pre-extracts the UMI from its qname using
+  the supplied `bismark_io::umi::extract_*` function.
+- `BamReader::records_with_umi(extractor)` and the same on
+  `ThreadedBamReader`, `SamReader`, `CramReader`, `AnyReader`. Each
+  yields `BismarkRecord`s with `umi` populated at parse time.
+- New type alias `bismark_io::Umi = smallvec::SmallVec<[u8; 16]>` —
+  stack-allocated for ≤16-byte UMIs (covers all known Bismark
+  workflows including 8-mer dual-UMI without the `+`), heap fallback
+  for longer UMIs (e.g. 17-byte dual-UMI of form `XXXXXXXX+YYYYYYYY`).
+
+### Changed
+
+- `BismarkRecord` gains a private `umi: Option<Umi>` field. The struct
+  has only private fields, so this is a semver-additive change — no
+  external caller can pattern-match or struct-literal-construct.
+
+### Dependencies
+
+- New: `smallvec = "=1.13.2"` (widely used; one transitive dep).
+  Pinned exact-version per the workspace's policy.
+
 ## [1.0.0-beta.4] — 2026-05-25
 
 UMI extraction helpers for Bismark qnames, supporting Perl

--- a/rust/bismark-io/Cargo.toml
+++ b/rust/bismark-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-io"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 description = "Bismark-aware BAM/SAM/CRAM I/O on top of noodles"
 edition.workspace = true
 rust-version.workspace = true
@@ -24,6 +24,10 @@ noodles-core = "=0.20.0"
 noodles-bgzf = "=0.47.0"
 noodles-csi = "=0.50.0"
 thiserror = "2"
+# Phase B (v1.2 UMI epic): BismarkRecord carries an optional UMI as a
+# stack-allocated SmallVec for ≤16-byte UMIs (covers all known Bismark
+# workflows; longer UMIs heap-allocate without semantic change).
+smallvec = "=1.13.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/bismark-io/README.md
+++ b/rust/bismark-io/README.md
@@ -4,7 +4,7 @@ Bismark-aware BAM/SAM/CRAM I/O on top of [`noodles`](https://github.com/zaeleus/
 
 `bismark-io` is the shared library crate for [Bismark](https://github.com/FelixKrueger/Bismark)'s Rust rewrite. It wraps the `noodles` crate family to expose record types that already know about Bismark's strand classification (OT/CTOT/OB/CTOB derived from the `XR:Z:` and `XG:Z:` tags), tag-decoded accessors (`XM`, `XR`, `XG`, `MD`, `NM`), and CIGAR-aware position helpers. Every Bismark Rust binary crate (`bismark-dedup`, `bismark-extractor`, `bismark-bedgraph`, …) depends on it.
 
-**Status:** v1.0.0-beta.4 — adds `umi::extract_barcode` + `umi::extract_bclconvert` zero-copy UMI extractors (additive; existing API unchanged). Prior beta-line additions: beta.2 `ThreadedBamReader`/`Writer` (used by `bismark-dedup`'s `--parallel N`); beta.3 magic-byte file-format detection. See [`CHANGELOG.md`](./CHANGELOG.md).
+**Status:** v1.0.0-beta.5 — `BismarkRecord` gains an optional `umi` field and `*_with_umi` reader constructors that pre-extract UMIs at parse time (additive; non-UMI workflows byte-for-byte unchanged). Prior beta-line additions: beta.2 `ThreadedBamReader`/`Writer` (used by `bismark-dedup`'s `--parallel N`); beta.3 magic-byte file-format detection; beta.4 `umi::extract_barcode` + `umi::extract_bclconvert` zero-copy extractors. See [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## Why a Bismark wrapper around `noodles`?
 

--- a/rust/bismark-io/src/lib.rs
+++ b/rust/bismark-io/src/lib.rs
@@ -32,7 +32,7 @@ pub use pair::BismarkPair;
 pub use read::{
     AlignmentKind, AnyReader, BamReader, CramReader, SamReader, ThreadedBamReader, open_reader,
 };
-pub use record::{BismarkRecord, ReadIdentity};
+pub use record::{BismarkRecord, ReadIdentity, Umi};
 pub use strand::BismarkStrand;
 pub use umi::{extract_barcode, extract_bclconvert};
 pub use write::{AnyWriter, BamWriter, CramWriter, SamWriter, ThreadedBamWriter, open_writer};

--- a/rust/bismark-io/src/read.rs
+++ b/rust/bismark-io/src/read.rs
@@ -260,6 +260,27 @@ impl<R: BufRead> BamReader<R> {
             .record_bufs(header)
             .filter_map(filter_unmapped_then_classify)
     }
+
+    /// Iterator yielding one [`BismarkRecord`] per mapped alignment, with
+    /// the UMI pre-extracted from each record's qname using `extractor`.
+    ///
+    /// `extractor` is typically [`crate::umi::extract_barcode`] (for
+    /// `--barcode` / `--umi` mode) or [`crate::umi::extract_bclconvert`]
+    /// (for `--bclconvert` mode). Records whose qname does NOT match the
+    /// extractor's pattern still flow through with `umi == None`; the
+    /// downstream dedup pipeline emits `UmiExtractionFailed` faithful to
+    /// Perl `deduplicate_bismark:662-663`.
+    ///
+    /// Added in `bismark-io` v1.0.0-beta.5 for Phase B of the v1.2 UMI epic.
+    pub fn records_with_umi(
+        &mut self,
+        extractor: fn(&[u8]) -> Option<&[u8]>,
+    ) -> impl Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_ {
+        let header = &self.header;
+        self.inner
+            .record_bufs(header)
+            .filter_map(move |item| filter_unmapped_then_classify_with_umi(item, extractor))
+    }
 }
 
 /// **Threaded** BAM reader that uses [`noodles_bgzf::io::MultithreadedReader`]
@@ -332,6 +353,19 @@ impl ThreadedBamReader {
             .record_bufs(header)
             .filter_map(filter_unmapped_then_classify)
     }
+
+    /// As [`Self::records`] but pre-extracts a UMI from each record's
+    /// qname using `extractor`. See [`BamReader::records_with_umi`] for
+    /// details. Added in v1.0.0-beta.5 for Phase B of the v1.2 UMI epic.
+    pub fn records_with_umi(
+        &mut self,
+        extractor: fn(&[u8]) -> Option<&[u8]>,
+    ) -> impl Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_ {
+        let header = &self.header;
+        self.inner
+            .record_bufs(header)
+            .filter_map(move |item| filter_unmapped_then_classify_with_umi(item, extractor))
+    }
 }
 
 /// SAM reader producing [`BismarkRecord`]s.
@@ -376,6 +410,19 @@ impl<R: BufRead> SamReader<R> {
         self.inner
             .record_bufs(header)
             .filter_map(filter_unmapped_then_classify)
+    }
+
+    /// As [`Self::records`] but pre-extracts a UMI per record. See
+    /// [`BamReader::records_with_umi`] for details. Added in v1.0.0-beta.5
+    /// for Phase B of the v1.2 UMI epic.
+    pub fn records_with_umi(
+        &mut self,
+        extractor: fn(&[u8]) -> Option<&[u8]>,
+    ) -> impl Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_ {
+        let header = &self.header;
+        self.inner
+            .record_bufs(header)
+            .filter_map(move |item| filter_unmapped_then_classify_with_umi(item, extractor))
     }
 }
 
@@ -431,6 +478,18 @@ impl<R: Read + Seek> CramReader<R> {
             .records(header)
             .filter_map(filter_unmapped_then_classify)
     }
+
+    /// As [`Self::records`] but pre-extracts a UMI per record. See
+    /// [`BamReader::records_with_umi`] for details. Added in v1.0.0-beta.5.
+    pub fn records_with_umi(
+        &mut self,
+        extractor: fn(&[u8]) -> Option<&[u8]>,
+    ) -> impl Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_ {
+        let header = &self.header;
+        self.inner
+            .records(header)
+            .filter_map(move |item| filter_unmapped_then_classify_with_umi(item, extractor))
+    }
 }
 
 // `build_fasta_repository` is imported at the top of this file; it lives
@@ -474,6 +533,20 @@ impl<R: BufRead, RC: Read + Seek> AnyReader<R, RC> {
             Self::Cram(r) => Box::new(r.records()),
         }
     }
+
+    /// As [`Self::records`] but pre-extracts a UMI from each record's
+    /// qname using `extractor`. See [`BamReader::records_with_umi`] for
+    /// details. Added in v1.0.0-beta.5 for Phase B of the v1.2 UMI epic.
+    pub fn records_with_umi(
+        &mut self,
+        extractor: fn(&[u8]) -> Option<&[u8]>,
+    ) -> Box<dyn Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_> {
+        match self {
+            Self::Bam(r) => Box::new(r.records_with_umi(extractor)),
+            Self::Sam(r) => Box::new(r.records_with_umi(extractor)),
+            Self::Cram(r) => Box::new(r.records_with_umi(extractor)),
+        }
+    }
 }
 
 /// Open a BAM, SAM, or CRAM file by path, dispatching on extension.
@@ -514,6 +587,26 @@ fn filter_unmapped_then_classify(
                 None // unmapped — silently drop
             } else {
                 Some(BismarkRecord::from_noodles_record(rec))
+            }
+        }
+        Err(e) => Some(Err(BismarkIoError::Io(e))),
+    }
+}
+
+/// Companion to [`filter_unmapped_then_classify`] that also pre-extracts
+/// the UMI via `extractor`. Used by `records_with_umi` on all reader
+/// variants. Added in v1.0.0-beta.5 for Phase B of the v1.2 UMI epic.
+fn filter_unmapped_then_classify_with_umi(
+    item: std::io::Result<RecordBuf>,
+    extractor: fn(&[u8]) -> Option<&[u8]>,
+) -> Option<Result<BismarkRecord, BismarkIoError>> {
+    match item {
+        Ok(rec) => {
+            let flags = u16::from(rec.flags());
+            if (flags & 0x4) != 0 {
+                None
+            } else {
+                Some(BismarkRecord::from_noodles_record_with_umi(rec, extractor))
             }
         }
         Err(e) => Some(Err(BismarkIoError::Io(e))),
@@ -915,6 +1008,40 @@ read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTC\tIIIII\tXM:Z:.....\tXG:Z:CT\n";
             1,
             "AnyReader must inherit the unmapped silent filter"
         );
+    }
+
+    // ─── Phase B (v1.2 UMI): records_with_umi() reader tests ───────────
+
+    /// SAM with one mapped record whose qname has a `--barcode`-format
+    /// UMI tail. Used to verify `records_with_umi` populates the `umi`
+    /// field at parse time.
+    const SAM_ONE_MAPPED_WITH_UMI: &[u8] = b"@HD\tVN:1.6\tSO:unsorted\n\
+@SQ\tSN:chr1\tLN:1000\n\
+read1:CTCCTTAG\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTC\tIIIII\tXM:Z:.....\tXR:Z:CT\tXG:Z:CT\n";
+
+    #[test]
+    fn sam_records_with_umi_populates_umi_field() {
+        let mut reader = SamReader::new(Cursor::new(SAM_ONE_MAPPED_WITH_UMI)).unwrap();
+        let records: Vec<_> = reader
+            .records_with_umi(crate::umi::extract_barcode)
+            .collect();
+        assert_eq!(records.len(), 1);
+        let rec = records.into_iter().next().unwrap().unwrap();
+        assert_eq!(rec.umi().unwrap().as_slice(), b"CTCCTTAG");
+    }
+
+    #[test]
+    fn sam_records_with_umi_no_umi_in_qname_yields_none() {
+        // SAM_ONE_MAPPED's qname is `read1` (no `:`). With --barcode mode,
+        // extractor returns None → record's umi field is None → dedup
+        // pipeline will surface UmiExtractionFailed downstream.
+        let mut reader = SamReader::new(Cursor::new(SAM_ONE_MAPPED)).unwrap();
+        let records: Vec<_> = reader
+            .records_with_umi(crate::umi::extract_barcode)
+            .collect();
+        assert_eq!(records.len(), 1);
+        let rec = records.into_iter().next().unwrap().unwrap();
+        assert!(rec.umi().is_none());
     }
 
     #[test]

--- a/rust/bismark-io/src/record.rs
+++ b/rust/bismark-io/src/record.rs
@@ -12,10 +12,18 @@
 
 use noodles_sam::alignment::RecordBuf;
 use noodles_sam::alignment::record_buf::Cigar;
+use smallvec::SmallVec;
 
 use crate::error::BismarkIoError;
 use crate::strand::BismarkStrand;
 use crate::tags;
+
+/// Stack-allocated UMI storage. Inline capacity is 16 bytes — covers all
+/// known Bismark UMI workflows (≤16 ASCII bytes including dual-UMI `+`
+/// separators). UMIs longer than 16 bytes (notably dual-UMI of form
+/// `XXXXXXXX+YYYYYYYY` at 17 bytes) heap-allocate transparently; the
+/// dedup-key equality contract is unaffected.
+pub type Umi = SmallVec<[u8; 16]>;
 
 /// Read identity within a paired-end (or single-end) alignment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -60,6 +68,14 @@ pub struct BismarkRecord {
     inner: RecordBuf,
     record_strand: BismarkStrand,
     read_identity: ReadIdentity,
+    /// Pre-extracted UMI (Phase B / v1.2). `None` for the v1.0/v1.1
+    /// non-UMI path — readers constructed via [`crate::BamReader::new`]
+    /// and the other no-UMI constructors set this to `None`. Set to
+    /// `Some(...)` by the `*_with_umi` reader constructors when the qname
+    /// matches the chosen extractor's pattern. UMI-aware dedup downstream
+    /// errors on `None` records in UMI mode (faithful to Perl
+    /// `deduplicate_bismark:662-663`).
+    umi: Option<Umi>,
 }
 
 impl BismarkRecord {
@@ -97,7 +113,30 @@ impl BismarkRecord {
             inner,
             record_strand,
             read_identity,
+            umi: None,
         })
+    }
+
+    /// Construct as [`Self::from_noodles_record`] AND pre-extract the UMI
+    /// from the record's qname using `extractor` (typically
+    /// [`crate::umi::extract_barcode`] or
+    /// [`crate::umi::extract_bclconvert`]).
+    ///
+    /// If `extractor` returns `Some`, the bytes are stored in the
+    /// record's `umi` field. If it returns `None`, the field is left as
+    /// `None` — the dedup pipeline downstream is responsible for emitting
+    /// `UmiExtractionFailed` when UMI mode is engaged but a record has
+    /// no UMI (faithful to Perl `deduplicate_bismark:662-663`).
+    ///
+    /// Records with no qname (`name() == None`) also get `umi: None`.
+    pub fn from_noodles_record_with_umi(
+        inner: RecordBuf,
+        extractor: fn(&[u8]) -> Option<&[u8]>,
+    ) -> Result<Self, BismarkIoError> {
+        let mut rec = Self::from_noodles_record(inner)?;
+        let qname_bytes: Option<&[u8]> = rec.inner.name().map(AsRef::as_ref);
+        rec.umi = qname_bytes.and_then(extractor).map(SmallVec::from_slice);
+        Ok(rec)
     }
 
     /// Strand derived from THIS record's own `XR:Z:`/`XG:Z:` tags.
@@ -140,6 +179,20 @@ impl BismarkRecord {
     /// for reference-span, read-span, and aligned-position helpers.
     pub fn cigar(&self) -> &Cigar {
         self.inner.cigar()
+    }
+
+    /// Pre-extracted UMI (Phase B / v1.2). `None` when the reader was
+    /// constructed via a non-UMI constructor (the v1.0/v1.1 default) or
+    /// when the qname did not match the chosen UMI extractor's pattern.
+    pub fn umi(&self) -> Option<&Umi> {
+        self.umi.as_ref()
+    }
+
+    /// Set the record's UMI in place. Used by reader constructors that
+    /// pre-extract UMIs at parse time, and by test code that constructs
+    /// records manually.
+    pub fn set_umi(&mut self, umi: Option<Umi>) {
+        self.umi = umi;
     }
 }
 
@@ -287,5 +340,68 @@ mod tests {
         assert_eq!(ReadIdentity::Single.as_str(), "SE");
         assert_eq!(ReadIdentity::R1.as_str(), "R1");
         assert_eq!(ReadIdentity::R2.as_str(), "R2");
+    }
+
+    /// Synthesize a record with a qname (used by UMI tests). Returns
+    /// a noodles `RecordBuf` ready for `from_noodles_record_with_umi`.
+    fn synth_with_qname(qname: &[u8], xr: &[u8], xg: &[u8], xm: &[u8], seq: &[u8]) -> RecordBuf {
+        let mut record = synth(xr, xg, xm, seq, 0);
+        *record.name_mut() = Some(BString::from(qname.to_vec()));
+        record
+    }
+
+    #[test]
+    fn umi_field_is_none_for_default_constructor() {
+        let r = synth_with_qname(b"read:CTCCTTAG", b"CT", b"CT", b".....", b"ACGTC");
+        let bm = BismarkRecord::from_noodles_record(r).unwrap();
+        assert!(
+            bm.umi().is_none(),
+            "non-UMI constructor must leave umi as None"
+        );
+    }
+
+    #[test]
+    fn from_noodles_record_with_umi_extracts_barcode_format() {
+        let r = synth_with_qname(b"read:CTCCTTAG", b"CT", b"CT", b".....", b"ACGTC");
+        let bm =
+            BismarkRecord::from_noodles_record_with_umi(r, crate::umi::extract_barcode).unwrap();
+        let umi = bm.umi().expect("barcode extractor must populate umi");
+        assert_eq!(umi.as_slice(), b"CTCCTTAG");
+    }
+
+    #[test]
+    fn from_noodles_record_with_umi_extracts_bclconvert_format() {
+        let r = synth_with_qname(
+            b"A00001:1:HABC:1:1101:1000:2000:CAAGAG_1:N:0:AATGACGC",
+            b"CT",
+            b"CT",
+            b".....",
+            b"ACGTC",
+        );
+        let bm =
+            BismarkRecord::from_noodles_record_with_umi(r, crate::umi::extract_bclconvert).unwrap();
+        let umi = bm.umi().expect("bclconvert extractor must populate umi");
+        assert_eq!(umi.as_slice(), b"CAAGAG");
+    }
+
+    #[test]
+    fn from_noodles_record_with_umi_no_umi_in_qname_yields_none() {
+        // qname has no `:` → extractor returns None → umi field is None.
+        // (Dedup pipeline downstream is responsible for `UmiExtractionFailed`.)
+        let r = synth_with_qname(b"plain_qname_no_colon", b"CT", b"CT", b".....", b"ACGTC");
+        let bm =
+            BismarkRecord::from_noodles_record_with_umi(r, crate::umi::extract_barcode).unwrap();
+        assert!(bm.umi().is_none());
+    }
+
+    #[test]
+    fn set_umi_replaces_existing_umi() {
+        let r = synth_with_qname(b"read:OLD", b"CT", b"CT", b".....", b"ACGTC");
+        let mut bm = BismarkRecord::from_noodles_record(r).unwrap();
+        assert!(bm.umi().is_none());
+        bm.set_umi(Some(Umi::from_slice(b"NEWUMI42")));
+        assert_eq!(bm.umi().unwrap().as_slice(), b"NEWUMI42");
+        bm.set_umi(None);
+        assert!(bm.umi().is_none());
     }
 }


### PR DESCRIPTION
## Summary

Activates `--barcode` / `--umi` / `--bclconvert` flags on `deduplicate_bismark_rs`, engaging UMI-aware dedup byte-for-byte against Perl `deduplicate_bismark v0.25.1`'s `deduplicate_barcoded_rrbs` codepath. Position-only workflows (v1.0/v1.1) are byte-for-byte unchanged.

- **bismark-io**: `1.0.0-beta.4 → 1.0.0-beta.5` (additive: optional `umi` field on `BismarkRecord` + `*_with_umi` reader constructors)
- **bismark-dedup**: `1.1.0-beta.2 → 1.2.0-beta.1`
- **API-evolution**: new sibling `pub fn run_*_umi` functions; v1.1 signatures preserved verbatim — zero breaking changes for external callers
- **Banner strings**: ported faithfully from Perl `deduplicate_bismark:167/172` (STDERR startup) and `:903`/`:908` (per-file end summary — hyphen-form on STDERR, space-form in report file)
- **Failure handling**: `UmiExtractionFailed` errors at first failed record AND unlinks any partial output, honouring the plan's "no partial output on disk" invariant (verified empirically)

## Test plan

- [x] `cargo test --workspace` — all 290+ tests pass (146 bismark-io lib, 86 bismark-dedup lib, 28 integration, 7+3 sanity, 6 filename, 3 doctests; 5 oxy-only `byte_identity_real_data` ignored)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] **Headline byte-identity (V4/V5)** confirmed against the 10K Phase 0-bis CI fixtures — both `--barcode` and `--bclconvert` retained-qname sets match Perl exactly
- [x] **Diagnostic property (V6)**: Rust `--barcode` retains 148 more reads than position-only on `synth_barcode_10k`, and position-only is a strict subset of UMI mode
- [x] **`--parallel 4` × UMI byte-identity (V9)** against `--parallel 1` UMI output
- [x] **Partial-output cleanup (C1)** verified empirically: `--bclconvert` on barcode-format input errors AND leaves zero partial BAM on disk
- [x] **Banner byte-precision (C2)**: unit tests pin both forms (space line 908 in report file, hyphen line 903 on STDERR); negative test confirms non-UMI mode emits neither startup banner
- [ ] **Phase C** (next): real-data byte-identity gate on oxy 10M PE baselines

## Workflow trail

Plan rev 2 + dual plan-review (both APPROVE) + dual code-review (both NEEDS-FIXES → all findings addressed inline) + plan-manager audit (COMPLETE-WITH-DEVIATIONS) all on file under `~/.claude/plans/05252026_bismark-dedup-umi-v1.2/phaseB-*/`.

Findings folded back before merge: fabricated STDERR banner replaced with Perl-faithful line 167/172 strings; partial-output cleanup via `cleanup_partial_output_on_err` helper applied to all four `run_*_umi` functions; report-format STDERR vs file form differentiated via new `format_stderr()`; integration test path-normalisation tightened to keep banner intact; `UnsupportedFlagV1` dead-code variant removed; README flag rows + "Out of scope" section updated.

(Supersedes #837 — closed due to wrong base.)