### PR TITLE
feat(bismark-io): v1.0.0-beta.6 — read-orientation iter_aligned adapter (closes #843)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-io"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "bstr",
  "noodles-bam",

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -19,7 +19,7 @@ name = "deduplicate_bismark_rs"
 path = "src/main.rs"
 
 [dependencies]
-bismark-io = { version = "=1.0.0-beta.5", path = "../bismark-io" }
+bismark-io = { version = "=1.0.0-beta.6", path = "../bismark-io" }
 # noodles-sam pinned to match bismark-io =1.0.0's transitive choice.
 # Needed directly for `Header` (returned by `bismark_io::open_reader`
 # via `AnyReader::header`) and for test-helper types.

--- a/rust/bismark-io/CHANGELOG.md
+++ b/rust/bismark-io/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes to `bismark-io` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.6] — 2026-05-26
+
+**Read-orientation `iter_aligned()` adapter** on `BismarkRecord` for the
+upcoming bismark-extractor port (epic #798). Resolves
+[#843](https://github.com/FelixKrueger/Bismark/issues/843).
+
+Additive only — non-extractor workflows continue to use `xm()` +
+`cigar()` directly. The new iterator hides the
+`-`-strand-reverse-complement orientation correction needed for M-bias
+accumulation by sequencing-cycle position.
+
+### Added
+
+- New struct `AlignedXmCall { read_pos_5p: u32, ref_pos: u32, xm_byte: u8 }`
+  in `record.rs`. Re-exported at the crate root.
+- New method `BismarkRecord::iter_aligned() -> std::vec::IntoIter<AlignedXmCall>`.
+  For each XM byte that aligns to a reference position (skipping
+  insertions and soft-clips), yields a triple with the read coordinate
+  oriented by the **5' end of the sequenced read**:
+  - **`+` strand records (OT / CTOB)**: forward iteration; `read_pos_5p == BAM read_pos`.
+  - **`-` strand records (OB / CTOT)**: reverse iteration; `read_pos_5p == seq_len - 1 - BAM read_pos`.
+
+  Internally: one CIGAR walk via `CigarExt::aligned_positions` + one
+  `Vec<AlignedXmCall>` allocation per record (~1.1 KiB for 100-bp reads
+  with 95 aligned positions). Materializes before yielding to keep the
+  type signature clean (`std::vec::IntoIter`).
+- 8 unit tests covering:
+  - Forward strand (OT) 5M CIGAR — identity.
+  - Reverse strand (OB) 5M CIGAR — reversal + remapping.
+  - Forward + insertion (skips insertion positions, ref_pos correct).
+  - Forward + deletion (advances ref_pos correctly).
+  - Forward + soft-clip (skips clipped positions).
+  - Reverse + soft-clip (orient + clip together).
+  - CTOB strand — forward orientation (closes the OT/CTOB grouping).
+  - CTOT strand — reverse orientation (closes the OB/CTOT grouping).
+
+### Why
+
+`bismark_methylation_extractor` (Perl, line 1619-1621 SE + 2877-2886 PE)
+reverses both the XM string AND the expanded CIGAR for `-` strand reads
+because BAM stores reverse-complemented reads aligned to the `+` strand.
+Walking BAM-stored XM with BAM-stored CIGAR for `-` strand records puts
+M-bias positions end-to-end-flipped on every reverse-strand call. This
+iterator centralizes the orientation correction in `bismark-io` so the
+extractor (and any future consumer doing per-cycle XM analysis)
+inherits the corrected stream.
+
+### Compatibility
+
+- bismark-dedup's `=1.0.0-beta.5` path-dep pin needs updating to `=1.0.0-beta.6`
+  to compile (workspace constraint), but bismark-dedup's source is unchanged
+  and its own version stays at `1.2.x-beta.y`.
+- No existing API touched. `xm()`, `cigar()`, `record_strand()`, etc.
+  still return the same BAM-stored bytes/types.
+
+### Perl reference
+
+- `bismark_methylation_extractor:1619-1621` (SE `meth_call` reverse)
+- `:1933-1939` (PE R1)
+- `:2877-2886` (PE R2 + CIGAR reverse)
+- `:4422-4425` (yacht)
+
 ## [1.0.0-beta.5] — 2026-05-25
 
 UMI plumbing on `BismarkRecord` for Phase B of the v1.2 UMI/RRBS epic.

--- a/rust/bismark-io/Cargo.toml
+++ b/rust/bismark-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-io"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 description = "Bismark-aware BAM/SAM/CRAM I/O on top of noodles"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-io/README.md
+++ b/rust/bismark-io/README.md
@@ -4,7 +4,7 @@ Bismark-aware BAM/SAM/CRAM I/O on top of [`noodles`](https://github.com/zaeleus/
 
 `bismark-io` is the shared library crate for [Bismark](https://github.com/FelixKrueger/Bismark)'s Rust rewrite. It wraps the `noodles` crate family to expose record types that already know about Bismark's strand classification (OT/CTOT/OB/CTOB derived from the `XR:Z:` and `XG:Z:` tags), tag-decoded accessors (`XM`, `XR`, `XG`, `MD`, `NM`), and CIGAR-aware position helpers. Every Bismark Rust binary crate (`bismark-dedup`, `bismark-extractor`, `bismark-bedgraph`, …) depends on it.
 
-**Status:** v1.0.0-beta.5 — `BismarkRecord` gains an optional `umi` field and `*_with_umi` reader constructors that pre-extract UMIs at parse time (additive; non-UMI workflows byte-for-byte unchanged). Prior beta-line additions: beta.2 `ThreadedBamReader`/`Writer` (used by `bismark-dedup`'s `--parallel N`); beta.3 magic-byte file-format detection; beta.4 `umi::extract_barcode` + `umi::extract_bclconvert` zero-copy extractors. See [`CHANGELOG.md`](./CHANGELOG.md).
+**Status:** v1.0.0-beta.6 — `BismarkRecord::iter_aligned()` yields read-orientation-corrected `AlignedXmCall { read_pos_5p, ref_pos, xm_byte }` triples for consumers doing per-cycle XM analysis (e.g. bismark-extractor's M-bias accumulation). Hides the `-`-strand-reverse-complement orientation correction in bismark-io. Additive; non-extractor workflows unchanged. Prior beta-line additions: beta.2 `ThreadedBamReader`/`Writer`; beta.3 magic-byte file-format detection; beta.4 `umi::extract_barcode` + `umi::extract_bclconvert`; beta.5 `BismarkRecord.umi` field + `*_with_umi` reader constructors. See [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## Why a Bismark wrapper around `noodles`?
 

--- a/rust/bismark-io/src/lib.rs
+++ b/rust/bismark-io/src/lib.rs
@@ -32,7 +32,7 @@ pub use pair::BismarkPair;
 pub use read::{
     AlignmentKind, AnyReader, BamReader, CramReader, SamReader, ThreadedBamReader, open_reader,
 };
-pub use record::{BismarkRecord, ReadIdentity, Umi};
+pub use record::{AlignedXmCall, BismarkRecord, ReadIdentity, Umi};
 pub use strand::BismarkStrand;
 pub use umi::{extract_barcode, extract_bclconvert};
 pub use write::{AnyWriter, BamWriter, CramWriter, SamWriter, ThreadedBamWriter, open_writer};

--- a/rust/bismark-io/src/record.rs
+++ b/rust/bismark-io/src/record.rs
@@ -14,9 +14,32 @@ use noodles_sam::alignment::RecordBuf;
 use noodles_sam::alignment::record_buf::Cigar;
 use smallvec::SmallVec;
 
+use crate::cigar::CigarExt;
 use crate::error::BismarkIoError;
 use crate::strand::BismarkStrand;
 use crate::tags;
+
+/// One read-orientation-corrected XM call, yielded by
+/// [`BismarkRecord::iter_aligned`].
+///
+/// Required by `bismark-extractor` (epic #798) for M-bias accumulation
+/// by sequencing-cycle position. See [`BismarkRecord::iter_aligned`]
+/// for the orientation contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlignedXmCall {
+    /// 0-based read position from the **5' end of the sequenced read**.
+    /// For `+` strand records (OT / CTOB) this equals the BAM-stored
+    /// `read_pos`; for `-` strand records (OB / CTOT) it's the reversal
+    /// (so position 0 = first sequencing cycle of the original read).
+    pub read_pos_5p: u32,
+    /// 1-based reference position the XM byte aligns to. Walks the CIGAR
+    /// to handle InDels correctly.
+    pub ref_pos: u32,
+    /// Raw XM tag byte at this read position. NOT
+    /// orientation-corrected — caller's `classify_xm_byte` interprets
+    /// `Z`/`z`/`X`/`x`/`H`/`h`/`U`/`u`/`.` directly.
+    pub xm_byte: u8,
+}
 
 /// Stack-allocated UMI storage. Inline capacity is 16 bytes — covers all
 /// known Bismark UMI workflows (≤16 ASCII bytes including dual-UMI `+`
@@ -193,6 +216,79 @@ impl BismarkRecord {
     /// records manually.
     pub fn set_umi(&mut self, umi: Option<Umi>) {
         self.umi = umi;
+    }
+
+    /// Iterate XM calls oriented by the **5' end of the sequenced read**.
+    ///
+    /// For each XM byte that aligns to a reference position (skipping
+    /// insertions and soft-clips), yields an [`AlignedXmCall`]. Walks
+    /// the CIGAR to maintain `ref_pos` correctly through InDels.
+    ///
+    /// **Orientation correction** (the core reason for this method): BAM
+    /// stores `-` strand reads reverse-complemented (so they align to
+    /// the `+` strand). Walking the BAM-stored XM with the BAM-stored
+    /// CIGAR puts M-bias positions end-to-end-flipped for every `-`
+    /// strand record — `XM[0]` in the BAM is the **3'** end of the
+    /// sequenced read, not the 5'. This iterator corrects that:
+    ///
+    /// - **`+` strand records (OT / CTOB)**: `read_pos_5p == BAM read_pos`;
+    ///   iteration order is forward.
+    /// - **`-` strand records (OB / CTOT)**: `read_pos_5p == seq_len - 1 - BAM read_pos`;
+    ///   iteration order is reversed (so the first emitted item is at
+    ///   `read_pos_5p == 0`, matching Perl's
+    ///   `deduplicate_bismark`/`bismark_methylation_extractor` semantics
+    ///   at lines 1619-1621 + 2877-2886).
+    ///
+    /// **Perl reference**: `bismark_methylation_extractor` reverses both
+    /// the XM string AND the expanded CIGAR for `-` strand reads to
+    /// achieve the same effect. This iterator hides the reversal
+    /// complexity from consumers (extractor, future bismark2bedGraph).
+    ///
+    /// Returns a fully-materialized iterator — call cost is one CIGAR
+    /// walk + one Vec allocation. For 100-bp reads with 95 aligned
+    /// positions, that's ~95 × 12 bytes ≈ 1.1 KiB per record.
+    ///
+    /// Added in `bismark-io 1.0.0-beta.6` (issue #843, SPEC §6.5).
+    pub fn iter_aligned(&self) -> std::vec::IntoIter<AlignedXmCall> {
+        let is_forward = matches!(self.record_strand, BismarkStrand::OT | BismarkStrand::CTOB);
+        let xm = self.xm();
+        let seq_len = xm.len() as u32;
+        let alignment_start = self.alignment_start().unwrap_or(1) as u32;
+
+        // Walk the CIGAR producing one AlignedPosition per read base.
+        // Filter to positions that have a `ref_offset` (matches; skips
+        // insertions and soft-clips) and pair with the XM byte at the
+        // BAM-stored read_pos.
+        let mut calls: Vec<AlignedXmCall> = self
+            .cigar()
+            .aligned_positions()
+            .filter_map(|ap| {
+                let ref_offset = ap.ref_offset?;
+                let read_pos = ap.read_pos as u32;
+                // Defensive: XM length == seq length per the
+                // `from_noodles_record` parity check, so this index is
+                // always in bounds for matches.
+                let xm_byte = xm[ap.read_pos];
+                Some(AlignedXmCall {
+                    read_pos_5p: read_pos, // re-mapped below for `-` strand
+                    ref_pos: alignment_start + ref_offset as u32,
+                    xm_byte,
+                })
+            })
+            .collect();
+
+        if !is_forward {
+            // `-` strand: re-map read_pos_5p to count from sequenced 5'
+            // (which is the LAST BAM-stored read_pos), then reverse the
+            // iteration order so the first emitted item is at
+            // read_pos_5p == 0.
+            for call in calls.iter_mut() {
+                call.read_pos_5p = seq_len.saturating_sub(1).saturating_sub(call.read_pos_5p);
+            }
+            calls.reverse();
+        }
+
+        calls.into_iter()
     }
 }
 
@@ -403,5 +499,234 @@ mod tests {
         assert_eq!(bm.umi().unwrap().as_slice(), b"NEWUMI42");
         bm.set_umi(None);
         assert!(bm.umi().is_none());
+    }
+
+    // ─────────────────── iter_aligned() tests (#843) ───────────────────
+    //
+    // The orientation contract: `+` strand records (OT/CTOB) iterate
+    // forward with `read_pos_5p == BAM read_pos`. `-` strand records
+    // (OB/CTOT) iterate REVERSE with `read_pos_5p == seq_len - 1 -
+    // BAM read_pos` (so position 0 = first sequencing cycle of the
+    // original sequenced read, matching Perl semantics).
+
+    use noodles_core::Position;
+    use noodles_sam::alignment::record::cigar::Op;
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    use noodles_sam::alignment::record_buf::Cigar;
+
+    /// Build a synthetic record with explicit CIGAR ops + strand tags.
+    /// Sequence + XM are the same length (5 bases / 5 XM chars by
+    /// default; caller can pass longer via `xm` arg).
+    fn synth_with_cigar(
+        xr: &[u8],
+        xg: &[u8],
+        xm: &[u8],
+        seq: &[u8],
+        alignment_start: usize,
+        cigar_ops: &[(Kind, usize)],
+    ) -> BismarkRecord {
+        let mut record = RecordBuf::default();
+        *record.flags_mut() = noodles_sam::alignment::record::Flags::from(0);
+        *record.sequence_mut() = Sequence::from(seq.to_vec());
+        *record.alignment_start_mut() = Some(Position::try_from(alignment_start).unwrap());
+        *record.cigar_mut() = Cigar::from(
+            cigar_ops
+                .iter()
+                .map(|(k, n)| Op::new(*k, *n))
+                .collect::<Vec<_>>(),
+        );
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XR"), Value::String(BString::from(xr.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XM"), Value::String(BString::from(xm.to_vec())));
+        BismarkRecord::from_noodles_record(record).unwrap()
+    }
+
+    #[test]
+    fn iter_aligned_forward_strand_ot_5m_identity() {
+        // OT pair-strand: walk BAM XM + CIGAR forward.
+        // 5-base read, 5M CIGAR, alignment_start=100.
+        // Expected: (read_pos_5p, ref_pos, xm) = (0,100,Z), (1,101,z), (2,102,X), (3,103,h), (4,104,.)
+        let bm = synth_with_cigar(b"CT", b"CT", b"ZzXh.", b"ACGTC", 100, &[(Kind::Match, 5)]);
+        let calls: Vec<_> = bm.iter_aligned().collect();
+        assert_eq!(calls.len(), 5);
+        assert_eq!(
+            calls[0],
+            AlignedXmCall {
+                read_pos_5p: 0,
+                ref_pos: 100,
+                xm_byte: b'Z'
+            }
+        );
+        assert_eq!(
+            calls[4],
+            AlignedXmCall {
+                read_pos_5p: 4,
+                ref_pos: 104,
+                xm_byte: b'.'
+            }
+        );
+    }
+
+    #[test]
+    fn iter_aligned_reverse_strand_ob_reverses_and_remaps_read_pos() {
+        // OB pair-strand: walk BAM XM in REVERSE, with read_pos_5p remapped.
+        // Same fixture as the forward test but XR=CT XG=GA → OB.
+        // Expected (in reverse): (0, 104, '.'), (1, 103, h), (2, 102, X), (3, 101, z), (4, 100, Z)
+        let bm = synth_with_cigar(b"CT", b"GA", b"ZzXh.", b"ACGTC", 100, &[(Kind::Match, 5)]);
+        let calls: Vec<_> = bm.iter_aligned().collect();
+        assert_eq!(calls.len(), 5);
+        assert_eq!(
+            calls[0],
+            AlignedXmCall {
+                read_pos_5p: 0,
+                ref_pos: 104,
+                xm_byte: b'.'
+            }
+        );
+        assert_eq!(
+            calls[4],
+            AlignedXmCall {
+                read_pos_5p: 4,
+                ref_pos: 100,
+                xm_byte: b'Z'
+            }
+        );
+    }
+
+    #[test]
+    fn iter_aligned_forward_strand_with_insertion_skips_insertion() {
+        // 5M2I3M: read positions 0-4 + 7-9 align to reference; 5-6 are
+        // insertion (no ref_pos). Forward orientation.
+        // alignment_start=100; ref positions: 100,101,102,103,104, [skip], 105,106,107
+        let bm = synth_with_cigar(
+            b"CT",
+            b"CT",
+            b"ZZZZZ..HHH", // 10 XM bytes (matches 5M2I3M read span)
+            b"AAAAAAAAAA", // 10-base sequence
+            100,
+            &[(Kind::Match, 5), (Kind::Insertion, 2), (Kind::Match, 3)],
+        );
+        let calls: Vec<_> = bm.iter_aligned().collect();
+        // 8 aligned positions (the 2 insertion bases are skipped).
+        assert_eq!(calls.len(), 8);
+        // First 5: read_pos 0-4 → ref_pos 100-104, XM Z
+        assert_eq!(calls[0].read_pos_5p, 0);
+        assert_eq!(calls[0].ref_pos, 100);
+        assert_eq!(calls[0].xm_byte, b'Z');
+        assert_eq!(calls[4].read_pos_5p, 4);
+        assert_eq!(calls[4].ref_pos, 104);
+        // Next 3: read_pos 7,8,9 (NOT 5,6,7 — insertion bumps read but not ref)
+        //         → ref_pos 105,106,107, XM H
+        assert_eq!(calls[5].read_pos_5p, 7);
+        assert_eq!(calls[5].ref_pos, 105);
+        assert_eq!(calls[5].xm_byte, b'H');
+        assert_eq!(calls[7].read_pos_5p, 9);
+        assert_eq!(calls[7].ref_pos, 107);
+    }
+
+    #[test]
+    fn iter_aligned_forward_strand_with_deletion_skips_ref_positions() {
+        // 5M2D3M: read 8 bases; ref 10 bases (deletion advances ref only).
+        // alignment_start=100; ref positions: 100,101,102,103,104, [skip 105,106], 107,108,109
+        let bm = synth_with_cigar(
+            b"CT",
+            b"CT",
+            b"ZZZZZHHH",
+            b"AAAAAAAA",
+            100,
+            &[(Kind::Match, 5), (Kind::Deletion, 2), (Kind::Match, 3)],
+        );
+        let calls: Vec<_> = bm.iter_aligned().collect();
+        assert_eq!(calls.len(), 8); // 8 read bases align
+        assert_eq!(calls[4].read_pos_5p, 4);
+        assert_eq!(calls[4].ref_pos, 104);
+        // Position 5 in the iter is read_pos=5, but ref_pos=107 (deletion-jump).
+        assert_eq!(calls[5].read_pos_5p, 5);
+        assert_eq!(calls[5].ref_pos, 107);
+        assert_eq!(calls[5].xm_byte, b'H');
+        assert_eq!(calls[7].ref_pos, 109);
+    }
+
+    #[test]
+    fn iter_aligned_forward_strand_with_soft_clip_skips_clipped_positions() {
+        // 2S6M2S: read 10 bases; ref 6 bases. Soft-clipped at both ends.
+        // read_pos 0-1 + 8-9 are soft-clipped (no ref_pos); 2-7 align.
+        // alignment_start=100; ref: 100..105 for read 2..7
+        let bm = synth_with_cigar(
+            b"CT",
+            b"CT",
+            b"..ZZZZZZ..",
+            b"AAAAAAAAAA",
+            100,
+            &[(Kind::SoftClip, 2), (Kind::Match, 6), (Kind::SoftClip, 2)],
+        );
+        let calls: Vec<_> = bm.iter_aligned().collect();
+        assert_eq!(calls.len(), 6); // only the 6 matched positions
+        assert_eq!(calls[0].read_pos_5p, 2);
+        assert_eq!(calls[0].ref_pos, 100);
+        assert_eq!(calls[0].xm_byte, b'Z');
+        assert_eq!(calls[5].read_pos_5p, 7);
+        assert_eq!(calls[5].ref_pos, 105);
+    }
+
+    #[test]
+    fn iter_aligned_reverse_strand_with_soft_clip_orient_correctly() {
+        // 2S6M2S on `-` strand. Forward order would yield read_pos 2..7
+        // mapped to ref 100..105. Reverse strand should yield in reverse
+        // order, with read_pos_5p remapped.
+        // seq_len = 10. read_pos_5p = 10 - 1 - bam_read_pos.
+        // bam_read_pos 7 → read_pos_5p 2
+        // bam_read_pos 2 → read_pos_5p 7
+        let bm = synth_with_cigar(
+            b"CT", // XR
+            b"GA", // XG → OB (reverse pair-strand)
+            b"..ZZZZZZ..",
+            b"AAAAAAAAAA",
+            100,
+            &[(Kind::SoftClip, 2), (Kind::Match, 6), (Kind::SoftClip, 2)],
+        );
+        let calls: Vec<_> = bm.iter_aligned().collect();
+        assert_eq!(calls.len(), 6);
+        // First emitted: highest bam_read_pos (7) → read_pos_5p (10-1-7=2)
+        //                ref_pos = 105 (rightmost)
+        assert_eq!(calls[0].read_pos_5p, 2);
+        assert_eq!(calls[0].ref_pos, 105);
+        // Last emitted: lowest bam_read_pos (2) → read_pos_5p (10-1-2=7)
+        //               ref_pos = 100 (leftmost)
+        assert_eq!(calls[5].read_pos_5p, 7);
+        assert_eq!(calls[5].ref_pos, 100);
+    }
+
+    #[test]
+    fn iter_aligned_ctob_strand_is_forward_orientation() {
+        // CTOB (XR=GA XG=GA) is in the forward group per
+        // `is_forward(strand)`. Verify orientation matches OT.
+        let bm = synth_with_cigar(b"GA", b"GA", b"ZzXh.", b"ACGTC", 100, &[(Kind::Match, 5)]);
+        assert_eq!(bm.record_strand(), BismarkStrand::CTOB);
+        let calls: Vec<_> = bm.iter_aligned().collect();
+        // Should be forward order (same as OT case above)
+        assert_eq!(calls[0].read_pos_5p, 0);
+        assert_eq!(calls[4].read_pos_5p, 4);
+        assert_eq!(calls[0].ref_pos, 100);
+        assert_eq!(calls[4].ref_pos, 104);
+    }
+
+    #[test]
+    fn iter_aligned_ctot_strand_is_reverse_orientation() {
+        // CTOT (XR=GA XG=CT) is in the reverse group. Same orientation
+        // as OB.
+        let bm = synth_with_cigar(b"GA", b"CT", b"ZzXh.", b"ACGTC", 100, &[(Kind::Match, 5)]);
+        assert_eq!(bm.record_strand(), BismarkStrand::CTOT);
+        let calls: Vec<_> = bm.iter_aligned().collect();
+        // Reverse: first emitted is bam_read_pos=4 → read_pos_5p=0, ref_pos=104
+        assert_eq!(calls[0].read_pos_5p, 0);
+        assert_eq!(calls[0].ref_pos, 104);
+        assert_eq!(calls[0].xm_byte, b'.');
     }
 }

--- a/rust/bismark-io/src/record.rs
+++ b/rust/bismark-io/src/record.rs
@@ -248,12 +248,31 @@ impl BismarkRecord {
     /// walk + one Vec allocation. For 100-bp reads with 95 aligned
     /// positions, that's ~95 × 12 bytes ≈ 1.1 KiB per record.
     ///
+    /// **Insertion-position semantic divergence vs Perl** (documented for
+    /// future readers): Perl `bismark_methylation_extractor` emits XM
+    /// entries at insertion positions with `xm_byte == b'.'` and the
+    /// preceding match's `ref_pos`. This Rust iterator **skips** them
+    /// (via `CigarExt::aligned_positions().filter_map(|ap| ap.ref_offset?)`).
+    /// Behaviorally identical for the bismark-extractor's M-bias use
+    /// case (Perl's `.` at insertions is filtered by `classify_xm_byte`
+    /// before counting), but consumers emitting raw XM bytes per read
+    /// position (e.g. yacht-mode any_C_context output) should consult
+    /// the XM tag directly rather than this iterator.
+    ///
     /// Added in `bismark-io 1.0.0-beta.6` (issue #843, SPEC §6.5).
     pub fn iter_aligned(&self) -> std::vec::IntoIter<AlignedXmCall> {
         let is_forward = matches!(self.record_strand, BismarkStrand::OT | BismarkStrand::CTOB);
         let xm = self.xm();
         let seq_len = xm.len() as u32;
-        let alignment_start = self.alignment_start().unwrap_or(1) as u32;
+        // `from_noodles_record` doesn't validate alignment_start (unmapped
+        // records are filtered upstream at the reader-iterator layer per
+        // `read.rs::filter_unmapped_then_classify`). A mapped record without
+        // alignment_start is a structural invariant violation — `expect`
+        // surfaces it loudly rather than silently producing wrong ref_pos.
+        let alignment_start = self.alignment_start().expect(
+            "iter_aligned: record has no alignment_start; reader-iterator \
+             should have filtered this as unmapped (flags & 0x4)",
+        ) as u32;
 
         // Walk the CIGAR producing one AlignedPosition per read base.
         // Filter to positions that have a `ref_offset` (matches; skips
@@ -715,6 +734,68 @@ mod tests {
         assert_eq!(calls[4].read_pos_5p, 4);
         assert_eq!(calls[0].ref_pos, 100);
         assert_eq!(calls[4].ref_pos, 104);
+    }
+
+    /// PE-pair coverage (both reviewers' Medium finding): R2 of an OT
+    /// pair has `record_strand == CTOT` (per-record XR/XG classification:
+    /// XR=GA XG=CT for the reverse-complemented mate). `iter_aligned`
+    /// must reverse the R2 walk so M-bias positions count from the
+    /// sequenced 5' of the R2 read. Mirrors Perl's per-mate reversal at
+    /// `bismark_methylation_extractor:1933-1939` (PE R1) +
+    /// `:2877-2886` (PE R2).
+    ///
+    /// Note: this is structurally the same fixture as
+    /// `iter_aligned_ctot_strand_is_reverse_orientation` (single record
+    /// with CTOT classification) — the per-record orientation is what
+    /// matters; `BismarkRecord` doesn't carry pair context. This test
+    /// adds the FLAG bits (0x81 = R2 + paired) so future readers see
+    /// the PE-pair context explicitly.
+    #[test]
+    fn iter_aligned_pe_r2_of_ot_pair_is_reverse_orientation() {
+        // R2 of OT pair: XR=GA XG=CT → record_strand=CTOT (reverse).
+        // FLAG 0x81 = R2 + paired.
+        let mut record = RecordBuf::default();
+        *record.flags_mut() = noodles_sam::alignment::record::Flags::from(0x81);
+        *record.sequence_mut() = Sequence::from(b"ACGTC".to_vec());
+        *record.alignment_start_mut() = Some(Position::try_from(200).unwrap());
+        *record.cigar_mut() = Cigar::from(vec![Op::new(Kind::Match, 5)]);
+        record.data_mut().insert(
+            Tag::from(*b"XR"),
+            Value::String(BString::from(b"GA".to_vec())),
+        );
+        record.data_mut().insert(
+            Tag::from(*b"XG"),
+            Value::String(BString::from(b"CT".to_vec())),
+        );
+        record.data_mut().insert(
+            Tag::from(*b"XM"),
+            Value::String(BString::from(b"Z.x.H".to_vec())),
+        );
+        let bm = BismarkRecord::from_noodles_record(record).unwrap();
+        assert_eq!(bm.record_strand(), BismarkStrand::CTOT);
+        assert_eq!(bm.read_identity(), ReadIdentity::R2);
+
+        let calls: Vec<_> = bm.iter_aligned().collect();
+        assert_eq!(calls.len(), 5);
+        // Reverse-strand: first emitted is bam_read_pos=4 → read_pos_5p=0,
+        // ref_pos=204, xm='H'. Last emitted is bam_read_pos=0 →
+        // read_pos_5p=4, ref_pos=200, xm='Z'.
+        assert_eq!(
+            calls[0],
+            AlignedXmCall {
+                read_pos_5p: 0,
+                ref_pos: 204,
+                xm_byte: b'H'
+            }
+        );
+        assert_eq!(
+            calls[4],
+            AlignedXmCall {
+                read_pos_5p: 4,
+                ref_pos: 200,
+                xm_byte: b'Z'
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #843. Required by the upcoming bismark-extractor port (epic #798, [SPEC §6.5](https://github.com/FelixKrueger/Bismark/blob/rust/extractor-recon/rust/bismark-extractor/SPEC.md)).

Adds \`BismarkRecord::iter_aligned()\` which yields read-orientation-corrected \`AlignedXmCall\` triples — hides the \`-\`-strand-reverse-complement orientation correction so consumers doing per-cycle XM analysis (M-bias accumulation, etc.) inherit the corrected stream.

## Why

Perl \`bismark_methylation_extractor\` (lines 1619-1621 SE, 2877-2886 PE) reverses both the XM string AND the expanded CIGAR for \`-\` strand reads. This isn't output formatting — BAM stores \`-\` strand reads reverse-complemented (aligned to \`+\` strand), so \`XM[0]\` in the BAM is the **3' end of the sequenced read**, not the 5'. For M-bias by sequencing-cycle position, we need 5'-oriented bytes. Without this iterator, walking unreversed XM with BAM-stored CIGAR would put M-bias positions end-to-end-flipped for every \`-\` strand record — exactly the structural byte-identity regression the SPEC §6.5 rev 1 rewrite identified.

## API

\`\`\`rust
pub struct AlignedXmCall {
    pub read_pos_5p: u32,   // 0-based, from 5' of sequenced read
    pub ref_pos: u32,       // 1-based reference position
    pub xm_byte: u8,        // raw XM byte; caller classifies
}

impl BismarkRecord {
    pub fn iter_aligned(&self) -> std::vec::IntoIter<AlignedXmCall>;
}
\`\`\`

| Strand | Iteration order | \`read_pos_5p\` |
|--------|-----------------|---------------|
| OT / CTOB (forward) | forward | \`== BAM read_pos\` |
| OB / CTOT (reverse) | **reverse** | \`== seq_len - 1 - BAM read_pos\` |

Built on the existing \`CigarExt::aligned_positions\` primitive (filters insertions + soft-clips automatically). One CIGAR walk + one Vec allocation per record (~1.1 KiB for 100-bp reads with 95 aligned positions).

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] All 294 workspace tests pass (154 bismark-io lib + 86 bismark-dedup lib + ...; **+8 new iter_aligned tests**)
- [x] **8 new unit tests** cover:
  - OT 5M CIGAR → identity (forward orientation)
  - OB 5M CIGAR → reversal + remapping (reverse orientation)
  - Forward + insertion → skips insertion positions, ref_pos correct
  - Forward + deletion → advances ref_pos correctly
  - Forward + soft-clip → skips clipped positions
  - Reverse + soft-clip → orient + clip together
  - CTOB strand → forward orientation (closes OT/CTOB grouping)
  - CTOT strand → reverse orientation (closes OB/CTOT grouping)

## Compatibility

- Additive only. \`xm()\`, \`cigar()\`, \`record_strand()\`, etc. still return the same BAM-stored types.
- bismark-dedup's path-dep pin updates \`=1.0.0-beta.5\` → \`=1.0.0-beta.6\` to compile (workspace constraint), but bismark-dedup source is unchanged and its own version stays at \`1.2.x-beta.y\`.

## Release plan

Ships as \`bismark-io 1.0.0-beta.6\`. After dual code-review + your authorization, tag + \`cargo publish\` (Strategy A — heads only, matching the v1.2 pattern).

This PR unblocks bismark-extractor Phase B (the SE/PE extraction loops) per SPEC §10. Phase A (workspace scaffold + CLI + argument structs) doesn't depend on \`iter_aligned\` and can land in parallel.

## Workflow trail

- Issue body: comprehensive design rationale + API sketch (#843)
- SPEC rev 2 §6.5: locks the iter_aligned() plan as the resolution to both rev 1 reviewers' XM-reversal finding (PR #841)
- Sub-issue: filed under #794 (bismark-io epic); formally linked via GitHub Sub-issues API