### PR TITLE
feat(extractor): Phase B — SE extraction loop + XM routing + eager output map

### DIFF
--- a/plans/.gitignore
+++ b/plans/.gitignore
@@ -1,0 +1,1 @@
+archived/

--- a/plans/05262026_bismark-extractor/CODE_REVIEW_PHASE_B_A.md
+++ b/plans/05262026_bismark-extractor/CODE_REVIEW_PHASE_B_A.md
@@ -1,0 +1,136 @@
+# Code Review — Phase B (Reviewer A)
+
+**Scope:** Phase B implementation of `bismark-extractor` (commit on branch `rust/iron-chancellor`). Review against `PHASE_B_PLAN.md` rev 1.
+
+**Reviewer focus:** Logic, errors, structure. Cross-referenced against Perl source `bismark_methylation_extractor` lines 2900-3060 (per-call write order/format), 5400-5500 (eager-open + header), and `bismark-io::BismarkRecord::iter_aligned` semantics.
+
+**Validation already passing:** 50 tests green, clippy clean, fmt clean.
+
+## Summary
+
+Phase B is **substantially complete and correct**. The plan rev-1 critical fixes (eager-open with header, counter-before-mbias-only short-circuit, `read_pos_5p` including soft-clip in count) are all implemented faithfully. Perl byte-identity expectations are met for: (i) the literal header line, (ii) the per-call tab-separated row format including the `+`/`-` strand-char-vs-methylation column convention (verified against Perl 2911/2921/2931/2941/2951/2961), and (iii) the directional-library CTOT/CTOB header-only file invariant. The kernel correctly uses `aligned.xm_byte` from `iter_aligned`'s orientation-corrected stream; no re-indexing of `record.xm()` slipped in.
+
+Findings are concentrated in three areas: (1) a plan↔code structural divergence (`write_call` panic vs typed `InternalError`), (2) one missing test enumerated in plan §7.1 (`cleanup_partial_outputs_continues_past_one_failure`), and (3) several minor structural items (excessive `pub` widening, `.expect()` use on filtered-upstream invariants). None of these block Phase B merging.
+
+## Issues by area
+
+### Logic
+
+**L1 (Medium) — `+`/`-` column in `write_call` is correct, but the doc comment in `output.rs:122` is misleading.**
+
+The comment says "tab-separated row: read_id<TAB>strand<TAB>chr<TAB>ref_pos<TAB>xm_byte<LF>", which is *what the docs of §4.2 say* but is **factually wrong** about the second column's semantic meaning. The Perl source at 2911/2921/2931/2941 prints `'+'` for methylated and `'-'` for unmethylated calls — **NOT** a strand character. The Rust code's `strand_char = if call.methylated { '+' } else { '-' }` is correct; only the variable name and the doc-comment label "strand" are misleading. Cite Perl 2929: `if ($methylation_calls[$index] eq 'Z') { ... print ... '+' ... } elsif ($methylation_calls[$index] eq 'z') { ... print ... '-' ... }`. This is a meth-state indicator that the Perl source happened to encode with `+`/`-`. Rename `strand_char` → `meth_char` and update the doc comment. (Plan §4.2 also propagates this same labelling error, but plan text isn't shipped — the code-level comment should be corrected.)
+
+**L2 (Low) — `extract_calls` ignore-region check + soft-clip interaction is correct but undertested.**
+
+The plan §7.1 `extract_calls_walks_cigar_with_soft_clips` covers the `read_pos==2` invariant for `2S8M` with `ignore_5p=0`. There is no test combining soft-clip with non-zero `--ignore`. Consider adding `extract_calls_soft_clip_plus_ignore_5p_combines_correctly`: a `5S20M` record with `ignore_5p=10` should drop first 10 read_pos values (which includes all 5 soft-clip positions + first 5 aligned positions). The current code handles this correctly via `lo=10` and `read_pos_5p < lo` filter, but it's not asserted.
+
+**L3 (Low) — `state.report.records_processed` uses saturating_add but `state.report.calls_total` is also saturating_add.**
+
+Saturating arithmetic at u64 means you'd need 1.8 × 10¹⁹ records to actually saturate; this is dead defence but harmless. Consistent with the codebase style (dedup uses similar pattern).
+
+### Errors
+
+**E1 (Medium) — `OutputFileMap::write_call` panics on missing key instead of returning `InternalError`.**
+
+Plan §5.3 explicitly says "Missing key is an `InternalError`". The implementation at `output.rs:117-120` uses `.expect("OutputFileMap missing key — eager-open should have created all 12; this is an InternalError caller should catch")`. This is a programmer-invariant violation panic (cannot fire because eager-open creates all 12 keys), but the plan-specified contract is a typed error path. Two ways to resolve:
+
+- **Recommended**: change the return type of `write_call` from `Result<(), std::io::Error>` to `Result<(), BismarkExtractorError>` and convert the `expect` to `.ok_or_else(|| BismarkExtractorError::InternalError { message: ... })`. This requires propagating the change through `route_call`'s signature and `extract_se`'s `route_call?` site. ~10 LOC.
+- **Alternative (lower-effort)**: accept the panic as an internal-invariant guard. Document in the type-level rustdoc on `OutputFileMap` that "the 12 default-mode keys are guaranteed by eager-open" and the panic is a defence against future refactors.
+
+For Phase B alpha (single caller, well-tested), either is defensible. The plan contract favours #1.
+
+**E2 (Low) — `pipeline.rs:89` `.expect("mapped record must have reference_sequence_id")` is a panic-on-input.**
+
+`bismark-io::records()` filters records with FLAG & 0x4 (unmapped) per `read.rs:7,256`. A mapped record without a `reference_sequence_id` is malformed input, not a programmer bug. Compare to `bismark-dedup/src/pipeline.rs:224` which uses `.ok_or_else(|| InternalError { ... })` for the same situation. Recommendation: replace with `.ok_or_else(|| { state.cleanup_partial_outputs(); BismarkExtractorError::InternalError { message: ... } })` for consistency with the dedup precedent and a graceful failure mode.
+
+**E3 (Low) — `extract_se` `state.finalize(config)?` does NOT call cleanup on failure.**
+
+This is **intentional** per `state.rs:73-78` doc + plan §5.4 invariant. Verified correct. However, the actual Perl behaviour after `finalize`-equivalent failure (e.g., disk-full during splitting-report write) is to die with already-written split files in place — same as the Rust port. No action required; flagged as positive verification.
+
+**E4 (Low) — Cleanup ordering on error paths is consistent across all 4 sites in `pipeline.rs`.**
+
+All 4 pre-finalize error sites (`reader_result` line 65-68, PAIRED-flag 75-82, `chr_table.get` 91-101, `extract_calls` 108-112, `route_call` 116-119) correctly call `state.cleanup_partial_outputs()` before propagating. Verified correct. The smoke test `smoke_se_rejects_record_with_paired_flag_set` exercises one of these paths end-to-end and confirms 0 files remain.
+
+### Efficiency
+
+**P1 (Low) — `render_qname` allocates a new `String` per record even when no `Err(InvalidXmByte)` will fire.**
+
+`call.rs:143` renders the QNAME unconditionally at the top of `extract_calls`. For a typical 55M-record run, this is 55M small allocations (~30 bytes each, ~1.6 GiB allocator traffic) purely for error-message scaffolding. Consider lazy-rendering inside the `classify_xm_byte` error path via a closure or `Cow<str>`. Phase F (rayon multicore) will amplify this allocator pressure. **Not a Phase B blocker** — flag for Phase F profiling.
+
+**P2 (Low) — `format_meth_line` performs 7 individual `write_all` calls instead of one buffered format.**
+
+`output.rs:123-132` issues 7 separate `write_all` syscalls per call. With `BufWriter` buffering this is amortised, but each call still hits the BufWriter state machine. A single `writeln!(w, "{}\t{}\t{}\t{}\t{}", ...)` may inline better and reduce instruction count by ~3x. The `record_name: &[u8]` part complicates this (writeln expects `Display`); current approach is reasonable. Phase F profiling target.
+
+### Structure
+
+**S1 (Medium) — Plan §7.1 lists `cleanup_partial_outputs_continues_past_one_failure` but it's absent from tests.**
+
+The test `cleanup_partial_outputs_removes_all_12_files` exists; the "continues past one failure" variant does not. Adding a test that pre-removes one of the 12 files (so `remove_file` fails on it) and asserts the other 11 are still cleaned up + `eprintln!` warning fires would close this gap. ~15 LOC.
+
+**S2 (Low) — Several `pub(crate)` items promoted to `pub` for test visibility.**
+
+`XmClassification`, `OutputKey`, `OutputFileMap`, `SplittingReport`, `BISMARK_VERSION`, `SPLIT_FILE_HEADER`, `MbiasPos`, `MbiasTable`, `ExtractState`, `route_call`, `extract_calls`, `build_chr_name_table`, `derive_basename` are all `pub` in the lib surface. The skill brief flagged this for audit.
+
+Acceptable for an alpha crate (1.0.0-alpha.2) — most of these are foundational types the binary builds on, and the SemVer policy for `alpha` allows iteration. The only items that look genuinely *internal* are:
+- `OutputKey` — internal map-key with no external use. Could revert to `pub(crate)` with `#[cfg(test)] pub` if integration tests need it. Low priority.
+- `XmClassification` — internal enum the kernel uses. Tests use it; could keep `pub` or move classifier tests inline as `#[cfg(test)] mod tests` in `call.rs`.
+
+Recommendation: live with the wider surface for Phase B; revisit at v1.0 stabilisation when SemVer hits.
+
+**S3 (Low) — `derive_basename` matches Perl spec but has a subtle "default" path.**
+
+The current code returns the filename unchanged if none of `.bam`/`.sam`/`.cram` match. Perl's regex chain also leaves the filename unchanged in that case (Perl's `s/.../.../;` is non-fatal on no-match). Verified correct. The test `derive_basename_strips_known_suffixes` covers the no-match case (`a` → `a`) and the case-sensitive case (`a.BAM` → `a.BAM`). Good coverage.
+
+**S4 (Low) — `state.rs` field naming inconsistency.**
+
+`ExtractState::fhs` is the file-handle map (named after Perl's `%fhs` hash). Adjacent fields use spelled-out names: `mbias`, `report`, `input_path`, `splitting_report_path`, `emit_splitting_report`. The Perl-mnemonic `fhs` is fine for someone reading both source trees side-by-side, but a future maintainer who hasn't touched the Perl will read `fhs` as cryptic. Consider `output_files` or `split_files` at a later cleanup. Non-blocking.
+
+**S5 (Nit) — `output.rs:43-56` `DEFAULT_KEYS` is a static `[(_, _); 12]`.**
+
+Could be a `const fn` enumeration over `CytosineContext::all() × BismarkStrand::all()` if the enums grew `all()` constructors. Mostly cosmetic; the explicit list is more grep-friendly. Keep as-is.
+
+**S6 (Nit) — Plan §7.1 listed `extract_se_two_records_route_to_different_files` and `extract_se_empty_input_writes_only_header_files` as unit tests; both are implemented at the smoke-test level only.**
+
+Both are covered functionally by `smoke_se_directional_produces_all_12_files_and_report` (multi-record OT+OB routing) and `smoke_se_empty_bam_writes_only_header_files` (empty BAM). Acceptable — they exercise the full pipeline rather than the unit. The smoke variant is arguably stronger coverage.
+
+## Cross-reference vs the 10 scrutiny items
+
+1. **xm_byte invariant** — VERIFIED. `call.rs:147-156` uses `aligned.xm_byte`; no `record.xm()[...]` reindexing. Defensive doc-comment at lines 112-117 captures the invariant.
+2. **Eager-open file creation** — VERIFIED. `output.rs:83-97` creates all 12 files unconditionally; header written immediately when `!no_header`. Matches Perl 5405-5499 (read end-to-end). Test `output_file_map_eagerly_creates_all_strand_files_for_default_mode` asserts 12-files-exist-pre-write-call.
+3. **`route_call` ordering** — VERIFIED. `route.rs:30-68`: mbias accumulate (line 31-40) → counter increment (43-63) → mbias_only short-circuit (66-68) → write (70-75). The order matches the plan §5.5 spec. Test `route_call_increments_counter_before_mbias_only_short_circuit` locks the invariant.
+4. **Cleanup invariant** — VERIFIED. All 4 pre-finalize error sites call `state.cleanup_partial_outputs()`; `finalize` errors do NOT cleanup (plan §5.4 invariant). See E3.
+5. **`derive_basename`** — VERIFIED. Case-sensitive single-suffix strip via `strip_suffix`. Test covers `a.BAM` (unchanged), `a.bam.gz` (unchanged), `/path/to/sample.bam` (→ `sample`).
+6. **Phase-gate dispatch** — VERIFIED. `main.rs::run` has 6 rejections (multiple files, PE, non-default mode, gzip, parallel!=1, bedgraph/cytosine_report) before `extract_se` is invoked. Each is tested by a `main_rejects_*` test.
+7. **Non-ASCII chr name** — VERIFIED. `header.rs:24-39` errors with `NonAsciiChromosomeName`. Test `build_chr_name_table_rejects_non_ascii` exercises it with `"chr_α"` UTF-8 bytes.
+8. **`pub(crate)` → `pub` audit** — See S2.
+9. **Test coverage vs §7.1** — Mostly covered. Gaps: `cleanup_partial_outputs_continues_past_one_failure` (see S1). The `extract_se_two_records_...` / `extract_se_empty_input_...` tests are covered at smoke level (see S6).
+10. **`percent_meth` zero-denominator** — VERIFIED. `output.rs:194-201` returns 0.0 for zero total; no NaN, no panic. Test `splitting_report_percentage_handles_zero_denominator` asserts.
+
+## Fixes applied
+
+None — Reviewer A is a research/review role.
+
+## Prioritised recommendations
+
+**Critical:** None.
+
+**High:** None.
+
+**Medium:**
+- **E1**: Decide between (a) widening `OutputFileMap::write_call`'s return type to `BismarkExtractorError` for typed-error parity with the plan, or (b) documenting `.expect()` as an internal invariant. Pick one and update either the code or the plan text.
+- **L1**: Rename `strand_char` → `meth_char` in `output.rs:121` and fix the misleading doc-comment at line 122. The behaviour is byte-correct; only the label is misleading.
+- **S1**: Add `cleanup_partial_outputs_continues_past_one_failure` test (~15 LOC) to close the plan §7.1 gap.
+
+**Low:**
+- **E2**: Replace `.expect("mapped record must have reference_sequence_id")` in `pipeline.rs:89` with `.ok_or_else(|| InternalError { ... })` for consistency with the dedup precedent.
+- **L2**: Add `extract_calls_soft_clip_plus_ignore_5p` test combining soft-clip and ignore_5p semantics.
+- **P1**: Note the `render_qname` allocation cost as a Phase F profiling target.
+- **P2**: Note the 7-write-call write pattern as a Phase F profiling target.
+
+**Nits:** S3-S6.
+
+## Verdict
+
+**APPROVE-WITH-NITS.**
+
+The implementation faithfully executes plan rev 1's three critical fixes (eager-open + header, counter-before-mbias_only short-circuit, soft-clip read_pos counting). Perl byte-identity is locked at the header-line and per-call-row level for the default-mode SE subset. The plan↔code divergences are limited to one structural choice (`.expect()` vs typed `InternalError`) and one missing test (`cleanup_partial_outputs_continues_past_one_failure`). Neither blocks merging; both can be addressed before Phase C arrives.

--- a/plans/05262026_bismark-extractor/CODE_REVIEW_PHASE_B_B.md
+++ b/plans/05262026_bismark-extractor/CODE_REVIEW_PHASE_B_B.md
@@ -1,0 +1,130 @@
+# Code Review — bismark-extractor Phase B (Reviewer B)
+
+**Reviewer:** B (independent of Reviewer A)
+**Date:** 2026-05-26
+**Branch:** `rust/iron-chancellor`
+**Files reviewed:** `rust/bismark-extractor/src/{call,mbias,output,state,route,header,pipeline,error,main,lib}.rs`, `Cargo.toml`, `tests/sanity.rs`, `tests/se_phase_b.rs`, `tests/se_phase_b_smoke.rs`
+**Plan reviewed against:** `plans/05262026_bismark-extractor/PHASE_B_PLAN.md` rev 1
+**Validation status reported:** 50 tests passing, clippy clean, fmt clean
+
+---
+
+## Summary
+
+Phase B is a clean, well-bounded implementation. The eager-open file map, the rev-1 routing-order fix, the orientation-respecting kernel, and the phase-gate dispatch are all faithful to both the plan and the Perl reference (spot-checked at lines 32, 2911-2961, 5151-5205). Byte-identity-critical surfaces (header literal, suffix-strip, `+`/`-` strand char) match Perl exactly. The smoke test covers a respectable bug surface without requiring a Perl baseline.
+
+Findings concentrate on **Phase-F readiness** (per-record allocation pressure), **one minor efficiency miss** (header clone), **two test-coverage gaps** vs the plan, and **error-wrapping ambiguity** that will compound at Phases C/E. No correctness issues block merge.
+
+---
+
+## Issues by area
+
+### Logic / Correctness
+
+**L1. `route_call` `+`/`-` strand char encoding (false alarm — verified correct).** [Resolved]
+Initial concern was that the Rust `let strand_char = if call.methylated { '+' } else { '-' };` was encoding methylation status, not physical strand orientation. Direct verification against Perl (lines 2911, 2921, 2931, 2941, 2951, 2961) confirms the `+`/`-` field is indeed `+` for uppercase-XM (methylated) and `-` for lowercase-XM (unmethylated). Rust matches. No defect.
+
+**L2. `BismarkIoError::Io` vs `IoWrite` jacket asymmetry. [Low]**
+`error.rs` has both `BismarkIo(#[from] BismarkIoError)` and `IoWrite(#[from] std::io::Error)`. A `std::io::Error` raised by extractor code (e.g. `OutputFileMap::write_call`) wraps as `IoWrite`. A `std::io::Error` originating *inside* a bismark-io reader gets wrapped twice: `io::Error -> BismarkIoError::Io -> BismarkExtractorError::BismarkIo`. So the same underlying error type wears two different jackets depending on origin. Display strings differ (`"output write failed: ..."` vs `"<transparent BismarkIoError display>"`). Not a bug today, but at Phase C (PE) and Phase F (rayon) when error paths multiply, debugging which `io::Error` came from where will be harder. **Recommend:** flatten `BismarkIo` to `#[error("input read failed: {0}")] InputRead(#[from] BismarkIoError)` — distinct error display lets ops triage by reading the message.
+
+**L3. `cleanup_partial_outputs_continues_past_one_failure` test missing.** [Low]
+Plan §7.1 promises this test ("**Rev 1 (A Optional)**: one remove failure doesn't prevent the other 11"). Not present in either test file. The `cleanup_all` implementation does loop over all 12 entries and `eprintln!`s on individual failures — behaviour is correct, but the regression guard is absent. **Recommend:** add a test that pre-locks/pre-deletes one file path so `remove_file` returns `Err`, then asserts the other 11 are removed.
+
+**L4. `flush_all` ordering before `write_splitting_report` is correct, doc-comment overstates the rationale.** [Nit]
+`state.rs:80` calls `fhs.flush_all()` before `write_splitting_report`. The output module's doc comment (`output.rs:136-138`) says "so the report can name accurate file sizes if it ever needs to" — Phase B's report doesn't include file sizes. The doc comment forward-promises a Phase-D/H behaviour without an issue link. Either drop the speculative justification or add a TODO referencing Phase H. (No behavior bug.)
+
+### Efficiency / Phase-F readiness
+
+**E1. Per-record QNAME clone in `extract_calls` is unconditional. [Medium — Phase F concern, not Phase B blocker]**
+`call.rs:143`: `let read_id = render_qname(record);` runs once per record **even on the happy path** where no `InvalidXmByte` ever fires. `render_qname` does `String::from_utf8_lossy(...).into_owned()` — for 55M records at ~30-byte QNAMEs that's ~1.6 GiB of allocation churn, all wasted. Under rayon (Phase F) this churn multiplies across threads and hits the allocator's mutex.
+**Recommend (Phase F):** pass a closure or `Cow<'_, str>`: `extract_calls` accepts `read_id_lazy: impl FnOnce() -> String` (or `&dyn Fn() -> String`) and `classify_xm_byte` only calls it on the error path. Alternative: pass `&[u8]` QNAME and only allocate the String in `InvalidXmByte` construction.
+**Phase B verdict:** non-blocker — flag for Phase F.
+
+**E2. `reader.header().clone()` in `extract_se` is avoidable. [Low]**
+`pipeline.rs:56`: `let header = reader.header().clone();` then `build_chr_name_table(&header)`. The `clone()` is needed only because `reader.records(&mut self)` mutably borrows `reader` later — but `chr_table` is fully constructed *before* `records()` is called and the `header` binding is then unused. Could be: `let chr_table = build_chr_name_table(reader.header())?;` and drop the `let header = ...` line. Saves a header clone (cheap for tiny genomes, ~50-100 KiB for human, more for multi-megabase contig genomes like assemblies-in-progress). **Recommend:** remove the clone.
+
+**E3. `OutputFileMap::write_call`: 8 separate `write_all` calls per row. [Low]**
+`output.rs:122-132` does 8 `BufWriter::write_all` calls per call line. Each goes through a virtual call + capacity check. For 55M PE × ~20 calls = 1.1B `write_all` calls = ~9B vtable hops. The 8-KiB `BufWriter` capacity is small (each writer's per-flush amortization is ~400 lines). **Recommend (Phase F):** use a thread-local `Vec<u8>` scratch buffer (`format_meth_line` writes into it, single `write_all` flushes it), and bump `BufWriter` capacity to 64 KiB to reduce syscall pressure. Non-blocker for Phase B.
+
+### Errors / Defensive coding
+
+**Err1. `OutputFileMap::write_call`'s `.expect("OutputFileMap missing key ...")`. [Verified safe]**
+The key is `OutputKey { context: call.context, strand }`. `CytosineContext` has exactly 3 variants. `BismarkStrand` has exactly 4 variants (verified at `bismark-io/src/strand.rs:36-45`). `DEFAULT_KEYS` enumerates all 12. No `BismarkStrand` value can escape the map. `.expect` is safe. **Optional polish:** convert to a `BismarkExtractorError::InternalError` with `let Some(...) = map.get_mut(&key) else { return Err(InternalError {...}); };` so test fixtures that construct corrupted state surface a typed error instead of a panic.
+
+**Err2. `extract_se`'s refid lookup panics if `reference_sequence_id` is `None`. [Low]**
+`pipeline.rs:86-89`: `.expect("mapped record must have reference_sequence_id")`. bismark-io filters unmapped at the iterator, but the invariant is only documented in a comment in `record.rs`. If that filter ever regresses (e.g. a future bismark-io variant exposes unfiltered records), this panics rather than returning an `InternalError`. **Recommend:** convert to `ok_or_else(InternalError {...})`. Same pattern as the `chr_table.get(refid)` branch immediately below.
+
+**Err3. `state.cleanup_partial_outputs()` is called from every pre-finalize error site, but `flags_bits & 0x1` check happens AFTER `record_result` decode. [Verified safe]**
+If the BAM has a corrupt first record, `record_result` returns `Err`, the cleanup runs, and we exit early. If the first record is well-formed but PAIRED-flagged, we cleanup and exit. Order is correct.
+
+### Structure / Style
+
+**S1. `state.rs::ExtractState::new` adds an `input_path` parameter not in the plan signature.** [Nit]
+Plan §5.4 had `new(config, input_basename)`. Implementation expanded to `new(config, input_path, input_basename)` because the splitting report needs the input file path. Reasonable evolution; document briefly in the doc-comment that the signature deviates from the plan. (Plan-coverage check will catch this.)
+
+**S2. `write_splitting_report` takes 4 positional args.** [Low]
+`output.rs:212`: `(path, input_path, config, report)`. Approaching the SPEC §6.1 rule-of-thumb threshold (3-4 args is fine; 5+ is plan-violating). Currently OK; Phase D (M-bias writer) and Phase E will add more report fields. Keep the signature flat or introduce `ReportContext { input_path, config, report }`.
+
+**S3. `state.rs`'s `#[allow(dead_code)] pub mode: OutputMode` is acceptable pre-wiring.** [Verified]
+Phase B main dispatch only allows `OutputMode::Default`, so the field is stored but never read. `#[allow(dead_code)]` is the right tool — `cfg(feature = "phase-e")` would over-engineer for a 3-month timeline. No change needed.
+
+**S4. Doc comment on `OutputFileMap::flush_all` forward-promises Phase D behaviour without issue link.** [Nit]
+See L4 above.
+
+### Tests
+
+**T1. `extract_calls_walks_cigar_with_soft_clips` is NOT a false-positive test.** [Verified]
+Spot-checked against `bismark-io/src/cigar.rs:131-138` and `record.rs:284`. CIGAR `2S8M` produces two AlignedPosition items with `read_pos == 0, 1` and `ref_offset == None`, then 8 items with `read_pos == 2..10` and `ref_offset == Some(0..8)`. The `filter_map(|ap| ap.ref_offset?)` in `iter_aligned` discards the soft-clip items but leaves `read_pos` at its post-increment value. The test's `assert_eq!(calls[0].read_pos, 2)` is correct and meaningful — it locks the soft-clip-includes-in-count invariant against future regressions in `aligned_positions`.
+
+**T2. Smoke test's OB record uses synthetic XR=CT, XG=GA. [Verified realistic enough for Phase B]**
+`from_xr_xg("CT", "GA")` produces `BismarkStrand::OB` (verified in `strand.rs:60`). The XM `Z....` on OB strand will be reversed by `iter_aligned`, so the Z byte (BAM position 0) emerges at `read_pos_5p == 4`. It still classifies as CpG-meth and routes to `CpG_OB_*.txt`. **Caveat:** real Bismark OB records have a reverse-complemented sequence too — the smoke test's `seq=b"ACGTC"` doesn't reflect that. Not a functional issue for Phase B (extractor doesn't use the sequence; only XR/XG/XM/CIGAR matter), but document the fixture's structural-vs-biological scope in a comment so a future reader doesn't assume it's a faithful Bismark output.
+
+**T3. Plan promises `cleanup_partial_outputs_continues_past_one_failure`; not present.** [Low — see L3]
+
+**T4. Plan promises `extract_se_two_records_route_to_different_files`; implicitly covered by smoke.** [Nit]
+Plan §7.1 lists this as a unit test in `tests/se_phase_b.rs`, but the smoke test's 3+2 OT/OB fixture covers the same behaviour end-to-end. Acceptable substitution; plan-coverage check will note it.
+
+**T5. `route_call_increments_counter_before_mbias_only_short_circuit` test forces `state.mbias_only = true` even though main rejects.** [Verified safe pre-wiring]
+The test is the only place the `mbias_only` short-circuit branch is exercised in Phase B. It locks the rev-1 ordering invariant (counter increment BEFORE the short-circuit). This is correct pre-wiring for Phase E: when E lands `--mbias_only` enablement at main dispatch, this test will fail if E accidentally inverts the ordering. **No trap.** If Phase E changes the semantic (unlikely — Perl is the truth), the test rightly breaks and forces a deliberate update.
+
+### Phase-C readiness
+
+**PC1. `ExtractState::new(config, input_path, input_basename)` carries over cleanly to PE.** [Verified]
+PE pipeline will need the same chr_table + ExtractState + cleanup_on_error pattern. `mbias[1]` is already pre-wired (R2 slot) and exercised by `route_call_r2_goes_to_mbias_index_1` test. `ReadIdentity::R2` routing path is already live.
+
+**PC2. The `flags_bits & 0x1` check needs to be lifted to a header-level dispatch in Phase C.** [Note]
+Phase B rejects PE per-record (correct for the current architecture). Phase C will need either (a) `detect_paired_from_header` from `bismark-dedup` promoted to bismark-io, OR (b) keep per-record check + branch to PE handling in the loop. Plan §9.2 #3 already calls this out — no surprise.
+
+**PC3. `derive_basename` is PE-compatible.** [Verified]
+PE doesn't change the input-file model (still one BAM per invocation; PE means flag 0x1 set in records, not "two input files"). No refactoring needed.
+
+**PC4. `extract_se` and the future `extract_pe` will share ~80% of body code.** [Recommend]
+Reading-loop scaffolding (open_reader, build_chr_name_table, derive_basename, ExtractState::new, finalize) is identical. Plan a private `extract_records<F: FnMut(BismarkRecord, &mut ExtractState) -> Result<...>>` helper at Phase C entry to keep PE and SE bodies thin. Not a Phase B fix.
+
+---
+
+## Fixes applied
+
+None — Reviewer B is read-only per skill spec.
+
+---
+
+## Prioritized recommendations
+
+| Priority | Item | Action |
+|---|---|---|
+| Medium | **E1.** QNAME allocation on hot path (1.6 GiB churn at 55M records). | Phase F: make `read_id` lazy (closure or `Cow`). |
+| Low | **L3 / T3.** Missing `cleanup_partial_outputs_continues_past_one_failure` test. | Add the test. |
+| Low | **L2.** `BismarkIo` vs `IoWrite` jacket symmetry. | Phase C: rename `BismarkIo` to `InputRead` with distinct display string. |
+| Low | **E2.** Avoidable `reader.header().clone()`. | Drop the clone. |
+| Low | **E3.** 8 `write_all` per call line. | Phase F: scratch buffer + larger BufWriter. |
+| Low | **Err2.** `reference_sequence_id().expect(...)` panics on regression. | Convert to typed `InternalError`. |
+| Nit | **S1.** `ExtractState::new` signature drift from plan. | Document the extra param. |
+| Nit | **L4 / S4.** Speculative doc comment on `flush_all`. | Drop or link future-phase issue. |
+| Nit | **T2.** Smoke OB fixture doesn't reverse-complement seq. | Add a comment clarifying structural scope. |
+
+---
+
+## Verdict: **APPROVE-WITH-NITS**
+
+Phase B is correct, well-tested, byte-identity-locked at every gateable boundary (header literal, suffix-strip, `+`/`-` field, ordering invariants), and ready to merge. The one missing test (L3/T3) is a small follow-up. All other items are Phase-F or Phase-C concerns that don't block merge.

--- a/plans/05262026_bismark-extractor/COVERAGE_PHASE_B.md
+++ b/plans/05262026_bismark-extractor/COVERAGE_PHASE_B.md
@@ -1,0 +1,196 @@
+# Plan Coverage Report — Phase B
+
+**Mode:** B (code vs. implementation plan)
+**Plan(s):** `plans/05262026_bismark-extractor/PHASE_B_PLAN.md` (rev 1)
+**Date:** 2026-05-26
+**Verdict:** INCOMPLETE — 3 items unresolved (2 missing unit tests, 1 missing fixture/regenerate script)
+
+## Summary
+
+- Total items: 64
+- DONE: 60
+- PARTIAL: 1
+- MISSING: 3
+- DEVIATED: 0
+
+(Notes:
+- Mandatory implementation/behaviour items: all DONE.
+- Test list: 38 of the 41 plan-listed tests are present and pass; 2 are missing
+  (one explicitly listed in plan §7.1; one acknowledged-but-not-relocated to the
+  smoke file); 1 plan-listed deliverable was implemented in a different file
+  with equivalent behavior (PARTIAL — see Item T-30).
+- All 90 implemented tests pass under `cargo test -p bismark-extractor`.)
+
+## Coverage ledger — scope, behaviour, signatures, outline
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | SE-only (PE rejected at main dispatch) | §2, §5 main.rs | DONE | `main.rs:60-64` |
+| 2 | OutputMode::Default only (others rejected) | §2 | DONE | `main.rs:67-75` |
+| 3 | No `--gzip` (rejected) | §2 | DONE | `main.rs:78-82` |
+| 4 | `--parallel 1` only (others rejected) | §2 | DONE | `main.rs:85-92` |
+| 5 | No `--bedGraph` / `--cytosine_report` (rejected) | §2 | DONE | `main.rs:95-100` |
+| 6 | M-bias accumulator IN Phase B; writer deferred to D | §2 | DONE | `mbias.rs` accumulators; no writer wired |
+| 7 | Splitting-report skeleton | §2, §4.3 | DONE | `output.rs::write_splitting_report` |
+| 8 | Eager-open output files (12 files unconditionally) | §2 (C1 rev 1) | DONE | `output.rs::OutputFileMap::new` (DEFAULT_KEYS x 12) |
+| 9 | `mbias_only_silence` kernel param deferred to Phase E | §2 (I3 rev 1) | DONE | `extract_calls` signature is 3 args; conditional die deferred |
+| 10 | Splitting-report counter ordering BEFORE `mbias_only` short-circuit | §2 (I4 rev 1), §5.5 | DONE | `route.rs:42-67` order matches spec |
+| 11 | §4.1 single positional file; multi-input rejection | §4.1 | DONE | `main.rs:50-57` |
+| 12 | §4.2 12 files eager-open + version header | §4.2 | DONE | `output.rs` + tests pass |
+| 13 | §4.3 splitting report: param-summary + per-context counts + percentages | §4.3 | DONE | `output.rs::write_splitting_report` emits all sections |
+| 14 | §4.4 M-bias accumulator unless `--mbias_off` | §4.4 | DONE | `route.rs:30-40` guards on `state.mbias_off` |
+| 15 | §4.5 empty BAM edge case | §4.5 | DONE | `smoke_se_empty_bam_writes_only_header_files` |
+| 16 | §4.5 soft-clip read_pos counting | §4.5 | DONE | `extract_calls_walks_cigar_with_soft_clips` |
+| 17 | §4.5 InvalidXmByte cleanup | §4.5 | DONE | `pipeline.rs:107-113` cleanup-on-err |
+| 18 | §4.5 PAIRED-flag rejection | §4.5 | DONE | `pipeline.rs:73-82` + smoke covers |
+| 19 | §4.5 output_dir auto-create | §4.5 | DONE | `output.rs:78` `create_dir_all` |
+| 20 | §4.5 non-ASCII chr name rejection | §4.5 | DONE | `header.rs::build_chr_name_table` |
+| 21 | §5.1 call.rs: CytosineContext / MethCall / XmClassification / classify_xm_byte / extract_calls | §5.1 | DONE | `call.rs` full surface present |
+| 22 | §5.2 mbias.rs: MbiasPos + MbiasTable::accumulate | §5.2 | DONE | `mbias.rs` |
+| 23 | §5.3 output.rs: OutputKey / OutputFileMap (eager, single map of (PathBuf, BufWriter)) / SplittingReport / write_splitting_report | §5.3 | DONE | `output.rs:32-64` uses single `HashMap<OutputKey, (PathBuf, BufWriter<File>)>` |
+| 24 | §5.4 state.rs: ExtractState + new/finalize/cleanup_partial_outputs | §5.4 | DONE | `state.rs` |
+| 25 | §5.5 route.rs: route_call with rev-1 ordering | §5.5 | DONE | `route.rs:22-77` |
+| 26 | §5.6 pipeline.rs: extract_se | §5.6 | DONE | `pipeline.rs:54-129` |
+| 27 | §5.7 header.rs: build_chr_name_table with ASCII assert | §5.7 | DONE | `header.rs:24-40` |
+| 28 | §5.8 error variants: PhaseNotYetImplemented, InvalidXmByte, IoWrite, BismarkIo, InternalError, NonAsciiChromosomeName | §5.8 | DONE | `error.rs:132-187` all six present |
+| 29 | §6 step 1: add 6 error variants | §6 | DONE | see Item 28 |
+| 30 | §6 step 2: create call.rs | §6 | DONE | `src/call.rs` exists |
+| 31 | §6 step 3: create mbias.rs | §6 | DONE | `src/mbias.rs` exists |
+| 32 | §6 step 4: create output.rs (eager-open, single map, cleanup_all, format_meth_line, SplittingReport) | §6 | DONE | `src/output.rs` |
+| 33 | §6 step 5: create state.rs (new/finalize/cleanup_partial_outputs) | §6 | DONE | `src/state.rs` |
+| 34 | §6 step 6: create route.rs (rev-1 ordering) | §6 | DONE | `src/route.rs` |
+| 35 | §6 step 7: create header.rs (ASCII assertion) | §6 | DONE | `src/header.rs` |
+| 36 | §6 step 8: create pipeline.rs (extract_se + derive_basename) | §6 | DONE | `src/pipeline.rs` |
+| 37 | §6 step 9: update lib.rs (pub mod + re-exports) | §6 | DONE | `src/lib.rs:40-56` |
+| 38 | §6 step 10: update main.rs::run (5 PhaseNotYetImplemented paths + extract_se) | §6 | DONE | `src/main.rs:41-107` |
+| 39 | §6 step 11: bump Cargo.toml to 1.0.0-alpha.2 | §6 | DONE | `Cargo.toml:3` |
+| 40 | §6 step 12: leave src/params.rs untouched | §6 | DONE | unmodified |
+| 41 | §6 step 13: write tests | §6 / §7 | PARTIAL | 38 of 41 plan-§7.1 named tests + smoke; see Test verification |
+| 42 | §6 step 14: `cargo test && cargo clippy && cargo fmt --check` | §6 | DONE (test side) | 90/90 tests pass; clippy + fmt not run in this audit but `cargo test` finished cleanly |
+| 43 | §3.2 commit `tests/data/regenerate.sh` and synthetic BAM fixture | §3.2 | MISSING | No `tests/data/` directory exists. Smoke test builds the BAM in-process instead — functional coverage is achieved, but the plan-listed deliverable (committed regenerate.sh + README.md per §7.2-§7.3) is absent |
+
+## Coverage ledger — validation matrix (plan §10)
+
+| # | Validation item | Source | Status | Notes |
+|---|-----------------|--------|--------|-------|
+| V1 | Eager-open + header bytes match Perl | §10 | DONE | `output_file_map_eagerly_creates_*` + `output_file_header_matches_perl_format` |
+| V2 | `-`-strand orientation invariant | §10 | DONE | `extract_calls_minus_strand_orients_5prime` + `..._orients_both_calls` |
+| V3 | Missing CHG/CHH closure (Alan's bug) | §10 | DONE | 4 mbias_routes_to_{chg,chh}_* + `route_single_record_with_mixed_contexts_*` |
+| V4 | Partial-output cleanup | §10 | PARTIAL | `cleanup_partial_outputs_removes_all_12_files` present; `cleanup_partial_outputs_continues_past_one_failure` MISSING |
+| V5 | Phase-gate rejections (6) | §10 | DONE | 6 main_rejects_* tests pass |
+| V6 | PAIRED-flag rejection | §10 | DONE | `smoke_se_rejects_record_with_paired_flag_set` |
+| V7 | Counter ordering vs `mbias_only` | §10 | DONE | `route_call_increments_counter_before_mbias_only_short_circuit` |
+| V8 | Soft-clip read_pos counting | §10 | DONE | `extract_calls_walks_cigar_with_soft_clips` |
+| V9 | Non-ASCII chr rejection | §10 | DONE | `build_chr_name_table_rejects_non_ascii` |
+| V10 | output_dir auto-create | §10 | DONE | `output_file_map_creates_output_dir_if_missing` |
+| V11 | E2E smoke | §10 | DONE | `smoke_se_directional_produces_all_12_files_and_report` |
+| V12 | Empty input | §10 | DONE | `smoke_se_empty_bam_writes_only_header_files` |
+| V13 | Clippy + fmt | §10 | NOT-RUN | Plan step §6.14; out of scope for this coverage audit; `cargo test` clean |
+
+## Test verification (Mode B)
+
+All tests run under `cargo test -p bismark-extractor` — 40 lib unit + 4 sanity + 43 se_phase_b + 3 smoke = **90 passing, 0 failing**.
+
+| # | Plan §7.1 test name | Where implemented | Status |
+|---|---------------------|-------------------|--------|
+| T-01 | classify_xm_byte_classifies_all_six_methylation_bytes | tests/se_phase_b.rs:138 | PASS |
+| T-02 | classify_xm_byte_skips_U_u_dot | tests/se_phase_b.rs:159 | PASS |
+| T-03 | classify_xm_byte_rejects_invalid | tests/se_phase_b.rs:174 | PASS |
+| T-04 | extract_calls_classifies_all_six_methylation_bytes | tests/se_phase_b.rs:197 | PASS |
+| T-05 | extract_calls_respects_ignore_5p | tests/se_phase_b.rs:211 | PASS |
+| T-06 | extract_calls_respects_ignore_3p | tests/se_phase_b.rs:221 | PASS |
+| T-07 | extract_calls_walks_cigar_with_indels | tests/se_phase_b.rs:231 | PASS |
+| T-08 | extract_calls_walks_cigar_with_soft_clips | tests/se_phase_b.rs:254 | PASS |
+| T-09 | extract_calls_empty_xm_yields_empty_vec | tests/se_phase_b.rs:279 | PASS |
+| T-10 | extract_calls_minus_strand_orients_5prime | tests/se_phase_b.rs:286 | PASS |
+| T-11 | extract_calls_rejects_invalid_xm_byte_with_error | tests/se_phase_b.rs:325 | PASS |
+| T-12 | mbias_accumulate_increments_meth_for_Z | tests/se_phase_b.rs:351 | PASS |
+| T-13 | mbias_accumulate_increments_unmeth_for_z | tests/se_phase_b.rs:358 | PASS |
+| T-14 | mbias_accumulate_routes_to_chg_for_X | tests/se_phase_b.rs:365 | PASS |
+| T-15 | mbias_accumulate_routes_to_chg_for_x | tests/se_phase_b.rs:376 | PASS |
+| T-16 | mbias_accumulate_routes_to_chh_for_H | tests/se_phase_b.rs:383 | PASS |
+| T-17 | mbias_accumulate_routes_to_chh_for_h | tests/se_phase_b.rs:390 | PASS |
+| T-18 | mbias_R2_index_ready | tests/se_phase_b.rs:755 | PASS |
+| T-19 | route_call_default_mode_routes_to_strand_specific_file | tests/se_phase_b.rs:606 | PASS |
+| T-20 | route_single_record_with_mixed_contexts_routes_to_one_strand_directory | tests/se_phase_b.rs:637 | PASS |
+| T-21 | format_meth_line_exact_bytes | tests/se_phase_b.rs:496 (`..._for_unmethylated`) | PASS (renamed; behavior matches) |
+| T-22 | output_file_map_eagerly_creates_all_strand_files_for_default_mode | tests/se_phase_b.rs:401 | PASS |
+| T-23 | output_file_map_omits_header_when_no_header_true | tests/se_phase_b.rs:429 | PASS |
+| T-24 | output_file_header_matches_perl_format | tests/se_phase_b.rs:442 | PASS |
+| T-25 | output_file_map_creates_output_dir_if_missing | tests/se_phase_b.rs:463 | PASS |
+| T-26 | cleanup_partial_outputs_removes_all_12_files | tests/se_phase_b.rs:515 | PASS |
+| T-27 | cleanup_partial_outputs_continues_past_one_failure | — | **MISSING** |
+| T-28 | route_call_increments_counter_before_mbias_only_short_circuit | tests/se_phase_b.rs:686 | PASS |
+| T-29 | splitting_report_emits_per_context_counts | tests/se_phase_b.rs:544 | PASS |
+| T-30 | splitting_report_percentage_handles_zero_denominator | tests/se_phase_b.rs:531 | PASS |
+| T-31 | build_chr_name_table_rejects_non_ascii | tests/se_phase_b.rs:783 | PASS |
+| T-32 | derive_basename_strips_known_suffixes | tests/se_phase_b.rs:807 | PASS |
+| T-33 | extract_se_rejects_record_with_paired_flag_set | tests/se_phase_b_smoke.rs (`smoke_se_rejects_record_with_paired_flag_set`) | PASS (relocation acknowledged in se_phase_b.rs:910-912 comment) |
+| T-34 | main_rejects_paired_end_with_phase_error | tests/se_phase_b.rs:839 | PASS |
+| T-35 | main_rejects_multiple_input_files | tests/se_phase_b.rs:852 | PASS |
+| T-36 | main_rejects_multicore_with_phase_error | tests/se_phase_b.rs:864 | PASS |
+| T-37 | main_rejects_gzip_with_phase_error | tests/se_phase_b.rs:876 | PASS |
+| T-38 | main_rejects_comprehensive_with_phase_error | tests/se_phase_b.rs:887 | PASS |
+| T-39 | main_rejects_bedgraph_with_phase_error | tests/se_phase_b.rs:898 | PASS |
+| T-40 | extract_se_two_records_route_to_different_files | — | **MISSING** |
+| T-41 | extract_se_empty_input_writes_only_header_files | tests/se_phase_b_smoke.rs (`smoke_se_empty_bam_writes_only_header_files`) | PASS (relocated to smoke file; functional coverage equivalent) |
+| T-42 (§7.2) | smoke_se_directional_produces_all_12_files_and_report | tests/se_phase_b_smoke.rs | PASS |
+
+### Bonus tests (not in plan §7.1 but added during implementation)
+
+| Test | File | Notes |
+|------|------|-------|
+| extract_calls_minus_strand_orients_both_calls | se_phase_b.rs:304 | Strengthens orientation invariant — bonus, not gap |
+| extract_calls_ignore_larger_than_seq_returns_empty | se_phase_b.rs:340 | Edge-case (ignore > seq_len, plan §4.5 row) |
+| output_file_map_write_call_appends_after_header | se_phase_b.rs:476 | Header + payload-write co-test |
+| splitting_report_percentage_for_50_50 | se_phase_b.rs:538 | Sanity for percent calc |
+| route_call_r2_goes_to_mbias_index_1 | se_phase_b.rs:725 | R2 index plumbing — covers Phase C precursor |
+| build_chr_name_table_returns_ascii_names_in_order | se_phase_b.rs:769 | Happy-path counterpart to ASCII-reject |
+
+## Gaps (detail)
+
+### Item T-27 (MISSING test): `cleanup_partial_outputs_continues_past_one_failure`
+
+**Expected (plan §7.1):** A test that drops/locks one of the 12 output files such that `std::fs::remove_file` would fail for that file, then asserts the remaining 11 are still removed and the `cleanup_all` call does not panic.
+
+**Found:** Nothing. Only `cleanup_partial_outputs_removes_all_12_files` exists (covers the happy-path cleanup).
+
+**Gap:** The robustness invariant — "one failed remove doesn't prevent others" — is implemented (`output.rs:149-164` continues iterating past `remove_file` errors) but not unit-tested. Plan §10 row "Partial-output cleanup" explicitly lists this test as one of the two cleanup checks.
+
+### Item T-40 (MISSING test): `extract_se_two_records_route_to_different_files`
+
+**Expected (plan §7.1, "Rev 1 (B §4)" annotation):** Two records (one OT, one OB) → calls land in `*_OT_*` and `*_OB_*` respectively; multi-record accumulator correctness.
+
+**Found:** Functionally covered by `smoke_se_directional_produces_all_12_files_and_report` (which uses 3 OT + 2 OB records and asserts CpG_OB / CHH_OB / *_OT_* files all have content). But the named unit test that would isolate "two records, different strands → different files" without going through the binary spawn is absent.
+
+**Gap:** No dedicated unit-level multi-record routing test. Smoke gives end-to-end coverage but loses the locality that a focused unit test provides.
+
+### Item 43 (MISSING fixture deliverable): `tests/data/regenerate.sh` + `tests/data/se_directional_phase_b.bam` + README
+
+**Expected (plan §3.2 + §7.2-§7.3):** Commit `tests/data/regenerate.sh` and `tests/data/se_directional_phase_b.bam` (per §3.2) plus a `tests/data/README.md` documenting how to regenerate the smoke BAM from a synthetic FASTA (per §7.3).
+
+**Found:** No `tests/data/` directory. Smoke test instead constructs synthetic BAMs in-test via `BamWriter::from_path`. This is functionally equivalent (and arguably preferable — fewer binary blobs in the repo) but deviates from the plan-listed deliverable.
+
+**Gap:** Either commit the documented deliverables, or update the plan to document the in-test BAM-construction approach as an intentional deviation.
+
+### Item V13: clippy / fmt verification not performed
+
+**Expected (plan §6 step 14, §10 row 13):** `cargo clippy -p bismark-extractor -- -D warnings && cargo fmt --check`.
+
+**Found:** Out of scope for this coverage audit; only `cargo test` was run. `cargo test` succeeded cleanly with no warnings printed in the captured output. Plan-step verification of clippy + fmt remains the implementer's responsibility.
+
+**Gap:** Not a coverage gap per se — the audit didn't exercise this. Listing it here so it isn't lost.
+
+## Verdict
+
+**INCOMPLETE — 3 items unresolved.**
+
+The implementation is functionally complete: every scope decision, behaviour, signature, edge case, and validation item in the plan is implemented and the supporting tests pass (90/90 green). All Phase B exit criteria (eager-open output map, version-header byte fidelity, splitting-report skeleton, M-bias accumulator, route_call rev-1 ordering, six phase-gate rejections, PAIRED-flag-on-SE rejection, non-ASCII chr name rejection, output_dir autocreate, partial-output cleanup, end-to-end smoke) are working.
+
+The three unresolved items are documentation/test-coverage gaps, not behaviour gaps:
+
+1. **T-27** — add the `cleanup_partial_outputs_continues_past_one_failure` test in `tests/se_phase_b.rs`. The behaviour exists (`output.rs:149-164`) but is unit-test-uncovered.
+2. **T-40** — add the `extract_se_two_records_route_to_different_files` test in `tests/se_phase_b.rs`. The behaviour is exercised end-to-end by the smoke test, but the focused unit test is absent.
+3. **Item 43** — either commit `tests/data/regenerate.sh` + `tests/data/se_directional_phase_b.bam` + `tests/data/README.md` (the plan's §3.2 / §7.3 deliverable), or update the plan to record the in-test BAM-construction approach as an intentional deviation.
+
+None of these block Phase B merge if the user is willing to formally re-classify them. If strict plan coverage is required, all three are mechanical fixes.

--- a/plans/05262026_bismark-extractor/PHASE_B_PLAN.md
+++ b/plans/05262026_bismark-extractor/PHASE_B_PLAN.md
@@ -1,0 +1,668 @@
+# `bismark-extractor` Phase B — SE extraction loop + XM routing + output-file map + splitting-report skeleton
+
+**Status:** rev 2 — implementation complete (91 tests green, clippy + fmt clean) with dual-code-review nits folded in. Phase B is ready for merge / for Phase C to begin.
+**Date:** 2026-05-26.
+**Slug:** `plans/05262026_bismark-extractor/PHASE_B_PLAN.md`.
+**Phase target:** SPEC §10 row B — ~800 LOC (rev 2 actual: ~1,100 LOC including tests).
+
+## Revision history
+
+- **rev 0** (2026-05-26): initial Phase B plan.
+- **rev 2** (2026-05-26): post-implementation close-out folding both code-reviewers' Medium/Low findings + plan-manager coverage gaps.
+  - **Reviewer A L1 / Reviewer B L1 (Medium)** — renamed `strand_char` → `meth_char` in `OutputFileMap::write_call` and rewrote the doc comment to accurately label the `+`/`-` column as a methylation-state indicator (not a strand char). Behaviour was already byte-correct per Perl 2911-2961; only the label drifted from the truth.
+  - **Reviewer A E1 (Medium)** — widened `OutputFileMap::write_call` return type from `Result<(), io::Error>` to `Result<(), BismarkExtractorError>`. The previously-unreachable `.expect("missing key")` panic is now a typed `InternalError`, matching the plan §5.3 contract. Propagated through `route_call`'s signature.
+  - **Reviewer A E2 / Reviewer B Err2 (Low)** — replaced `pipeline.rs::extract_se`'s `reference_sequence_id().expect()` with a typed `InternalError` path (matches `bismark-dedup/src/pipeline.rs:224` precedent).
+  - **Reviewer B E2 (Low)** — dropped `reader.header().clone()` in `extract_se`; now passes `reader.header()` by reference to `build_chr_name_table`. One Header clone saved per run.
+  - **Reviewer B L4 / S4 (Nit)** — trimmed the speculative "so the report can name accurate file sizes" doc-comment on `OutputFileMap::flush_all` (it forward-promised a behaviour that won't ship).
+  - **Plan-manager T-27 / Reviewer A S1 / Reviewer B L3 (Low) — RESOLVED.** Added `cleanup_partial_outputs_continues_past_one_failure` test in `tests/se_phase_b.rs` (pre-deletes one file so `cleanup_all` hits `Err` on that path; asserts the other 11 still removed). Closes the plan §7.1 gap.
+  - **Plan-manager T-40 — DEVIATION DOCUMENTED.** Plan §7.1 promised `extract_se_two_records_route_to_different_files` as a unit test. Actual implementation covers this via the smoke test `smoke_se_directional_produces_all_12_files_and_report` (3 OT + 2 OB records exercising multi-record routing end-to-end through the binary). Smoke coverage is functionally stronger than the unit-level test would have been; no separate unit test added.
+  - **Plan-manager Item 43 — DEVIATION DOCUMENTED.** Plan §3.2 / §7.3 listed `tests/data/regenerate.sh` + `tests/data/se_directional_phase_b.bam` + `tests/data/README.md` as committed deliverables. Actual implementation builds BAMs in-process via `bismark_io::BamWriter::from_path` from `tests/se_phase_b_smoke.rs`. **Rationale for deviation:** fewer binary blobs in the repo, fully reproducible from code, no toolchain dependency. The smoke test serves the same role (end-to-end binary exercise without Perl baseline) without the file-system artefacts. If Phase H needs a committed BAM for the 10M/55M byte-identity gate, it can add one then.
+  - **Reviewer B Phase-F items (E1 lazy QNAME, L2 BismarkIo rename, E3 scratch-buffer write)** — out of scope for Phase B rev 2; tracked for Phase F profiling per the plan §13 follow-up list.
+  - **Verification (rev 2):** `cargo test -p bismark-extractor` → 91 tests pass (40 lib + 4 sanity + 44 se_phase_b + 3 smoke). `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --check` clean.
+- **rev 1** (2026-05-26): folded findings from dual plan-review.
+  - **C1 (B, Critical) — RESOLVED.** Verified against Perl source lines 5140-5325 (`--merge_non_CpG` branch) + 5405-5700+ (default branch): Perl opens **all 12** strand×context files eagerly via `open(...) unless($mbias_only)` and writes the version header immediately via `print ... unless($no_header) unless($mbias_only)`. The SPEC §8.4 "0-byte (Perl) or absent (Rust)" framing was factually wrong about Perl. Phase B switches to **eager-open with immediate header write**, re-frames Alan's "spurious CTOT/CTOB" structural fix as `record_strand` correctness (no record's calls split across files), and flags SPEC §8.4 for a corrective edit (separate task, not Phase B implementation).
+  - **I1 (B, Important).** `read_pos_5p` from `iter_aligned` **includes soft-clip positions in the count** (verified at `bismark-io::CigarExt::aligned_positions` cigar.rs:131-138, plus `iter_aligned` filter at record.rs:284). Plan §4.5 + §7.1 test prose updated.
+  - **I3 (B, Important).** `mbias_only_silence` kernel param dropped from Phase B (deferred to Phase E). Reduces `extract_calls` signature to 3 args; the conditional `die`-vs-skip on invalid XM moves to Phase E.
+  - **I4 (B, Important).** `route_call` reorders: M-bias → splitting-report counters → `mbias_only` short-circuit → file write. Documented as a SPEC §7.5 deviation (Perl truth: counters accumulate even under `--mbias_only`); follow-up task queued to fix SPEC §7.5.
+  - **I5 (B, Important).** Added an end-to-end smoke test that does NOT require the Perl toolchain (synthetic BAM → run binary → assert file set + non-emptiness + parseable splitting report).
+  - **A Important #1.** `record.inner().flags().bits()` → `u16::from(record.inner().flags())` (noodles API correctness).
+  - **A Important #2 / B Optional O2 — RESOLVED.** Perl suffix-strip is case-sensitive single-extension (`s/sam$/txt/`, `s/bam$/txt/`, `s/cram$/txt/`); Rust `derive_basename` matches. No `.bam.gz` handling.
+  - **A Important #3-#6.** Added missing tests: per-record PAIRED-flag rejection; `--multiple` files rejection; mixed-context routing on a single record (closes Alan's split-across-files bug at unit level); literal-header-bytes assertion.
+  - **A Important #7.** `finalize`-failure invariant stated in §5.4.
+  - **A Important #8.** `BismarkStrand`-from-XR/XG vs Perl strand-classification documented as a Phase H assumption.
+  - **A Important #9.** Defensive comment for `extract_calls`: must use `aligned.xm_byte`, never `record.xm()[read_pos_5p]`.
+  - **B Optional O1.** `build_chr_name_table` asserts ASCII chr names + errors loudly on non-ASCII.
+  - **B Optional O4.** `OutputFileMap` collapses `fhs`+`paths` into one `HashMap<OutputKey, (PathBuf, BufWriter<File>)>`.
+  - **B Optional O5.** `extract_calls` uses `Vec::new()` (no preallocation heuristic).
+  - **B "output_dir missing"** — `OutputFileMap::new` calls `std::fs::create_dir_all` defensively (Perl `make_path` precedent).
+  - **A Optional #14 / B confirmation.** Locked `detect_paired_from_header` as Phase C work (already exists in `bismark-dedup/src/pipeline.rs:137`; promote to `bismark-io` when Phase C wires PE auto-detect).
+  - **Verdict change**: rev 0 split (A: APPROVE-WITH-NITS, B: NEEDS-REVISIONS) → rev 1 awaiting confirmation.
+
+## Epic linkage
+
+- **Design contract:** `rust/bismark-extractor/SPEC.md` (in-repo, rev 2). Note: SPEC §8.4 row "Directional library" has a factual error about Perl's empty-file behavior; SPEC fix is queued as a separate task once Phase B implementation lands.
+- **GitHub umbrella:** issue [#798](https://github.com/FelixKrueger/Bismark/issues/798) (bismark-extractor port).
+- **Prior phases:** Phase A (workspace scaffold + CLI) merged at commit `144ca2d` (PR #847, closes #846).
+- **Phase B will close:** the placeholder gap for the SE / default-mode / single-core / non-gzip subset of the pipeline.
+
+## 1. Goal
+
+Wire the first end-to-end extraction path: read a Bismark-aligned BAM/SAM/CRAM, classify each record's XM-tag bytes into methylation calls, route those calls to per-(context × strand) split files on disk, and emit a Perl-shaped `_splitting_report.txt`. After Phase B, the binary produces real output for an SE directional BAM in `OutputMode::Default` on a single core; PE, non-default modes, gzip, multicore, and the bedGraph/cytosine_report chain remain stubbed (rejected at the resolved-config boundary).
+
+## 2. Scope decisions (locked, rev 1)
+
+| Decision | Choice | Reasoning |
+|----------|--------|-----------|
+| Library mode | **SE only** | PE is Phase C. |
+| Output mode | **`OutputMode::Default` only** | Other modes are Phase E. |
+| Compression | **No `--gzip`** | Phase E. |
+| Parallelism | **`--parallel 1` only** | Phase F. |
+| Downstream chain | **No `--bedGraph` / `--cytosine_report`** | Phase G. |
+| M-bias **accumulator** | **In Phase B** (per SPEC §7.5 step 1) | Cheap; structurally clean; avoids rewriting `route_call` at Phase D. |
+| M-bias **writer** (`M-bias.txt`) | **Phase D** | Per SPEC §10 row D. |
+| Splitting-report content | **Functional Perl-shaped emission** | Byte-identity gated at Phase H. |
+| **Output-file creation** | **Eager (rev 1)** — open all 12 strand×context files at `OutputFileMap::new()` time + write header line immediately | Matches Perl source 5405-5700+ (default branch) / 5140-5325 (merge_non_CpG branch). Lazy was a rev 0 bug. |
+| **`mbias_only_silence` kernel param** | **Deferred to Phase E** | Phase B rejects `--mbias_only` at main dispatch; the param would be dead code. |
+| **Splitting-report counter ordering** | **Increment BEFORE `mbias_only` short-circuit** in `route_call` | SPEC §7.5 pseudocode shows counter AFTER short-circuit, which would break Perl byte-identity under `--mbias_only`. SPEC fix is a separate task. |
+| Auto-detect path (SE vs PE) | **Defensive per-record PAIRED-flag check** in SE loop | Phase C promotes `detect_paired_from_header` from `bismark-dedup/src/pipeline.rs:137` to `bismark-io`. |
+
+## 3. Context
+
+### 3.1 Source documents read end-to-end
+
+- `rust/bismark-extractor/SPEC.md` §§2, 3, 4, 5, 6.1–6.3, 6.5, 7.1, 7.2, 7.5, 7.7, 8.1, 8.4, 10, 11, 12, 14 (rev 2). **Note: SPEC §8.4 "Directional library" row needs correction — see Revision history.**
+- `rust/bismark-extractor/src/{lib,cli,error,params,main}.rs` (Phase A state).
+- `rust/bismark-io/src/{record,read,strand,cigar,pair}.rs` — in particular `BismarkRecord::iter_aligned` (record.rs:240-312), `BismarkRecord::record_strand`, `open_reader`, `AnyReader::records`, `AlignedXmCall`, `CigarExt::aligned_positions` (cigar.rs:131-138 — confirms `SoftClip` increments `read_pos`).
+- `rust/bismark-dedup/src/pipeline.rs` — precedent for reader-opening, header → chr-name resolution (line 51, 71, 93, 194), and `detect_paired_from_header` (line 137).
+- **Perl `bismark_methylation_extractor` directly read** for rev 1:
+  - 5405-5700+: default-mode eager file-open + header-write (all 12 strand×context files).
+  - 5140-5325: `--merge_non_CpG`-mode eager file-open + header-write.
+  - 5148, 5151, 5159: `open(...) unless($mbias_only)` and `print "Bismark methylation extractor version $version\n" unless($no_header) unless($mbias_only)`.
+  - 1619-1650 (SE `--ignore` semantics), 2970-2972 / 3052-3054 (invalid-XM `die`), 4245-4267 (soft-clip handling).
+
+### 3.2 Code placement
+
+All Phase B code lands inside `rust/bismark-extractor/`:
+
+- **New modules**:
+  - `src/call.rs` — `MethCall`, `CytosineContext`, `classify_xm_byte`, `extract_calls`.
+  - `src/mbias.rs` — `MbiasTable`, `MbiasPos`. Accumulators only.
+  - `src/output.rs` — `OutputFileMap` (eager-open), `OutputKey`, `SplittingReport`, `write_splitting_report`, `format_meth_line`.
+  - `src/state.rs` — `ExtractState`.
+  - `src/route.rs` — `route_call`.
+  - `src/pipeline.rs` — `extract_se` SE main loop.
+  - `src/header.rs` — refID → chr-name lookup builder (with ASCII assertion).
+- **Modified modules**:
+  - `src/lib.rs` — `pub mod` declarations + re-exports.
+  - `src/main.rs` — replace placeholder `run()` with config-dispatch; reject non-SE / non-default / multicore / gzip / bedGraph / cytosine_report / multiple-inputs with `PhaseNotYetImplemented`.
+  - `src/error.rs` — add `PhaseNotYetImplemented`, `InvalidXmByte`, `IoWrite (#[from] std::io::Error)`, `BismarkIo (#[from] BismarkIoError)`, `InternalError`, `NonAsciiChromosomeName`.
+  - `src/params.rs` — left untouched in Phase B (see §9.2 #5).
+- **Tests**:
+  - `tests/sanity.rs` — extend with one SE smoke.
+  - `tests/se_phase_b.rs` — unit tests enumerated below.
+  - `tests/se_phase_b_smoke.rs` — end-to-end smoke (synthetic BAM, no Perl baseline; rev 1 addition).
+  - `tests/data/regenerate.sh` — fixture-generation script committed even if baseline gen is deferred.
+  - `tests/data/se_directional_phase_b.bam` — synthetic SE input (~50 reads with CpG + CHG + CHH motifs).
+
+### 3.3 Crate version
+
+`1.0.0-alpha.1` → `1.0.0-alpha.2`.
+
+### 3.4 Binary behaviour
+
+Today: validates flags, prints stderr "Phase A" note, exits 0.
+
+After Phase B: validates flags → dispatches on `ResolvedConfig`. Supported subset runs `extract_se`; unsupported subset returns `PhaseNotYetImplemented { feature }`.
+
+## 4. Behaviour specification
+
+### 4.1 Inputs
+
+- One positional `PathBuf`. `len > 1` → `PhaseNotYetImplemented { feature: "multiple input files (--multiple equivalent)" }`.
+- Resolved CLI subset.
+
+### 4.2 Outputs (rev 1: eager-open)
+
+**12 split files** are created **unconditionally** at `OutputFileMap::new()` time (matching Perl). Each file gets the version header line on creation, gated by `!config.no_header` (Phase B's main dispatch rejects `--mbias_only` so the second Perl guard is implicitly true).
+
+The 12 keys are the cross product `{CpG, CHG, CHH} × {OT, CTOT, CTOB, OB}`:
+
+| Filename pattern | Always created? | Initial content |
+|------------------|-----------------|-----------------|
+| `CpG_OT_{basename}.txt`<br>`CpG_CTOT_{basename}.txt`<br>`CpG_CTOB_{basename}.txt`<br>`CpG_OB_{basename}.txt` | Yes | `Bismark methylation extractor version v0.25.1\n` (unless `--no_header`) |
+| `CHG_{OT|CTOT|CTOB|OB}_{basename}.txt` | Yes | (same) |
+| `CHH_{OT|CTOT|CTOB|OB}_{basename}.txt` | Yes | (same) |
+
+For directional SE input (Bismark default), CTOT/CTOB files remain at 1 line (header only) for byte-identity with Perl baseline.
+
+`{basename}` = input file with **case-sensitive single-suffix stripped**: `.bam` / `.sam` / `.cram`. No `.bam.gz` handling (matches Perl `s/bam$/txt/` etc.).
+
+**Header line text** (`!config.no_header` case): literal `Bismark methylation extractor version v0.25.1\n`. The `$version` Perl variable is the Bismark suite version (currently `v0.25.1`); for Phase B's port we hardcode `v0.25.1` to lock byte-identity. If Bismark's Perl version ever bumps, the Rust port follows suit in the same release.
+
+Each post-header line is tab-separated:
+```
+read_id<TAB>strand_char<TAB>chr<TAB>ref_pos<TAB>xm_byte<LF>
+```
+
+### 4.3 Splitting report
+
+Written at `state.finalize()` time to `{output_dir}/{basename}_splitting_report.txt` unless `config.emit_splitting_report == false`.
+
+- Parameter-summary block (one line per relevant CLI flag).
+- `--fasta` annotation line iff `config.fasta_annotation == true`.
+- Per-context counts.
+- Percentage methylation per context (`%.2f` format; zero-denominator → `0.00`).
+
+Phase B aims for "Perl-shaped"; exact byte-identity is Phase H.
+
+### 4.4 M-bias accumulator (no writer in Phase B)
+
+For every routed `MethCall` (subject to `!config.mbias_off`), increment one cell of `state.mbias[0]` (SE/R1 index). M-bias writer is Phase D.
+
+### 4.5 Edge cases (rev 1)
+
+| Case | Handling |
+|------|----------|
+| Empty input BAM | All 12 split files exist, each containing only the header line (matches Perl exactly — fixes rev 0). Splitting report still written; exit 0. |
+| Coordinate-sorted input | `bismark-io` rejects upstream; extractor propagates. |
+| Single record at `alignment_start == 1` | Handled by `iter_aligned`. |
+| Soft-clipped boundary (`5S95M`) | **Rev 1 correction**: `iter_aligned` only **emits** AlignedXmCall items for matches (soft-clip filtered by `filter_map(|ap| ap.ref_offset?)` in record.rs:284), but the `read_pos_5p` field for the first emitted item is **5** (not 0) — because `CigarExt::aligned_positions` increments `read_pos` through soft-clip operations (cigar.rs:131-138) and `iter_aligned` does NOT renumber. The XM tag at the soft-clipped positions contains `.` per Bismark convention, so a hypothetical `xm[0..5]` lookup would yield non-call bytes anyway. **Net Phase B behavior matches Perl byte-identically** (Perl operates on `substr(meth_call, ignore)` over the full XM including soft-clip-corresponding `.` bytes). The ignore-region check `read_pos_5p >= ignore_5p && read_pos_5p < seq_len - ignore_3p` works because both bounds operate on the full read length (XM length). |
+| Insertion / Deletion | Handled by `iter_aligned`. |
+| `N` base in read | XM byte at that position is `.` → `SkipNonCytosine` → no call. |
+| `--ignore` > seq_len | Saturating arithmetic + early-out. |
+| `U` / `u` / `.` XM bytes | Silently skipped. |
+| Invalid XM byte (e.g. `Q`) | `classify_xm_byte` returns `Err(InvalidXmByte)`. SE loop calls `state.cleanup_partial_outputs()` before propagating. **No `mbias_only_silence` kernel param in Phase B** (deferred to Phase E). |
+| Unmapped record | Filtered upstream by `bismark-io`. |
+| **PE record (PAIRED flag set) reaches SE pipeline** | On first such record: `state.cleanup_partial_outputs()` + return `PhaseNotYetImplemented { feature: "paired-end extraction (input has PAIRED flag set)" }`. Check via `u16::from(record.inner().flags()) & 0x1 != 0` (rev 1 API correction). |
+| `output_dir` doesn't exist on disk | `OutputFileMap::new` calls `std::fs::create_dir_all(output_dir)?` defensively (rev 1 addition; matches Perl `make_path`). |
+| Non-ASCII chromosome name in @SQ | `build_chr_name_table` returns `Err(NonAsciiChromosomeName { name })`. Loud failure — no silent UTF-8 substitution (rev 1 addition). |
+
+## 5. Signatures (proposed, rev 1)
+
+### 5.1 `call.rs`
+
+```rust
+//! Methylation-call classification + per-record extraction kernel.
+
+use bismark_io::{AlignedXmCall, BismarkRecord};
+use crate::error::BismarkExtractorError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CytosineContext { CpG = 0, CHG = 1, CHH = 2 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MethCall {
+    pub ref_pos: u32,
+    pub read_pos: u32,   // 0-based 5'-oriented; INCLUDES soft-clip positions in the count (see §4.5)
+    pub context: CytosineContext,
+    pub methylated: bool,
+    pub xm_byte: u8,
+}
+
+pub(crate) enum XmClassification {
+    Call(CytosineContext, /*methylated*/ bool),
+    SkipUnknownContext,
+    SkipNonCytosine,
+}
+
+pub(crate) fn classify_xm_byte(
+    byte: u8,
+    ref_pos: u32,
+    read_id: &str,
+) -> Result<XmClassification, BismarkExtractorError>;
+
+/// Extract all `MethCall`s from one record. Delegates to `record.iter_aligned()`.
+///
+/// **Invariant** (defensive comment in implementation): use `aligned.xm_byte`
+/// from the iterator. NEVER re-index `record.xm()[read_pos_5p]` — for `-` strand
+/// reads the XM byte at `read_pos_5p` does NOT equal the BAM-stored XM[read_pos_5p].
+/// `iter_aligned` carries the orientation-corrected XM byte alongside `read_pos_5p`.
+///
+/// **Phase B**: invalid XM byte always returns `Err(InvalidXmByte)`. Phase E will
+/// add a `mbias_only_silence: bool` kernel param to mirror Perl's conditional die
+/// `die "..." unless ($mbias_only)`.
+pub fn extract_calls(
+    record: &BismarkRecord,
+    ignore_5p: u32,
+    ignore_3p: u32,
+) -> Result<Vec<MethCall>, BismarkExtractorError>;
+```
+
+### 5.2 `mbias.rs`
+
+Same as rev 0. `MbiasPos { meth: u64, unmeth: u64 }`, `MbiasTable { cpg, chg, chh: Vec<MbiasPos> }`, `accumulate(context, position_1based, methylated)`.
+
+### 5.3 `output.rs` (rev 1: eager-open + single map)
+
+```rust
+use bismark_io::BismarkStrand;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use crate::call::{CytosineContext, MethCall};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct OutputKey {
+    pub context: CytosineContext,
+    pub strand: BismarkStrand,
+}
+
+pub(crate) struct OutputFileMap {
+    // Single map (rev 1: combines old `fhs` + `paths` to remove drift risk).
+    files: HashMap<OutputKey, (PathBuf, BufWriter<File>)>,
+}
+
+impl OutputFileMap {
+    /// Eagerly opens all 12 (context × strand) split files in `output_dir`.
+    /// Writes the version header line to each file unless `no_header == true`.
+    /// Creates `output_dir` via `create_dir_all` if missing.
+    pub fn new(
+        output_dir: &Path,
+        input_basename: &str,
+        no_header: bool,
+    ) -> Result<Self, std::io::Error>;
+
+    /// Append a `MethCall` line to the appropriate split file. Key MUST exist
+    /// (eager-open guarantees this for the 12 standard SE/PE keys). Missing
+    /// key is an `InternalError`.
+    pub fn write_call(
+        &mut self,
+        record_name: &[u8],
+        chr: &str,
+        call: MethCall,
+        strand: BismarkStrand,
+    ) -> Result<(), std::io::Error>;
+
+    /// Flush every writer (called from `finalize`).
+    pub fn flush_all(&mut self) -> Result<(), std::io::Error>;
+
+    /// On error paths: drop all writers + delete all 12 files (even header-only ones).
+    /// Best-effort: one failed remove doesn't prevent others.
+    pub fn cleanup_all(&mut self);
+}
+
+pub(crate) fn write_splitting_report(
+    path: &Path,
+    config: &ResolvedConfig,
+    report: &SplittingReport,
+) -> Result<(), std::io::Error>;
+
+#[derive(Debug, Default)]
+pub(crate) struct SplittingReport {
+    pub records_processed: u64,
+    pub calls_total: u64,
+    pub calls_cpg_meth: u64, pub calls_cpg_unmeth: u64,
+    pub calls_chg_meth: u64, pub calls_chg_unmeth: u64,
+    pub calls_chh_meth: u64, pub calls_chh_unmeth: u64,
+}
+```
+
+### 5.4 `state.rs`
+
+```rust
+pub(crate) struct ExtractState {
+    pub mode: OutputMode,
+    pub mbias_off: bool,
+    pub mbias_only: bool,   // always false in Phase B (rejected at main dispatch)
+    pub mbias: [MbiasTable; 2],
+    pub fhs: OutputFileMap,
+    pub report: SplittingReport,
+}
+
+impl ExtractState {
+    /// Constructs `OutputFileMap` eagerly (12 files + headers).
+    pub fn new(config: &ResolvedConfig, input_basename: &str) -> Result<Self, std::io::Error>;
+
+    /// Flush all writers, then write splitting report.
+    ///
+    /// **Invariant (rev 1)**: `finalize` failure leaves the already-written split
+    /// files in place on disk. The caller does NOT invoke `cleanup_partial_outputs`
+    /// after a `finalize` failure — the records had already been successfully
+    /// routed; failure here means the report write or final flush hit an I/O error
+    /// after the data was on disk. Matches Perl's "die after writing" semantics.
+    pub fn finalize(&mut self, config: &ResolvedConfig) -> Result<(), BismarkExtractorError>;
+
+    /// Drop writers + remove all 12 files. Called from `extract_se`'s pre-finalize
+    /// error paths (InvalidXmByte, PAIRED-flag-on-SE, reader error, route I/O error).
+    pub fn cleanup_partial_outputs(&mut self);
+}
+```
+
+### 5.5 `route.rs` (rev 1: counter ordering fixed)
+
+```rust
+/// Phase B routing order (deliberately deviates from SPEC §7.5 pseudocode —
+/// see plan §13 #2 + revision history). Order:
+///   1. Increment M-bias counter (unless `state.mbias_off`).
+///   2. Increment splitting-report counters (unconditional — matches Perl).
+///   3. If `state.mbias_only`: return early. (Phase B: never; reserved for E.)
+///   4. Write split-file line.
+pub(crate) fn route_call(
+    state: &mut ExtractState,
+    record: &BismarkRecord,
+    chr: &str,
+    strand: BismarkStrand,
+    call: MethCall,
+    read_identity: ReadIdentity,
+) -> Result<(), std::io::Error>;
+```
+
+### 5.6 `pipeline.rs`
+
+```rust
+pub fn extract_se(
+    input: &Path,
+    config: &ResolvedConfig,
+) -> Result<(), BismarkExtractorError> {
+    let mut reader = open_reader(input, /*cram_ref=*/ None)?;
+    let header = reader.header().clone();
+    let chr_table = build_chr_name_table(&header)?;       // rev 1: errors on non-ASCII
+
+    let input_basename = derive_basename(input);
+    let mut state = ExtractState::new(config, &input_basename)?;   // rev 1: eager-creates 12 files + headers
+
+    for record_result in reader.records() {
+        let record = match record_result {
+            Ok(r) => r,
+            Err(e) => { state.cleanup_partial_outputs(); return Err(e.into()); }
+        };
+
+        // Rev 1: defensive PAIRED-flag check via `u16::from(flags)`.
+        let flags_bits: u16 = record.inner().flags().into();
+        if flags_bits & 0x1 != 0 {
+            state.cleanup_partial_outputs();
+            return Err(BismarkExtractorError::PhaseNotYetImplemented {
+                feature: "paired-end extraction (input has PAIRED flag set)".to_string(),
+            });
+        }
+
+        let refid = record.inner().reference_sequence_id()
+            .expect("mapped record must have reference_sequence_id");
+        let chr = chr_table.get(refid).ok_or_else(|| {
+            BismarkExtractorError::InternalError { message: format!(
+                "record refid {refid} out of range vs header (count {})", chr_table.len()
+            )}
+        })?;
+
+        let strand = record.record_strand();
+        let read_identity = ReadIdentity::from_flags(flags_bits);
+
+        let calls = match extract_calls(&record, config.ignore_5p_r1, config.ignore_3p_r1) {
+            Ok(c) => c,
+            Err(e) => { state.cleanup_partial_outputs(); return Err(e); }
+        };
+
+        for call in calls {
+            if let Err(io_err) = route_call(&mut state, &record, chr, strand, call, read_identity) {
+                state.cleanup_partial_outputs();
+                return Err(io_err.into());
+            }
+        }
+        state.report.records_processed += 1;
+    }
+
+    state.finalize(config)?;
+    Ok(())
+}
+```
+
+### 5.7 `header.rs` (rev 1: ASCII-asserts)
+
+```rust
+pub(crate) fn build_chr_name_table(
+    header: &Header,
+) -> Result<Vec<String>, BismarkExtractorError> {
+    let mut out = Vec::with_capacity(header.reference_sequences().len());
+    for (name, _ref_seq) in header.reference_sequences() {
+        let bytes: &[u8] = name.as_ref();
+        if !bytes.is_ascii() {
+            return Err(BismarkExtractorError::NonAsciiChromosomeName {
+                name: String::from_utf8_lossy(bytes).into_owned(),
+            });
+        }
+        // Safe: just validated ASCII.
+        out.push(String::from_utf8(bytes.to_vec()).expect("ASCII verified above"));
+    }
+    Ok(out)
+}
+```
+
+### 5.8 New error variants
+
+```rust
+#[error("not yet implemented in this build: {feature}")]
+PhaseNotYetImplemented { feature: String },
+
+#[error("invalid XM byte {byte:#04x} ({byte_char}) in read {read_id} at ref_pos {ref_pos}")]
+InvalidXmByte { byte: u8, byte_char: char, ref_pos: u32, read_id: String },
+
+#[error("output write failed: {0}")]
+IoWrite(#[from] std::io::Error),
+
+#[error(transparent)]
+BismarkIo(#[from] bismark_io::BismarkIoError),
+
+#[error("internal invariant violated: {message}")]
+InternalError { message: String },
+
+#[error(
+    "chromosome name in @SQ header contains non-ASCII bytes: {name}. \
+     Bismark output filenames + bedGraph/cytosine_report subprocesses require ASCII chr names."
+)]
+NonAsciiChromosomeName { name: String },
+```
+
+## 6. Implementation outline (rev 1)
+
+1. **Add error variants** in `src/error.rs` (six new ones — see §5.8).
+2. **Create `src/call.rs`**: `CytosineContext`, `MethCall`, `XmClassification`, `classify_xm_byte`, `extract_calls`. Loop body uses `record.iter_aligned()` directly; `Vec::new()` for collected calls (no preallocation heuristic). **Defensive comment**: "use `aligned.xm_byte`; NEVER re-index `record.xm()[read_pos_5p]` — `read_pos_5p` is 5'-oriented post-orientation-correction, while `record.xm()` is BAM-stored." Invalid XM byte → `Err(InvalidXmByte)` unconditionally (Phase B; Phase E adds the conditional skip).
+3. **Create `src/mbias.rs`**: `MbiasPos`, `MbiasTable`, `MbiasTable::accumulate`.
+4. **Create `src/output.rs`**:
+   - `OutputKey { context, strand }`.
+   - `OutputFileMap { files: HashMap<OutputKey, (PathBuf, BufWriter<File>)> }` (single map — rev 1).
+   - `OutputFileMap::new(output_dir, input_basename, no_header)`:
+     1. `std::fs::create_dir_all(output_dir)?` (rev 1).
+     2. For each of 12 `(context, strand)` keys: compute filename `{context}_{strand}_{basename}.txt`, open `BufWriter::with_capacity(8 * 1024, File::create(path)?)`, write header line (`Bismark methylation extractor version v0.25.1\n`) unless `no_header`, store in map.
+   - `write_call`: look up key (must exist — eager-open guarantees), write tab-separated row.
+   - `flush_all`: iterate, call `flush()`.
+   - `cleanup_all`: iterate, drop writer, `let _ = std::fs::remove_file(path);` (best-effort; eprintln on failure).
+   - `format_meth_line(record_name, chr, call, strand) -> String` — tab-separated row.
+   - `SplittingReport` struct + `write_splitting_report` writer.
+5. **Create `src/state.rs`**: `ExtractState`, `::new` (calls `OutputFileMap::new`), `::finalize` (flush_all → write_splitting_report), `::cleanup_partial_outputs` (delegates to `fhs.cleanup_all`).
+6. **Create `src/route.rs`**: `route_call` with rev-1 ordering (M-bias → counters → `mbias_only` short-circuit → write).
+7. **Create `src/header.rs`**: `build_chr_name_table` with ASCII assertion (§5.7).
+8. **Create `src/pipeline.rs`**: `extract_se` (§5.6) + `derive_basename(path: &Path) -> String`. **`derive_basename`**: extract file stem from `path.file_name()`; strip ONE of the three suffixes `.bam`/`.sam`/`.cram` from the end of the resulting string (case-sensitive; do nothing if none match). No double-suffix handling. Matches Perl `s/sam$/txt/; s/bam$/txt/; s/cram$/txt/`.
+9. **Update `src/lib.rs`**: `pub mod` + re-exports.
+10. **Update `src/main.rs::run`**: dispatch on `ResolvedConfig`. Five `PhaseNotYetImplemented` paths + `extract_se` for the supported subset. AutoDetect treated as SE (per-record check catches PE).
+11. **Update `Cargo.toml`**: `version = "1.0.0-alpha.2"`.
+12. **Leave `src/params.rs` untouched** — `ExtractParams` deferred to Phase C/D (see §9.2 #5).
+13. **Write tests** (§7 below).
+14. **Run `cargo test -p bismark-extractor && cargo clippy -p bismark-extractor -- -D warnings && cargo fmt --check`**.
+
+## 7. Tests (rev 1: folded both reviewers' additions)
+
+### 7.1 Unit tests (in `tests/se_phase_b.rs`)
+
+| Test | Asserts |
+|------|---------|
+| `classify_xm_byte_classifies_all_six_methylation_bytes` | `Z`/`z`/`X`/`x`/`H`/`h` → `Call(ctx, m)`. |
+| `classify_xm_byte_skips_U_u_dot` | `U`/`u`/`.` → skips. |
+| `classify_xm_byte_rejects_invalid` | `Q` → `Err(InvalidXmByte)`. |
+| `extract_calls_classifies_all_six_methylation_bytes` | Synthetic OT record produces all 6 calls. |
+| `extract_calls_respects_ignore_5p` | `ignore_5p=3` drops first 3 read positions. |
+| `extract_calls_respects_ignore_3p` | `ignore_3p=3` drops last 3 read positions. |
+| `extract_calls_walks_cigar_with_indels` | `5M2D5M`, `5M2I5M` → correct ref_pos for each call. |
+| `extract_calls_walks_cigar_with_soft_clips` | **Rev 1**: `2S8M` CIGAR → first emitted call has `read_pos == 2` (not 0); `iter_aligned`'s `read_pos_5p` includes soft-clip in count. |
+| `extract_calls_empty_xm_yields_empty_vec` | XM of all `.` → empty Vec. |
+| `extract_calls_minus_strand_orients_5prime` | **Critical**: OB strand record; first emitted call's `xm_byte` equals the LAST BAM-stored XM byte (orientation invariant). |
+| `extract_calls_rejects_invalid_xm_byte_with_error` | XM contains `Q` → `Err(InvalidXmByte { byte: b'Q', ... })`. |
+| `mbias_accumulate_increments_meth_for_Z` | `MbiasTable::accumulate(CpG, 5, true)` → `cpg[5].meth == 1`. |
+| `mbias_accumulate_increments_unmeth_for_z` | (mirror) |
+| `mbias_accumulate_routes_to_chg_for_X` | **Closes Alan's missing-CHG bug**. |
+| `mbias_accumulate_routes_to_chg_for_x` | (mirror) |
+| `mbias_accumulate_routes_to_chh_for_H` | **Closes Alan's missing-CHH bug**. |
+| `mbias_accumulate_routes_to_chh_for_h` | (mirror) |
+| `mbias_R2_index_ready` | `state.mbias[1]` exists, zero-initialised. |
+| `route_call_default_mode_routes_to_strand_specific_file` | CpG-meth + OT → `CpG_OT_*.txt` content matches `format_meth_line` output. |
+| **`route_single_record_with_mixed_contexts_routes_to_one_strand_directory`** | **Rev 1 (A Important #5)**: single record with CpG + CHG + CHH calls, all on OT strand → all calls land in `*_OT_*` files; no call in `*_CTOT_*` / `*_CTOB_*` / `*_OB_*` non-header content. **Closes Alan's split-across-files bug structurally at unit level.** |
+| `format_meth_line_exact_bytes` | Tab-separated line format byte-exact. |
+| **`output_file_map_eagerly_creates_all_strand_files_for_default_mode`** | **Rev 1 (B Critical C1)**: `OutputFileMap::new` produces 12 files on disk before any `write_call`; each contains exactly the header line (when `no_header == false`). |
+| **`output_file_map_omits_header_when_no_header_true`** | **Rev 1 (A Important #6)**: `OutputFileMap::new` with `no_header=true` produces 12 empty files. |
+| **`output_file_header_matches_perl_format`** | **Rev 1 (A Important #6)**: literal first-line bytes of a freshly-opened `CpG_OT_*.txt` equal `"Bismark methylation extractor version v0.25.1\n"`. |
+| `output_file_map_creates_output_dir_if_missing` | **Rev 1 (B)**: `OutputFileMap::new` on a non-existent `output_dir` creates the directory. |
+| `cleanup_partial_outputs_removes_all_12_files` | **Rev 1 (B C1 follow-on)**: after `InvalidXmByte` mid-record, all 12 files (including header-only CTOT/CTOB) are absent. |
+| `cleanup_partial_outputs_continues_past_one_failure` | **Rev 1 (A Optional)**: one remove failure doesn't prevent the other 11. |
+| **`route_call_increments_counter_before_mbias_only_short_circuit`** | **Rev 1 (B I4)**: under a synthetic `state.mbias_only=true` (force-set in test, even though Phase B's main dispatch rejects), splitting-report counter still increments. Locks the rev-1 ordering. |
+| `splitting_report_emits_per_context_counts` | After a 6-call synthetic record, the report file contains correct counts. |
+| **`splitting_report_percentage_handles_zero_denominator`** | **Rev 1 (A Optional)**: empty CHH context → `C methylated in CHH context: 0.00%` (not NaN, not divide-by-zero panic). |
+| **`build_chr_name_table_rejects_non_ascii`** | **Rev 1 (B O1)**: synthetic @SQ with non-ASCII chr name → `Err(NonAsciiChromosomeName { name })`. |
+| `derive_basename_strips_known_suffixes` | `"a.bam"` → `"a"`, `"a.sam"` → `"a"`, `"a.cram"` → `"a"`, `"a"` → `"a"`, `"a.BAM"` → `"a.BAM"` (case-sensitive), `"a.bam.gz"` → `"a.bam"` (only strips final `.gz`-less? actually no `.gz`-strip — verify: `a.bam.gz` → `a.bam.gz` per Perl `s/bam$/txt/` not matching `.gz` suffix). **Rev 1 (A Important #2 / B O2)**: case-sensitive single-suffix only; no `.bam.gz` handling. |
+| `extract_se_rejects_record_with_paired_flag_set` | **Rev 1 (A Important #3)**: synthetic SE record with FLAG `0x1` set → `Err(PhaseNotYetImplemented { feature: "paired-end extraction ..." })` after cleanup. |
+| `main_rejects_paired_end_with_phase_error` | `--paired` → `PhaseNotYetImplemented`. |
+| **`main_rejects_multiple_input_files`** | **Rev 1 (A Important #4)**: two positional file args → `PhaseNotYetImplemented { feature: "multiple input files ..." }`. |
+| `main_rejects_multicore_with_phase_error` | `--parallel 4` → `PhaseNotYetImplemented`. |
+| `main_rejects_gzip_with_phase_error` | `--gzip` → `PhaseNotYetImplemented`. |
+| `main_rejects_comprehensive_with_phase_error` | `--comprehensive` → `PhaseNotYetImplemented`. |
+| `main_rejects_bedgraph_with_phase_error` | `--bedGraph` → `PhaseNotYetImplemented`. |
+| **`extract_se_two_records_route_to_different_files`** | **Rev 1 (B §4)**: two records (one OT, one OB) → calls land in `*_OT_*` and `*_OB_*` respectively; multi-record accumulator correctness. |
+| `extract_se_empty_input_writes_only_header_files` | **Rev 1 (B C1 follow-on)**: empty BAM → all 12 files exist with header only; splitting report written; exit 0. |
+
+### 7.2 End-to-end smoke (`tests/se_phase_b_smoke.rs`) — **rev 1 (B I5) addition**
+
+Synthetic ~10-record SE directional BAM committed at `tests/data/se_directional_phase_b_smoke.bam` (generation script at `tests/data/regenerate_smoke.sh`). The smoke test does NOT require the Perl toolchain.
+
+- Run binary via `assert_cmd::Command::cargo_bin("bismark-methylation-extractor-rs")`.
+- Pass the synthetic BAM, an output dir under `tempfile::tempdir()`, and `--single`.
+- Assertions:
+  - Exit code 0.
+  - All 12 split files exist on disk.
+  - Each file's first line equals the version header.
+  - At least one of `CpG_OT_*.txt`, `CHG_OT_*.txt`, `CHH_OT_*.txt` has more than 1 line (records actually routed).
+  - `_splitting_report.txt` exists, parses (line count > 5), contains `Total methylated C's in CpG context:` substring.
+
+Catches: binary panic, wrong output dir, missing flush in finalize, wrong basename, missing-CHG/CHH (one of the 3 OT files would be header-only and would NOT have a content line — assertion catches it).
+
+### 7.3 Perl-baseline integration test — deferred to Phase H
+
+Per SPEC §8.3 the byte-identity gate runs on 10M + 55M PE WGBS data with full Perl baseline. Phase B does NOT build the Perl baseline locally. The smoke test in §7.2 + the unit tests in §7.1 + Phase C's PE arrival + Phase H's gate together cover the validation pyramid.
+
+Phase B still commits `tests/data/regenerate_smoke.sh` and a `tests/data/README.md` documenting how to regenerate the smoke BAM from a synthetic FASTA, so Phase H can extend the script if needed.
+
+## 8. Efficiency
+
+- One Vec allocation per record from `iter_aligned` (~1.1 KiB at 95 aligned positions).
+- One `Vec<MethCall>` allocation per record from `extract_calls` (`Vec::new()`; amortised growth).
+- 12-entry HashMap with `BufWriter<File>` (8 KiB each, ~100 KiB total).
+- `MbiasTable` grows lazily to ~5 KiB total per record-identity.
+- `SplittingReport` ~64 bytes.
+
+Profile target (informational): SE extract on 10M PE WGBS at parallel=1 reaches ≥ 1.5× Perl. Hard gate: byte-identity (Phase H).
+
+For 55M PE reads = ~110M allocations / ~200 MiB temp heap traffic — allocator hot-path at parallel=1; under rayon (Phase F) this compounds. Flag for Phase F: a `iter_aligned_into(&mut Vec<...>)` variant in `bismark-io` could halve this. Not a Phase B concern.
+
+## 9. Assumptions + open questions (rev 1)
+
+### 9.1 Locked assumptions
+
+- **Header line bytes**: literal `"Bismark methylation extractor version v0.25.1\n"`. Verified at Perl 5159, 5182, 5205, 5228, 5429, 5452, 5475, 5498, ... All branches emit the same literal.
+- **Suffix stripping**: case-sensitive, single-extension `.bam`/`.sam`/`.cram` only. Verified at Perl 5410-5412 etc.
+- **Eager file-open**: all 12 strand×context files opened at `OutputFileMap::new` time. Verified at Perl 5405-5700+.
+- **`output_dir` may be missing**: `create_dir_all` defensively. Perl `make_path` precedent.
+- **AutoDetect paired-mode treated as SE** in Phase B; per-record PAIRED-flag check rejects on first PE record.
+- **U/u XM bytes**: silently skipped.
+- **BismarkStrand-from-XR/XG matches Perl's per-record strand-classification** for all 4 strands × all 3 contexts. **Phase H risk** (A Important #8): dedup's v1.0 gate didn't exercise the strand → split-file-filename mapping. Phase B's smoke test + Phase H's full WGBS gate are the catchers.
+- **Chromosome names are ASCII**: enforced via `build_chr_name_table` (rev 1 addition). Errors loudly otherwise.
+
+### 9.2 Open questions (non-blocking)
+
+1. **(Open)** Splitting-report exact byte-identity: Phase B aims for "Perl-shaped", Phase H gates exact bytes. Acceptable risk.
+2. **(Resolved rev 1)** `derive_basename`: case-sensitive single-suffix `.bam`/`.sam`/`.cram`. No `.bam.gz`. Verified at Perl 5410-5412.
+3. **(Resolved rev 1 via B confirmation)** `detect_paired_from_header`: lives at `bismark-dedup/src/pipeline.rs:137`. Phase C promotes it to `bismark-io` (additive bump to v1.0.0-beta.7) and replaces Phase B's per-record PAIRED-flag check.
+4. **(Open, low priority)** `ExtractParams` struct revival: defer to Phase C/D when arg count grows; Phase B's signatures stay below the threshold.
+
+### 9.3 Critical questions
+
+**None.**
+
+## 10. Validation (rev 1)
+
+| What to verify | How | Expected |
+|----------------|-----|----------|
+| Eager-open + header bytes match Perl | `output_file_map_eagerly_creates_all_strand_files_for_default_mode` + `output_file_header_matches_perl_format` | All 12 files exist after `OutputFileMap::new`; first line of each is the literal Perl header. |
+| `-` strand orientation invariant | `extract_calls_minus_strand_orients_5prime` | First emitted call's `xm_byte` is the BAM-stored last byte. |
+| Missing CHG/CHH context routes (Alan's bug) | 4 `mbias_accumulate_routes_to_{chg,chh}_for_{X,x,H,h}` tests + `route_single_record_with_mixed_contexts_routes_to_one_strand_directory` | All increments land correctly; one record routes to one strand directory. |
+| Partial-output cleanup | `cleanup_partial_outputs_removes_all_12_files` + `cleanup_partial_outputs_continues_past_one_failure` | All 12 files absent after error; one failure tolerated. |
+| Phase-gate rejections (5 unsupported + multiple-files = 6) | 6 `main_rejects_*` tests | Each unsupported config returns `PhaseNotYetImplemented`. |
+| Per-record PAIRED-flag rejection | `extract_se_rejects_record_with_paired_flag_set` | Cleanup runs before error. |
+| Counter ordering vs `mbias_only` | `route_call_increments_counter_before_mbias_only_short_circuit` | Splitting-report counter increments even when `mbias_only=true`. |
+| Header-line format byte equality | `output_file_header_matches_perl_format` | Literal byte equality. |
+| Soft-clip read_pos counting | `extract_calls_walks_cigar_with_soft_clips` | First emitted call has `read_pos == soft_clip_len`. |
+| Non-ASCII chr name rejection | `build_chr_name_table_rejects_non_ascii` | Loud error. |
+| `output_dir` autocreate | `output_file_map_creates_output_dir_if_missing` | Dir created; files placed inside. |
+| End-to-end smoke (rev 1 addition) | `tests/se_phase_b_smoke.rs` | Exit 0; 12 files; non-empty OT files; splitting report parses. |
+| Empty input | `extract_se_empty_input_writes_only_header_files` | 12 header-only files; report with zero counts. |
+| Clippy + rustfmt | `cargo clippy -- -D warnings && cargo fmt --check` | Clean. |
+
+## 11. Integration with later phases
+
+(Unchanged from rev 0 — see PR conversation if you want detail. Brief recap: C wires PE + `detect_paired_from_header` promotion to bismark-io; D adds M-bias writer; E adds mode dispatch + gzip + `mbias_only_silence` kernel param revival; F adds rayon multicore; G adds bedGraph/cytosine_report subprocess; H runs byte-identity gate on 10M + 55M PE WGBS.)
+
+## 12. Self-review (rev 1)
+
+**Efficiency.** Eager-open is +12 file-create syscalls per run (small fixed cost). Header writes are 12 × ~50 bytes = 600 bytes — irrelevant. Per-call HashMap lookup unchanged. Memory profile unchanged. No regression vs rev 0.
+
+**Logic.** rev 1's `route_call` ordering (M-bias → counter → mbias_only short-circuit → write) is the correct one per Perl. `cleanup_partial_outputs` now removes 12 files instead of 0..n — slightly more I/O on the error path but the correct semantic.
+
+**Edge cases.** Empty input now produces 12 header-only files (matches Perl). Soft-clip prose corrected. PAIRED-flag rejection unchanged.
+
+**Integration.** No bismark-io bump still required (Phase C will need v1.0.0-beta.7 for `detect_paired_from_header`). No new Cargo deps.
+
+**Risks remaining.**
+
+- **R1**: Splitting-report exact format may drift from Phase B's emission. Phase H bridge.
+- **R2**: `BismarkStrand`-vs-Perl per-strand classification (A Important #8). Phase H exercises for the first time.
+- **R3**: SPEC §8.4 needs editorial fix (separate task). Phase B's plan now overrides the SPEC's wrong description.
+- **R4 (Phase E follow-up)**: SPEC §7.5 pseudocode counter-ordering bug; queue a SPEC fix.
+
+## 13. Follow-up tasks queued by rev 1
+
+1. **SPEC fix #1**: edit `rust/bismark-extractor/SPEC.md` §8.4 row "Directional library" — replace "0-byte (Perl) or absent (Rust)" with "all 12 strand×context files exist; CTOT/CTOB contain only the version header line for directional libraries". Cite Perl lines 5405-5700+.
+2. **SPEC fix #2**: edit SPEC §7.5 pseudocode to put splitting-report counter increment BEFORE the `mbias_only` short-circuit. Cite Perl behavior + plan §5.5.
+3. **bismark-io v1.0.0-beta.7** (Phase C): promote `detect_paired_from_header` from `bismark-dedup` into `bismark-io::read`. Additive bump.
+
+These are tracked here so they don't get lost; none block Phase B implementation.
+
+## 14. Sub-issue (GitHub)
+
+To be filed by user as a child of #798 at work-start. Suggested title + body:
+
+```sh
+gh issue create \
+  --title "feat(extractor): Phase B — SE extraction loop + XM routing + eager output-file map + splitting-report skeleton" \
+  --body "$(cat <<'EOF'
+Phase B of the bismark-extractor port (umbrella #798).
+
+Scope (locked in plans/05262026_bismark-extractor/PHASE_B_PLAN.md rev 1):
+
+- SE extraction loop + XM-byte classification (SPEC §7.1, §7.2).
+- **Eager** output-file map: all 12 strand×context files opened at run-start with the Perl version header (SPEC §7.5 + Perl source 5405-5700+).
+- Splitting-report skeleton (SPEC §4.3, §7.7).
+- M-bias counter accumulator (writer deferred to Phase D).
+
+Out of scope (deferred to later phases): PE, non-default output modes, --gzip, --parallel > 1, --bedGraph, --cytosine_report, --multiple inputs — all rejected at the resolved-config boundary with PhaseNotYetImplemented.
+
+Plan revision history (full detail in the plan file):
+- rev 0: initial draft.
+- rev 1: folded dual plan-review findings. Critical fix: switch from lazy to eager file creation to match Perl byte-identity. Plus 14 other corrections (test additions, prose fixes, error-type widening).
+
+Estimated ~800 LOC per SPEC §10 row B.
+EOF
+)" \
+  --label "rust-rewrite" \
+  --label "bismark-extractor"
+```
+
+(Run from outside the broken-gh environment — see PROGRESS.md for the macOS keychain workaround.)

--- a/plans/05262026_bismark-extractor/PLAN_REVIEW_PHASE_B_A.md
+++ b/plans/05262026_bismark-extractor/PLAN_REVIEW_PHASE_B_A.md
@@ -1,0 +1,204 @@
+# Plan review — `bismark-extractor` Phase B (Reviewer A)
+
+**Reviewing:** `plans/05262026_bismark-extractor/PHASE_B_PLAN.md` (rev 0, 2026-05-26).
+**Against:** `rust/bismark-extractor/SPEC.md` rev 2 (in-repo), Phase A source (`rust/bismark-extractor/src/*`), and `rust/bismark-io` v1.0.0-beta.6 surface.
+**Reviewer:** A (fresh context window, no shared state with Reviewer B).
+
+## Verdict at a glance
+
+**APPROVE-WITH-NITS.** The plan is well-grounded in the SPEC, the `iter_aligned`/`record_strand` contracts hold up, and the structural prevention claims (Alan's missing-CHG/CHH and split-across-files bugs) are credibly closed by the proposed routing match + lazy file map. The kernel/SE-loop composition is correct. Several findings are worth addressing **before** the implementation trigger; none are blockers.
+
+---
+
+## 1. Logic review
+
+### 1.1 SE loop composition — OK, with one ordering subtlety
+
+The per-record pipeline (PE-flag guard → refid lookup → strand → `extract_calls` → `route_call`) composes correctly. `extract_calls` returns `Vec<MethCall>` already 5'-oriented (delegated to `iter_aligned`), so `route_call`'s M-bias increment at `call.read_pos + 1` is the correct cycle-position 1-based index — verified by reading `record.rs` lines 263-311.
+
+**Subtle issue (Important):** the PE-flag check at §5.6 line 376 reads `record.inner().flags().bits() & 0x1`. Noodles' `Flags` type does not expose `.bits()`; the project convention (see `read.rs:585` in bismark-io, and dedup pipeline) is `u16::from(record.inner().flags()) & 0x1`. This is an API typo but worth fixing in the plan so the implementer doesn't waste a compile cycle.
+
+### 1.2 `extract_calls` — ignore-region semantics for `-` strand: correct, but the plan's prose at §4.5 is misleading
+
+The §4.5 row "Soft-clipped boundary" describes the ignore check as `read_pos_5p >= ignore_5p && read_pos_5p < seq_len - ignore_3p`, **using `seq_len`** rather than `xm.len()`. §6 step 2 then writes `hi = xm.len().saturating_sub(ignore_3p)` — also correct since the XM length equals the *read* length (validated at parse time in `from_noodles_record`).
+
+Where this gets subtle: for `-` strand reads, `iter_aligned` reverses the iteration order AND remaps `read_pos_5p` to count from the sequenced 5' end. So when the loop sees `read_pos_5p = 0`, that is the **last** BAM-stored XM byte. Walking `xm[read_pos_5p as usize]` would index the WRONG byte — but the plan doesn't do that; it uses `aligned.xm_byte` carried inside `AlignedXmCall`, which is already the correctly-paired XM byte for that 5' position. **This is correct as designed**, but the plan should explicitly state in §6 step 2 / §5.1 that `extract_calls` **must not re-index into `record.xm()` by `read_pos_5p`** — the `xm_byte` carried by the iterator is the load-bearing value. Today's prose ("`b: u8 = xm[read_pos as usize]`" in SPEC §7.1 illustrative pseudocode) creates exactly this trap for implementers who skim. (Important — adds one defensive comment in `call.rs`.)
+
+### 1.3 Refid out-of-range path — covered, panic-free
+
+Plan handles refid → chr table miss via `BismarkExtractorError::InternalError { message }` rather than `expect`. Good — matches the "no silent wrong output" invariant and is also a strict improvement on the SPEC §7.7-style "defensive" panic. The plan's `expect(...)` at §5.6 line 385 (`record.inner().reference_sequence_id().expect(...)`) is fine because the reader filters unmapped upstream, so the expect can fire only on an upstream invariant violation. Acceptable.
+
+### 1.4 Empty XM / `--ignore` > seq_len — covered
+
+Saturating arithmetic + the `lo >= hi` short-circuit are both correct.
+
+### 1.5 Splitting-report on error path — DELIBERATELY suppressed; one half-step missing
+
+§4.5 "Invalid XM byte" row says the splitting report is NOT written on error. Good. But the plan does not explicitly say what happens to the empty splitting-report file IF it was created earlier in the run — and §10 row "Empty input" says the splitting report IS written for the empty-input success path. The two paths can't collide today because `state.finalize()` is the only writer for the report, but a future Phase D/E may stream sections early. **Optional**: add a one-line invariant note in §5.4: "`finalize()` is the only writer for `_splitting_report.txt`; partial-error path leaves it absent."
+
+### 1.6 PE-flag rejection cleanup order — race-free
+
+§5.6 calls `state.cleanup_partial_outputs()` before returning the `PhaseNotYetImplemented` error. Good. The cleanup runs even when `OutputFileMap` is empty (no writes have happened yet) — idempotent per §5.3 spec.
+
+---
+
+## 2. Assumptions review
+
+### 2.1 Perl-version split-file header — defensible
+
+Locking `Bismark methylation extractor version v0.25.1\n` as the header line for byte-identity at Phase H is the right call. The risk is that Perl actually emits something invocation-dependent (e.g. the program name from `$0`); the plan acknowledges this in §9.2 open question #1 and bridges in Phase H. Acceptable. (Optional: spend 5 minutes now grepping Perl line ~30 for the exact `print` statement — if it's `print OUT "Bismark methylation extractor version $bismark_version\n"` then the assumption is good; if it's `print OUT "$0 version $bismark_version\n"` it differs.)
+
+### 2.2 Lazy file-handle creation — well-grounded
+
+SPEC §8.4 explicitly permits this; the assumption that Perl's empty CTOT/CTOB files for directional libraries map to "absent" Rust files is reasonable. Phase H gate will catch any drift. **One nit (Optional):** the integration baseline at §7.2 will fail `cmp` if Perl emits **0-byte** CTOT/CTOB files (it likely does — open `>` in Perl creates the file even if nothing is written). The plan's integration test (§7.2) will need to either (a) skip the `cmp` for empty files, (b) `touch` an absent Rust file before comparison, or (c) generate the baseline using Bismark's `--comprehensive` to suppress the empties. Worth flagging now so the fixture generator isn't surprised.
+
+### 2.3 AutoDetect-as-SE — defensible but under-specified for one edge case
+
+§9.1 + §6 step 10 say AutoDetect treats first record's PAIRED flag as the decider. But §6 step 10 says "if AutoDetect AND first record has PAIRED flag set, error with PhaseNotYetImplemented." What if the input has zero mapped records (empty BAM)? The current logic never enters the per-record loop, so the AutoDetect resolution never happens — the extractor proceeds as SE with no records, emits an empty splitting report, exits 0. That's the right behavior, but the plan should state it explicitly. (Optional.)
+
+### 2.4 Implicit assumption: `record_strand()` matches Phase H Perl strand classification
+
+The plan's split-file routing keys on `record.record_strand()` (an SE call) and SPEC §6.1 says "for SE the **record-strand** routes the record." That's consistent. But — `bismark-io::BismarkStrand` is derived from XR+XG tag bytes (`strand.rs:48`), whereas Perl derives strand from a flag+XG combination (Perl ~lines 1500-1550). Have these been proven byte-equivalent? Dedup's v1.0 byte-identity gate validated this for the dedup output, which doesn't emit per-strand split files — so the **strand-classification → split-file-filename** mapping is exercised for the first time in extractor Phase B's integration test. Worth documenting in §9.1 as a locked assumption that Phase H will catch any drift. (Important — names a risk that's currently silent.)
+
+### 2.5 `derive_basename` suffix list — incomplete
+
+§9.2 #4 says "strip `.bam`/`.sam`/`.cram` only." Perl's basename helper (~line 5000-ish) also handles `.bam.gz`/`.sam.gz` per real-world filename conventions. The plan's `derive_basename` at §6 step 8 mentions `.bam.gz`/`.sam.gz` but §9.2 #4 contradicts this. Reconcile. (Important — affects splitting-report filename byte-identity, which Phase H gates.)
+
+---
+
+## 3. Efficiency review
+
+### 3.1 Per-record allocation profile — acceptable for Phase B; flag for Phase F
+
+- `iter_aligned()` allocates one `Vec<AlignedXmCall>` (~1.1 KiB for 95-bp reads).
+- `extract_calls` allocates one `Vec<MethCall>` (~1-2 KiB capacity at `xm.len() / 8`).
+
+For 55M PE reads this is ~110M allocations / ~200 MiB of temporary heap traffic; allocator hot-path. **At Phase B's single-threaded scope this is below the perf gate**, but it's the kind of cost that compounds under rayon (Phase F). Optional flag: a future `iter_aligned_into(&mut Vec<...>)` reusing a caller-owned buffer could halve this. Not a Phase B concern; just don't claim "no low-hanging perf wins" in the self-review.
+
+### 3.2 HashMap-keyed `OutputFileMap` — acceptable
+
+§8 self-review acknowledges this; for 6-12 keys the overhead is negligible. A typed `[Option<BufWriter<File>>; 12]` would be faster but adds dispatch boilerplate. Defer.
+
+### 3.3 `String::from_utf8_lossy` for chr name on every call — minor
+
+Plan calls this "one borrow + zero alloc in practice." That's only true if the lossy path is the no-op fast path. **It is** — `Cow::Borrowed` for valid UTF-8 — so the call is genuinely free. But the chr-table build in `header.rs` at §5.7 uses `.into_owned()` which DOES allocate per chr. That's once per file, not per call. OK.
+
+### 3.4 No I/O batching considered for splitting-report — fine
+
+8-KiB BufWriter on the report file is overkill for ~50 lines; not worth optimizing.
+
+---
+
+## 4. Validation sufficiency
+
+### 4.1 Coverage of the highest-risk failure modes
+
+| Risk class | Phase B test | Strength |
+|---|---|---|
+| `-` strand orientation flip (§6.5 invariant) | `extract_calls_minus_strand_orients_5prime` | Strong if it asserts the **byte content** at position 0 matches the expected 5' XM byte. Plan's wording is ambiguous — "verify first emitted call has `read_pos==0` corresponds to the 3' BAM-stored byte." This actually means: the call.xm_byte at read_pos_5p=0 equals `record.xm()[xm.len() - 1]` for `-` strand. Recommend the implementer write the assertion in that explicit form. |
+| Missing CHG/CHH context (Alan's bug) | 4 `mbias_accumulate_routes_to_{chg,chh}_for_{X,x,H,h}` tests | Strong — direct unit coverage. Plus the integration test §7.2 exercises this at the integration level. |
+| Strand-routing splits a single record (Alan's other bug) | `route_call_default_mode_routes_to_strand_specific_file` | **Weak as written** — only one strand/context combination is asserted. To structurally close the bug, you want a test that processes a single record with calls in **all three contexts** and asserts that all output goes to files keyed on the SAME `record_strand`. The plan doesn't have this test. Add: `route_single_record_with_mixed_contexts_routes_to_one_strand_directory`. (Important.) |
+| Lazy file creation (no spurious CTOT/CTOB) | `output_file_map_lazy_creates_only_keys_seen` | Strong. |
+| Partial-output cleanup on error | `cleanup_partial_outputs_removes_open_files` | Acceptable. **Gap:** what if `cleanup_all` itself fails (e.g. one `remove_file` returns `EACCES`)? Plan says "best-effort cleanup, log via `eprintln!` on failure." Test should assert that one failing remove doesn't prevent the others. Add: `cleanup_partial_outputs_continues_past_one_failure`. (Optional.) |
+| Phase-gate rejections (5 unsupported flag combos) | 5 `main_rejects_*_with_phase_error` tests | Coverage is good. **One missing:** `main_rejects_multiple_input_files` — the plan says §4.1 rejects `files.len() > 1` but no test enumerates this. Add. (Important.) |
+| Empty input | `extract_se_empty_input_writes_no_split_files` | Listed in §10 but not in §7.1's test table. Either add to §7.1 or reference §10 explicitly. (Optional.) |
+| PE record arriving at SE pipeline | Implicit in `main_rejects_paired_end_with_phase_error` | The CLI-level rejection is covered. **But** the §4.5 defensive per-record check (PAIRED flag set on input the user passed as SE) isn't tested. Add: `extract_se_rejects_record_with_paired_flag_set`. (Important — this is the load-bearing test that protects against tooling-error inputs the plan explicitly names.) |
+| Invalid XM byte under `--mbias_only=true` parameter | `extract_calls_under_mbias_only_silence_skips_invalid` | Good — closes SPEC §8.1 rev 2 row. |
+
+### 4.2 Could a Phase B bug slip past Phase B and only surface at Phase H?
+
+Plausible silent-failure scenarios:
+
+1. **Splitting-report content drift.** §10 has no per-line assertion on the report contents; `splitting_report_emits_per_context_counts` asserts counts but not the verbatim section headers. A drift in headers ("Total methylated C's" vs "Total methylated C's in CpG context") would pass Phase B and only fail Phase H byte-equal. Mitigated by the plan's §9.2 #2 explicit acceptance of this risk. **Acceptable, but optionally add a snapshot test of the literal lines** so the implementer freezes the exact format early.
+2. **Header line in split files.** Only golden-asserted in `format_meth_line_exact_bytes` per the plan's table — but that test asserts the call line, not the header. No Phase B test catches drift in the header line. Recommend adding `output_file_header_matches_perl_format` asserting the literal first line of a freshly-created split file. (Important.)
+3. **Percentage formatting.** `%.2f` for empty contexts → `0.00` per §4.3. No explicit test for the zero-denominator path. Add. (Optional.)
+4. **Strand-classification vs Perl mapping.** Per §2.4 above — Phase B routes on `BismarkStrand` derived from XR/XG; if Perl's mapping differs in some edge case (e.g. non-directional library with specific tag combos), Phase H catches it. No Phase B mitigation possible without a Perl-baseline; flag as acceptable.
+
+---
+
+## 5. Alternatives worth considering
+
+### 5.1 Reuse `bismark-dedup::detect_paired_from_header` instead of per-record PAIRED-flag check
+
+The plan in §4.5 / §6 step 10 uses a defensive per-record PAIRED-flag check. This is correct but loses the SPEC §11 `@PG ID:Bismark` semantic. **`bismark-dedup::pipeline::detect_paired_from_header` already exists at `bismark-dedup/src/pipeline.rs:137`** and walks the header for the Bismark PG line. The plan's §9.2 #3 considers this and chooses "re-implement inline if `bismark-io` doesn't expose one." But the dedup helper is already there in the workspace, in another crate. Two paths:
+
+- **(a)** Keep the per-record PAIRED check (Phase B's current plan). Acceptable but doesn't match SPEC §11.
+- **(b)** Promote `detect_paired_from_header` from `bismark-dedup` into `bismark-io` in a tiny additive bump (`v1.0.0-beta.7`) and call it once at reader-open time. This is a 30-LOC refactor and the function is genuinely shared; this is the cleaner Phase C-ready approach.
+
+**Recommendation:** do (a) for Phase B as the plan states, but **add a note in §9.2 #3** that (b) is the locked Phase C plan. Don't let the per-record check linger into Phase C as the only PE-detection mechanism. (Optional.)
+
+### 5.2 `ExtractParams` deferral — defensible
+
+§9.2 #5 documents not using `ExtractParams` in Phase B. The plan's defense ("argument struct, not 14-arg function — Phase B has 6 args max") is sound. The SPEC's intent in §6.3 was prevention of bug-class via argument-routing, and a 6-arg `extract_calls` is below the threshold. **But:** `route_call` itself has 6 args (`state, record, chr, strand, call, read_identity`), and once Phase C adds PE this becomes 7-8 args. Phase C will revisit. Acceptable, with the small risk that the deferral creates a Phase C "refactor everything to use ExtractParams" task. (Optional — flag in §13 as a known Phase C item.)
+
+### 5.3 `OutputKey` as `(CytosineContext, BismarkStrand)` vs typed array
+
+Plan uses `HashMap<OutputKey, BufWriter<File>>`. A typed `[Option<BufWriter<File>>; 12]` indexed by `(context as usize) * 4 + (strand as usize)` would be slightly faster, zero-alloc, and the dispatch boilerplate is one match. Not worth retrofitting for Phase B but worth a one-line note for Phase F. (Optional.)
+
+---
+
+## 6. SPEC drift check
+
+Read the plan and SPEC side-by-side. Found:
+
+- **No semantic drift** on §§7.1, 7.2, 7.5, 7.7 — the plan implements what the SPEC describes (with the documented `ExtractParams` deferral).
+- **Minor drift on §6.3** (the `ExtractParams` deferral, plan §9.2 #5) — documented and defensible.
+- **§4.3 row 4 (`--fasta` annotation line)** is honoured by the plan at §4.3 line 122 (good).
+- **§5 invalid-XM row** maps to the plan's `BismarkExtractorError::InvalidXmByte` in §5.8 (good).
+- **§8.4 directional row** maps to lazy file creation (good).
+- **§7.4 (overlap detection)** correctly deferred to Phase C — the plan doesn't try to implement it.
+
+---
+
+## 7. Other findings
+
+### 7.1 `chr_table.get(refid)` — type mismatch
+
+§5.6 line 386 calls `chr_table.get(refid)` where `chr_table: Vec<String>` per §5.7. `Vec::get(&self, index: usize)` takes `usize`, but noodles' `reference_sequence_id()` returns `Option<usize>`. So the call works, but the plan's prose at §5.6 line 384 says "refid: usize" implicitly. Confirm `chr_table.get(refid)` returns `Option<&String>` not `Option<&str>` — the chr binding is `&String` and feeds into `route_call(... chr: &str ...)` via deref coercion. **Minor wording**: the plan should clarify whether `chr` is `&String`, `&str`, or `String`. (Optional.)
+
+### 7.2 `cleanup_partial_outputs` ordering vs `?` propagation
+
+The plan handles three error sites (`reader.records()`, PE-flag check, `extract_calls`, `route_call`) with explicit `match`+cleanup blocks. The `state.finalize(config)?` at end of `extract_se` uses bare `?` — but `finalize` itself can fail (file flush + report write). If `finalize` returns `Err`, the SE loop has already succeeded, so partial-output cleanup would be wrong. Confirm with the implementer that `finalize` errors leave outputs in place. **Action**: state this invariant in §5.4: "`finalize` failure leaves output files written so far in place; caller does NOT cleanup post-finalize." (Important — silent contract not stated.)
+
+### 7.3 Tests for SPEC §6.2 `[MbiasTable; 2]` invariant
+
+`mbias_R2_index_ready` covers the "index 1 exists" claim. Good — closes the structural invariant at unit-test level.
+
+### 7.4 Sub-issue creation (§14) — not part of code review
+
+The `gh issue create` snippet is fine and matches Phase A's precedent. The "gh CLI broken via macOS keychain TLS error" note is true for the host but out-of-scope for the plan review.
+
+---
+
+## 8. Action items (prioritized)
+
+### Critical
+
+*(none)*
+
+### Important — address before implementation trigger
+
+1. Fix the noodles `flags()` API call in §5.6 (use `u16::from(record.inner().flags())` not `.bits()`).
+2. Add `derive_basename` policy reconciliation — §6 step 8 lists `.bam.gz`/`.sam.gz` but §9.2 #4 says single-suffix only. Pick one and align.
+3. Add test `extract_se_rejects_record_with_paired_flag_set` (the load-bearing per-record PE guard at §4.5).
+4. Add test `main_rejects_multiple_input_files` (the `files.len() > 1` rejection).
+5. Add test `route_single_record_with_mixed_contexts_routes_to_one_strand_directory` (structural closure of Alan's split-across-files bug at unit level — current plan only asserts one strand+context combo).
+6. Add test `output_file_header_matches_perl_format` asserting the literal first-line header content (so Phase H drift gets caught at Phase B unit level).
+7. State the `finalize`-failure invariant in §5.4 (post-finalize errors do NOT trigger cleanup).
+8. Document the assumption that `BismarkStrand`-from-XR/XG matches Perl's strand-classification across all 4 strands × all 3 contexts (currently unstated; Phase H is the only catcher).
+9. Add a defensive comment to §5.1 / §6 step 2: `extract_calls` must use `aligned.xm_byte` (the iterator's carried byte), NOT `record.xm()[read_pos_5p]` — the latter would silently flip `-` strand reads.
+
+### Optional
+
+10. Spend 5 minutes verifying the exact Perl source line for the split-file header string (§9.1 #1) — would convert an "open question" into a "locked" one.
+11. Add test `cleanup_partial_outputs_continues_past_one_failure` for the best-effort-cleanup contract.
+12. Add a `percentage_formatting_handles_zero_denominator` test for the `0.00` empty-context case.
+13. Add a Phase H readiness note: integration baseline needs to handle Perl's empty CTOT/CTOB files vs Rust's absent files (touch-or-skip strategy).
+14. Note Phase C dependency on promoting `detect_paired_from_header` from `bismark-dedup` to `bismark-io` (and update §9.2 #3 with this Phase C plan).
+15. Note Phase C/D revisit of `ExtractParams` once the argument count grows.
+
+---
+
+## 9. Verdict
+
+**APPROVE-WITH-NITS.** The plan is implementation-ready in its skeleton; the Important items above are 1-2 LOC each (test additions + a couple of prose clarifications) and don't require re-design. The Phase B kernel + routing + lazy file map + splitting-report shape are sound. Structural prevention of Alan's two documented bugs is real and verifiable at unit-test level. Recommend the user fold the Important items, then proceed to implementation.

--- a/plans/05262026_bismark-extractor/PLAN_REVIEW_PHASE_B_B.md
+++ b/plans/05262026_bismark-extractor/PLAN_REVIEW_PHASE_B_B.md
@@ -1,0 +1,240 @@
+# Plan Review — Phase B (`bismark-extractor`) — Reviewer B
+
+**Plan:** `plans/05262026_bismark-extractor/PHASE_B_PLAN.md` (rev 0).
+**SPEC:** `rust/bismark-extractor/SPEC.md` (rev 2).
+**Reviewer:** B (independent; A running in parallel; no shared state).
+**Verdict (TL;DR):** **NEEDS-REVISIONS** — one *Critical* item (eager- vs lazy-open file creation contradicts Perl semantics and the SPEC's "structural prevention of Alan's bug" framing); several *Important* items around boundary semantics, header ordering, `--no_header` vs `--mbias_only` guards, and the `mbias_only_silence` dead-code branch; a handful of *Optional* nits.
+
+---
+
+## 1. Logic review
+
+### Critical
+
+**C1. Lazy file creation contradicts Perl's eager file creation — direct byte-identity hazard.**
+
+Plan §2 / §4.2 / §4.5 / §9.1 lock in "open on first write per `(context, strand)` key" and claim "all output files absent" for empty input and that this "Closes Alan's 'spurious CTOT/CTOB files' bug structurally" (also echoed in SPEC §8.4: "CTOT/CTOB drained empty" / "absent depending on FH-creation strategy").
+
+But Perl actually **opens every configured strand file eagerly at the start of the run** and writes the version header line immediately. See `bismark_methylation_extractor`:
+- Lines 5148-5151 open `CpG_OT`; line 5159 writes the header.
+- Lines 5171-5174 open `CpG_CTOT`; line 5182 writes the header.
+- Same for CTOB (5194/5205) and OB (5217/5228), then all four for `Non_CpG_*` (5243-5323).
+- All of these are guarded only by `unless($mbias_only)` and `unless($no_header)` — *not* by "any call was actually routed here".
+
+So for a directional SE BAM with `--no_header` off, the Perl baseline contains 12 files (or 6 for SE comprehensive depending on mode), with `CpG_CTOT_*`, `CpG_CTOB_*`, `CHG_CTOT_*`, `CHG_CTOB_*`, `CHH_CTOT_*`, `CHH_CTOB_*` each containing **just the version header line** (no records).
+
+Consequences:
+1. The plan's `output_file_map_lazy_creates_only_keys_seen` validation test (§7.1 + §10) codifies the *wrong* invariant: the Rust port will leave CTOT/CTOB files absent from disk, while the Perl baseline will have them present with one-line content. Phase H byte-identity will fail.
+2. The "empty input" edge case (§4.5 first row) similarly diverges: Perl still writes 12 one-line header files for an empty BAM; the Rust plan writes none.
+3. Alan's "spurious CTOT/CTOB" bug, as framed in SPEC §8.4 / §12, must have been about *spurious CONTENT* (mis-routed records) in those files, not about their existence. If we treat "no file on disk" as the structural fix, we introduce a new byte-identity regression while claiming to close an old one.
+
+**Recommended resolution:** switch `OutputFileMap` to eager-open at construction time (one file per configured `(context, strand)` for the active `OutputMode`), write the header line immediately at open time (gated by `!no_header && !mbias_only`), and keep the lazy `HashMap` only as an internal cache if you want — but DO touch every key the mode requires. The unit test `output_file_map_lazy_creates_only_keys_seen` should be rewritten as `output_file_map_eagerly_creates_all_strand_files_for_default_mode_with_header`. Update SPEC §8.4 row "Directional library" similarly: assert CTOT/CTOB files exist on disk and contain *exactly the header line* (not "0-byte / absent").
+
+If you genuinely want to keep lazy creation for performance, you have to do so in BOTH the open-time path AND a "touch all configured keys before finalize()" pass — but that's strictly more work than eager-open. Just open eagerly.
+
+### Important
+
+**I1. `iter_aligned` `read_pos_5p` is NOT "post-soft-clip read coords."**
+
+Plan §4.5 row "soft-clipped boundary" claims the boundary check operates on the "5'-oriented post-soft-clip read position." This is misleading. `bismark-io::CigarExt::aligned_positions()` (cigar.rs:131-138) increments `read_pos` THROUGH soft-clip operations (`SoftClip` increments `self.read_pos += 1` per base, same as `Match`). `BismarkRecord::iter_aligned` then filters `filter_map(|ap| ap.ref_offset?)` which drops the soft-clip positions but does NOT renumber the remaining `read_pos`. So for `+` strand `5S95M`, the first emitted call has `read_pos_5p == 5`, not `0`. The XM `xm[read_pos]` indexing still works because the XM length equals the read sequence length (soft-clip bytes in XM are `.`).
+
+The plan's edge-case row for `2S8M` ("first emitted call has `read_pos == 0`") is *wrong*. Plan §7.1 test `extract_calls_walks_cigar_with_soft_clips` will catch this if assertion is written, but the prose-level claim "soft-clip not counted in `iter_aligned`'s yielded positions" is incorrect.
+
+Net behavior happens to match Perl byte-identically (I verified `--ignore` semantics against Perl lines 1627, 1651 and the soft-clip handling at 4245-4247) — Perl's `substr(meth_call, ignore)` operates on the same BAM-stored XM length including soft-clip, so the math lines up — but the plan should update its prose to say "`read_pos_5p` counts from the 5' end of the sequenced read INCLUDING soft-clipped bases (matches Perl's pre-CIGAR-adjustment indexing)." Fix the test assertion accordingly.
+
+**I2. Header line emission and `--no_header` guard logic.**
+
+Plan §4.2 says: "Perl writes `Bismark methylation extractor version v0.25.1\n` ... unless `--no_header`." Correct so far. But the plan's `OutputFileMap::write_call` emits the header lazily *on first write*. Combined with C1, this means:
+
+- (a) For files that never receive a call, no header is emitted — wrong vs Perl.
+- (b) For files that do receive a call, the order of header emission across files depends on the order records appear in the BAM (e.g. if the first record routes to `CpG_OT`, that file's header is written first). Perl's header order is determined by the static file-open order (CpG_OT → CpG_CTOT → CpG_CTOB → CpG_OB → Non_CpG_OT → ...). For byte-identity *within* one file the header content is identical, so this is mostly fine, but it confirms that lazy emission is structurally different from Perl and gives Phase H more work to track down drift sources.
+
+Additionally, the plan misses that Perl's header guard is `unless($no_header) ... unless($mbias_only)` (double-guarded). The plan's spec phrasing "suppressed by `config.no_header == true`" is correct in the directional path; just verify that the `mbias_only` short-circuit (which Phase B doesn't expose but still has a kernel param) skips header emission as well when wired in Phase E.
+
+**I3. `mbias_only_silence` kernel param is dead code in Phase B.**
+
+`extract_calls`'s `mbias_only_silence: bool` (plan §5.1, called with `false` from `extract_se`) only matters under `--mbias_only`, but Phase B's main dispatch rejects `--mbias_only` with `PhaseNotYetImplemented`. So the `true` branch is shipped + unit-tested (`extract_calls_under_mbias_only_silence_skips_invalid` in §7.1) but unreachable from `main`.
+
+This isn't strictly wrong — pre-wiring kernel params for Phase E is fine — but the plan should either:
+1. Document explicitly that `mbias_only_silence` is "pre-wired for Phase E; Phase B's CLI dispatch keeps it at `false`" (one line in §13 / risks), OR
+2. Defer the parameter entirely to Phase E and pass nothing in Phase B (smaller surface, less dead code).
+
+Option 1 is fine but flag the dead branch explicitly. Currently the plan smuggles it into the kernel signature without naming the deviation from the "no dead code in Phase B" implicit contract.
+
+**I4. Splitting-report counter increment order under `--mbias_only`.**
+
+Plan §6 step 6 says: M-bias accumulation step + splitting-report counter increment both happen inside `route_call`. SPEC §7.5 pseudocode shows: step 1 = M-bias accumulate; step 2 = `if state.mbias_only: return` (early-out); step 3 = splitting-report counters.
+
+This means under `--mbias_only`, the splitting-report counters DO NOT fire. But Perl's `_splitting_report.txt` *does* contain per-context counts even in `--mbias_only` mode (the counts are accumulated regardless of whether file writes happen). The SPEC's pseudocode short-circuits before the counter increment — which would break `_splitting_report.txt` content under `--mbias_only`.
+
+Phase B rejects `--mbias_only` so this doesn't bite in Phase B, but the SPEC pseudocode is wrong-as-written and the plan inherits the bug for Phase E. Recommend explicit ordering in the plan §6 step 6:
+
+```
+1. accumulate M-bias (unless mbias_off)
+2. increment splitting-report counters  ← happens regardless of mbias_only
+3. if mbias_only: return
+4. format + write split-file line
+```
+
+Document this deviation from SPEC §7.5 in the plan's §13. Phase E will need it.
+
+**I5. Integration-test fixture is "defer if infeasible" — no minimal end-to-end smoke test.**
+
+Plan §7.2 says the integration test "is `#[ignore]`'d behind `RUN_FIXTURE_INTEGRATION=1`" and "if creating the Perl baseline is infeasible during the implementation pass ... defer the integration test to Phase H." That leaves Phase B with zero whole-pipeline tests that actually run the binary end-to-end on a real BAM.
+
+This is a *validation sufficiency* gap (skill review area #4). A Phase B bug in the SE main loop (e.g. wrong record-iteration ordering, BufWriter not flushed in `finalize`, lazy-open with the wrong path joining) could pass every unit test and only surface at Phase H byte-identity.
+
+**Recommended minimal smoke:** build the synthetic ~50-read BAM in Phase B (NO Perl baseline needed for the smoke), run the Rust binary on it via `assert_cmd`, and assert:
+- The expected file set exists on disk after the run.
+- Each split file is non-empty (or contains at least the header line per C1).
+- The splitting report exists and parses (line-count > 0).
+- Exit code is 0.
+
+This costs maybe ~60 LOC and catches a wide class of "the binary panicked / produced nothing / wrote to the wrong dir" bugs *without* depending on the Perl toolchain. The full byte-identity comparison can still defer to Phase H, but a "binary ran end-to-end and produced something" smoke gate belongs in Phase B.
+
+Also: the plan should commit the fixture-generation script `tests/data/regenerate.sh` even if the *baseline* generation is deferred — that way Phase H is one-command to regenerate.
+
+### Optional / nit
+
+**O1. `String::from_utf8_lossy` on chr names — silent UTF-8 substitution.**
+
+Plan §8 + §9.1 row "Refid → chr name" says "Bismark chr names are ASCII in practice; lossy fallback can't hurt byte-identity for ASCII inputs." Defensible default, but the substitution `\u{fffd}` (3 bytes) for any non-ASCII byte (1 byte) would silently corrupt output if a user supplies a custom assembly with non-ASCII chr names. Two cleaner options:
+
+- Cheap: assert in `build_chr_name_table` that every chr name is ASCII; error out with a clear message if not. One `is_ascii()` check per chr.
+- Cheaper: document as a Phase H concern (the byte-identity test would fail loudly, and Bismark's own genome-prep doesn't accept non-ASCII names anyway).
+
+Pick one. Don't leave it as a silent lossy-substitution that the user won't notice.
+
+**O2. `derive_basename` corner cases unspecified.**
+
+Plan §9.2 #4 says "only strip the single trailing extension." Doesn't specify:
+- `foo.bam.tmp.bam` — strips to `foo.bam.tmp` (one extension).
+- `foo` (no extension) — stays `foo`.
+- `FOO.BAM` (uppercase) — Perl is case-sensitive on suffix match (`s/bam$/txt/` is case-sensitive in Perl); Rust port should match this.
+- `foo.sam.gz` — plan §6 step 8 lists `.bam.gz` and `.sam.gz` in the helper; does it also strip `.cram.gz`? (CRAM doesn't compress with gzip, so probably moot, but specify.)
+
+One short example block in the plan would resolve all of these.
+
+**O3. SE non-directional test coverage.**
+
+Plan §7.1 tests `output_file_map_lazy_creates_only_keys_seen` covers a directional input that touches only `CpG_OT`. No test covers a non-directional SE input that touches CTOT and CTOB. SPEC §8.4 has a "Non-directional library" fixture row but the plan's §7.1 doesn't enumerate a unit-level test for CTOT/CTOB strand routing.
+
+Given C1 (eager-open fix), this becomes less critical (all 4 strand files will exist regardless). But a unit test that drives a synthetic CTOT-strand record through `route_call` and asserts the call ends up in `CpG_CTOT_*` would close the audit gap explicitly.
+
+**O4. `paths` mirror in `OutputFileMap` is fragile.**
+
+Plan §5.3: `OutputFileMap` carries both `fhs: HashMap<OutputKey, BufWriter<File>>` and `paths: HashMap<OutputKey, PathBuf>` "for cleanup_partial_outputs." Two parallel maps risk drifting (a key in `fhs` without a matching `paths` entry, or vice versa, due to a bug). Combine into a single `HashMap<OutputKey, (PathBuf, BufWriter<File>)>` — same cost, no invariant to maintain.
+
+**O5. `extract_calls`'s `xm.len() / 8` heuristic.**
+
+`Vec::with_capacity(xm.len() / 8)` (plan §6 step 2) is the "CpG density heuristic." For mostly-`.`-XM reads (most of the read is non-cytosine), this over-allocates; for very-CpG-dense (e.g. CGI overlap), it under-allocates and Vec grows. A simpler `Vec::with_capacity(xm.len() / 16)` or even `Vec::new()` with reliance on amortized growth gives identical perf in profiling. Minor cleanup.
+
+**O6. Header content independence from emission order.**
+
+Plan §4.2 says the header is a fixed Perl-version string — no per-file metadata. So C1's note about lazy emission ordering doesn't affect header *content* byte-identity; only *file existence* matters. Good — but explicitly note this in the plan so the user knows the order question is moot.
+
+---
+
+## 2. Assumptions
+
+### Confirmed against source
+
+- **`iter_aligned` orientation correction**: verified in `bismark-io/src/record.rs:263-311`. For `+` strand: forward iteration, `read_pos_5p == BAM read_pos`. For `-` strand: remapped to `seq_len - 1 - read_pos` and reversed. Plan §3.1 + §6.5 inheritance is correct.
+- **Insertion semantics divergence vs Perl**: `record.rs:251-260` documents that `iter_aligned` SKIPS insertion positions (Perl emits them with `xm_byte=='.'`). Plan delegates to `iter_aligned` without re-flagging this — fine for Phase B's M-bias path because Perl's `.` would be filtered by `classify_xm_byte` anyway, but the plan should explicitly reference this divergence as "inherited from bismark-io; no Phase B work" for future readers.
+- **`ReadIdentity::from_flags(u16)`** signature verified in `bismark-io/src/record.rs:64`. Plan §5.6 call site is correct.
+- **`detect_paired_from_header`** already exists in `bismark-dedup/src/pipeline.rs:137` — plan §9.2 open question #3 ("re-implement inline if bismark-io doesn't expose one") can be resolved: it lives in `bismark-dedup`, not `bismark-io`. For Phase B, "AutoDetect → treat as SE, error on first PE record" is fine; the dedup helper should move to `bismark-io` when Phase C wires PE.
+
+### Surfaced (implicit)
+
+- The plan assumes `record.inner().flags().bits() & 0x1 != 0` is the right PAIRED-flag check. Noodles `Flags::is_segmented()` is the idiomatic equivalent. Either works; just pick one for the codebase consistency with dedup (which uses `Flags` methods, e.g. `flags().is_first_segment()`).
+- The plan assumes `BufWriter<File>` with 8 KiB default buffer is enough. `BufWriter::with_capacity(8 * 1024, ...)` is the explicit form. Phase B's efficiency-target paragraph says 8 KiB but the code snippet just says `BufWriter::new(...)` which yields a default 8 KiB — happens to match. Worth being explicit in the implementation.
+- The plan doesn't say what happens if `output_dir` doesn't exist on disk. Perl creates it (lines 970 area, `make_path`). Phase A might already do this in `ResolvedConfig`; if not, Phase B's `OutputFileMap::new` should `std::fs::create_dir_all(output_dir)` defensively.
+
+---
+
+## 3. Efficiency
+
+Acceptable for Phase B. The dominant cost is `iter_aligned`'s materialization (one ~1.1 KiB Vec per record) — already paid in `bismark-io`. `OutputFileMap` HashMap lookup is `O(1)`; for 12 keys an enum-indexed `[Option<BufWriter<File>>; 12]` array would be faster but the difference is well below the noise floor of file I/O at parallel=1.
+
+Minor:
+- The HashMap can be `FxHashMap` (already a dep of `bismark-dedup`); cheap perf win, but really negligible at this scale.
+- Per O5, the pre-allocation heuristic is overkill.
+
+No scalability concerns at parallel=1.
+
+---
+
+## 4. Validation sufficiency
+
+Coverage map vs the listed validation table (plan §10):
+
+| Validation row | Sufficient? |
+|----------------|------------|
+| Orientation invariant for `-` strand | ✓ Strong unit test. Catches the orientation regression class. |
+| Missing CHG/CHH M-bias routes | ✓ Four explicit tests. Closes Alan's bug at unit level. |
+| Lazy file creation | ✗ **Codifies the wrong invariant** (per C1). Should be eager-open + header-write tests. |
+| Partial-output cleanup on InvalidXmByte | ✓ Direct test exists. |
+| Phase-gate dispatch | ✓ Five rejection tests. Comprehensive. |
+| End-to-end SE smoke | ✗ **Defers to Phase H if infeasible** (per I5). Leaves no whole-pipeline test in Phase B. |
+| Empty input | ✗ Mentioned in §4.5 but no explicit test enumerated in §7.1. Add `extract_se_empty_input_writes_no_split_files` (renamed per C1 to "...writes_only_header_lines"). |
+| Clippy + rustfmt | ✓ Standard hygiene gate. |
+
+Other gaps:
+- No test for `extract_se` on a multi-record BAM where successive records produce calls across different `(context, strand)` keys (i.e. the loop's accumulator + file-handle map correctness). Add at least one synthetic 2-record test.
+- No test for the splitting-report's *parameter summary* section. Plan §4.3 says "parameter summary block — one line per relevant CLI flag — matches Perl's tone." Without at least one assertion on what parameters appear, this block can silently drift from Perl. Suggest a unit test that snapshots one minimal config's parameter section against a golden string (defer exact byte-identity to Phase H but lock the structure now).
+- No assertion that `flush_all` actually flushes before `write_splitting_report` runs (a tricky ordering bug: if the splitting report is written first, the split files may be missing trailing data on `Drop`). Add `extract_se_flushes_split_files_before_writing_report` or just structure `finalize()` to call `flush_all()` first and let `Drop` handle final close.
+
+---
+
+## 5. Alternatives considered
+
+**A1. Eager-open vs lazy-open (C1 above).** Pick eager-open. Cheap, matches Perl, simplifies header-emission ordering, removes one entire class of byte-identity drift. No real reason to keep lazy.
+
+**A2. Enum-indexed file array vs HashMap.** A typed enum (e.g. `OutputKey { Cpg(StrandIdx), Chg(StrandIdx), Chh(StrandIdx) }`) maps to a `[Option<BufWriter<File>>; 12]` lookup table. Faster, less heap. But more boilerplate. Plan §5.3's HashMap is the right Phase B choice — defer the array form to Phase F when multicore actually puts lookup on the hot path.
+
+**A3. `ExtractParams` struct usage.** Plan §6 step 12 / §9.2 #5 defer this. Fine for Phase B. SPEC §6.3 explicitly motivates `ExtractParams` as a structural anti-bug device for the 14-arg `extract_calls` Alan's port had. Phase B's 6-arg signature is below that threshold and the kernel function itself is simple enough that the struct adds no value. Defensible.
+
+**A4. `read_pos_5p` semantic clarity.** Three options:
+- (a) Rename `read_pos_5p` in `bismark-io` to `read_pos_5p_including_softclip` — verbose but unambiguous.
+- (b) Keep the name, add a one-line docstring clarification.
+- (c) Renumber in `iter_aligned` so the first emitted call always has `read_pos_5p == 0` (would require additional bookkeeping for soft-clips).
+
+The plan implicitly assumes (b). Confirm in the plan §3.1 reference list that `bismark-io`'s `iter_aligned` doc actually states this — if not, file a bismark-io docs follow-up.
+
+---
+
+## 6. Action items
+
+### Critical (block implementation)
+
+1. **C1.** Switch `OutputFileMap` to eager-open for all configured `(context, strand)` keys in `OutputMode::Default`. Write the header line at open time (gated by `!no_header && !mbias_only`). Rewrite the `output_file_map_lazy_creates_only_keys_seen` test as `..._eagerly_creates_all_strand_files_for_default_mode_with_header`. Update §4.5 row "Empty input" + §8.4 SPEC row "Directional library" + §10 validation row accordingly. Reconcile with the SPEC's "structural prevention of Alan's bug" claim — likely re-frame as "PE pair-strand routes the whole pair (not per-record strand)" which is the actual structural fix, not "files don't exist on disk."
+
+### Important (request before APPROVE)
+
+2. **I1.** Fix plan §4.5 + §7.1 prose: `iter_aligned`'s `read_pos_5p` includes soft-clipped positions in the count. Update the `extract_calls_walks_cigar_with_soft_clips` test assertion to match (first emitted call has `read_pos_5p == soft_clip_len`, not `0`, for `+` strand). Net behavior vs Perl is still correct — only the prose/assertion is wrong.
+3. **I2.** Document header emission ordering and content invariance explicitly. With C1 fixed, header order is the static file-open order (matches Perl). Add one test `output_file_map_writes_header_to_all_files_in_static_order_when_no_header_off`.
+4. **I3.** Decide on `mbias_only_silence` kernel param: either keep + document the dead branch in §13 risks, or defer to Phase E entirely.
+5. **I4.** Plan §6 step 6 ordering: increment splitting-report counters BEFORE the `mbias_only` short-circuit, not after. Document the deviation from SPEC §7.5 in §13 and queue the SPEC fix.
+6. **I5.** Add a minimal end-to-end smoke test in Phase B that doesn't require the Perl toolchain (synthetic BAM → run binary → assert file set + non-empty). Commit `tests/data/regenerate.sh` even if Perl baseline gen is deferred.
+
+### Optional
+
+7. **O1.** Either ASCII-assert chr names in `build_chr_name_table` or document non-ASCII as a Phase H concern.
+8. **O2.** Specify `derive_basename` behavior for edge inputs (uppercase suffix, no suffix, double suffix).
+9. **O3.** Add a unit test for non-directional SE (CTOT/CTOB strand routing) at the `route_call` level.
+10. **O4.** Combine `fhs` + `paths` into a single `HashMap<OutputKey, (PathBuf, BufWriter<File>)>` to remove the dual-map invariant.
+11. **O5.** Drop or simplify `xm.len() / 8` preallocation; default `Vec::new()` is fine.
+12. **O6.** Plan should add one explicit `extract_se_empty_input_*` test and one multi-record `extract_se_two_records_route_to_different_files` test.
+13. **O7.** Use `Flags::is_segmented()` instead of `flags().bits() & 0x1` for codebase consistency with dedup.
+
+---
+
+## 7. Verdict
+
+**NEEDS-REVISIONS.**
+
+Justification: C1 is a direct byte-identity hazard built into the data-structure design and the plan's "structural fix" framing. Fixing it isn't large (eager-open at `OutputFileMap::new`, write headers immediately) but it changes the test surface and the SPEC §8.4 invariant materially. I1/I2/I4 are correctness clarifications that don't change LOC much but need to be locked before implementation starts. I5 is a Phase-B-internal validation gap — it's possible to ship Phase B without an end-to-end smoke and rely on Phase H, but doing so concentrates risk at the byte-identity gate where the user explicitly wants problems caught earlier.
+
+Once C1 + I1-I5 are resolved (mostly edits to plan + test list, no major code-shape change), this is a solid APPROVE — the algorithm shape, SE-only scoping, kernel delegation to `iter_aligned`, partial-output cleanup, and phase-gate rejections are all well-thought-out. The plan is otherwise unusually thorough for a Phase B port.
+
+Reviewed against SPEC.md rev 2; bismark-io v1.0.0-beta.6 source (record.rs, cigar.rs); Perl `bismark_methylation_extractor` v0.25.1 (lines 1619-1660 ignore semantics, 4245-4267 soft-clip handling, 5076-5430 file-open + header emission); `bismark-dedup` pipeline.rs (precedent for chr-table + auto-detect helper).

--- a/plans/05262026_bismark-extractor/PROGRESS.md
+++ b/plans/05262026_bismark-extractor/PROGRESS.md
@@ -1,0 +1,49 @@
+# `bismark-extractor` — overall progress (umbrella #798)
+
+**Design contract:** `rust/bismark-extractor/SPEC.md` (rev 2, in-repo).
+**Branch:** `rust/iron-chancellor`.
+**Crate version:** `1.0.0-alpha.1` (Phase A merged); Phase B bumps to `1.0.0-alpha.2`.
+
+## Phase status table
+
+| Phase | Scope | LOC est. | Status | Sub-issue | Plan file |
+|-------|-------|----------|--------|-----------|-----------|
+| A | Workspace scaffold + CLI + flag-validation | ~500 | ✅ **merged** (2026-05-26, commit `144ca2d`, PR #847) | #846 | (spec recon, `~/.claude/plans/create-a-team-of-snoopy-music.md`) |
+| **B** | **SE extraction loop + XM routing + eager output-file map + splitting-report skeleton + M-bias accumulator** | **~1,100 LOC actual** | ✅ **implementation complete (rev 2); ready to commit + PR** | _(to file once gh works; suggested body in PHASE_B_PLAN.md §14)_ | `PHASE_B_PLAN.md` rev 2 |
+| C | PE extraction + overlap handling + `--ignore_r2` / `--ignore_3prime_r2` | ~600 | ⏸ not started | — | — |
+| D | M-bias accumulation per (context × read_identity) + `M-bias.txt` writer | ~500 | ⏸ not started (accumulator wired in Phase B) | — | — |
+| E | `--comprehensive` / `--merge_non_CpG` / `--yacht` output mode dispatch + `--gzip` | ~400 | ⏸ not started | — | — |
+| F | Rayon-based `--multicore N` (byte-identical invariant) | ~700 | ⏸ not started | — | — |
+| G | `--bedGraph` + `--cytosine_report` subprocess chain | ~400 | ⏸ not started | — | — |
+| H | Real-data byte-identity gate (10M + 55M PE WGBS) + CHANGELOG + version tag | ~200 test | ⏸ not started | — | — |
+
+## Pipeline steps for **Phase B**
+
+| Step | Status | Owner | Output |
+|------|--------|-------|--------|
+| 1. Spec sections identified (§7.1, §7.2, §7.5, §7.7) | ✅ done | Felix + Claude | (SPEC.md rev 2 already covers) |
+| 2. Plan written to file | ✅ done | Claude | `PHASE_B_PLAN.md` rev 0 (now superseded by rev 2) |
+| 3. **Manual review of plan by Felix** | ✅ done (implicit — directed straight to dual reviewers) | Felix | — |
+| 4. Dual plan-reviewer agents | ✅ done | Claude (Agent ×2) | `PLAN_REVIEW_PHASE_B_A.md` (APPROVE-WITH-NITS) + `PLAN_REVIEW_PHASE_B_B.md` (NEEDS-REVISIONS — eager-open critical) |
+| 5. Plan revisions folding both reviews | ✅ done | Claude | `PHASE_B_PLAN.md` rev 1 — Critical C1 (eager-open) verified against Perl source 5405-5700+ + 14 other fixes |
+| 6. Implementation trigger | ✅ done | Felix ("implement") | — |
+| 7. Implementation | ✅ done | Claude | 10 source files (call/mbias/output/state/route/header/pipeline/error/main/lib) + 2 test files. Crate version 1.0.0-alpha.1 → 1.0.0-alpha.2 |
+| 8. Dual code-reviewer agents | ✅ done | Claude (Agent ×2) | `CODE_REVIEW_PHASE_B_A.md` + `CODE_REVIEW_PHASE_B_B.md` (both APPROVE-WITH-NITS) |
+| 9. plan-manager coverage audit | ✅ done | Claude (Agent) | `COVERAGE_PHASE_B.md` — INCOMPLETE on 3 coverage items (no behaviour bugs) |
+| 10. **Tight fix-up (rev 2)** | ✅ done | Claude | Added T-27 test; renamed `strand_char` → `meth_char`; dropped `header.clone()`; widened `write_call` + `reference_sequence_id` to typed errors; deviations documented for T-40 + Item 43 |
+| 11. Sub-issue filed on GitHub as child of #798 | ✅ done | Claude | [#848](https://github.com/FelixKrueger/Bismark/issues/848) (filed 2026-05-26 after `brew upgrade gh` 2.91.0 → 2.92.0) |
+| 12. PR opened, byte-identity smoke test green | ⏸ ready | — | — |
+| 13. Merge to `rust/iron-chancellor` | ⏸ ready | — | — |
+| 6. **Implementation trigger from Felix** ("implement" / `/code-implementation`) | ⏸ blocked on #4–#5 | Felix | — |
+| 7. Implementation (modules per §3.2 of plan) | ⏸ | Claude | code changes in `rust/bismark-extractor/` |
+| 8. Dual code-reviewer agents | ⏸ | Claude (Agent tool ×2) | `CODE_REVIEW_PHASE_B_A.md` + `CODE_REVIEW_PHASE_B_B.md` |
+| 9. `plan-manager` coverage audit | ⏸ | Claude (Agent tool) | `COVERAGE_PHASE_B.md` |
+| 10. Sub-issue filed on GitHub as child of #798 | 🟡 **deferred** (gh CLI broken; command surfaced in chat) | Felix | issue link committed back to this table |
+| 11. PR opened, byte-identity smoke test green | ⏸ | — | — |
+| 12. Merge to `rust/iron-chancellor` | ⏸ | — | — |
+
+## Notes
+
+- Sub-issue filing is currently **blocked by a macOS keychain TLS error** affecting `gh` CLI in this environment (`tls: failed to verify certificate: x509: OSStatus -26276`). Workaround: user runs the command from their normal terminal (see PHASE_B_PLAN.md §14 for the copy-pasteable form).
+- Per global CLAUDE.md workflow: manual review of the plan **must** happen before agent plan-reviewers are launched. No reviewers launched yet.
+- Per global CLAUDE.md workflow: implementation requires an explicit trigger ("implement" or `/code-implementation`). No code edits planned until then.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -115,11 +115,14 @@ dependencies = [
 
 [[package]]
 name = "bismark-extractor"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "assert_cmd",
  "bismark-io",
+ "bstr",
  "clap",
+ "noodles-core 0.20.0",
+ "noodles-sam",
  "predicates",
  "tempfile",
  "thiserror",

--- a/rust/bismark-extractor/Cargo.toml
+++ b/rust/bismark-extractor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bismark-extractor"
-version = "1.0.0-alpha.1"
-description = "Rust port of Bismark Perl's bismark_methylation_extractor script (Phase A scaffold)"
+version = "1.0.0-alpha.2"
+description = "Rust port of Bismark Perl's bismark_methylation_extractor script (Phase B: SE extraction)"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -22,8 +22,14 @@ path = "src/main.rs"
 bismark-io = { version = "=1.0.0-beta.6", path = "../bismark-io" }
 clap = { version = "=4.5.30", features = ["derive"] }
 thiserror = "=2.0.0"
+# noodles-sam pinned to match bismark-io's transitive choice (matches dedup precedent).
+# Used for `Header` in the chr-name lookup table builder (header.rs) and in tests.
+noodles-sam = "=0.85.0"
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"
 predicates = "=3.1.2"
 tempfile = "=3.10.1"
+# Used by tests for synthetic record + header construction.
+bstr = "=1.10.0"
+noodles-core = "=0.20.0"

--- a/rust/bismark-extractor/src/call.rs
+++ b/rust/bismark-extractor/src/call.rs
@@ -1,0 +1,171 @@
+//! Methylation-call classification + per-record extraction kernel.
+//!
+//! Phase B (rev 1): delegates the CIGAR walk + `-`-strand orientation
+//! correction to `bismark-io 1.0.0-beta.6`'s `BismarkRecord::iter_aligned`.
+//! Per SPEC §7.1 rev 2 note, the kernel is a thin filter over that iterator.
+
+use bismark_io::BismarkRecord;
+
+use crate::error::BismarkExtractorError;
+
+/// Cytosine context. `#[repr(u8)]` lets `[T; 3]` arrays index by context
+/// via `as usize`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum CytosineContext {
+    /// CpG context — `Z`/`z`.
+    CpG = 0,
+    /// CHG context — `X`/`x`.
+    CHG = 1,
+    /// CHH context — `H`/`h`.
+    CHH = 2,
+}
+
+/// One methylation call extracted from a Bismark record.
+///
+/// `Copy` (16 bytes). Per-record extraction returns `Vec<MethCall>` which
+/// the caller drains.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MethCall {
+    /// 1-based reference position. From `AlignedXmCall::ref_pos`.
+    pub ref_pos: u32,
+    /// 0-based read position from the **5' end of the sequenced read**.
+    /// **Includes soft-clipped positions in the count** (rev 1 correction
+    /// per Reviewer B I1) — `iter_aligned` inherits `CigarExt::aligned_positions`'s
+    /// `read_pos` which increments through soft-clip ops; the filter drops
+    /// emission for soft-clip positions but does not renumber the remaining
+    /// ones. For a `+`-strand `5S95M` record the first emitted call has
+    /// `read_pos == 5`. Matches Perl `substr(meth_call, ignore)` indexing
+    /// over the full XM tag length.
+    pub read_pos: u32,
+    /// CpG / CHG / CHH.
+    pub context: CytosineContext,
+    /// `true` for uppercase XM (`Z`/`X`/`H`), `false` for lowercase.
+    pub methylated: bool,
+    /// Literal XM byte (`Z`/`z`/`X`/`x`/`H`/`h`). Preserved for
+    /// `format_meth_line` byte-identity output.
+    pub xm_byte: u8,
+}
+
+/// Outcome of classifying one XM byte.
+///
+/// Exposed as `pub` so integration tests can assert classification
+/// directly; treated as an internal type for non-test callers (the public
+/// kernel entry point is `extract_calls`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum XmClassification {
+    /// Methylation call at known context + methylation state.
+    Call(CytosineContext, /*methylated*/ bool),
+    /// `U` / `u` — unknown context (CN or CHN). Silently skipped per
+    /// Perl 2970/3052/4548.
+    SkipUnknownContext,
+    /// `.` — non-cytosine base. Silently skipped.
+    SkipNonCytosine,
+}
+
+/// Classify one XM byte against the SPEC §5 table.
+///
+/// Phase B always errors on invalid bytes (mirrors Perl `die` at lines
+/// 2972/3054). Phase E will add a `mbias_only_silence` kernel parameter
+/// to mirror Perl's conditional die `die "..." unless ($mbias_only)`.
+pub fn classify_xm_byte(
+    byte: u8,
+    ref_pos: u32,
+    read_id: &str,
+) -> Result<XmClassification, BismarkExtractorError> {
+    match byte {
+        b'Z' => Ok(XmClassification::Call(CytosineContext::CpG, true)),
+        b'z' => Ok(XmClassification::Call(CytosineContext::CpG, false)),
+        b'X' => Ok(XmClassification::Call(CytosineContext::CHG, true)),
+        b'x' => Ok(XmClassification::Call(CytosineContext::CHG, false)),
+        b'H' => Ok(XmClassification::Call(CytosineContext::CHH, true)),
+        b'h' => Ok(XmClassification::Call(CytosineContext::CHH, false)),
+        b'U' | b'u' => Ok(XmClassification::SkipUnknownContext),
+        b'.' => Ok(XmClassification::SkipNonCytosine),
+        other => Err(BismarkExtractorError::InvalidXmByte {
+            byte: other,
+            byte_char: other as char,
+            ref_pos,
+            read_id: read_id.to_string(),
+        }),
+    }
+}
+
+/// Render the QNAME of a record as a `String` (lossy-decode for non-UTF-8).
+///
+/// Used to attach a read-id to `InvalidXmByte` errors. Records without a
+/// QNAME (rare) are rendered as the literal string `"<unnamed>"`.
+fn render_qname(record: &BismarkRecord) -> String {
+    match record.inner().name() {
+        Some(name) => String::from_utf8_lossy(name.as_ref()).into_owned(),
+        None => "<unnamed>".to_string(),
+    }
+}
+
+/// Extract all methylation calls from one record.
+///
+/// Walks `record.iter_aligned()` (which already applies the `-`-strand
+/// orientation correction per SPEC §6.5). Filters by ignore-region in
+/// 5'-oriented read coordinates, classifies each XM byte, and emits one
+/// `MethCall` per CpG/CHG/CHH call.
+///
+/// # Implementation invariant
+///
+/// This function **must use `aligned.xm_byte`** (carried by the iterator).
+/// It must **never** re-index `record.xm()[read_pos_5p]` — for `-`-strand
+/// records `read_pos_5p` counts from the sequenced 5' end while `record.xm()`
+/// is BAM-stored, so the indices disagree by `seq_len - 1 - read_pos`.
+///
+/// # Errors
+///
+/// `BismarkExtractorError::InvalidXmByte` on any byte outside
+/// `Z`/`z`/`X`/`x`/`H`/`h`/`U`/`u`/`.`. Phase E will add an `mbias_only`
+/// silencing path.
+pub fn extract_calls(
+    record: &BismarkRecord,
+    ignore_5p: u32,
+    ignore_3p: u32,
+) -> Result<Vec<MethCall>, BismarkExtractorError> {
+    // XM length equals the read sequence length (parity check in
+    // `from_noodles_record`). Use this to compute the 3'-side ignore
+    // boundary in 5'-oriented coordinates.
+    let xm_len = record.xm().len() as u32;
+    let lo = ignore_5p;
+    let hi = xm_len.saturating_sub(ignore_3p);
+
+    // Early-out if the ignore-region check would skip every position.
+    if lo >= hi {
+        return Ok(Vec::new());
+    }
+
+    // Render the QNAME once so error-path messages have it. The Vec allocation
+    // here is small (typical QNAME ~30 bytes) and happens once per record.
+    let read_id = render_qname(record);
+
+    let mut calls: Vec<MethCall> = Vec::new();
+
+    for aligned in record.iter_aligned() {
+        // Ignore-region check operates on the 5'-oriented read position
+        // (which includes soft-clip in the count — see `MethCall::read_pos`).
+        if aligned.read_pos_5p < lo || aligned.read_pos_5p >= hi {
+            continue;
+        }
+
+        // Use `aligned.xm_byte`; NEVER re-index `record.xm()[read_pos_5p]`.
+        // The iterator carries the orientation-corrected byte.
+        match classify_xm_byte(aligned.xm_byte, aligned.ref_pos, &read_id)? {
+            XmClassification::Call(context, methylated) => {
+                calls.push(MethCall {
+                    ref_pos: aligned.ref_pos,
+                    read_pos: aligned.read_pos_5p,
+                    context,
+                    methylated,
+                    xm_byte: aligned.xm_byte,
+                });
+            }
+            XmClassification::SkipUnknownContext | XmClassification::SkipNonCytosine => {}
+        }
+    }
+
+    Ok(calls)
+}

--- a/rust/bismark-extractor/src/error.rs
+++ b/rust/bismark-extractor/src/error.rs
@@ -1,10 +1,13 @@
 //! Typed errors for `bismark-extractor`.
 //!
-//! Phase A: errors produced at the CLI-validation boundary. Phase B+
-//! will add pipeline/extraction errors via `#[from] BismarkIoError`
-//! (same pattern as `bismark-dedup`'s `BismarkDedupError`).
+//! Phase A: errors produced at the CLI-validation boundary.
+//! Phase B (rev 1): adds pipeline/extraction errors — `PhaseNotYetImplemented`,
+//! `InvalidXmByte`, `IoWrite`, `BismarkIo`, `InternalError`,
+//! `NonAsciiChromosomeName`.
 
 use std::path::PathBuf;
+
+use bismark_io::BismarkIoError;
 
 /// All errors raised by `bismark-extractor` at validation time. Pipeline
 /// + extraction errors land in subsequent phases.
@@ -125,4 +128,60 @@ pub enum BismarkExtractorError {
     /// subprocess.
     #[error("--genome_folder path does not exist: {0}")]
     GenomeFolderNotFound(PathBuf),
+
+    // ─── Phase B (rev 1) additions ─────────────────────────────────────
+    /// Feature gated behind a later phase. Phase B uses this to reject
+    /// configurations outside the supported subset (PE, multicore,
+    /// non-default mode, gzip, bedGraph, cytosine_report, multiple input
+    /// files).
+    #[error("not yet implemented in this build: {feature}")]
+    PhaseNotYetImplemented {
+        /// Human-readable description of the unsupported feature, naming
+        /// the phase that will land it.
+        feature: String,
+    },
+
+    /// Invalid XM tag byte at a given reference position. Mirrors Perl's
+    /// `die` at lines 2972 / 3054.
+    #[error("invalid XM byte 0x{byte:02x} ({byte_char:?}) in read {read_id} at ref_pos {ref_pos}")]
+    InvalidXmByte {
+        /// Offending byte value.
+        byte: u8,
+        /// Same byte rendered as a `char` (ASCII for any plausible XM).
+        byte_char: char,
+        /// 1-based reference position the byte was extracted from.
+        ref_pos: u32,
+        /// QNAME of the offending read (debug aid).
+        read_id: String,
+    },
+
+    /// Wrap `std::io::Error` for write-side failures (split files +
+    /// splitting report + `create_dir_all`).
+    #[error("output write failed: {0}")]
+    IoWrite(#[from] std::io::Error),
+
+    /// Wrap `bismark_io::BismarkIoError` from reader paths.
+    #[error(transparent)]
+    BismarkIo(#[from] BismarkIoError),
+
+    /// Invariant violation that "should never fire" (e.g. refid out of
+    /// range vs header). Surfaces loudly rather than panicking.
+    #[error("internal invariant violated: {message}")]
+    InternalError {
+        /// Diagnostic message.
+        message: String,
+    },
+
+    /// Chromosome name in @SQ contains non-ASCII bytes. Bismark output
+    /// filenames + bedGraph/cytosine_report subprocesses require ASCII
+    /// chr names.
+    #[error(
+        "chromosome name in @SQ header contains non-ASCII bytes: {name}. \
+         Bismark output filenames + bedGraph/cytosine_report subprocesses \
+         require ASCII chr names."
+    )]
+    NonAsciiChromosomeName {
+        /// Offending chr name (lossy-rendered for the error message).
+        name: String,
+    },
 }

--- a/rust/bismark-extractor/src/header.rs
+++ b/rust/bismark-extractor/src/header.rs
@@ -1,0 +1,40 @@
+//! SAM header → ASCII chromosome-name lookup table.
+//!
+//! Built once per input file at `extract_se` entry. Mirrors `bismark-dedup`'s
+//! refid-table pattern (`pipeline.rs:64-82`) but returns chr **names** rather
+//! than interned u32 ids — the extractor's output lines embed the literal
+//! chr string.
+//!
+//! Per Reviewer B Optional O1: non-ASCII chr names fail loudly via
+//! [`BismarkExtractorError::NonAsciiChromosomeName`] rather than silently
+//! UTF-8-substituting `\u{fffd}` (which would corrupt byte-identity).
+
+use noodles_sam::Header;
+
+use crate::error::BismarkExtractorError;
+
+/// Build a `Vec<String>` indexed by `noodles_sam::Record::reference_sequence_id()`
+/// (i.e. the 0-based insertion order of `header.reference_sequences()`).
+///
+/// # Errors
+///
+/// `BismarkExtractorError::NonAsciiChromosomeName` if any `@SQ SN:...` value
+/// contains non-ASCII bytes. Bismark's downstream tools (bismark2bedGraph,
+/// coverage2cytosine) cannot round-trip non-ASCII names safely.
+pub fn build_chr_name_table(header: &Header) -> Result<Vec<String>, BismarkExtractorError> {
+    let mut out = Vec::with_capacity(header.reference_sequences().len());
+    for (name, _ref_seq) in header.reference_sequences() {
+        let bytes: &[u8] = name.as_ref();
+        if !bytes.is_ascii() {
+            return Err(BismarkExtractorError::NonAsciiChromosomeName {
+                name: String::from_utf8_lossy(bytes).into_owned(),
+            });
+        }
+        // Safe: just ASCII-validated.
+        out.push(
+            String::from_utf8(bytes.to_vec())
+                .expect("ASCII verified immediately above; from_utf8 cannot fail"),
+        );
+    }
+    Ok(out)
+}

--- a/rust/bismark-extractor/src/lib.rs
+++ b/rust/bismark-extractor/src/lib.rs
@@ -6,24 +6,27 @@
 //!
 //! ## Status
 //!
-//! **Phase A — workspace scaffold + CLI** (this crate version: `1.0.0-alpha.1`).
-//! The binary boots, `--help` prints all 35 flags, `--version` emits a
-//! provenance string, and `Cli::validate()` rejects every documented flag
-//! mutex from SPEC §11 + Perl source. No extraction logic yet — that's
-//! Phase B (SE loop) through G (subprocess chain).
+//! **Phase B — SE extraction loop** (crate version: `1.0.0-alpha.2`).
+//! The binary now runs end-to-end on SE Bismark BAM/SAM/CRAM input in
+//! `OutputMode::Default` at `--parallel 1`, producing the 12 strand×context
+//! split files (eagerly opened with the Perl version header line) plus
+//! `_splitting_report.txt`. PE, non-default modes, `--gzip`, `--parallel > 1`,
+//! and the `--bedGraph` / `--cytosine_report` subprocess chain are rejected
+//! at the resolved-config boundary with [`BismarkExtractorError::PhaseNotYetImplemented`].
 //!
 //! See [SPEC.md §10](../SPEC.md) for the full phase outline.
 //!
-//! ## Library surface (Phase A)
+//! ## Library surface
 //!
 //! - [`cli::Cli`] — clap-derived parser matching all 35 Perl flags.
 //! - [`cli::ResolvedConfig`] — validated subset of CLI args + derived
 //!   [`cli::OutputMode`] and [`cli::PairedMode`].
 //! - [`error::BismarkExtractorError`] — typed errors raised at validation
-//!   + (later) the extraction-pipeline boundary.
-//! - [`params::ExtractParams`] — Phase-B-onwards argument struct (typed
-//!   replacement for the 14-arg `extract_calls` signature seen in the
-//!   prior-art Rust port). Phase A defines the shape; Phase B populates.
+//!   and the extraction-pipeline boundary.
+//! - [`params::ExtractParams`] — scaffold for Phase C/D/E parameter
+//!   structs; not yet used in Phase B.
+//! - [`call::extract_calls`] — Phase B kernel.
+//! - [`pipeline::extract_se`] — Phase B SE main loop.
 //!
 //! ## Binary
 //!
@@ -34,13 +37,23 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod call;
 pub mod cli;
 pub mod error;
+pub mod header;
+pub mod mbias;
+pub mod output;
 pub mod params;
+pub mod pipeline;
+pub mod route;
+pub mod state;
 
+pub use call::{CytosineContext, MethCall, extract_calls};
 pub use cli::{Cli, OutputMode, PairedMode, ResolvedConfig};
 pub use error::BismarkExtractorError;
+pub use mbias::{MbiasPos, MbiasTable};
 pub use params::ExtractParams;
+pub use pipeline::extract_se;
 
 /// Returns a TG-style provenance string for the binary's `--version` output.
 ///

--- a/rust/bismark-extractor/src/main.rs
+++ b/rust/bismark-extractor/src/main.rs
@@ -1,12 +1,13 @@
 //! Binary entry point for `bismark-methylation-extractor-rs`.
 //!
-//! Phase A: parses CLI, validates flags, prints provenance on `--version`.
-//! NO extraction logic — that's Phase B onward. A run that passes
-//! validation currently prints a one-line note + exits 0 (placeholder
-//! pipeline call site).
+//! Phase B (rev 1): dispatches on the resolved config — SE + default mode +
+//! parallel=1 + no gzip + no bedGraph/cytosine_report + single input file
+//! routes to [`bismark_extractor::extract_se`]. Every other configuration
+//! returns a [`BismarkExtractorError::PhaseNotYetImplemented`] naming the
+//! deferring phase.
 //!
 //! Exit codes:
-//! - `0` — success (currently: validation passes + placeholder exit)
+//! - `0` — success
 //! - `1` — any [`BismarkExtractorError`]
 //! - `2` — clap parse error (clap convention)
 
@@ -14,9 +15,9 @@ use std::process::ExitCode;
 
 use clap::Parser;
 
-use bismark_extractor::cli::Cli;
+use bismark_extractor::cli::{Cli, OutputMode, PairedMode};
 use bismark_extractor::error::BismarkExtractorError;
-use bismark_extractor::version_string;
+use bismark_extractor::{extract_se, version_string};
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
@@ -38,17 +39,69 @@ fn main() -> ExitCode {
 }
 
 fn run(cli: Cli) -> Result<(), BismarkExtractorError> {
-    let _config = cli.validate()?;
+    let config = cli.validate()?;
 
-    // Phase A placeholder: validation passed, but no pipeline exists yet.
-    // Phase B lands the SE extraction loop and wires it here. For now,
-    // explicitly tell the user the binary is not yet feature-complete.
-    eprintln!(
-        "note: bismark-methylation-extractor-rs is in Phase A (scaffold + CLI). \
-         Extraction pipeline lands in Phase B (SE) through G (subprocess chain). \
-         For production use, run Perl `bismark_methylation_extractor` until \
-         Phase H (byte-identity gate) is reached. See \
-         <https://github.com/FelixKrueger/Bismark/issues/798> for status."
-    );
-    Ok(())
+    // Phase B dispatches on the supported subset. Anything outside the
+    // subset is rejected with `PhaseNotYetImplemented` naming the phase
+    // that will land it. This avoids silent acceptance of half-implemented
+    // code paths.
+
+    // Multiple input files: deferred (would mirror dedup's --multiple).
+    if config.files.len() != 1 {
+        return Err(BismarkExtractorError::PhaseNotYetImplemented {
+            feature: format!(
+                "multiple input files ({} given); v1.x feature",
+                config.files.len()
+            ),
+        });
+    }
+
+    // Paired-end: Phase C.
+    if config.paired_mode == PairedMode::PairedEnd {
+        return Err(BismarkExtractorError::PhaseNotYetImplemented {
+            feature: "paired-end extraction; arrives in Phase C".to_string(),
+        });
+    }
+
+    // Non-default output modes: Phase E.
+    if config.output_mode != OutputMode::Default {
+        return Err(BismarkExtractorError::PhaseNotYetImplemented {
+            feature: format!(
+                "output mode {:?}; --comprehensive / --merge_non_CpG / --yacht / \
+                 --mbias_only arrive in Phase E",
+                config.output_mode
+            ),
+        });
+    }
+
+    // Gzip-compressed output: Phase E.
+    if config.gzip {
+        return Err(BismarkExtractorError::PhaseNotYetImplemented {
+            feature: "--gzip; arrives in Phase E".to_string(),
+        });
+    }
+
+    // Multicore: Phase F.
+    if config.parallel != 1 {
+        return Err(BismarkExtractorError::PhaseNotYetImplemented {
+            feature: format!(
+                "--parallel {} (only --parallel 1 supported); multicore arrives in Phase F",
+                config.parallel
+            ),
+        });
+    }
+
+    // Downstream subprocess chain: Phase G.
+    if config.bedgraph || config.cytosine_report {
+        return Err(BismarkExtractorError::PhaseNotYetImplemented {
+            feature: "--bedGraph / --cytosine_report subprocess chain; arrives in Phase G"
+                .to_string(),
+        });
+    }
+
+    // Supported subset: SE (or AutoDetect treated as SE; per-record PAIRED-flag
+    // check inside the loop catches PE BAMs). Default mode. Single core.
+    // Plain (uncompressed) output. No subprocess chain.
+    let input = config.files[0].clone();
+    extract_se(&input, &config)
 }

--- a/rust/bismark-extractor/src/mbias.rs
+++ b/rust/bismark-extractor/src/mbias.rs
@@ -1,0 +1,60 @@
+//! M-bias accumulator.
+//!
+//! Phase B accumulates counters per (read-identity × context × 1-based
+//! position) only; the `M-bias.txt` writer lands in Phase D.
+//!
+//! Per SPEC §6.2 + §7.7: the surrounding state holds an `[MbiasTable; 2]`
+//! indexed by read-identity (0 = R1/SE, 1 = R2). Per-context iteration in
+//! the writer (Phase D) enumerates all 3 contexts explicitly — no
+//! `_ => {}` fallthrough — which closes Alan's missing-CHG/CHH bug
+//! structurally.
+
+use crate::call::CytosineContext;
+
+/// Counts at one read-coordinate position. 16 bytes; `Copy`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MbiasPos {
+    /// Methylated calls (uppercase XM).
+    pub meth: u64,
+    /// Unmethylated calls (lowercase XM).
+    pub unmeth: u64,
+}
+
+/// Per (context × position) table for one read identity.
+///
+/// Each `Vec<MbiasPos>` grows lazily — index `i` is the 1-based read
+/// position (so index 0 is unused; an extra slot vs Perl's hash-based
+/// storage, but trivial in bytes).
+#[derive(Debug, Default)]
+pub struct MbiasTable {
+    /// CpG counters keyed by 1-based read position.
+    pub cpg: Vec<MbiasPos>,
+    /// CHG counters.
+    pub chg: Vec<MbiasPos>,
+    /// CHH counters.
+    pub chh: Vec<MbiasPos>,
+}
+
+impl MbiasTable {
+    /// Increment the cell at (context, 1-based position) for one call.
+    ///
+    /// Grows the underlying `Vec` lazily; no preallocation needed because
+    /// reads have bounded length (~150 bp typical, ~300 bp max).
+    pub fn accumulate(&mut self, context: CytosineContext, position_1based: u32, methylated: bool) {
+        let vec = match context {
+            CytosineContext::CpG => &mut self.cpg,
+            CytosineContext::CHG => &mut self.chg,
+            CytosineContext::CHH => &mut self.chh,
+        };
+        let idx = position_1based as usize;
+        if vec.len() <= idx {
+            vec.resize(idx + 1, MbiasPos::default());
+        }
+        let bucket = &mut vec[idx];
+        if methylated {
+            bucket.meth = bucket.meth.saturating_add(1);
+        } else {
+            bucket.unmeth = bucket.unmeth.saturating_add(1);
+        }
+    }
+}

--- a/rust/bismark-extractor/src/output.rs
+++ b/rust/bismark-extractor/src/output.rs
@@ -1,0 +1,334 @@
+//! Per-(context × strand) split-file map + splitting-report writer.
+//!
+//! Phase B (rev 1): **eager-open** all 12 strand×context files at
+//! [`OutputFileMap::new`] time and write the version header immediately,
+//! matching Perl `bismark_methylation_extractor` lines 5405-5700+ (default
+//! mode) and 5140-5325 (`--merge_non_CpG` mode). Rev 0's lazy-creation
+//! design codified the wrong byte-identity invariant — see plan rev 1
+//! changelog.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use bismark_io::BismarkStrand;
+
+use crate::call::{CytosineContext, MethCall};
+use crate::cli::ResolvedConfig;
+use crate::error::BismarkExtractorError;
+
+/// Bismark version string. Hardcoded to lock byte-identity with Perl's
+/// `$version` variable. Update in lockstep with Perl `bismark_methylation_extractor`
+/// at release time.
+pub const BISMARK_VERSION: &str = "v0.25.1";
+
+/// The literal header line Perl writes as the first line of every split
+/// file (when `!--no_header && !--mbias_only`). Verified at Perl lines
+/// 5159, 5182, 5205, 5228, 5429, 5452, 5475, 5498, etc.
+pub const SPLIT_FILE_HEADER: &str = "Bismark methylation extractor version v0.25.1\n";
+
+/// Key into the 12-element output-file map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct OutputKey {
+    /// CpG / CHG / CHH.
+    pub context: CytosineContext,
+    /// OT / CTOT / CTOB / OB.
+    pub strand: BismarkStrand,
+}
+
+/// All 12 (context, strand) keys for `OutputMode::Default` SE/PE. Order
+/// follows Perl's file-open order: per-context block, then OT/CTOT/CTOB/OB
+/// within each. (Per-file content is independent of this order; the order
+/// only matters for any error-message stability and for the unit test.)
+const DEFAULT_KEYS: [(CytosineContext, BismarkStrand); 12] = [
+    (CytosineContext::CpG, BismarkStrand::OT),
+    (CytosineContext::CpG, BismarkStrand::CTOT),
+    (CytosineContext::CpG, BismarkStrand::CTOB),
+    (CytosineContext::CpG, BismarkStrand::OB),
+    (CytosineContext::CHG, BismarkStrand::OT),
+    (CytosineContext::CHG, BismarkStrand::CTOT),
+    (CytosineContext::CHG, BismarkStrand::CTOB),
+    (CytosineContext::CHG, BismarkStrand::OB),
+    (CytosineContext::CHH, BismarkStrand::OT),
+    (CytosineContext::CHH, BismarkStrand::CTOT),
+    (CytosineContext::CHH, BismarkStrand::CTOB),
+    (CytosineContext::CHH, BismarkStrand::OB),
+];
+
+/// Eagerly-opened per-(context, strand) split files.
+///
+/// Rev 1 layout: one map keyed by [`OutputKey`] storing both the path
+/// (for cleanup) and an 8-KiB `BufWriter<File>`. Combining the two
+/// removes the rev-0 risk that `fhs` and `paths` could drift apart.
+pub struct OutputFileMap {
+    files: HashMap<OutputKey, (PathBuf, BufWriter<File>)>,
+}
+
+impl OutputFileMap {
+    /// Eagerly open all 12 default-mode split files in `output_dir`.
+    ///
+    /// Writes the version header line to each file unless `no_header == true`.
+    /// Creates `output_dir` via `create_dir_all` if missing (matches Perl
+    /// `make_path` behaviour).
+    pub fn new(
+        output_dir: &Path,
+        input_basename: &str,
+        no_header: bool,
+    ) -> Result<Self, std::io::Error> {
+        std::fs::create_dir_all(output_dir)?;
+
+        let mut files: HashMap<OutputKey, (PathBuf, BufWriter<File>)> =
+            HashMap::with_capacity(DEFAULT_KEYS.len());
+
+        for (context, strand) in DEFAULT_KEYS {
+            let filename = format!(
+                "{ctx}_{strand}_{base}.txt",
+                ctx = context_prefix(context),
+                strand = strand_label(strand),
+                base = input_basename,
+            );
+            let path = output_dir.join(filename);
+            let file = File::create(&path)?;
+            let mut writer = BufWriter::with_capacity(8 * 1024, file);
+            if !no_header {
+                writer.write_all(SPLIT_FILE_HEADER.as_bytes())?;
+            }
+            files.insert(OutputKey { context, strand }, (path, writer));
+        }
+
+        Ok(OutputFileMap { files })
+    }
+
+    /// Append a `MethCall` line to the appropriate split file.
+    ///
+    /// `record_name` is the raw QNAME bytes from the BAM (used verbatim in
+    /// the output line — Bismark QNAMEs are ASCII in practice).
+    ///
+    /// # Output format
+    ///
+    /// Tab-separated row matching Perl 2911-2961:
+    /// ```text
+    /// read_id<TAB>meth_char<TAB>chr<TAB>ref_pos<TAB>xm_byte<LF>
+    /// ```
+    /// where `meth_char` is `+` for methylated calls (uppercase XM) and `-`
+    /// for unmethylated calls (lowercase XM). **It is a methylation-state
+    /// indicator, not a strand indicator** (Reviewer A L1 fix in rev 2 —
+    /// the original "strand char" labelling was a Perl-fidelity nit).
+    ///
+    /// # Errors
+    ///
+    /// `BismarkExtractorError::IoWrite` on I/O failures. `InternalError` if
+    /// the `(context, strand)` key is somehow missing from the eager-open
+    /// map — should not be possible because [`OutputFileMap::new`] inserts
+    /// all 12 (3 contexts × 4 strands) keys at construction time, but
+    /// surfaces loudly rather than panicking if it ever happens.
+    pub fn write_call(
+        &mut self,
+        record_name: &[u8],
+        chr: &str,
+        call: MethCall,
+        strand: BismarkStrand,
+    ) -> Result<(), BismarkExtractorError> {
+        let key = OutputKey {
+            context: call.context,
+            strand,
+        };
+        let (_, writer) =
+            self.files
+                .get_mut(&key)
+                .ok_or_else(|| BismarkExtractorError::InternalError {
+                    message: format!(
+                        "OutputFileMap missing key (context={:?}, strand={:?}) — \
+                     eager-open should have created all 12 keys at OutputFileMap::new time",
+                        call.context, strand,
+                    ),
+                })?;
+        let meth_char: u8 = if call.methylated { b'+' } else { b'-' };
+        writer.write_all(record_name)?;
+        writer.write_all(b"\t")?;
+        writer.write_all(&[meth_char])?;
+        writer.write_all(b"\t")?;
+        writer.write_all(chr.as_bytes())?;
+        writer.write_all(b"\t")?;
+        writer.write_all(call.ref_pos.to_string().as_bytes())?;
+        writer.write_all(b"\t")?;
+        writer.write_all(&[call.xm_byte])?;
+        writer.write_all(b"\n")?;
+        Ok(())
+    }
+
+    /// Flush all 12 writers. Called from `ExtractState::finalize` before
+    /// the splitting-report is written so any buffered call lines are on
+    /// disk before the run terminates.
+    pub fn flush_all(&mut self) -> Result<(), std::io::Error> {
+        for (_, writer) in self.files.values_mut() {
+            writer.flush()?;
+        }
+        Ok(())
+    }
+
+    /// Drop all writers + best-effort remove every file. Called from
+    /// `extract_se`'s pre-finalize error paths. One failed `remove_file`
+    /// doesn't prevent the others — we log via `eprintln!` and continue.
+    pub fn cleanup_all(&mut self) {
+        // Drain into a vec to avoid double-borrow.
+        let entries: Vec<_> = self.files.drain().collect();
+        for (_, (path, _writer)) in entries {
+            // `_writer` drops here; file handle closes.
+            if let Err(e) = std::fs::remove_file(&path) {
+                // Don't propagate — this is best-effort cleanup. Print so
+                // an operator can see what went wrong without us hiding it.
+                eprintln!(
+                    "warning: failed to remove partial output file {}: {}",
+                    path.display(),
+                    e
+                );
+            }
+        }
+    }
+}
+
+/// Per-context counts accumulated during the SE/PE loop. Drives the
+/// `_splitting_report.txt` content at finalize time.
+#[derive(Debug, Default)]
+pub struct SplittingReport {
+    /// Total records iterated (SE: one per record; PE: one per pair —
+    /// PE arrives in Phase C).
+    pub records_processed: u64,
+    /// Total methylation calls (`Z`+`z`+`X`+`x`+`H`+`h`).
+    pub calls_total: u64,
+    /// `Z`.
+    pub calls_cpg_meth: u64,
+    /// `z`.
+    pub calls_cpg_unmeth: u64,
+    /// `X`.
+    pub calls_chg_meth: u64,
+    /// `x`.
+    pub calls_chg_unmeth: u64,
+    /// `H`.
+    pub calls_chh_meth: u64,
+    /// `h`.
+    pub calls_chh_unmeth: u64,
+}
+
+impl SplittingReport {
+    /// Compute percent methylation for one context. Returns `0.00` (not NaN)
+    /// for empty contexts — matches Perl behaviour for the zero-denominator
+    /// case.
+    pub fn percent_meth(meth: u64, unmeth: u64) -> f64 {
+        let total = meth.saturating_add(unmeth);
+        if total == 0 {
+            0.0
+        } else {
+            (meth as f64) * 100.0 / (total as f64)
+        }
+    }
+}
+
+/// Write `{output_dir}/{basename}_splitting_report.txt`.
+///
+/// Phase B emits a Perl-shaped report; byte-equality is a Phase H concern.
+/// The shape mirrors Perl's section ordering:
+///   - parameter-summary block (input file, optional `--fasta` annotation,
+///     etc.)
+///   - per-context counts
+///   - per-context methylation percentages
+pub fn write_splitting_report(
+    path: &Path,
+    input_path: &Path,
+    config: &ResolvedConfig,
+    report: &SplittingReport,
+) -> Result<(), std::io::Error> {
+    let mut w = BufWriter::with_capacity(8 * 1024, File::create(path)?);
+
+    // Header / parameter summary
+    writeln!(
+        w,
+        "Bismark methylation extractor version {}",
+        BISMARK_VERSION
+    )?;
+    writeln!(w)?;
+    writeln!(w, "Input file: {}", input_path.display())?;
+    writeln!(w, "Output directory: {}", config.output_dir.display())?;
+
+    // --fasta annotation line (SPEC §3 row 4, Perl line 5040)
+    if config.fasta_annotation {
+        writeln!(
+            w,
+            "Genomic equivalent sequences will be printed out in FastA format"
+        )?;
+    }
+
+    // Trim settings.
+    writeln!(w, "--ignore: {}", config.ignore_5p_r1)?;
+    writeln!(w, "--ignore_3prime: {}", config.ignore_3p_r1)?;
+
+    writeln!(w)?;
+    writeln!(w, "Processed {} reads in total", report.records_processed)?;
+    writeln!(w)?;
+
+    writeln!(w, "Total number of C's analysed:\t{}", report.calls_total)?;
+    writeln!(w)?;
+
+    writeln!(
+        w,
+        "Total methylated C's in CpG context:\t{}",
+        report.calls_cpg_meth
+    )?;
+    writeln!(
+        w,
+        "Total unmethylated C's in CpG context:\t{}",
+        report.calls_cpg_unmeth
+    )?;
+    writeln!(
+        w,
+        "Total methylated C's in CHG context:\t{}",
+        report.calls_chg_meth
+    )?;
+    writeln!(
+        w,
+        "Total unmethylated C's in CHG context:\t{}",
+        report.calls_chg_unmeth
+    )?;
+    writeln!(
+        w,
+        "Total methylated C's in CHH context:\t{}",
+        report.calls_chh_meth
+    )?;
+    writeln!(
+        w,
+        "Total unmethylated C's in CHH context:\t{}",
+        report.calls_chh_unmeth
+    )?;
+    writeln!(w)?;
+
+    let pct_cpg = SplittingReport::percent_meth(report.calls_cpg_meth, report.calls_cpg_unmeth);
+    let pct_chg = SplittingReport::percent_meth(report.calls_chg_meth, report.calls_chg_unmeth);
+    let pct_chh = SplittingReport::percent_meth(report.calls_chh_meth, report.calls_chh_unmeth);
+    writeln!(w, "C methylated in CpG context:\t{:.2}%", pct_cpg)?;
+    writeln!(w, "C methylated in CHG context:\t{:.2}%", pct_chg)?;
+    writeln!(w, "C methylated in CHH context:\t{:.2}%", pct_chh)?;
+
+    w.flush()?;
+    Ok(())
+}
+
+/// Strand label used in output filenames.
+fn strand_label(strand: BismarkStrand) -> &'static str {
+    match strand {
+        BismarkStrand::OT => "OT",
+        BismarkStrand::CTOT => "CTOT",
+        BismarkStrand::CTOB => "CTOB",
+        BismarkStrand::OB => "OB",
+    }
+}
+
+/// Context prefix used in output filenames.
+fn context_prefix(context: CytosineContext) -> &'static str {
+    match context {
+        CytosineContext::CpG => "CpG",
+        CytosineContext::CHG => "CHG",
+        CytosineContext::CHH => "CHH",
+    }
+}

--- a/rust/bismark-extractor/src/pipeline.rs
+++ b/rust/bismark-extractor/src/pipeline.rs
@@ -1,0 +1,147 @@
+//! SE extraction pipeline (Phase B).
+//!
+//! Per SPEC §7.2: one record at a time, classify XM bytes, route to split
+//! files + accumulate M-bias counters + bump splitting-report counters.
+//!
+//! PE (Phase C), multicore (Phase F), gzip (Phase E), bedGraph/cytosine_report
+//! subprocess (Phase G), and non-default output modes (Phase E) are rejected
+//! at `main::run`'s config-dispatch boundary, not here.
+
+use std::path::Path;
+
+use bismark_io::{ReadIdentity, open_reader};
+
+use crate::call::extract_calls;
+use crate::cli::ResolvedConfig;
+use crate::error::BismarkExtractorError;
+use crate::header::build_chr_name_table;
+use crate::route::route_call;
+use crate::state::ExtractState;
+
+/// Strip a single Bismark-recognised suffix from the input path's basename.
+///
+/// Matches Perl `s/sam$/txt/; s/bam$/txt/; s/cram$/txt/` semantics:
+/// **case-sensitive**, **single-extension only**. `foo.bam.gz` is NOT
+/// transformed (Perl wouldn't either — `s/bam$/txt/` doesn't match `.gz`).
+/// `foo.BAM` (uppercase) is left as `foo.BAM` (Perl regex is case-sensitive).
+///
+/// # Panics
+///
+/// Panics if `path` has no filename component — caller guarantees a real
+/// input file (validated at `Cli::validate`).
+pub fn derive_basename(path: &Path) -> String {
+    let filename = path
+        .file_name()
+        .expect("input path validated by Cli::validate must have a filename")
+        .to_string_lossy()
+        .into_owned();
+    // Strip exactly one of the three known extensions.
+    for ext in [".bam", ".sam", ".cram"] {
+        if let Some(stem) = filename.strip_suffix(ext) {
+            return stem.to_string();
+        }
+    }
+    filename
+}
+
+/// SE extraction main loop.
+///
+/// Opens the input, builds the chr-name table + state (which eagerly
+/// creates 12 split files + writes headers), then iterates records:
+/// extract calls → route each call → tally records. On any error before
+/// `finalize`, runs `state.cleanup_partial_outputs()` to remove all 12
+/// files before propagating.
+pub fn extract_se(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkExtractorError> {
+    let mut reader = open_reader(input, /*cram_ref=*/ None)?;
+    // Rev 2: build chr_table from `&reader.header()` directly — no Header
+    // clone (Reviewer B E2). The borrow is released before `reader.records()`
+    // takes its own mutable borrow further down.
+    let chr_table = build_chr_name_table(reader.header())?;
+
+    let input_basename = derive_basename(input);
+    let mut state = ExtractState::new(config, input, &input_basename)?;
+
+    for record_result in reader.records() {
+        let record = match record_result {
+            Ok(r) => r,
+            Err(e) => {
+                state.cleanup_partial_outputs();
+                return Err(e.into());
+            }
+        };
+
+        // Defensive PAIRED-flag check: SE pipeline must not silently accept
+        // PE input. Rev 1: use `u16::from(flags)` per the noodles convention
+        // (bismark-io read.rs:585, dedup pipeline.rs:1186).
+        let flags_bits: u16 = record.inner().flags().into();
+        if flags_bits & 0x1 != 0 {
+            state.cleanup_partial_outputs();
+            return Err(BismarkExtractorError::PhaseNotYetImplemented {
+                feature: "paired-end extraction (input has PAIRED flag set); \
+                          PE arrives in Phase C"
+                    .to_string(),
+            });
+        }
+
+        // Resolve chr name. bismark-io filters unmapped records (FLAG & 0x4)
+        // at the iterator layer, so mapped records normally always have a
+        // reference_sequence_id. Rev 2 (Reviewer A E2 / Reviewer B Err2):
+        // convert the previous `.expect()` to a typed `InternalError` for
+        // consistency with the dedup precedent and a graceful failure mode
+        // should the upstream invariant ever regress.
+        let refid = match record.inner().reference_sequence_id() {
+            Some(r) => r,
+            None => {
+                state.cleanup_partial_outputs();
+                return Err(BismarkExtractorError::InternalError {
+                    message: "mapped record has no reference_sequence_id; \
+                              bismark-io::records should have filtered this \
+                              as unmapped (FLAG & 0x4)"
+                        .to_string(),
+                });
+            }
+        };
+        let chr = match chr_table.get(refid) {
+            Some(name) => name.as_str(),
+            None => {
+                state.cleanup_partial_outputs();
+                return Err(BismarkExtractorError::InternalError {
+                    message: format!(
+                        "record refid {} out of range vs header (count {})",
+                        refid,
+                        chr_table.len()
+                    ),
+                });
+            }
+        };
+
+        let strand = record.record_strand();
+        let read_identity = ReadIdentity::from_flags(flags_bits);
+
+        let calls = match extract_calls(&record, config.ignore_5p_r1, config.ignore_3p_r1) {
+            Ok(c) => c,
+            Err(e) => {
+                state.cleanup_partial_outputs();
+                return Err(e);
+            }
+        };
+
+        for call in calls {
+            // Rev 2: `route_call` now returns `BismarkExtractorError` directly
+            // (was io::Error), which captures both write_call's IoWrite path
+            // and the (unreachable-in-practice) InternalError for missing
+            // OutputFileMap keys.
+            if let Err(err) = route_call(&mut state, &record, chr, strand, call, read_identity) {
+                state.cleanup_partial_outputs();
+                return Err(err);
+            }
+        }
+        state.report.records_processed = state.report.records_processed.saturating_add(1);
+    }
+
+    // Post-loop: no `cleanup_partial_outputs` on finalize failure — the data
+    // is already on disk, and the contract (state.rs::finalize doc) is that
+    // post-finalize errors don't trigger cleanup.
+    state.finalize(config)?;
+    Ok(())
+}

--- a/rust/bismark-extractor/src/route.rs
+++ b/rust/bismark-extractor/src/route.rs
@@ -1,0 +1,78 @@
+//! Per-call routing: M-bias accumulator → splitting-report counters →
+//! split-file write.
+//!
+//! Rev 1 ordering correction (from Reviewer B I4): the splitting-report
+//! counter increment must happen BEFORE the `mbias_only` short-circuit,
+//! not after — Perl accumulates counts even under `--mbias_only`. The SPEC
+//! §7.5 pseudocode has the ordering wrong; SPEC fix is queued as a separate
+//! task. Phase B locks the correct order here.
+
+use bismark_io::{BismarkRecord, BismarkStrand, ReadIdentity};
+
+use crate::call::{CytosineContext, MethCall};
+use crate::error::BismarkExtractorError;
+use crate::state::ExtractState;
+
+/// Route one extracted call.
+///
+/// Order:
+/// 1. Increment M-bias counter (unless `state.mbias_off`).
+/// 2. Increment splitting-report counters (unconditional — matches Perl).
+/// 3. If `state.mbias_only`: return early.
+/// 4. Write the split-file line.
+pub fn route_call(
+    state: &mut ExtractState,
+    record: &BismarkRecord,
+    chr: &str,
+    strand: BismarkStrand,
+    call: MethCall,
+    read_identity: ReadIdentity,
+) -> Result<(), BismarkExtractorError> {
+    // ── 1. M-bias accumulation ──
+    if !state.mbias_off {
+        let table_idx = match read_identity {
+            ReadIdentity::Single | ReadIdentity::R1 => 0,
+            ReadIdentity::R2 => 1,
+        };
+        // 1-based position for the M-bias table — matches the format
+        // `M-bias.txt` will emit in Phase D.
+        let pos_1based = call.read_pos.saturating_add(1);
+        state.mbias[table_idx].accumulate(call.context, pos_1based, call.methylated);
+    }
+
+    // ── 2. Splitting-report counters (unconditional, BEFORE mbias_only short-circuit) ──
+    state.report.calls_total = state.report.calls_total.saturating_add(1);
+    match (call.context, call.methylated) {
+        (CytosineContext::CpG, true) => {
+            state.report.calls_cpg_meth = state.report.calls_cpg_meth.saturating_add(1);
+        }
+        (CytosineContext::CpG, false) => {
+            state.report.calls_cpg_unmeth = state.report.calls_cpg_unmeth.saturating_add(1);
+        }
+        (CytosineContext::CHG, true) => {
+            state.report.calls_chg_meth = state.report.calls_chg_meth.saturating_add(1);
+        }
+        (CytosineContext::CHG, false) => {
+            state.report.calls_chg_unmeth = state.report.calls_chg_unmeth.saturating_add(1);
+        }
+        (CytosineContext::CHH, true) => {
+            state.report.calls_chh_meth = state.report.calls_chh_meth.saturating_add(1);
+        }
+        (CytosineContext::CHH, false) => {
+            state.report.calls_chh_unmeth = state.report.calls_chh_unmeth.saturating_add(1);
+        }
+    }
+
+    // ── 3. `--mbias_only` short-circuit (skips split-file write) ──
+    if state.mbias_only {
+        return Ok(());
+    }
+
+    // ── 4. Split-file write ──
+    let qname: &[u8] = match record.inner().name() {
+        Some(name) => name.as_ref(),
+        None => b"<unnamed>",
+    };
+    state.fhs.write_call(qname, chr, call, strand)?;
+    Ok(())
+}

--- a/rust/bismark-extractor/src/state.rs
+++ b/rust/bismark-extractor/src/state.rs
@@ -1,0 +1,98 @@
+//! Aggregated extraction state — file handles, M-bias counters, splitting
+//! report.
+//!
+//! Owned by the SE/PE pipeline; created at `extract_se` entry and dropped
+//! at exit. Per SPEC §6.1 + §6.3: per-call helpers receive `&mut ExtractState`
+//! rather than 14 positional args.
+
+use std::path::Path;
+
+use crate::cli::{OutputMode, ResolvedConfig};
+use crate::error::BismarkExtractorError;
+use crate::mbias::MbiasTable;
+use crate::output::{OutputFileMap, SplittingReport, write_splitting_report};
+
+/// Aggregated mutable state threaded through `route_call`.
+pub struct ExtractState {
+    /// Resolved output mode. Phase B always sees `Default` (main dispatch
+    /// rejects others); Phase E reads this field to pick between
+    /// `Comprehensive` / `MergeNonCpG` / `Yacht` / `MbiasOnly` routing.
+    #[allow(dead_code)]
+    pub mode: OutputMode,
+    /// `--mbias_off` — skip M-bias accumulation entirely.
+    pub mbias_off: bool,
+    /// `--mbias_only` — skip per-context split-file writes (Phase B always
+    /// false; main dispatch rejects `--mbias_only` until Phase E).
+    pub mbias_only: bool,
+    /// `[R1/SE, R2]` M-bias tables. Phase B only ever increments index 0;
+    /// Phase C starts populating index 1 for paired-end reads.
+    pub mbias: [MbiasTable; 2],
+    /// Eagerly-opened per-(context, strand) split files.
+    pub fhs: OutputFileMap,
+    /// Per-context counters for the splitting report.
+    pub report: SplittingReport,
+    /// Path of the input BAM/SAM/CRAM — needed for splitting-report header.
+    input_path: std::path::PathBuf,
+    /// Where to write `_splitting_report.txt`.
+    splitting_report_path: std::path::PathBuf,
+    /// Whether to emit the splitting report at finalize time.
+    emit_splitting_report: bool,
+}
+
+impl ExtractState {
+    /// Construct state for one input file. Eagerly opens all 12 split files
+    /// in `config.output_dir` (writing the version header line to each
+    /// unless `config.no_header`).
+    pub fn new(
+        config: &ResolvedConfig,
+        input_path: &Path,
+        input_basename: &str,
+    ) -> Result<Self, BismarkExtractorError> {
+        let fhs = OutputFileMap::new(&config.output_dir, input_basename, config.no_header)?;
+        let splitting_report_path = config
+            .output_dir
+            .join(format!("{input_basename}_splitting_report.txt"));
+        Ok(Self {
+            mode: config.output_mode,
+            mbias_off: config.mbias_off,
+            // Phase B never reaches `extract_se` with mbias_only set
+            // (main.rs::run rejects), but ExtractState carries the field
+            // for Phase E's route_call short-circuit pre-wiring.
+            mbias_only: false,
+            mbias: [MbiasTable::default(), MbiasTable::default()],
+            fhs,
+            report: SplittingReport::default(),
+            input_path: input_path.to_path_buf(),
+            splitting_report_path,
+            emit_splitting_report: config.emit_splitting_report,
+        })
+    }
+
+    /// Flush every split-file writer + emit the splitting report.
+    ///
+    /// **Invariant** (rev 1): `finalize` failure leaves the already-written
+    /// split files in place on disk. The caller does NOT invoke
+    /// `cleanup_partial_outputs` after a `finalize` failure — the records
+    /// had already been routed successfully; failure here means the report
+    /// write or final flush hit an I/O error after the data was on disk.
+    /// Matches Perl's "die after writing" semantics.
+    pub fn finalize(&mut self, config: &ResolvedConfig) -> Result<(), BismarkExtractorError> {
+        self.fhs.flush_all()?;
+        if self.emit_splitting_report {
+            write_splitting_report(
+                &self.splitting_report_path,
+                &self.input_path,
+                config,
+                &self.report,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Drop file handles + remove every partially-written split file. Called
+    /// from `extract_se`'s pre-finalize error paths. Best-effort; one removal
+    /// failure doesn't prevent the others.
+    pub fn cleanup_partial_outputs(&mut self) {
+        self.fhs.cleanup_all();
+    }
+}

--- a/rust/bismark-extractor/tests/sanity.rs
+++ b/rust/bismark-extractor/tests/sanity.rs
@@ -5,7 +5,6 @@
 //! + `--version` matches the provenance regex.
 
 use assert_cmd::Command;
-use predicates::prelude::*; // PredicateBooleanExt for `.and()`
 use predicates::str::is_match;
 
 #[test]
@@ -95,18 +94,7 @@ fn help_text_lists_all_35_flags() {
     }
 }
 
-/// Placeholder note from main.rs should appear when a real input is
-/// passed (validation passes but no pipeline exists yet).
-#[test]
-fn phase_a_placeholder_note_emitted_on_valid_invocation() {
-    // Create a temp file so the validate(..InputFileNotFound..) branch
-    // doesn't fire.
-    let tmp = tempfile::Builder::new().suffix(".bam").tempfile().unwrap();
-    std::fs::write(tmp.path(), b"x").unwrap();
-
-    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
-    cmd.arg(tmp.path()).assert().success().stderr(
-        predicates::str::contains("Phase A (scaffold + CLI)")
-            .and(predicates::str::contains("issues/798")),
-    );
-}
+// Phase A's `phase_a_placeholder_note_emitted_on_valid_invocation` test
+// was removed in Phase B — the placeholder stderr note no longer exists
+// because `main.rs::run` now dispatches to the real `extract_se` pipeline.
+// Phase B's end-to-end smoke test lives at `tests/se_phase_b_smoke.rs`.

--- a/rust/bismark-extractor/tests/se_phase_b.rs
+++ b/rust/bismark-extractor/tests/se_phase_b.rs
@@ -1,0 +1,951 @@
+//! Phase B unit tests — kernel + routing + output map + state machinery.
+//!
+//! Organisation mirrors the plan §7.1 test list, grouped by module under
+//! `#[cfg(test)] mod` blocks. Heavy synthetic-record construction sits in
+//! a `helpers` module shared by all groups.
+//!
+//! End-to-end smoke that runs the binary on a real BAM lives at
+//! `tests/se_phase_b_smoke.rs` (does not require Perl).
+
+// Test names intentionally mirror the SPEC §8.1 / plan §7.1 labels, which
+// embed uppercase XM byte names (`Z`, `X`, `H`, `R2`) for at-a-glance
+// mapping to the documented test surface.
+#![allow(non_snake_case)]
+
+use std::fs;
+use std::io::Read;
+
+use assert_cmd::Command;
+use bismark_extractor::call::{CytosineContext, MethCall, classify_xm_byte, extract_calls};
+use bismark_extractor::cli::{Cli, ResolvedConfig};
+use bismark_extractor::error::BismarkExtractorError;
+use bismark_extractor::header::build_chr_name_table;
+use bismark_extractor::mbias::{MbiasPos, MbiasTable};
+use bismark_extractor::output::{
+    BISMARK_VERSION, OutputFileMap, SPLIT_FILE_HEADER, SplittingReport, write_splitting_report,
+};
+use bismark_extractor::pipeline::derive_basename;
+use bismark_extractor::route::route_call;
+use bismark_extractor::state::ExtractState;
+use bismark_io::{BismarkStrand, ReadIdentity};
+use clap::Parser;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Test helpers — synthetic BismarkRecord construction
+// ─────────────────────────────────────────────────────────────────────────
+
+mod helpers {
+    use bismark_io::BismarkRecord;
+    use bstr::BString;
+    use noodles_sam::Header;
+    use noodles_sam::alignment::record::cigar::Op;
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    use noodles_sam::alignment::record::data::field::Tag;
+    use noodles_sam::alignment::record_buf::data::field::Value;
+    use noodles_sam::alignment::record_buf::{Cigar, RecordBuf, Sequence};
+    use noodles_sam::header::record::value::Map;
+    use noodles_sam::header::record::value::map::ReferenceSequence;
+    use std::num::NonZeroUsize;
+
+    /// Build a synthetic `BismarkRecord` with the given XR/XG/XM, sequence,
+    /// alignment_start (1-based), and CIGAR ops. FLAG defaults to 0
+    /// (single-end, mapped, plus-strand) unless overridden.
+    #[allow(clippy::too_many_arguments)]
+    pub fn synth(
+        xr: &[u8],
+        xg: &[u8],
+        xm: &[u8],
+        seq: &[u8],
+        alignment_start: usize,
+        cigar_ops: &[(Kind, usize)],
+        flags: u16,
+        qname: &[u8],
+        refid: usize,
+    ) -> BismarkRecord {
+        use noodles_core::Position;
+        use noodles_sam::alignment::record::Flags;
+        let mut record = RecordBuf::default();
+        *record.flags_mut() = Flags::from(flags);
+        *record.sequence_mut() = Sequence::from(seq.to_vec());
+        *record.alignment_start_mut() = Some(Position::try_from(alignment_start).unwrap());
+        *record.reference_sequence_id_mut() = Some(refid);
+        *record.cigar_mut() = Cigar::from(
+            cigar_ops
+                .iter()
+                .map(|(k, n)| Op::new(*k, *n))
+                .collect::<Vec<_>>(),
+        );
+        *record.name_mut() = Some(BString::from(qname.to_vec()));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XR"), Value::String(BString::from(xr.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XM"), Value::String(BString::from(xm.to_vec())));
+        BismarkRecord::from_noodles_record(record).expect("synth produces a valid BismarkRecord")
+    }
+
+    /// Most-common SE OT record builder for tests that don't care about FLAG/QNAME.
+    pub fn ot_record(xm: &[u8], seq: &[u8]) -> BismarkRecord {
+        synth(
+            b"CT",
+            b"CT",
+            xm,
+            seq,
+            100,
+            &[(Kind::Match, xm.len())],
+            0,
+            b"read1",
+            0,
+        )
+    }
+
+    /// OB pair-strand SE record. Used for the orientation-invariant test.
+    pub fn ob_record(xm: &[u8], seq: &[u8]) -> BismarkRecord {
+        synth(
+            b"CT",
+            b"GA",
+            xm,
+            seq,
+            100,
+            &[(Kind::Match, xm.len())],
+            0,
+            b"read1",
+            0,
+        )
+    }
+
+    /// Build a header containing a single @SQ named `name` (with length 1000),
+    /// so `reference_sequence_id == 0` resolves to `name`.
+    pub fn header_with_single_chr(name: &str) -> Header {
+        let mut header = Header::default();
+        header.reference_sequences_mut().insert(
+            BString::from(name.as_bytes().to_vec()),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(1000).unwrap()),
+        );
+        header
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. classify_xm_byte tests
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn classify_xm_byte_classifies_all_six_methylation_bytes() {
+    use bismark_extractor::call::XmClassification;
+    for (byte, expected_ctx, expected_meth) in [
+        (b'Z', CytosineContext::CpG, true),
+        (b'z', CytosineContext::CpG, false),
+        (b'X', CytosineContext::CHG, true),
+        (b'x', CytosineContext::CHG, false),
+        (b'H', CytosineContext::CHH, true),
+        (b'h', CytosineContext::CHH, false),
+    ] {
+        match classify_xm_byte(byte, 1, "r").unwrap() {
+            XmClassification::Call(ctx, meth) => {
+                assert_eq!(ctx, expected_ctx, "byte {}", byte as char);
+                assert_eq!(meth, expected_meth, "byte {}", byte as char);
+            }
+            _ => panic!("byte {} should classify as Call", byte as char),
+        }
+    }
+}
+
+#[test]
+fn classify_xm_byte_skips_U_u_dot() {
+    use bismark_extractor::call::XmClassification;
+    for byte in [b'U', b'u'] {
+        assert!(matches!(
+            classify_xm_byte(byte, 1, "r").unwrap(),
+            XmClassification::SkipUnknownContext
+        ));
+    }
+    assert!(matches!(
+        classify_xm_byte(b'.', 1, "r").unwrap(),
+        XmClassification::SkipNonCytosine
+    ));
+}
+
+#[test]
+fn classify_xm_byte_rejects_invalid() {
+    let err = classify_xm_byte(b'Q', 42, "myread").unwrap_err();
+    match err {
+        BismarkExtractorError::InvalidXmByte {
+            byte,
+            byte_char,
+            ref_pos,
+            read_id,
+        } => {
+            assert_eq!(byte, b'Q');
+            assert_eq!(byte_char, 'Q');
+            assert_eq!(ref_pos, 42);
+            assert_eq!(read_id, "myread");
+        }
+        _ => panic!("expected InvalidXmByte"),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. extract_calls tests
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn extract_calls_classifies_all_six_methylation_bytes() {
+    // 6-base read on OT strand with all 6 methylation bytes in order.
+    let record = helpers::ot_record(b"ZzXxHh", b"ACGTAC");
+    let calls = extract_calls(&record, 0, 0).unwrap();
+    assert_eq!(calls.len(), 6);
+    assert_eq!(calls[0].xm_byte, b'Z');
+    assert_eq!(calls[0].context, CytosineContext::CpG);
+    assert!(calls[0].methylated);
+    assert_eq!(calls[5].xm_byte, b'h');
+    assert_eq!(calls[5].context, CytosineContext::CHH);
+    assert!(!calls[5].methylated);
+}
+
+#[test]
+fn extract_calls_respects_ignore_5p() {
+    let record = helpers::ot_record(b"ZzXxHh", b"ACGTAC");
+    let calls = extract_calls(&record, /*ignore_5p=*/ 3, 0).unwrap();
+    // First 3 positions skipped → 3 calls remain (positions 3,4,5)
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0].read_pos, 3);
+    assert_eq!(calls[0].xm_byte, b'x');
+}
+
+#[test]
+fn extract_calls_respects_ignore_3p() {
+    let record = helpers::ot_record(b"ZzXxHh", b"ACGTAC");
+    let calls = extract_calls(&record, 0, /*ignore_3p=*/ 3).unwrap();
+    // Last 3 positions skipped → 3 calls remain (positions 0,1,2)
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[2].read_pos, 2);
+    assert_eq!(calls[2].xm_byte, b'X');
+}
+
+#[test]
+fn extract_calls_walks_cigar_with_indels() {
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    // 5M2D5M — read 10 bases, ref 12 bases (deletion advances ref only).
+    let record = helpers::synth(
+        b"CT",
+        b"CT",
+        b"ZZZZZZZZZZ",
+        b"AAAAAAAAAA",
+        100,
+        &[(Kind::Match, 5), (Kind::Deletion, 2), (Kind::Match, 5)],
+        0,
+        b"r",
+        0,
+    );
+    let calls = extract_calls(&record, 0, 0).unwrap();
+    assert_eq!(calls.len(), 10);
+    assert_eq!(calls[4].ref_pos, 104);
+    // Position 5 of the read jumps to ref_pos 107 (deletion-skip).
+    assert_eq!(calls[5].read_pos, 5);
+    assert_eq!(calls[5].ref_pos, 107);
+}
+
+#[test]
+fn extract_calls_walks_cigar_with_soft_clips() {
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    // 2S8M — first 2 read positions are soft-clipped; emitted calls start
+    // at read_pos == 2 (rev 1 invariant: iter_aligned counts soft-clip
+    // positions in read_pos).
+    let record = helpers::synth(
+        b"CT",
+        b"CT",
+        b"..ZZZZZZZZ", // 10 XM bytes; first 2 are `.` (Bismark convention for soft-clip)
+        b"AAAAAAAAAA",
+        100,
+        &[(Kind::SoftClip, 2), (Kind::Match, 8)],
+        0,
+        b"r",
+        0,
+    );
+    let calls = extract_calls(&record, 0, 0).unwrap();
+    // 8 aligned positions emitted (soft-clip filtered by iter_aligned).
+    assert_eq!(calls.len(), 8);
+    // First emitted call's read_pos == 2, NOT 0 (rev 1 correction).
+    assert_eq!(calls[0].read_pos, 2);
+    assert_eq!(calls[0].ref_pos, 100);
+}
+
+#[test]
+fn extract_calls_empty_xm_yields_empty_vec() {
+    let record = helpers::ot_record(b"......", b"ACGTAC");
+    let calls = extract_calls(&record, 0, 0).unwrap();
+    assert!(calls.is_empty());
+}
+
+#[test]
+fn extract_calls_minus_strand_orients_5prime() {
+    // OB strand record. `iter_aligned` reverses XM iteration so the first
+    // emitted (read_pos_5p=0) call corresponds to the LAST BAM-stored byte.
+    // Critical orientation invariant: flipping this corrupts every `-` strand
+    // record's M-bias positions end-to-end.
+    //
+    // Fixture: XM `....Z` (BAM-stored position 4 = 'Z'). On OB strand the
+    // first emitted call should have read_pos_5p=0 with xm_byte='Z'.
+    let record = helpers::ob_record(b"....Z", b"ACGTC");
+    let calls = extract_calls(&record, 0, 0).unwrap();
+    assert_eq!(calls.len(), 1, "only one methylation byte in fixture");
+    assert_eq!(calls[0].read_pos, 0, "5'-end of sequenced read");
+    assert_eq!(calls[0].xm_byte, b'Z');
+    // Ref position is alignment_start + 4 (BAM read_pos 4 maps to ref 104).
+    assert_eq!(calls[0].ref_pos, 104);
+}
+
+#[test]
+fn extract_calls_minus_strand_orients_both_calls() {
+    // Stronger orientation check: BAM-stored XM `Zh...` on OB strand.
+    // After 5'-orientation, emission order is `.`, `.`, `.`, h, Z.
+    // (Non-call bytes skipped.) Two calls expected: at read_pos_5p=3 (h, CHH-unmeth)
+    // and read_pos_5p=4 (Z, CpG-meth).
+    let record = helpers::ob_record(b"Zh...", b"ACGTC");
+    let calls = extract_calls(&record, 0, 0).unwrap();
+    assert_eq!(calls.len(), 2);
+    // First call in 5'-order corresponds to BAM-stored position 1 ('h').
+    assert_eq!(calls[0].read_pos, 3);
+    assert_eq!(calls[0].xm_byte, b'h');
+    assert_eq!(calls[0].context, CytosineContext::CHH);
+    assert!(!calls[0].methylated);
+    // Second call corresponds to BAM-stored position 0 ('Z').
+    assert_eq!(calls[1].read_pos, 4);
+    assert_eq!(calls[1].xm_byte, b'Z');
+    assert_eq!(calls[1].context, CytosineContext::CpG);
+    assert!(calls[1].methylated);
+}
+
+#[test]
+fn extract_calls_rejects_invalid_xm_byte_with_error() {
+    let record = helpers::ot_record(b"ZzQXx.", b"ACGTAC");
+    let err = extract_calls(&record, 0, 0).unwrap_err();
+    match err {
+        BismarkExtractorError::InvalidXmByte {
+            byte, byte_char, ..
+        } => {
+            assert_eq!(byte, b'Q');
+            assert_eq!(byte_char, 'Q');
+        }
+        _ => panic!("expected InvalidXmByte"),
+    }
+}
+
+#[test]
+fn extract_calls_ignore_larger_than_seq_returns_empty() {
+    let record = helpers::ot_record(b"ZzXxHh", b"ACGTAC");
+    let calls = extract_calls(&record, 100, 0).unwrap();
+    assert!(calls.is_empty());
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 3. MbiasTable tests
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn mbias_accumulate_increments_meth_for_Z() {
+    let mut t = MbiasTable::default();
+    t.accumulate(CytosineContext::CpG, 5, true);
+    assert_eq!(t.cpg.get(5), Some(&MbiasPos { meth: 1, unmeth: 0 }));
+}
+
+#[test]
+fn mbias_accumulate_increments_unmeth_for_z() {
+    let mut t = MbiasTable::default();
+    t.accumulate(CytosineContext::CpG, 5, false);
+    assert_eq!(t.cpg.get(5), Some(&MbiasPos { meth: 0, unmeth: 1 }));
+}
+
+#[test]
+fn mbias_accumulate_routes_to_chg_for_X() {
+    let mut t = MbiasTable::default();
+    t.accumulate(CytosineContext::CHG, 7, true);
+    assert_eq!(t.chg.get(7), Some(&MbiasPos { meth: 1, unmeth: 0 }));
+    assert_eq!(
+        t.cpg.get(7).cloned().unwrap_or_default(),
+        MbiasPos::default()
+    );
+}
+
+#[test]
+fn mbias_accumulate_routes_to_chg_for_x() {
+    let mut t = MbiasTable::default();
+    t.accumulate(CytosineContext::CHG, 7, false);
+    assert_eq!(t.chg.get(7), Some(&MbiasPos { meth: 0, unmeth: 1 }));
+}
+
+#[test]
+fn mbias_accumulate_routes_to_chh_for_H() {
+    let mut t = MbiasTable::default();
+    t.accumulate(CytosineContext::CHH, 9, true);
+    assert_eq!(t.chh.get(9), Some(&MbiasPos { meth: 1, unmeth: 0 }));
+}
+
+#[test]
+fn mbias_accumulate_routes_to_chh_for_h() {
+    let mut t = MbiasTable::default();
+    t.accumulate(CytosineContext::CHH, 9, false);
+    assert_eq!(t.chh.get(9), Some(&MbiasPos { meth: 0, unmeth: 1 }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 4. OutputFileMap eager-open tests
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn output_file_map_eagerly_creates_all_strand_files_for_default_mode() {
+    let dir = tempfile::tempdir().unwrap();
+    let _map = OutputFileMap::new(dir.path(), "myinput", /*no_header=*/ false).unwrap();
+    drop(_map); // flush BufWriters via Drop
+
+    let expected = [
+        "CpG_OT_myinput.txt",
+        "CpG_CTOT_myinput.txt",
+        "CpG_CTOB_myinput.txt",
+        "CpG_OB_myinput.txt",
+        "CHG_OT_myinput.txt",
+        "CHG_CTOT_myinput.txt",
+        "CHG_CTOB_myinput.txt",
+        "CHG_OB_myinput.txt",
+        "CHH_OT_myinput.txt",
+        "CHH_CTOT_myinput.txt",
+        "CHH_CTOB_myinput.txt",
+        "CHH_OB_myinput.txt",
+    ];
+    for name in expected {
+        let path = dir.path().join(name);
+        assert!(path.exists(), "expected {} to exist", path.display());
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, SPLIT_FILE_HEADER, "header content for {}", name);
+    }
+}
+
+#[test]
+fn output_file_map_omits_header_when_no_header_true() {
+    let dir = tempfile::tempdir().unwrap();
+    let _map = OutputFileMap::new(dir.path(), "x", /*no_header=*/ true).unwrap();
+    drop(_map);
+    let path = dir.path().join("CpG_OT_x.txt");
+    let content = fs::read_to_string(&path).unwrap();
+    assert!(
+        content.is_empty(),
+        "no-header mode should produce empty file"
+    );
+}
+
+#[test]
+fn output_file_header_matches_perl_format() {
+    // The literal Perl header bytes — byte-identity-critical (Phase H gate).
+    assert_eq!(
+        SPLIT_FILE_HEADER, "Bismark methylation extractor version v0.25.1\n",
+        "header drift would break Phase H byte-identity"
+    );
+    assert_eq!(BISMARK_VERSION, "v0.25.1");
+
+    // And verify it actually reaches disk.
+    let dir = tempfile::tempdir().unwrap();
+    let _map = OutputFileMap::new(dir.path(), "x", false).unwrap();
+    drop(_map);
+    let mut content = String::new();
+    fs::File::open(dir.path().join("CpG_OT_x.txt"))
+        .unwrap()
+        .read_to_string(&mut content)
+        .unwrap();
+    assert_eq!(content, "Bismark methylation extractor version v0.25.1\n");
+}
+
+#[test]
+fn output_file_map_creates_output_dir_if_missing() {
+    let parent = tempfile::tempdir().unwrap();
+    let nested = parent.path().join("does/not/exist/yet");
+    assert!(!nested.exists());
+    let _map = OutputFileMap::new(&nested, "x", false).unwrap();
+    assert!(
+        nested.exists(),
+        "OutputFileMap::new should create output_dir"
+    );
+    assert!(nested.join("CpG_OT_x.txt").exists());
+}
+
+#[test]
+fn output_file_map_write_call_appends_after_header() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut map = OutputFileMap::new(dir.path(), "x", false).unwrap();
+    let call = MethCall {
+        ref_pos: 200,
+        read_pos: 5,
+        context: CytosineContext::CpG,
+        methylated: true,
+        xm_byte: b'Z',
+    };
+    map.write_call(b"read1", "chr1", call, BismarkStrand::OT)
+        .unwrap();
+    map.flush_all().unwrap();
+    drop(map);
+    let content = fs::read_to_string(dir.path().join("CpG_OT_x.txt")).unwrap();
+    let expected = format!("{}read1\t+\tchr1\t200\tZ\n", SPLIT_FILE_HEADER);
+    assert_eq!(content, expected);
+}
+
+#[test]
+fn format_meth_line_exact_bytes_for_unmethylated() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut map = OutputFileMap::new(dir.path(), "x", /*no_header=*/ true).unwrap();
+    let call = MethCall {
+        ref_pos: 42,
+        read_pos: 0,
+        context: CytosineContext::CHH,
+        methylated: false,
+        xm_byte: b'h',
+    };
+    map.write_call(b"r1", "1", call, BismarkStrand::CTOT)
+        .unwrap();
+    map.flush_all().unwrap();
+    drop(map);
+    let content = fs::read_to_string(dir.path().join("CHH_CTOT_x.txt")).unwrap();
+    assert_eq!(content, "r1\t-\t1\t42\th\n");
+}
+
+#[test]
+fn cleanup_partial_outputs_removes_all_12_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut map = OutputFileMap::new(dir.path(), "x", false).unwrap();
+    // Confirm 12 files exist pre-cleanup.
+    let count_before = fs::read_dir(dir.path()).unwrap().count();
+    assert_eq!(count_before, 12);
+    map.cleanup_all();
+    let count_after = fs::read_dir(dir.path()).unwrap().count();
+    assert_eq!(count_after, 0, "all 12 files should be removed");
+}
+
+#[test]
+fn cleanup_partial_outputs_continues_past_one_failure() {
+    // Rev 2 (Reviewer A S1 / Reviewer B L3 / plan-manager T-27): locks the
+    // best-effort cleanup contract — one `remove_file` failure must not
+    // prevent the other 11 from being removed.
+    //
+    // Trigger: pre-delete one of the 12 files out from under the OutputFileMap
+    // so its eventual `remove_file` call returns `NotFound`. The map's
+    // `cleanup_all` should iterate past that error and successfully remove
+    // the remaining 11.
+    let dir = tempfile::tempdir().unwrap();
+    let mut map = OutputFileMap::new(dir.path(), "x", false).unwrap();
+
+    // Pre-delete CpG_CTOT (a directional-library "always 0-byte" file).
+    let pre_deleted = dir.path().join("CpG_CTOT_x.txt");
+    fs::remove_file(&pre_deleted).unwrap();
+    assert!(
+        !pre_deleted.exists(),
+        "pre-condition: file deleted out-of-band"
+    );
+
+    // 11 files left on disk; map still holds all 12 entries.
+    let before = fs::read_dir(dir.path()).unwrap().count();
+    assert_eq!(before, 11);
+
+    // cleanup_all should not panic on the missing-file branch (eprintln only)
+    // and should remove the other 11.
+    map.cleanup_all();
+
+    let after = fs::read_dir(dir.path()).unwrap().count();
+    assert_eq!(
+        after, 0,
+        "11 remaining files should all be removed even though 1 was pre-deleted"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 5. SplittingReport tests
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn splitting_report_percentage_handles_zero_denominator() {
+    // Empty context (no calls) → 0.00, not NaN, not panic.
+    let pct = SplittingReport::percent_meth(0, 0);
+    assert_eq!(pct, 0.0);
+}
+
+#[test]
+fn splitting_report_percentage_for_50_50() {
+    let pct = SplittingReport::percent_meth(50, 50);
+    assert_eq!(pct, 50.0);
+}
+
+#[test]
+fn splitting_report_emits_per_context_counts() {
+    let dir = tempfile::tempdir().unwrap();
+    let report_path = dir.path().join("test_splitting_report.txt");
+    let input_path = std::path::PathBuf::from("/some/input.bam");
+    let cli = Cli::try_parse_from(["bismark-methylation-extractor-rs", "/tmp/x.bam"]).unwrap();
+    let config = cli.validate().unwrap_or_else(|_| {
+        // Validate fails because /tmp/x.bam doesn't exist, but we want a config.
+        // Re-issue with a real temp file.
+        let tmp = tempfile::Builder::new().suffix(".bam").tempfile().unwrap();
+        std::fs::write(tmp.path(), b"x").unwrap();
+        let cli = Cli::try_parse_from([
+            "bismark-methylation-extractor-rs",
+            tmp.path().to_str().unwrap(),
+        ])
+        .unwrap();
+        // Leak the tempfile so it isn't deleted while config holds the path.
+        let _ = tmp.into_temp_path().keep().unwrap();
+        cli.validate().unwrap()
+    });
+    let report = SplittingReport {
+        records_processed: 100,
+        calls_total: 600,
+        calls_cpg_meth: 50,
+        calls_cpg_unmeth: 50,
+        calls_chg_meth: 100,
+        calls_chg_unmeth: 0,
+        calls_chh_meth: 0,
+        calls_chh_unmeth: 400,
+    };
+    write_splitting_report(&report_path, &input_path, &config, &report).unwrap();
+    let content = fs::read_to_string(&report_path).unwrap();
+    assert!(content.contains("Processed 100 reads in total"));
+    assert!(content.contains("Total methylated C's in CpG context:\t50"));
+    assert!(content.contains("Total unmethylated C's in CHH context:\t400"));
+    assert!(content.contains("C methylated in CpG context:\t50.00%"));
+    assert!(content.contains("C methylated in CHG context:\t100.00%"));
+    assert!(content.contains("C methylated in CHH context:\t0.00%"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 6. route_call tests
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Helper: minimal valid `ResolvedConfig` for state construction in tests.
+fn test_config(output_dir: &std::path::Path) -> ResolvedConfig {
+    let tmp = tempfile::Builder::new().suffix(".bam").tempfile().unwrap();
+    std::fs::write(tmp.path(), b"x").unwrap();
+    let tmp_path = tmp.into_temp_path();
+    let path_str = tmp_path.to_str().unwrap().to_string();
+    let _ = tmp_path.keep().unwrap(); // leak so path remains valid
+
+    let cli = Cli::try_parse_from([
+        "bismark-methylation-extractor-rs",
+        &path_str,
+        "--output_dir",
+        output_dir.to_str().unwrap(),
+    ])
+    .unwrap();
+    cli.validate().expect("validate test config")
+}
+
+#[test]
+fn route_call_default_mode_routes_to_strand_specific_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let mut state = ExtractState::new(&config, std::path::Path::new("/tmp/x.bam"), "x").unwrap();
+    let record = helpers::ot_record(b"Z....", b"ACGTC");
+    let call = MethCall {
+        ref_pos: 100,
+        read_pos: 0,
+        context: CytosineContext::CpG,
+        methylated: true,
+        xm_byte: b'Z',
+    };
+    route_call(
+        &mut state,
+        &record,
+        "chr1",
+        BismarkStrand::OT,
+        call,
+        ReadIdentity::Single,
+    )
+    .unwrap();
+    state.fhs.flush_all().unwrap();
+
+    let cpg_ot = fs::read_to_string(dir.path().join("CpG_OT_x.txt")).unwrap();
+    assert!(cpg_ot.ends_with("read1\t+\tchr1\t100\tZ\n"));
+    // CpG_CTOT still only contains the header line (no call routed there).
+    let cpg_ctot = fs::read_to_string(dir.path().join("CpG_CTOT_x.txt")).unwrap();
+    assert_eq!(cpg_ctot, SPLIT_FILE_HEADER);
+}
+
+#[test]
+fn route_single_record_with_mixed_contexts_routes_to_one_strand_directory() {
+    // Closes Alan Hoyle's "one record split across multiple strand files" bug
+    // at unit-test level: a record on OT strand with calls in all 3 contexts
+    // must produce non-header content in CpG_OT, CHG_OT, CHH_OT only — not in
+    // any CTOT/CTOB/OB file.
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let mut state = ExtractState::new(&config, std::path::Path::new("/tmp/x.bam"), "x").unwrap();
+    let record = helpers::ot_record(b"ZXH..", b"ACGTC");
+
+    for call in extract_calls(&record, 0, 0).unwrap() {
+        route_call(
+            &mut state,
+            &record,
+            "chr1",
+            BismarkStrand::OT,
+            call,
+            ReadIdentity::Single,
+        )
+        .unwrap();
+    }
+    state.fhs.flush_all().unwrap();
+
+    // OT files for each context should have an extra line beyond the header.
+    for ctx in ["CpG", "CHG", "CHH"] {
+        let ot_path = dir.path().join(format!("{}_OT_x.txt", ctx));
+        let content = fs::read_to_string(&ot_path).unwrap();
+        assert!(
+            content.lines().count() == 2,
+            "{}_OT_x.txt should have header + 1 call line; got: {:?}",
+            ctx,
+            content
+        );
+    }
+    // CTOT/CTOB/OB files for all 3 contexts should contain only the header.
+    for ctx in ["CpG", "CHG", "CHH"] {
+        for strand in ["CTOT", "CTOB", "OB"] {
+            let p = dir.path().join(format!("{}_{}_x.txt", ctx, strand));
+            let content = fs::read_to_string(&p).unwrap();
+            assert_eq!(
+                content, SPLIT_FILE_HEADER,
+                "{}_{}_x.txt should only contain the header",
+                ctx, strand
+            );
+        }
+    }
+}
+
+#[test]
+fn route_call_increments_counter_before_mbias_only_short_circuit() {
+    // Rev 1 (Reviewer B I4): under --mbias_only, Perl still accumulates
+    // splitting-report counters. We force `state.mbias_only = true` in this
+    // test (even though Phase B's main dispatch rejects --mbias_only) and
+    // verify counters still tick.
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let mut state = ExtractState::new(&config, std::path::Path::new("/tmp/x.bam"), "x").unwrap();
+    state.mbias_only = true; // force the short-circuit branch
+    let record = helpers::ot_record(b"Z....", b"ACGTC");
+    let call = MethCall {
+        ref_pos: 100,
+        read_pos: 0,
+        context: CytosineContext::CpG,
+        methylated: true,
+        xm_byte: b'Z',
+    };
+    route_call(
+        &mut state,
+        &record,
+        "chr1",
+        BismarkStrand::OT,
+        call,
+        ReadIdentity::Single,
+    )
+    .unwrap();
+    // Counter must have incremented EVEN THOUGH the file write was short-circuited.
+    assert_eq!(state.report.calls_total, 1);
+    assert_eq!(state.report.calls_cpg_meth, 1);
+    // Verify the split-file write was indeed skipped (file still header-only).
+    state.fhs.flush_all().unwrap();
+    let cpg_ot = fs::read_to_string(dir.path().join("CpG_OT_x.txt")).unwrap();
+    assert_eq!(
+        cpg_ot, SPLIT_FILE_HEADER,
+        "write should have been short-circuited"
+    );
+}
+
+#[test]
+fn route_call_r2_goes_to_mbias_index_1() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let mut state = ExtractState::new(&config, std::path::Path::new("/tmp/x.bam"), "x").unwrap();
+    let record = helpers::ot_record(b"Z....", b"ACGTC");
+    let call = MethCall {
+        ref_pos: 100,
+        read_pos: 5,
+        context: CytosineContext::CpG,
+        methylated: true,
+        xm_byte: b'Z',
+    };
+    route_call(
+        &mut state,
+        &record,
+        "chr1",
+        BismarkStrand::OT,
+        call,
+        ReadIdentity::R2,
+    )
+    .unwrap();
+    // 1-based position 6 in mbias[1].cpg should now be (meth=1, unmeth=0).
+    let cell = state.mbias[1].cpg.get(6).copied().unwrap_or_default();
+    assert_eq!(cell, MbiasPos { meth: 1, unmeth: 0 });
+    // mbias[0] (R1/SE) should remain empty for this position.
+    let cell_r1 = state.mbias[0].cpg.get(6).copied().unwrap_or_default();
+    assert_eq!(cell_r1, MbiasPos::default());
+}
+
+#[test]
+fn mbias_R2_index_ready() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let state = ExtractState::new(&config, std::path::Path::new("/tmp/x.bam"), "x").unwrap();
+    // mbias is [MbiasTable; 2] — both indices exist after construction.
+    assert_eq!(state.mbias[0].cpg.len(), 0);
+    assert_eq!(state.mbias[1].cpg.len(), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 7. header / chr-name table tests
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn build_chr_name_table_returns_ascii_names_in_order() {
+    let mut header = helpers::header_with_single_chr("chr1");
+    use noodles_sam::header::record::value::Map;
+    use noodles_sam::header::record::value::map::ReferenceSequence;
+    use std::num::NonZeroUsize;
+    header.reference_sequences_mut().insert(
+        bstr::BString::from(b"chr2".to_vec()),
+        Map::<ReferenceSequence>::new(NonZeroUsize::new(2000).unwrap()),
+    );
+    let table = build_chr_name_table(&header).unwrap();
+    assert_eq!(table, vec!["chr1".to_string(), "chr2".to_string()]);
+}
+
+#[test]
+fn build_chr_name_table_rejects_non_ascii() {
+    use noodles_sam::Header;
+    use noodles_sam::header::record::value::Map;
+    use noodles_sam::header::record::value::map::ReferenceSequence;
+    use std::num::NonZeroUsize;
+    let mut header = Header::default();
+    // Non-ASCII chr name (UTF-8 bytes for "chr_α").
+    let non_ascii = b"chr_\xce\xb1";
+    header.reference_sequences_mut().insert(
+        bstr::BString::from(non_ascii.to_vec()),
+        Map::<ReferenceSequence>::new(NonZeroUsize::new(1000).unwrap()),
+    );
+    let err = build_chr_name_table(&header).unwrap_err();
+    assert!(matches!(
+        err,
+        BismarkExtractorError::NonAsciiChromosomeName { .. }
+    ));
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 8. derive_basename tests
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn derive_basename_strips_known_suffixes() {
+    use std::path::Path;
+    assert_eq!(derive_basename(Path::new("a.bam")), "a");
+    assert_eq!(derive_basename(Path::new("a.sam")), "a");
+    assert_eq!(derive_basename(Path::new("a.cram")), "a");
+    // No suffix: leave as-is.
+    assert_eq!(derive_basename(Path::new("a")), "a");
+    // Case-sensitive (Perl `s/bam$/txt/` doesn't match uppercase).
+    assert_eq!(derive_basename(Path::new("a.BAM")), "a.BAM");
+    // Compound suffix: only strip the LAST single extension. Per Perl,
+    // `a.bam.gz` does NOT match `s/bam$/txt/` because the suffix is `.gz`.
+    assert_eq!(derive_basename(Path::new("a.bam.gz")), "a.bam.gz");
+    // Directory components: only basename matters.
+    assert_eq!(derive_basename(Path::new("/path/to/sample.bam")), "sample");
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 9. main.rs phase-gate dispatch tests
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Helper: build a tempfile with a `.bam` suffix that passes `Cli::validate`'s
+/// file-existence check (won't be opened as a real BAM — phase-gate fires first).
+fn tempbam() -> tempfile::NamedTempFile {
+    let f = tempfile::Builder::new()
+        .suffix(".bam")
+        .tempfile()
+        .expect("tempfile");
+    std::fs::write(f.path(), b"x").expect("write tempfile");
+    f
+}
+
+#[test]
+fn main_rejects_paired_end_with_phase_error() {
+    let bam = tempbam();
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(bam.path())
+        .arg("--paired-end")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "paired-end extraction; arrives in Phase C",
+        ));
+}
+
+#[test]
+fn main_rejects_multiple_input_files() {
+    let bam1 = tempbam();
+    let bam2 = tempbam();
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(bam1.path())
+        .arg(bam2.path())
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("multiple input files"));
+}
+
+#[test]
+fn main_rejects_multicore_with_phase_error() {
+    let bam = tempbam();
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(bam.path())
+        .arg("--parallel")
+        .arg("4")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--parallel 4"));
+}
+
+#[test]
+fn main_rejects_gzip_with_phase_error() {
+    let bam = tempbam();
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(bam.path())
+        .arg("--gzip")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--gzip; arrives in Phase E"));
+}
+
+#[test]
+fn main_rejects_comprehensive_with_phase_error() {
+    let bam = tempbam();
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(bam.path())
+        .arg("--comprehensive")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Phase E"));
+}
+
+#[test]
+fn main_rejects_bedgraph_with_phase_error() {
+    let bam = tempbam();
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(bam.path())
+        .arg("--bedGraph")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "--bedGraph / --cytosine_report subprocess chain; arrives in Phase G",
+        ));
+}
+
+// Note: `extract_se_rejects_record_with_paired_flag_set` requires a real
+// BAM to drive through `open_reader → records()`. Implemented in
+// `tests/se_phase_b_smoke.rs` where the BAM-construction harness lives.
+
+// Note: `output_mode_default` is implicitly tested by the absence of a
+// phase-gate failure in `tests/se_phase_b_smoke.rs` (which uses default mode).

--- a/rust/bismark-extractor/tests/se_phase_b_smoke.rs
+++ b/rust/bismark-extractor/tests/se_phase_b_smoke.rs
@@ -1,0 +1,327 @@
+//! End-to-end Phase B smoke test.
+//!
+//! Builds a synthetic SE BAM in-test (no Perl toolchain required), runs the
+//! `bismark-methylation-extractor-rs` binary on it, and asserts:
+//! - exit code 0,
+//! - all 12 split files present,
+//! - each split file's first line is the Perl version header,
+//! - at least one of `{CpG,CHG,CHH}_OT_*.txt` has a content line beyond the
+//!   header (records actually routed),
+//! - `_splitting_report.txt` exists and contains expected substrings.
+//!
+//! Per plan rev 1 (Reviewer B I5): byte-equality of split files vs a Perl
+//! baseline is Phase H. Phase B's smoke gates "binary runs end-to-end and
+//! produces output" — a wide bug-class catcher without toolchain dependency.
+
+use std::fs;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use bismark_io::{BamWriter, BismarkRecord};
+use bstr::BString;
+use noodles_core::Position;
+use noodles_sam::Header;
+use noodles_sam::alignment::record::Flags;
+use noodles_sam::alignment::record::cigar::Op;
+use noodles_sam::alignment::record::cigar::op::Kind;
+use noodles_sam::alignment::record::data::field::Tag;
+use noodles_sam::alignment::record_buf::data::field::Value;
+use noodles_sam::alignment::record_buf::{Cigar, RecordBuf, Sequence};
+use noodles_sam::header::record::value::Map;
+use noodles_sam::header::record::value::map::ReferenceSequence;
+use std::num::NonZeroUsize;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Synthetic BAM helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+fn header_with_chr1() -> Header {
+    let mut header = Header::default();
+    header.reference_sequences_mut().insert(
+        BString::from(b"chr1".to_vec()),
+        Map::<ReferenceSequence>::new(NonZeroUsize::new(10_000).unwrap()),
+    );
+    header
+}
+
+fn synth_record(
+    qname: &[u8],
+    xr: &[u8],
+    xg: &[u8],
+    xm: &[u8],
+    seq: &[u8],
+    alignment_start: usize,
+    flags: u16,
+) -> BismarkRecord {
+    let mut record = RecordBuf::default();
+    *record.flags_mut() = Flags::from(flags);
+    *record.sequence_mut() = Sequence::from(seq.to_vec());
+    *record.alignment_start_mut() = Some(Position::try_from(alignment_start).unwrap());
+    *record.reference_sequence_id_mut() = Some(0); // chr1
+    *record.cigar_mut() = Cigar::from(vec![Op::new(Kind::Match, xm.len())]);
+    *record.name_mut() = Some(BString::from(qname.to_vec()));
+    record
+        .data_mut()
+        .insert(Tag::from(*b"XR"), Value::String(BString::from(xr.to_vec())));
+    record
+        .data_mut()
+        .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
+    record
+        .data_mut()
+        .insert(Tag::from(*b"XM"), Value::String(BString::from(xm.to_vec())));
+    BismarkRecord::from_noodles_record(record).expect("synth produces a valid BismarkRecord")
+}
+
+/// Write a small SE directional BAM (3 OT records + 2 OB records) at `path`.
+fn write_se_directional_bam(path: &std::path::Path) {
+    let header = header_with_chr1();
+    let mut writer = BamWriter::from_path(path, header).unwrap();
+
+    // Three OT records (XR=CT XG=CT) at varying alignment starts.
+    writer
+        .write_record(&synth_record(
+            b"read_OT_1",
+            b"CT",
+            b"CT",
+            b"Zz...",
+            b"ACGTC",
+            100,
+            0,
+        ))
+        .unwrap();
+    writer
+        .write_record(&synth_record(
+            b"read_OT_2",
+            b"CT",
+            b"CT",
+            b"..X..",
+            b"ACGTC",
+            200,
+            0,
+        ))
+        .unwrap();
+    writer
+        .write_record(&synth_record(
+            b"read_OT_3",
+            b"CT",
+            b"CT",
+            b"....H",
+            b"ACGTC",
+            300,
+            0,
+        ))
+        .unwrap();
+
+    // Two OB records (XR=CT XG=GA).
+    writer
+        .write_record(&synth_record(
+            b"read_OB_1",
+            b"CT",
+            b"GA",
+            b"Z....",
+            b"ACGTC",
+            400,
+            0,
+        ))
+        .unwrap();
+    writer
+        .write_record(&synth_record(
+            b"read_OB_2",
+            b"CT",
+            b"GA",
+            b"..h..",
+            b"ACGTC",
+            500,
+            0,
+        ))
+        .unwrap();
+
+    writer.finish().unwrap();
+}
+
+/// Write a 1-record BAM where the record has the PAIRED FLAG (0x1) set —
+/// triggers Phase B's per-record SE/PE guard.
+fn write_bam_with_paired_record(path: &std::path::Path) {
+    let header = header_with_chr1();
+    let mut writer = BamWriter::from_path(path, header).unwrap();
+    writer
+        .write_record(&synth_record(
+            b"paired_read",
+            b"CT",
+            b"CT",
+            b"Z....",
+            b"ACGTC",
+            100,
+            0x41, // 0x40 first-in-pair + 0x01 paired
+        ))
+        .unwrap();
+    writer.finish().unwrap();
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn smoke_se_directional_produces_all_12_files_and_report() {
+    let workdir = tempfile::tempdir().unwrap();
+    let bam_path: PathBuf = workdir.path().join("se_smoke.bam");
+    write_se_directional_bam(&bam_path);
+
+    let output_dir = workdir.path().join("out");
+
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(&bam_path)
+        .arg("--single-end")
+        .arg("--output_dir")
+        .arg(&output_dir)
+        .assert()
+        .success();
+
+    // All 12 split files must exist on disk.
+    let expected_files = [
+        "CpG_OT_se_smoke.txt",
+        "CpG_CTOT_se_smoke.txt",
+        "CpG_CTOB_se_smoke.txt",
+        "CpG_OB_se_smoke.txt",
+        "CHG_OT_se_smoke.txt",
+        "CHG_CTOT_se_smoke.txt",
+        "CHG_CTOB_se_smoke.txt",
+        "CHG_OB_se_smoke.txt",
+        "CHH_OT_se_smoke.txt",
+        "CHH_CTOT_se_smoke.txt",
+        "CHH_CTOB_se_smoke.txt",
+        "CHH_OB_se_smoke.txt",
+    ];
+    for name in expected_files {
+        let p = output_dir.join(name);
+        assert!(p.exists(), "expected output file: {}", p.display());
+        let content = fs::read_to_string(&p).unwrap();
+        let first_line = content.lines().next().unwrap_or("");
+        assert_eq!(
+            first_line, "Bismark methylation extractor version v0.25.1",
+            "header drift in {}",
+            name
+        );
+    }
+
+    // OT files for CpG / CHG / CHH should each have content beyond the
+    // header (the 3 OT records routed at least one call to each).
+    for ctx in ["CpG", "CHG", "CHH"] {
+        let p = output_dir.join(format!("{ctx}_OT_se_smoke.txt"));
+        let content = fs::read_to_string(&p).unwrap();
+        assert!(
+            content.lines().count() >= 2,
+            "{ctx}_OT should have header + at least one call line; got:\n{content}"
+        );
+    }
+
+    // OB files: CpG_OB and CHH_OB should have calls; CHG_OB should be header-only.
+    let cpg_ob = fs::read_to_string(output_dir.join("CpG_OB_se_smoke.txt")).unwrap();
+    assert!(
+        cpg_ob.lines().count() >= 2,
+        "CpG_OB should have a call from read_OB_1; got:\n{cpg_ob}"
+    );
+    let chh_ob = fs::read_to_string(output_dir.join("CHH_OB_se_smoke.txt")).unwrap();
+    assert!(
+        chh_ob.lines().count() >= 2,
+        "CHH_OB should have a call from read_OB_2; got:\n{chh_ob}"
+    );
+
+    // CTOT/CTOB files should be header-only (directional library: no
+    // records on those strands).
+    for ctx in ["CpG", "CHG", "CHH"] {
+        for strand in ["CTOT", "CTOB"] {
+            let p = output_dir.join(format!("{ctx}_{strand}_se_smoke.txt"));
+            let content = fs::read_to_string(&p).unwrap();
+            assert_eq!(
+                content, "Bismark methylation extractor version v0.25.1\n",
+                "directional library: {ctx}_{strand} must be header-only; got:\n{content}"
+            );
+        }
+    }
+
+    // Splitting report must exist + parse.
+    let report = fs::read_to_string(output_dir.join("se_smoke_splitting_report.txt")).unwrap();
+    assert!(report.contains("Bismark methylation extractor version v0.25.1"));
+    assert!(report.contains("Processed 5 reads in total"));
+    assert!(report.contains("Total number of C's analysed:"));
+    assert!(report.contains("Total methylated C's in CpG context:"));
+    assert!(report.contains("Total methylated C's in CHG context:"));
+    assert!(report.contains("Total methylated C's in CHH context:"));
+    assert!(report.contains("C methylated in CpG context:"));
+}
+
+#[test]
+fn smoke_se_rejects_record_with_paired_flag_set() {
+    // Plan §4.5 row "PE record reaches SE pipeline" + plan §7.1 row
+    // `extract_se_rejects_record_with_paired_flag_set`.
+    let workdir = tempfile::tempdir().unwrap();
+    let bam_path = workdir.path().join("paired_in_se.bam");
+    write_bam_with_paired_record(&bam_path);
+
+    let output_dir = workdir.path().join("out");
+
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(&bam_path)
+        .arg("--single-end")
+        .arg("--output_dir")
+        .arg(&output_dir)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "paired-end extraction (input has PAIRED flag set)",
+        ));
+
+    // Cleanup should have removed all 12 partial files. Two acceptable end
+    // states: output_dir doesn't exist (cleanup was so thorough it removed
+    // the dir — not the case in this impl) OR it exists but is empty.
+    if output_dir.exists() {
+        let count = fs::read_dir(&output_dir).unwrap().count();
+        assert_eq!(
+            count, 0,
+            "cleanup_partial_outputs should have removed all 12 files; \
+             found {count} stragglers"
+        );
+    }
+}
+
+#[test]
+fn smoke_se_empty_bam_writes_only_header_files() {
+    // Plan §10 row "Empty input" + plan §7.1 row
+    // `extract_se_empty_input_writes_only_header_files`.
+    let workdir = tempfile::tempdir().unwrap();
+    let bam_path = workdir.path().join("empty.bam");
+
+    // Build an empty BAM (header only, no records).
+    let header = header_with_chr1();
+    let writer = BamWriter::from_path(&bam_path, header).unwrap();
+    writer.finish().unwrap();
+
+    let output_dir = workdir.path().join("out");
+
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(&bam_path)
+        .arg("--single-end")
+        .arg("--output_dir")
+        .arg(&output_dir)
+        .assert()
+        .success();
+
+    // All 12 files exist with only the header line.
+    let dir_entries: Vec<_> = fs::read_dir(&output_dir).unwrap().collect();
+    // 12 split files + 1 splitting report
+    assert_eq!(dir_entries.len(), 13);
+    for ctx in ["CpG", "CHG", "CHH"] {
+        for strand in ["OT", "CTOT", "CTOB", "OB"] {
+            let p = output_dir.join(format!("{ctx}_{strand}_empty.txt"));
+            let content = fs::read_to_string(&p).unwrap();
+            assert_eq!(content, "Bismark methylation extractor version v0.25.1\n");
+        }
+    }
+
+    // Splitting report exists with 0 records.
+    let report = fs::read_to_string(output_dir.join("empty_splitting_report.txt")).unwrap();
+    assert!(report.contains("Processed 0 reads in total"));
+    assert!(report.contains("Total methylated C's in CpG context:\t0"));
+}


### PR DESCRIPTION
## Summary

Phase B of the bismark-extractor port (umbrella #798). Wires the first end-to-end extraction path: SE BAM/SAM/CRAM → 12 strand×context split files (eagerly opened with the literal Perl version header) + splitting report. PE, non-default output modes, `--gzip`, `--parallel > 1`, `--bedGraph` / `--cytosine_report`, and `--multiple` inputs are all rejected at the resolved-config boundary with `PhaseNotYetImplemented`.

Closes #848. Plan + reviews + coverage report committed under `plans/05262026_bismark-extractor/`.

## Key design choices

- **Kernel delegation** — `extract_calls` is a thin filter over `bismark-io v1.0.0-beta.6`'s `BismarkRecord::iter_aligned()`. No CIGAR walker in the extractor; orientation correction for `-`-strand reads lives in bismark-io (SPEC §6.5).
- **Eager output-file creation** — `OutputFileMap::new` opens all 12 (3 contexts × 4 strands) split files at construction time and writes the literal `Bismark methylation extractor version v0.25.1\n` header to each (unless `--no_header`). Verified against Perl source lines 5405-5700+ (default mode) and 5140-5325 (`--merge_non_CpG`). Rev 0's lazy approach was a byte-identity regression caught by Reviewer B during plan-review.
- **`route_call` ordering** — M-bias accumulate → splitting-report counter increment → `mbias_only` short-circuit → split-file write. Deviates from SPEC §7.5 pseudocode (which short-circuits before counter increment); SPEC fix queued as a follow-up so the v1.0 `--mbias_only` path doesn't lose counts.
- **Per-record PAIRED-flag check** — defensive guard against PE records reaching the SE pipeline. Phase C will promote `detect_paired_from_header` from `bismark-dedup` to `bismark-io v1.0.0-beta.7` and lift this to a header-level check.

## What's included

| Area | Files |
|---|---|
| Kernel | `src/call.rs` (extract_calls, classify_xm_byte, MethCall, CytosineContext) |
| M-bias counters | `src/mbias.rs` (writer deferred to Phase D) |
| Eager output map | `src/output.rs` (OutputFileMap, SplittingReport, write_splitting_report) |
| State + routing | `src/state.rs`, `src/route.rs` |
| Pipeline | `src/pipeline.rs` (extract_se, derive_basename), `src/header.rs` (build_chr_name_table with ASCII assert) |
| Phase-gate dispatch | `src/main.rs` (6 `PhaseNotYetImplemented` rejections; `extract_se` for supported subset) |
| Error variants | `src/error.rs` (+6: PhaseNotYetImplemented, InvalidXmByte, IoWrite, BismarkIo, InternalError, NonAsciiChromosomeName) |
| Unit tests | `tests/se_phase_b.rs` (44 tests) |
| Smoke tests | `tests/se_phase_b_smoke.rs` (3 end-to-end tests; builds synthetic BAM in-process via bismark-io::BamWriter — no Perl baseline needed) |
| Plan + reviews | `plans/05262026_bismark-extractor/` (PLAN rev 2, 2 plan reviews, 2 code reviews, plan-manager COVERAGE) |

Crate version: `1.0.0-alpha.1` → `1.0.0-alpha.2`. Cargo.lock + Cargo.toml bumps. New deps: `noodles-sam =0.85.0` (regular), `bstr =1.10.0` + `noodles-core =0.20.0` (dev).

## Plan revision history

- **rev 0** — initial draft.
- **rev 1** — folded dual plan-review findings. Critical fix: switch from lazy to eager file creation (verified against Perl source). Plus 14 other corrections (read_pos_5p semantics, route_call ordering, mbias_only_silence deferral, detect_paired_from_header confirmation, etc.).
- **rev 2** — folded dual code-review + plan-manager findings. `strand_char` → `meth_char` rename (Perl emits `+`/`-` as methylation-state, not strand), `write_call` + `route_call` error-type widening to typed `BismarkExtractorError`, drop `reader.header().clone()`, `reference_sequence_id().expect()` → typed `InternalError`, added `cleanup_partial_outputs_continues_past_one_failure` test. Two intentional deviations documented (T-40 covered by smoke; in-test BAM construction supersedes the planned `regenerate.sh` fixture).

## Test plan

- [x] `cargo test -p bismark-extractor` → **91 tests pass** (40 lib + 4 sanity + 44 se_phase_b + 3 smoke).
- [x] `cargo clippy -p bismark-extractor --all-targets -- -D warnings` → clean.
- [x] `cargo fmt -p bismark-extractor -- --check` → clean.
- [ ] Manual sanity-check on a real Bismark-aligned SE BAM (reviewer: feel free to skip; smoke test covers binary spawn + 12-file emission + report parse).
- [ ] Phase H byte-identity gate against 10M+55M PE WGBS — deferred per SPEC §10 row H.

## Out of scope (deferred)

- PE extraction (Phase C — next).
- M-bias.txt writer (Phase D; accumulators already in place).
- Non-default output modes + `--gzip` (Phase E).
- `--parallel > 1` (Phase F).
- `--bedGraph` / `--cytosine_report` subprocess chain (Phase G).
- Real-data byte-identity gate (Phase H).

Each is rejected at `main.rs::run` with a phase-naming error message; no silent half-implementation.