### PR TITLE
docs(bismark-dedup): Phase D polish — V10 validation + Rust thread-scaling

### DIFF
--- a/rust/bismark-dedup/CHANGELOG.md
+++ b/rust/bismark-dedup/CHANGELOG.md
@@ -76,6 +76,51 @@ arrives. Phase B of the v1.2 UMI epic. Position-only dedup workflows
 
 - New: `smallvec = "=1.13.2"`. Matches `bismark-io`'s pin.
 
+### Validation (Phase C V10 — production-scale byte-identity)
+
+Real-data byte-identity confirmed against Perl `deduplicate_bismark v0.25.1`
+on the full Olecka 2024 SRR24766921 RRBS sample (oxy host, BamReader
+with `--parallel 4`):
+
+| Mode | Retained qnames (Rust = Perl) | Report bytes |
+|------|------------------------------|--------------|
+| `--barcode` (single-threaded) | 6,524,173 | 299 |
+| `--barcode --parallel 4` | 6,524,173 | 299 |
+| `--bclconvert` (single-threaded) | 6,538,044 | 304 |
+| `--bclconvert --parallel 4` | 6,538,044 | 304 |
+
+Tests live in `bismark-dedup/tests/byte_identity_real_data.rs` as
+`#[ignore]`'d gates. Run on oxy via `cargo test --release --test
+byte_identity_real_data -- --ignored --exact byte_identity_real_data_umi_*`
+(see Phase C PR #839 for the run recipe).
+
+Both retained-qname sets and report bytes match Perl baselines
+exactly. `--parallel 4` produces identical output to the
+single-threaded path, confirming the BGZF-threaded UMI path's
+byte-identity invariant at production scale (~6.5M retained pairs).
+
+### Performance (BGZF thread scaling, oxy)
+
+Wall-clock + peak RSS for both UMI modes against the production-scale
+Phase 0 baselines on oxy (~951 MB input BAM per mode):
+
+| Mode | `--parallel 1` (wall) | `--parallel 4` (wall) | Speedup | Peak RSS |
+|------|----------------------|----------------------|---------|----------|
+| `--barcode` | 1:02.63 (62.6s) | 0:13.37 (13.4s) | **4.68×** | ~608 MB |
+| `--bclconvert` | 1:02.90 (62.9s) | 0:13.59 (13.6s) | **4.63×** | ~608 MB |
+
+In line with v1.1's measured 4.88× speedup on the larger 10M PE WGBS
+dataset — BGZF-threading speedup scales similarly across UMI vs
+non-UMI workloads. Peak RSS is essentially identical between
+single-threaded and `--parallel 4`, confirming the threaded path
+doesn't multiply dedup-state memory; only BGZF block buffers grow.
+
+A Perl-baseline measurement on the same oxy host is queued (network
+hiccup interrupted the run); will be added as a follow-up CHANGELOG
+note. The byte-identity tests already cite the production-scale
+correctness signal; the Perl-vs-Rust wall-time comparison is
+informational.
+
 ## [1.1.0-beta.2] — 2026-05-25
 
 Inherits **magic-byte file-format detection** from `bismark-io`


### PR DESCRIPTION
## Summary

CHANGELOG-only patch (no source changes). Adds two new subsections to the v1.2.0-beta.1 entry in \`bismark-dedup/CHANGELOG.md\`:

### Validation (Phase C V10 — production-scale byte-identity)

| Mode | Retained qnames (Rust = Perl) | Report bytes |
|------|------------------------------|--------------|
| \`--barcode\` (single-threaded) | 6,524,173 | 299 |
| \`--barcode --parallel 4\` | 6,524,173 | 299 |
| \`--bclconvert\` (single-threaded) | 6,538,044 | 304 |
| \`--bclconvert --parallel 4\` | 6,538,044 | 304 |

Cites the Phase C tests (\`tests/byte_identity_real_data.rs\`'s 4 new \`#[ignore]\`'d gates) for reproducibility.

### Performance (BGZF thread scaling, oxy)

| Mode | \`--parallel 1\` | \`--parallel 4\` | Speedup | Peak RSS |
|------|-----------------|------------------|---------|----------|
| \`--barcode\` | 1:02.63 | 0:13.37 | **4.68×** | ~608 MB |
| \`--bclconvert\` | 1:02.90 | 0:13.59 | **4.63×** | ~608 MB |

Measured on oxy host against the same Phase 0 baselines. In line with v1.1's 4.88× at N=4 on the 10M PE WGBS dataset. Peak RSS is essentially identical between single-threaded and \`--parallel 4\` — threading doesn't multiply dedup-state memory; only BGZF block buffers grow.

A Perl-baseline measurement on the same oxy host is queued as a follow-up CHANGELOG note (network hiccup interrupted the run mid-way; the byte-identity tests already cite the production-scale correctness signal, so the Perl-vs-Rust wall-time comparison is informational and can land in a follow-up commit).

## Test plan

- [x] \`cargo build -p bismark-dedup\` clean
- [x] \`cargo fmt --check\` clean
- [x] All 232 workspace lib tests still pass (146 + 86; unchanged from Phase B)
- [x] No source changes — CHANGELOG-only +45 LOC patch

## Workflow trail

Plan: \`~/.claude/plans/05252026_bismark-dedup-umi-v1.2/phaseD-polish-publish/PLAN.md\` (streamlined cadence per user: skip dual plan-review; CHANGELOG/docs polish + measurement-and-document pattern).

This PR closes the polish step. After merge, the remaining Phase D steps (per the plan, **gated on explicit user authorization**):
1. Create tags \`bismark-io-v1.0.0-beta.5\` + \`bismark-dedup-v1.2.0-beta.1\` (after this PR merges + iron-chancellor sync).
2. \`cargo publish --dry-run\` for both crates.
3. \`cargo publish\` (Strategy A: heads only — bismark-io beta.5 then bismark-dedup 1.2.0-beta.1).