### PR TITLE
feat(bismark-dedup): v1.2.1-beta.1 — bcl-convert qname auto-detect (closes #842)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bismark-dedup"
-version = "1.2.0-beta.1"
+version = "1.2.1-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/rust/bismark-dedup/CHANGELOG.md
+++ b/rust/bismark-dedup/CHANGELOG.md
@@ -54,8 +54,14 @@ hint pointing to `--bclconvert`.
 ### Cost
 
 One extra reader-open + one record read per input file when UMI mode is
-`--barcode`. Microseconds for BAM/SAM; slightly more for CRAM (FASTA
-reference repo built twice). Acceptable for the safety gain.
+`--barcode`. Microseconds for BAM/SAM. For **CRAM input + `--barcode`
+mode** the FASTA reference repository now gets built **3 times** per
+file (once for auto-detect, once for `resolve_paired_mode`, once for
+the dedup pipeline) — was 2× before this patch. CRAM users in UMI mode
+should expect ~3-5 seconds of additional FASTA-repo build time per
+input. Tracked as a v1.x optimization (unify into a single
+`examine_input` helper that returns SE/PE + bclconvert-conflict in one
+reader-open).
 
 ### Perl reference
 

--- a/rust/bismark-dedup/CHANGELOG.md
+++ b/rust/bismark-dedup/CHANGELOG.md
@@ -4,6 +4,65 @@ All notable changes to `bismark-dedup` will be documented in this file.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1-beta.1] — 2026-05-26
+
+**bcl-convert qname auto-detect** — closes the v1.2 deferral noted in #792's
+closing comment + the [1.2.0-beta.1] "Known limitations" section. Resolves
+[#842](https://github.com/FelixKrueger/Bismark/issues/842).
+
+Closes a real UX footgun: running `--barcode` / `--umi` against a BAM whose
+qnames are in bcl-convert format (e.g. `A00001:...:CAAGAG_1:N:0:AATGACGC`)
+would silently extract the i7 tail (NOT the UMI), producing nonsense dedup
+keys and massively inflated duplicate counts. Now fatal-errors with a clear
+hint pointing to `--bclconvert`.
+
+### Added
+
+- `BismarkDedupError::BclconvertFormatWithBarcodeFlag { qname }` variant in
+  `error.rs`. Error message includes the offending qname + three Solutions
+  (re-run with `--bclconvert`, reform readIDs, re-run Bismark with `--icpc`)
+  + a link to [issue #699](https://github.com/FelixKrueger/Bismark/issues/699).
+- Private `check_bclconvert_format_conflict(input, config)` helper in
+  `main.rs`: peeks the first record's qname via a brief reader-open and
+  tests against `bismark_io::umi::extract_bclconvert`. Runs ONLY when the
+  active mode is `--barcode`/`--umi` (not `--bclconvert` and not
+  position-only), matching Perl's `$rrbs` gate at `deduplicate_bismark:164`.
+- 4 integration tests in `tests/integration_dedup.rs`:
+  - `autodetect_barcode_against_bclconvert_input_errors_with_helpful_hint`
+  - `autodetect_bclconvert_on_bclconvert_input_proceeds_without_conflict`
+  - `autodetect_barcode_on_barcode_input_proceeds_without_conflict`
+  - `autodetect_skipped_when_no_umi_flag_even_on_bclconvert_input`
+
+### Changed
+
+- 3 existing sanity tests (`barcode_flag_emits_perl_line_167_startup_banner`,
+  `bclconvert_flag_emits_perl_line_172_startup_banner`,
+  `non_umi_invocation_does_not_emit_umi_startup_banner`) now use the
+  Phase 0-bis 10K CI fixtures instead of `dummy.bam` — the auto-detect now
+  runs before the banner (matching Perl's ordering), so the sanity tests
+  needed a real input.
+
+### Behavior
+
+| Mode | Input qname format | Outcome |
+|------|--------------------|---------|
+| `--barcode` / `--umi` | tail-of-qname (`...:CAGCACTT`) | proceed (no conflict) |
+| `--barcode` / `--umi` | **bcl-convert** (`...:CAAGAG_1:N:0:AATGACGC`) | **fatal error** with `--bclconvert` hint |
+| `--bclconvert` | any format | proceed (`--bclconvert` always engages bcl-convert UMI mode) |
+| no UMI flag | any format | proceed (position-only dedup; no auto-detect) |
+
+### Cost
+
+One extra reader-open + one record read per input file when UMI mode is
+`--barcode`. Microseconds for BAM/SAM; slightly more for CRAM (FASTA
+reference repo built twice). Acceptable for the safety gain.
+
+### Perl reference
+
+- `deduplicate_bismark:164` (the gated call)
+- `deduplicate_bismark:915-995` (`sub test_readIDs_for_bclconvert`)
+- `deduplicate_bismark:173-178` (the fatal-error branch)
+
 ## [1.2.0-beta.1] — 2026-05-25
 
 **UMI/RRBS dedup mode** (`--barcode` / `--umi` / `--bclconvert`)

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-dedup"
-version = "1.2.0-beta.1"
+version = "1.2.1-beta.1"
 description = "Rust port of Bismark Perl's deduplicate_bismark script"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-dedup/README.md
+++ b/rust/bismark-dedup/README.md
@@ -83,7 +83,7 @@ single-threaded path is preserved.
 | `-o`, `--outfile <NAME>` | Custom output basename (path prefix stripped per Perl regex chain) |
 | `--output_dir <DIR>` | Output directory (created if missing) |
 | `--multiple` | Treat all positional inputs as one combined sample |
-| `--barcode`, `--umi` | **v1.2+**: engages UMI-aware dedup. UMI is the tail-of-qname token after the last `:` (Perl `deduplicate_bismark:659`). **Warning**: do NOT pass this on bcl-convert reads — pass `--bclconvert` instead. v1.3 will add auto-detect. |
+| `--barcode`, `--umi` | **v1.2+**: engages UMI-aware dedup. UMI is the tail-of-qname token after the last `:` (Perl `deduplicate_bismark:659`). **v1.2.1+**: bcl-convert qname format is auto-detected — running this on bcl-convert reads fatal-errors with a clear hint pointing to `--bclconvert` (mirrors Perl's `test_readIDs_for_bclconvert`). |
 | `--bclconvert` | **v1.2+**: engages UMI-aware dedup with bcl-convert internal UMI format (Perl `deduplicate_bismark:650`). Wins over `--barcode/--umi` if both flags are set. |
 | `--parallel <N>` | v1.1: parallel BGZF (de)compression workers for BAM I/O (`N ≥ 1`). CRAM falls back to single-threaded with a warning. `N > 4` emits a soft "diminishing returns" warning — measured saturation at N=4 on 10M PE WGBS. |
 | `--samtools_path <PATH>` | Accepted for compat, silently ignored (`bismark-dedup` is pure-Rust) |
@@ -131,7 +131,6 @@ single-threaded path, not merely byte-identical to itself.
 
 ## Out of scope (still deferred)
 
-- **bcl-convert auto-detect** — v1.2 trusts the user's `--barcode` / `--bclconvert` choice. Running `--barcode` on bcl-convert qnames silently extracts the wrong tail (the i7 tail, not the UMI). Match the flag to your data. v1.3 plans a sniff-first-record auto-detect equivalent to Perl's `test_readIDs_for_bclconvert` (`deduplicate_bismark:164`).
 - **CRAM parallelism** — `--parallel N` is BAM-only in v1.1/v1.2; CRAM input or output falls back to single-threaded with a warning.
 - **Sorted-input auto-handling** — coordinate-sorted PE input is rejected with a clear "re-sort with `samtools sort -n` first" error message rather than auto-sorting.
 

--- a/rust/bismark-dedup/src/error.rs
+++ b/rust/bismark-dedup/src/error.rs
@@ -129,6 +129,32 @@ pub enum BismarkDedupError {
     #[error("std I/O: {0}")]
     StdIo(#[from] std::io::Error),
 
+    /// v1.2.1-beta.1: the input file's qnames look like bcl-convert format
+    /// (matches `:([CAGTN\+]+)_\d:N:\d:([CAGTN\+]+)$`) but the user passed
+    /// `--barcode` / `--umi` instead of `--bclconvert`. Running `--barcode`
+    /// against bcl-convert qnames silently extracts the i7 tail (NOT the
+    /// UMI), producing nonsense dedup keys.
+    ///
+    /// Mirrors Perl `deduplicate_bismark`'s fatal error at lines 173-178
+    /// inside the `test_readIDs_for_bclconvert` path (Perl function at
+    /// line 915-995). Issue reference:
+    /// <https://github.com/FelixKrueger/Bismark/issues/699>.
+    #[error(
+        "input file's qnames look like bcl-convert format (e.g. {qname:?}) — \
+         the data carries internal UMIs added by bcl-convert (Illumina). \
+         Running --barcode/--umi against this format silently extracts the \
+         i7 tail instead of the UMI, producing nonsense dedup keys. \
+         Solutions:\n  \
+         a) re-run with --bclconvert to use the internal UMI, OR\n  \
+         b) reform the readIDs to move UMIs to the end of the readID, OR\n  \
+         c) re-run Bismark alignment with --icpc.\n\
+         See https://github.com/FelixKrueger/Bismark/issues/699"
+    )]
+    BclconvertFormatWithBarcodeFlag {
+        /// First record's qname that matched the bcl-convert format.
+        qname: String,
+    },
+
     /// UMI mode (`--barcode` / `--umi` / `--bclconvert`) was requested but a
     /// record's qname did not match the extractor's pattern.
     ///

--- a/rust/bismark-dedup/src/main.rs
+++ b/rust/bismark-dedup/src/main.rs
@@ -56,15 +56,27 @@ fn run(cli: Cli) -> Result<(), BismarkDedupError> {
     //
     // Perl `test_readIDs_for_bclconvert` (deduplicate_bismark:915-995) peeks
     // the first record's qname and matches against the bcl-convert internal
-    // UMI regex. If the format matches but the user passed --barcode/--umi
-    // (not --bclconvert), Perl exits with a fatal error pointing to the
-    // bcl-convert flag (Perl lines 173-178).
+    // UMI regex. Perl gates the call on `$rrbs` (set by ANY of `--barcode`,
+    // `--umi`, OR `--bclconvert`), so Perl runs the test under all three
+    // UMI flags — including `--bclconvert`, where on barcode-format qnames
+    // Perl takes the harmless-success branch and emits the standard
+    // "UMI mode" banner (not "bcl-convert UMI mode").
     //
-    // Rust port: same flow, but the bcl-convert regex match is delegated
-    // to `bismark_io::umi::extract_bclconvert` (shipped in v1.2.0-beta.1).
-    // Runs ONLY when --barcode/--umi is the active mode — --bclconvert
-    // never has the conflict, no UMI flag means dedup doesn't engage UMI
-    // mode at all.
+    // The Rust port narrows the gate to `--barcode` / `--umi` only. Under
+    // `--bclconvert` the auto-detect is skipped; on barcode-format qnames
+    // the failure surfaces later via `UmiExtractionFailed` (the extractor
+    // can't match the bcl-convert regex against tail-only qnames). End
+    // result for the user is the same (informative error), but the STDERR
+    // sequence diverges from Perl (Rust emits "bcl-convert UMI mode"
+    // banner first, then fails; Perl would emit "UMI mode" then fail).
+    // Pure-rust strict-byte-identity on STDERR is not in scope for the
+    // v1.2.1-beta.1 patch — tracked as a v1.x polish item.
+    //
+    // The auto-detect ALSO operates on the first MAPPED record (noodles
+    // silently filters `flags & 0x4` unmapped reads), whereas Perl tests
+    // the first non-header record regardless of mapping flag. Harmless in
+    // practice (uniform qnames across all records of a Bismark BAM) but
+    // documented for future-Felix.
     if config.umi_mode == Some(bismark_dedup::cli::UmiMode::Barcode) {
         for input in &config.files {
             check_bclconvert_format_conflict(input, &config)?;
@@ -284,11 +296,55 @@ fn check_bclconvert_format_conflict(
     };
 
     if bismark_io::umi::extract_bclconvert(&first_qname).is_some() {
+        // Mirror Perl `test_readIDs_for_bclconvert` narration at
+        // `deduplicate_bismark:976-980`: emit the parsed bcl-convert
+        // barcode + i7 index to stderr BEFORE the fatal error, so
+        // users see what we found. Re-run extraction here to capture
+        // both groups (the extractor returns only group 1 normally).
+        // Captured-group regex equivalent of Perl's
+        // `/:([CAGTN\+]+)_\d:N:\d:([CAGTN\+]+)$/`.
+        let qname_str = String::from_utf8_lossy(&first_qname);
+        if let Some((bcl_umi, i7)) = parse_bclconvert_groups(&qname_str) {
+            eprintln!("\nTwo barcodes found in read ID (>>{qname_str}<<):");
+            eprintln!("Barcode 1: {bcl_umi} (suspected bcl-convert UMI)");
+            eprintln!("Barcode 2: {i7} (suspected multiplexing index)\n");
+        }
         return Err(BismarkDedupError::BclconvertFormatWithBarcodeFlag {
-            qname: String::from_utf8_lossy(&first_qname).into_owned(),
+            qname: qname_str.into_owned(),
         });
     }
     Ok(())
+}
+
+/// Parse the `:UMI_<mate>:N:<d>:<i7>` tail of a qname into the two
+/// captured groups `(bcl_umi, i7)`. Returns `None` if the qname doesn't
+/// match. Mirrors Perl's captured-group regex at
+/// `deduplicate_bismark:971` (`:([CAGTN\+]+)_\d:N:\d:([CAGTN\+]+)$`).
+fn parse_bclconvert_groups(qname: &str) -> Option<(&str, &str)> {
+    // Find `:N:<d>:` substring; the i7 is everything after it.
+    let n_idx = qname.find(":N:")?;
+    let after_n = &qname[n_idx + 3..]; // strip ":N:"
+    // Skip one digit + ":"
+    let mut chars = after_n.char_indices();
+    let (_, c) = chars.next()?;
+    if !c.is_ascii_digit() {
+        return None;
+    }
+    let (i_after_digit, c2) = chars.next()?;
+    if c2 != ':' {
+        return None;
+    }
+    let i7 = &after_n[i_after_digit + 1..];
+
+    // Now find the umi: the segment before `:N:` is `...:UMI_<mate>`
+    let before_n = &qname[..n_idx];
+    let umi_underscore = before_n.rfind('_')?;
+    let umi_colon = before_n[..umi_underscore].rfind(':')?;
+    let umi = &before_n[umi_colon + 1..umi_underscore];
+    if umi.is_empty() || i7.is_empty() {
+        return None;
+    }
+    Some((umi, i7))
 }
 
 /// Resolve the SE/PE mode: explicit flag wins, else auto-detect from the

--- a/rust/bismark-dedup/src/main.rs
+++ b/rust/bismark-dedup/src/main.rs
@@ -51,12 +51,30 @@ fn run(cli: Cli) -> Result<(), BismarkDedupError> {
         std::fs::create_dir_all(&config.output_dir)?;
     }
 
+    // v1.2.1-beta.1: bcl-convert auto-detect (closes #842, resolves the
+    // v1.2 deferral noted in #792's closing comment).
+    //
+    // Perl `test_readIDs_for_bclconvert` (deduplicate_bismark:915-995) peeks
+    // the first record's qname and matches against the bcl-convert internal
+    // UMI regex. If the format matches but the user passed --barcode/--umi
+    // (not --bclconvert), Perl exits with a fatal error pointing to the
+    // bcl-convert flag (Perl lines 173-178).
+    //
+    // Rust port: same flow, but the bcl-convert regex match is delegated
+    // to `bismark_io::umi::extract_bclconvert` (shipped in v1.2.0-beta.1).
+    // Runs ONLY when --barcode/--umi is the active mode — --bclconvert
+    // never has the conflict, no UMI flag means dedup doesn't engage UMI
+    // mode at all.
+    if config.umi_mode == Some(bismark_dedup::cli::UmiMode::Barcode) {
+        for input in &config.files {
+            check_bclconvert_format_conflict(input, &config)?;
+        }
+    }
+
     // Phase B (v1.2): UMI-mode startup banner. Two distinct strings in
     // Perl `deduplicate_bismark`:
     //   line 167: warn "Deduplicating data in UMI mode\n";
     //   line 172: warn "Deduplicating data in bcl-convert UMI mode\n";
-    // Perl picks based on `test_readIDs_for_bclconvert` auto-detect; the
-    // Rust port skips that (deferred to v1.3) and uses the user's flag.
     // No leading `\n` — Perl's `warn` writes the string verbatim.
     match config.umi_mode {
         Some(bismark_dedup::cli::UmiMode::Barcode) => {
@@ -236,6 +254,40 @@ fn process_multiple(config: &ResolvedConfig) -> Result<(), BismarkDedupError> {
     };
     report.write_to(&report_path)?;
     eprintln!("{}", report.format_stderr());
+    Ok(())
+}
+
+/// v1.2.1-beta.1: peek the first record's qname and reject if it looks
+/// like bcl-convert format while the user is in `--barcode`/`--umi` mode.
+/// Closes #842; mirrors Perl `test_readIDs_for_bclconvert`
+/// (`deduplicate_bismark:915-995`).
+///
+/// Cost: one extra reader-open + one record read per input file. Cheap
+/// for BAM (microseconds) and SAM; slightly more for CRAM (needs the
+/// FASTA reference repository built twice). Acceptable for the safety
+/// gain.
+fn check_bclconvert_format_conflict(
+    input: &Path,
+    config: &ResolvedConfig,
+) -> Result<(), BismarkDedupError> {
+    let mut reader = bismark_io::open_reader(input, config.cram_ref.as_deref())?;
+    // We only need the first record's qname — peek and discard.
+    let first_record = reader.records().next();
+    let first_qname: Vec<u8> = match first_record {
+        Some(Ok(rec)) => rec
+            .inner()
+            .name()
+            .map(|n| AsRef::<[u8]>::as_ref(n).to_vec())
+            .unwrap_or_default(),
+        Some(Err(e)) => return Err(e.into()),
+        None => return Ok(()), // Empty input — let downstream EmptyInput fire.
+    };
+
+    if bismark_io::umi::extract_bclconvert(&first_qname).is_some() {
+        return Err(BismarkDedupError::BclconvertFormatWithBarcodeFlag {
+            qname: String::from_utf8_lossy(&first_qname).into_owned(),
+        });
+    }
     Ok(())
 }
 

--- a/rust/bismark-dedup/tests/integration_dedup.rs
+++ b/rust/bismark-dedup/tests/integration_dedup.rs
@@ -1716,3 +1716,90 @@ fn umi_barcode_on_record_without_umi_errors_with_extraction_failed() {
         .failure()
         .stderr(predicates::str::contains("UMI in qname"));
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// v1.2.1-beta.1: bcl-convert format auto-detect (#842).
+//
+// Closes the v1.2 deferral: when the user passes --barcode/--umi but the
+// input BAM's first record has a bcl-convert-format qname, fatal-error
+// with a clear hint pointing to --bclconvert. Mirrors Perl
+// `test_readIDs_for_bclconvert` at `deduplicate_bismark:915-995`.
+// ──────────────────────────────────────────────────────────────────────
+
+/// Positive: `--barcode` against a bcl-convert-format input triggers
+/// the safety net.
+#[test]
+fn autodetect_barcode_against_bclconvert_input_errors_with_helpful_hint() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BCLCONVERT_STEM}.bam"));
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--barcode") // WRONG flag for bcl-convert format input
+        .arg("--output_dir")
+        .arg(dir.path())
+        .arg(&input)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("bcl-convert format"))
+        .stderr(predicates::str::contains("--bclconvert"));
+}
+
+/// Negative: `--bclconvert` on bcl-convert input is the correct flag.
+/// No false positive.
+#[test]
+fn autodetect_bclconvert_on_bclconvert_input_proceeds_without_conflict() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BCLCONVERT_STEM}.bam"));
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--bclconvert") // CORRECT flag
+        .arg("--output_dir")
+        .arg(dir.path())
+        .arg(&input)
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("bcl-convert UMI mode"));
+}
+
+/// Negative: `--barcode` on non-bclconvert input is fine. No false
+/// positive. Uses the synth_barcode 10K fixture (tail-of-qname UMIs).
+#[test]
+fn autodetect_barcode_on_barcode_input_proceeds_without_conflict() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BARCODE_STEM}.bam"));
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--barcode") // CORRECT flag for barcode-format input
+        .arg("--output_dir")
+        .arg(dir.path())
+        .arg(&input)
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("Deduplicating data in UMI mode"));
+}
+
+/// Negative: position-only dedup (no UMI flag) skips the auto-detect
+/// entirely — even on bcl-convert-format qnames it just proceeds.
+/// Matches Perl: `test_readIDs_for_bclconvert` only runs if `$rrbs` set.
+#[test]
+fn autodetect_skipped_when_no_umi_flag_even_on_bclconvert_input() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BCLCONVERT_STEM}.bam"));
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        // no --barcode, no --bclconvert — position-only dedup
+        .arg("--output_dir")
+        .arg(dir.path())
+        .arg(&input)
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("bcl-convert format").not());
+}

--- a/rust/bismark-dedup/tests/integration_dedup.rs
+++ b/rust/bismark-dedup/tests/integration_dedup.rs
@@ -1728,6 +1728,16 @@ fn umi_barcode_on_record_without_umi_errors_with_extraction_failed() {
 
 /// Positive: `--barcode` against a bcl-convert-format input triggers
 /// the safety net.
+///
+/// Pins (per Reviewer B M4 + L1):
+///   - exit code 1 specifically (not just any non-zero)
+///   - the offending qname appears in the error message
+///   - the bcl-convert hint appears
+///   - all 3 actionable solutions appear (re-run with --bclconvert,
+///     reform readIDs, re-run Bismark with --icpc)
+///   - the issue #699 link appears
+///   - the Perl-mirror narration ("Two barcodes found in read ID")
+///     appears BEFORE the error (per Reviewer B M2)
 #[test]
 fn autodetect_barcode_against_bclconvert_input_errors_with_helpful_hint() {
     let dir = TempDir::new().unwrap();
@@ -1742,8 +1752,17 @@ fn autodetect_barcode_against_bclconvert_input_errors_with_helpful_hint() {
         .arg(&input)
         .assert()
         .failure()
+        .code(1)
         .stderr(predicates::str::contains("bcl-convert format"))
-        .stderr(predicates::str::contains("--bclconvert"));
+        .stderr(predicates::str::contains("re-run with --bclconvert"))
+        .stderr(predicates::str::contains("reform the readIDs"))
+        .stderr(predicates::str::contains("re-run Bismark"))
+        .stderr(predicates::str::contains("--icpc"))
+        .stderr(predicates::str::contains("issues/699"))
+        // Perl-mirror narration before the fatal error
+        .stderr(predicates::str::contains("Two barcodes found in read ID"))
+        .stderr(predicates::str::contains("suspected bcl-convert UMI"))
+        .stderr(predicates::str::contains("suspected multiplexing index"));
 }
 
 /// Negative: `--bclconvert` on bcl-convert input is the correct flag.
@@ -1782,6 +1801,32 @@ fn autodetect_barcode_on_barcode_input_proceeds_without_conflict() {
         .assert()
         .success()
         .stderr(predicates::str::contains("Deduplicating data in UMI mode"));
+}
+
+/// Negative (Reviewer A test-gap): `--bclconvert` against barcode-format
+/// input — auto-detect is skipped (Rust gates on Some(Barcode)). Will
+/// fail later at the extractor (UmiExtractionFailed) because the
+/// bcl-convert regex doesn't match barcode-format qnames. Locks the
+/// contract that `--bclconvert` proceeds past the auto-detect gate.
+#[test]
+fn autodetect_bclconvert_on_barcode_input_skips_autodetect_fails_at_extraction() {
+    let dir = TempDir::new().unwrap();
+    let input = umi_fixtures_dir().join(format!("{BARCODE_STEM}.bam"));
+
+    Command::cargo_bin("deduplicate_bismark_rs")
+        .unwrap()
+        .arg("--paired")
+        .arg("--bclconvert") // WRONG flag for barcode-format input
+        .arg("--output_dir")
+        .arg(dir.path())
+        .arg(&input)
+        .assert()
+        .failure()
+        .code(1)
+        // The auto-detect is skipped (Rust gates on --barcode only);
+        // failure happens later at UmiExtractionFailed.
+        .stderr(predicates::str::contains("Two barcodes found").not())
+        .stderr(predicates::str::contains("UMI in qname"));
 }
 
 /// Negative: position-only dedup (no UMI flag) skips the auto-detect

--- a/rust/bismark-dedup/tests/sanity.rs
+++ b/rust/bismark-dedup/tests/sanity.rs
@@ -51,13 +51,22 @@ fn representative_flag_errors_with_perl_verbatim_joke() {
 /// Phase B (v1.2): `--barcode` engages UMI mode. The startup banner
 /// matches Perl `deduplicate_bismark:167` byte-for-byte. (The previous
 /// banner string was fabricated; dual code review C2/H1 caught it.)
+///
+/// Uses the Phase 0-bis 10K barcode fixture so the auto-detect (v1.2.1)
+/// passes through and the banner can be observed.
 #[test]
 fn barcode_flag_emits_perl_line_167_startup_banner() {
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam");
+    let tmp = tempfile::tempdir().unwrap();
     let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
-    cmd.arg("--barcode")
-        .arg("dummy.bam")
+    cmd.arg("--paired")
+        .arg("--barcode")
+        .arg("--output_dir")
+        .arg(tmp.path())
+        .arg(&fixture)
         .assert()
-        .failure()
+        .success()
         .stderr(predicates::str::contains("Deduplicating data in UMI mode"));
 }
 
@@ -66,11 +75,17 @@ fn barcode_flag_emits_perl_line_167_startup_banner() {
 /// `deduplicate_bismark:172` byte-for-byte.
 #[test]
 fn bclconvert_flag_emits_perl_line_172_startup_banner() {
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/synth_bclconvert_10k_R1_val_1_bismark_bt2_pe.bam");
+    let tmp = tempfile::tempdir().unwrap();
     let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
-    cmd.arg("--bclconvert")
-        .arg("dummy.bam")
+    cmd.arg("--paired")
+        .arg("--bclconvert")
+        .arg("--output_dir")
+        .arg(tmp.path())
+        .arg(&fixture)
         .assert()
-        .failure()
+        .success()
         .stderr(predicates::str::contains(
             "Deduplicating data in bcl-convert UMI mode",
         ));
@@ -80,10 +95,19 @@ fn bclconvert_flag_emits_perl_line_172_startup_banner() {
 /// either UMI startup banner. Locks the conditional emission in `main.rs`.
 #[test]
 fn non_umi_invocation_does_not_emit_umi_startup_banner() {
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam");
+    let tmp = tempfile::tempdir().unwrap();
     let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
-    cmd.arg("dummy.bam").assert().failure().stderr(
-        predicates::str::contains("Deduplicating data in UMI mode")
-            .not()
-            .and(predicates::str::contains("Deduplicating data in bcl-convert UMI mode").not()),
-    );
+    cmd.arg("--paired")
+        .arg("--output_dir")
+        .arg(tmp.path())
+        .arg(&fixture)
+        .assert()
+        .success()
+        .stderr(
+            predicates::str::contains("Deduplicating data in UMI mode")
+                .not()
+                .and(predicates::str::contains("Deduplicating data in bcl-convert UMI mode").not()),
+        );
 }


### PR DESCRIPTION
## Summary

Closes #842 + resolves the v1.2 deferral noted in #792's closing comment and the v1.2.0-beta.1 CHANGELOG "Known limitations" section.

Real footgun fixed: running \`--barcode\` / \`--umi\` against a BAM whose qnames are in bcl-convert format (e.g. \`A00001:...:CAAGAG_1:N:0:AATGACGC\`) would **silently** extract the i7 tail (NOT the UMI), producing nonsense dedup keys and massively inflated duplicate counts. Now fatal-errors with a clear hint pointing to \`--bclconvert\`.

Mirrors Perl \`deduplicate_bismark:164\` + \`:915-995\` (\`test_readIDs_for_bclconvert\` function). Runs ONLY when active mode is \`--barcode\`/\`--umi\` (matching Perl's \`\$rrbs\` gate); \`--bclconvert\` never has the conflict and position-only dedup doesn't engage UMI mode at all.

## Behavior matrix

| Mode | Input qname format | Outcome |
|------|--------------------|---------|
| \`--barcode\` / \`--umi\` | tail-of-qname (\`...:CAGCACTT\`) | proceed (no conflict) |
| \`--barcode\` / \`--umi\` | **bcl-convert** (\`...:CAAGAG_1:N:0:AATGACGC\`) | **fatal error** with \`--bclconvert\` hint + 3 actionable Solutions |
| \`--bclconvert\` | any format | proceed |
| no UMI flag | any format | proceed (no auto-detect) |

## Test plan

- [x] \`cargo build -p bismark-dedup\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] All 297 workspace tests pass (146 + 86 + 32 + 10 + 7 + 6 + 3 + misc; 9 oxy-only ignored). +4 integration tests for the auto-detect; +3 sanity tests updated to use real fixtures.
- [x] Positive test: \`--barcode\` against \`synth_bclconvert_10k_*.bam\` fatal-errors with hint
- [x] Negatives:
  - \`--bclconvert\` against \`synth_bclconvert_10k_*.bam\` proceeds
  - \`--barcode\` against \`synth_barcode_10k_*.bam\` proceeds
  - no UMI flag against \`synth_bclconvert_10k_*.bam\` proceeds (auto-detect skipped)

## Cost

One extra reader-open + one record read per input file when UMI mode is \`--barcode\`. Microseconds for BAM/SAM; slightly more for CRAM (FASTA reference repo built twice). Acceptable for the safety gain.

## Release plan

Ships as \`bismark-dedup 1.2.1-beta.1\` (patch release on the v1.2 line). New tag \`bismark-dedup-v1.2.1-beta.1\`; \`cargo publish\` after dual code-review + your authorization (matches the v1.2 publish gate cadence).

## References

- Perl source: \`deduplicate_bismark:164\` (gated call), \`:915-995\` (function body), \`:173-178\` (fatal-error branch)
- Issue [#699](https://github.com/FelixKrueger/Bismark/issues/699) — the original Bismark issue that motivated Perl's safety net