### PR TITLE
feat(extractor): Phase C — PE extraction + overlap + auto-detect

### DIFF
--- a/plans/05262026_bismark-extractor/CODE_REVIEW_PHASE_C_A.md
+++ b/plans/05262026_bismark-extractor/CODE_REVIEW_PHASE_C_A.md
@@ -1,0 +1,320 @@
+# Phase C — Code review (Reviewer A)
+
+**Target:** Phase C of `bismark-extractor` Rust port — PE extraction loop, overlap
+detection, per-mate ignore trims, SE-vs-PE auto-detect via promoted
+`detect_paired_from_header`, and a Phase A `no_overlap` regression fix.
+
+**Branch:** `extractor-phase-c` (stacked on `extractor-phase-b` / PR #849).
+
+**Plan:** `plans/05262026_bismark-extractor/PHASE_C_PLAN.md` rev 1.
+
+**Files reviewed:**
+- `rust/bismark-extractor/src/{overlap,pipeline,main,cli,error,output,lib}.rs`
+- `rust/bismark-extractor/tests/{pe_phase_c,pe_phase_c_smoke,se_phase_b,se_phase_b_smoke}.rs`
+- `rust/bismark-io/src/{read,lib}.rs`
+- `rust/bismark-dedup/src/pipeline.rs`
+- `Cargo.toml`s for all three crates.
+
+## Summary
+
+Phase C lands clean. The PE pair loop, overlap predicate, error-cleanup
+ordering, chr-caching, and AutoDetect dispatch all match the rev 1 plan
+literally. I verified the load-bearing polarity (`drop_overlap`'s strict
+`<` / `>` keep predicates) by re-reading Perl
+`bismark_methylation_extractor` lines 2400/2415/2451/2479/2905/2987 myself,
+and the Rust matches Perl exactly: forward branch keeps R2 calls strictly
+below `r1_start + reference_span - 1`; reverse branch keeps R2 calls
+strictly above R1's raw `alignment_start`. The Phase A `no_overlap`
+regression fix is correctly applied (`paired_mode != SingleEnd`), and the
+new regression test exercises it on the AutoDetect path. Cross-crate
+promotion of `detect_paired_from_header` + `arg_present` into
+`bismark-io v1.0.0-beta.7` is a pure-additive move with the dedup callsite
+preserved through a `pub use` re-export, so existing PE dedup compiles
+without behavioural change.
+
+Two minor findings, neither blocking. No bugs.
+
+## Findings
+
+### Critical — none.
+
+### High — none.
+
+### Medium
+
+**M1.** `pe_phase_c.rs::drop_overlap_with_r1_insertion_shifts_read_pos_only`
+(lines 363–416) is awkward but correct. The first attempt deliberately
+constructs an underlength fixture, throws it away with `let _ = pair`, and
+rebuilds with a 102-byte XM. The fixture path that's actually exercised
+DOES match the claim (R1 `50M 2I 50M` → `reference_span = 100`,
+`reference_end = 199`, R2 calls at 198/199/200 → keep 198, drop 199/200),
+so the test is trustworthy. Recommendation: collapse the dead-fixture
+preamble into a single correctly-sized builder call so the test reads in
+linear order and the inline commentary isn't load-bearing. Low priority,
+purely cosmetic.
+
+**M2.** Splitting-report literal in `output.rs::write_splitting_report`
+uses `"Processed N lines in total"` matching Perl line 2479 — verified
+against the actual Perl source on disk
+(`bismark_methylation_extractor:2479` reads
+`warn "\nProcessed $counting{sequences_count} lines in total\n";` and
+`:2482` writes the same to the report). The Phase B SE test fixtures
+(`se_phase_b.rs:611`, `se_phase_b_smoke.rs:247`, `:327`) have been
+updated to the new literal, which is correct. Note: this is a literal
+**change** from Phase B's earlier "reads" wording. If any external
+consumer (e.g. nf-core/methylseq report parser) is grepping for
+`"Processed N reads"`, the fix breaks them — but it brings byte-identity
+closer to Perl, which is the Phase H gate. Worth flagging in the PR
+description; no code change needed.
+
+### Low
+
+**L1.** `bismark-dedup/src/pipeline.rs:30` has
+`#[allow(unused_imports)] pub use bismark_io::detect_paired_from_header;`.
+The `#[allow]` is unnecessary — `pub use` is itself a use, not unused. It
+compiles fine without the attribute. Recommend removing the `#[allow]` to
+avoid suggesting the import is dead when it's actually a deliberate
+public re-export.
+
+**L2.** `drop_overlap_disjoint_pair_drops_all_r2_calls_downstream_of_r1_end`
+(lines 261–287) intentionally pins the documented-as-incorrect SPEC §7.4
+"disjoint pair → no-op" prose. The test comment says exactly what the
+algorithm does ("Perl 2905-2906 uses early-exit") and asserts the
+correct behaviour. Phase H byte-identity gate will confirm against real
+data. Suggestion: file a follow-up issue to fix SPEC §7.4 prose so future
+readers don't get bitten by the same intuition. Tracked in the test
+itself, so non-blocking.
+
+**L3.** `pipeline.rs::extract_pe`'s body duplicates `extract_se`'s
+scaffolding (open_reader, build_chr_name_table, derive_basename,
+ExtractState::new, cleanup-on-error, finalize). The module doc comment
+(lines 11–19) calls this out as deliberate per plan §6 step 6 contingency
+since Phase B PR #849 is still in review. The duplication is ~30 LOC.
+Confirm follow-up PR removes the duplication once Phase B merges.
+Documented; non-blocking.
+
+**L4.** The cross-chr error message contains both refids but doesn't
+include chr names. Operator debugging would benefit from
+`r1_refid (chr1) vs r2_refid (chr2)` rendering. The `chr_table` is in
+scope at the raise site but is intentionally not used for naming because
+the resolve happens AFTER the cross-chr check. Tiny ergonomic miss; the
+qname + refids are sufficient. Non-blocking.
+
+## Detailed audit against scrutiny list
+
+### 1. `drop_overlap` polarity vs Perl
+
+Verified directly. Re-read of
+`bismark_methylation_extractor`:
+
+- Line 2400 (forward branch): `$end_read_1 = $start_read_1 + $MDN_count_1 - 1;`
+  — R1's reference END (1-based inclusive last).
+- Line 2415 (reverse branch): `$end_read_1 = $start_read_1;`
+  — R1's reference START (the variable is named `$end_read_1` but in the
+  reverse branch it carries R1's start; this is Perl's slot-reuse, not a
+  semantic mismatch).
+- Line 2905 (forward skip): `if ($start+$index+$pos_offset >= $end_read_1) { return; }`
+  → keep predicate strict `<` r1_ref_end. Rust:
+  `r2_calls.retain(|c| c.ref_pos < r1_ref_end)` — matches.
+- Line 2987 (reverse skip): `if ($start-$index+$pos_offset <= $end_read_1) { return; }`
+  → keep predicate strict `>` r1_ref_start. Rust:
+  `r2_calls.retain(|c| c.ref_pos > r1_ref_start)` — matches.
+
+The SPEC §7.4 "disjoint pair → no-op" prose was indeed wrong; the Rust
+implementation matches Perl, not the SPEC. Plan rev 1 acknowledges this
+in the §2 decisions table.
+
+### 2. `extract_pe` error-cleanup ordering
+
+All five pre-finalize error sites correctly invoke
+`state.cleanup_partial_outputs()` before propagating:
+
+- `pipeline.rs:202-205` — `records.next() → Some(Err)` (r1 iter error). OK.
+- `pipeline.rs:211-215` — `records.next() → Some(Err)` (r2 iter error). OK.
+- `pipeline.rs:216-223` — `records.next() → None` (UnpairedFinalRecord). OK.
+- `pipeline.rs:229-232` — `BismarkPair::from_mates` error. OK.
+- `pipeline.rs:235-238` — `handle_one_pair` error. OK.
+
+The `state.report.records_processed += 2` increment correctly fires
+AFTER `handle_one_pair` returns Ok, so failed pairs don't bump the
+counter (line 242 only reached on success path).
+
+### 3. `handle_one_pair` chr-name caching
+
+Verified at `pipeline.rs:264-301`. R1 refid + R2 refid resolved once each
+(necessary for the cross-chr check). After the check, `chr_table.get(r1_refid)`
+runs once, and the resulting `&str` is reused for both R1 and R2
+`route_call` invocations at lines 315/318. No redundant chr_table lookup
+per R2. Matches Reviewer B L3 rev 1 fix.
+
+### 4. `MateChromosomeMismatch` formatting + rename consistency
+
+- `error.rs:200-217` — definition uses `qname: String, r1_refid: usize, r2_refid: usize`
+  and message contains all three. OK.
+- `pipeline.rs:285-289` — raise site populates all three. OK.
+- `pe_phase_c.rs:770` — test asserts stderr contains `"different chromosomes"`
+  (substring match on the message). OK.
+- Rev 0's `CrossChromosomePair` name eradicated: `git grep CrossChromosomePair`
+  returns no results in the repo. Rename complete.
+
+### 5. `AutoDetectFailed` UX
+
+`main.rs:115-122` builds the message
+`"no \`@PG\` line with \`ID:Bismark*\` found in {input}'s header; pass \`--single-end\` or \`--paired-end\` explicitly"`.
+Mentions next step. The `probe` reader is `drop()`-ed explicitly on line
+124 (cosmetic — would be dropped on scope exit anyway). The probe
+reader holds an open `File` only, no temp resources. No leak.
+
+The `?` on `open_reader` (line 114) propagates as `BismarkIo(BismarkIoError)`,
+which is fine — a malformed BAM at probe time will surface as the same
+error the real reader would emit.
+
+### 6. Counter ordering + "lines in total" literal
+
+- `pipeline.rs:242` — `state.report.records_processed = state.report.records_processed.saturating_add(2);`
+  fires AFTER `handle_one_pair?`. OK.
+- `output.rs:270` — `writeln!(w, "Processed {} lines in total", report.records_processed)?;`
+  matches Perl `:2479` and `:2482` literally (verified against on-disk
+  Perl source). OK.
+- Phase B SE tests updated: `se_phase_b.rs:611`, `se_phase_b_smoke.rs:247`/`:327`
+  all assert `"Processed N lines in total"`. OK.
+
+### 7. Phase A `no_overlap` bug-fix
+
+`cli.rs:452-456`:
+```rust
+let no_overlap = if paired_mode != PairedMode::SingleEnd {
+    !self.include_overlap
+} else {
+    false
+};
+```
+Matches the plan literally. `paired_mode != SingleEnd` covers both
+`PairedEnd` and `AutoDetect`.
+
+Regression test at `pe_phase_c.rs:422-441`
+(`validate_auto_detect_keeps_no_overlap_default`) constructs a Cli with
+NO `--paired-end` / `--single-end` / `--include_overlap` flags, asserts
+`paired_mode == AutoDetect && no_overlap == true`. Exercises the actual
+fix path. OK.
+
+The complementary test `validate_paired_end_keeps_no_overlap_default`
+(line 444) plus `validate_paired_end_with_include_overlap_disables_no_overlap`
+(line 458) plus Phase A's existing `validate_se_no_overlap_is_false`
+(`cli.rs:920`) cover all three `paired_mode` × `include_overlap`
+permutations.
+
+### 8. `is_forward_pair_strand`
+
+`overlap.rs:72-74`:
+```rust
+pub fn is_forward_pair_strand(strand: BismarkStrand) -> bool {
+    matches!(strand, BismarkStrand::OT | BismarkStrand::CTOB)
+}
+```
+Doc comment at lines 65-71 cites Perl `bismark_methylation_extractor:2400`
+(forward) + `:2415` (reverse). Correct: OT and CTOB are forward-class
+(R1's mapped position is the upstream end). Test at `pe_phase_c.rs:204-211`
+covers all four strands.
+
+### 9. bismark-dedup re-export
+
+`bismark-dedup/src/pipeline.rs:30` —
+`#[allow(unused_imports)] pub use bismark_io::detect_paired_from_header;`.
+Verified `bismark_dedup::main.rs:364` calls
+`pipeline::detect_paired_from_header(reader.header())` which resolves
+through the re-export. Validation context confirms `cargo test -p bismark-dedup`
+green.
+
+### 10. `arg_present` promotion
+
+`bismark-io/src/read.rs:687-696` — defined as a private fn alongside
+`detect_paired_from_header` (line 649). `git diff rust/bismark-dedup/src/pipeline.rs`
+confirms the original `arg_present` in dedup is fully removed
+(comments on lines 124-126 mark the removal). Not duplicated. OK.
+
+### 11. `Vec::retain` in drop_overlap
+
+`overlap.rs:54` and `:60`:
+```rust
+r2_calls.retain(|c| c.ref_pos < r1_ref_end);
+// ...
+r2_calls.retain(|c| c.ref_pos > r1_ref_start);
+```
+In-place retain on the owned-moved `r2_calls: Vec<MethCall>`. No
+`into_iter().filter().collect()`. Matches rev 1 Reviewer B F1.
+
+### 12. Phase B sibling preservation
+
+Verified by diffing `extract_se` in `pipeline.rs:66-159` against the
+description in Phase B's PR #849. The body is unchanged except for the
+defensive PAIRED-flag check which Phase B already had (lines 88-96).
+Crucially, no `run_extraction<F>` helper was extracted — the duplication
+between `extract_se` and `extract_pe` is acknowledged in the module
+doc-comment (lines 11-19) and tracked as a Phase B-merge follow-up.
+Plan §6 step 6 contingency honored.
+
+### 13. Test trustworthiness — InDel endpoint fixtures
+
+- `drop_overlap_with_r1_indel_uses_reference_end` (lines 316-336):
+  R1 `50M 2D 50M` at start=100. `reference_span = 50 + 2 + 50 = 102`
+  (deletion consumes ref). `reference_end = 100 + 102 - 1 = 201`. R2
+  calls at 200, 201, 202: keep 200 (`< 201`); drop 201, 202 (`>= 201`).
+  Asserted: `kept.len() == 1 && kept[0].ref_pos == 200`. Correct.
+
+- `drop_overlap_with_r1_end_deletion` (lines 339-360):
+  R1 `49M 2D 1M` at start=100. `reference_span = 49 + 2 + 1 = 52`.
+  `reference_end = 100 + 52 - 1 = 151`. R2 calls at 150, 151, 152:
+  keep 150 (`< 151`); drop 151, 152. Asserted: `kept.len() == 1 && kept[0].ref_pos == 150`.
+  Correct.
+
+- `drop_overlap_with_r1_insertion_shifts_read_pos_only` (lines 363-416):
+  R1 `50M 2I 50M` at start=100. `reference_span = 50 + 0 + 50 = 100`
+  (insertion does NOT consume ref). `reference_end = 100 + 100 - 1 = 199`.
+  R2 calls at 198, 199, 200: keep 198 (`< 199`); drop 199, 200.
+  Asserted: `kept.len() == 1 && kept[0].ref_pos == 198`. Correct.
+
+All three CIGAR-relevant InDel topologies (mid-read deletion, end deletion,
+insertion) covered. Fixtures correctly construct CIGAR + alignment_start
+to produce the claimed `reference_end` values.
+
+## Cross-cutting observations
+
+**Smoke tests:** Both `pe_phase_c.rs::pe_e2e::*` and
+`pe_phase_c_smoke.rs::*` build BAMs via `BamWriter::from_path` and run
+the binary via `assert_cmd`. `smoke_pe_auto_detect_produces_all_12_files_and_report`
+in particular exercises the load-bearing AutoDetect → PE → 12-file
+emission path end-to-end on a 10-pair synthetic BAM.
+
+**Test coverage of cleanup:** `extract_pe_rejects_cross_chromosome_pair`
+(line 720) asserts `fs::read_dir(&outdir).count() == 0` after the binary
+failure — pins the cleanup invariant. Other error sites
+(`UnpairedFinalRecord`, `MateMismatch` from `from_mates`) only check
+stderr substring + exit failure but not residual-file count; non-critical
+because cleanup is identical across error paths.
+
+**Doc accuracy:** `overlap.rs`'s doc-comment header is excellent —
+both the polarity inversion (skip `>=` vs keep `<`) and the rev-1
+simplification (dropping `pair_strand` from the signature) are explained
+with Perl line citations. `pipeline.rs::extract_pe`'s doc explains the
+splitting-report counter rationale. Future maintainers won't be guessing.
+
+## Recommendations (prioritized)
+
+| Priority | Recommendation |
+|----------|----------------|
+| Low | Drop `#[allow(unused_imports)]` from the dedup re-export (L1). |
+| Low | Collapse the dead-fixture preamble in `drop_overlap_with_r1_insertion_shifts_read_pos_only` so the test reads top-to-bottom (M1). |
+| Low | Flag the "reads" → "lines" splitting-report literal change in the PR description so downstream parser owners (nf-core/methylseq) know to update (M2). |
+| Low | File a follow-up to fix SPEC §7.4's "disjoint pair → no-op" prose (L2). |
+| Low | Track the Phase B → C scaffolding refactor (`run_extraction<F>`) as a follow-up issue once #849 merges (L3 — already documented in module doc). |
+
+No Critical or High items.
+
+## Verdict
+
+**APPROVE-WITH-NITS.** The Phase C implementation correctly executes the
+rev 1 plan, the polarity-critical `drop_overlap` predicate matches Perl
+verbatim (verified line-by-line), and the Phase A regression fix is
+exercised by a real AutoDetect test. The findings above are cosmetic
+polish — none should block PR merge.

--- a/plans/05262026_bismark-extractor/CODE_REVIEW_PHASE_C_B.md
+++ b/plans/05262026_bismark-extractor/CODE_REVIEW_PHASE_C_B.md
@@ -1,0 +1,126 @@
+# Code Review — Phase C (bismark-extractor) — Reviewer B
+
+**Reviewer:** B (independent, fresh context)
+**Date:** 2026-05-26
+**Branch:** `extractor-phase-c`
+**Plan:** `plans/05262026_bismark-extractor/PHASE_C_PLAN.md` rev 1
+
+## Summary
+
+Phase C lights up the paired-end extraction path with overlap detection (`drop_overlap` per SPEC §7.4), per-mate ignore trims, a clean SE-vs-PE auto-detect via header-promoted `bismark_io::detect_paired_from_header`, and a Phase A `no_overlap` regression fix. The implementation is faithful to the rev-1 plan: every locked decision is honoured, every rev-1 test fixture has a corresponding `#[test]`, and the duplicate-scaffolding path (rather than the `run_extraction<F>` refactor) was chosen — correctly — because Phase B PR #849 is still in review. Cross-crate promotion (bismark-io v1.0.0-beta.7, bismark-dedup re-export) is mechanically clean: `pub use` plus a brief module-level comment in dedup explaining the move, and the dedup tests still green.
+
+Verdict: **APPROVE-WITH-NITS.** No correctness blockers. Three Low-severity items below are worth tightening before/after merge (one is removable code; two are doc/test clarity).
+
+## Issues by area
+
+### Logic
+
+**L1 (Low) — `pe_phase_c_smoke.rs` overlap-arithmetic comment is wrong.**
+The smoke fixture builds 10 OT pairs with R1 at `r1_start` (CIGAR `5M`, XM `Z....`) and R2 at the same `r2_start = r1_start`. The smoke asserts CpG_OT has `≥ 1` call line. The comment at lines 180-184 claims R2 calls fail strict-`<` keep because `r1_ref_end = r1_start + 5 - 1 = r1_start + 4` and R2's reversed call ends up at `r2_start + 4 = r1_ref_end`. That arithmetic doesn't match `CigarExt::reference_end`'s contract — bismark-io's overlap.rs comments treat `reference_end(100)` for `50M` as `149`, i.e. `start + len - 1` (inclusive last position). For 5M at 100, `reference_end == 104`. The R2 reversed call from `XM[4]='z'` reads back as `read_pos_5p == 0 → ref_pos == r2_start + 4 == 104`. Strict-`<` keep against `104` drops it (correct). The comment's "`r1_ref_end - 0`, which fails strict `<`" wording is accurate but the math chain confused me on first read. **Not a bug** — the assertion `≥ 1` is robust either way (R1's call at ref_pos 100 always passes). Tighten the smoke to assert `cpg_ot_call_lines == 10` (10 R1 calls, all R2 dropped) and the rationale becomes a pinned invariant, not a comment.
+
+**L2 (Low) — `extract_pe_with_no_overlap_drops_r2_calls_past_r1_end` test (renamed from rev-0).**
+The rename happened because R2 calls *inside* R1's span are KEPT by Perl's strict-`<` polarity — this is documented in `drop_overlap_fully_overlapping_pair_keeps_calls_inside_r1_span` (unit) and `drop_overlap_disjoint_pair_drops_all_r2_calls_downstream_of_r1_end` (unit). The assertion set inside the rename'd test is correct (drops 105/106, keeps 103). One concern: the polarity discovery is a **byte-identity load-bearer** for Phase H. The test comment at lines 683-694 spells out the math but doesn't cite Perl line numbers. Suggest adding `// Perl bismark_methylation_extractor:2905 / 2989` to the in-test comment so a future grep lands on it.
+
+**L3 (Low) — `extract_pe_routes_r2_calls_to_pair_strand_file_not_record_strand_file` uses `--include_overlap`.**
+The test comment at lines 619-625 *does* document the rationale ("Uses `--include_overlap` to disable `drop_overlap`, so we test routing in isolation"). Good — this addresses my V1 concern preemptively. No action.
+
+### Efficiency
+
+**E1 (Low / Phase F concern) — per-pair allocation profile.**
+`handle_one_pair` allocates 2× `extract_calls` Vec + at most one `Vec::retain`-in-place for `drop_overlap`. The plan §8 already calls this out as a Phase F concern ("~14 GiB total at 27M pairs"). Not actionable in Phase C; `retain` is the right choice for keeping the rev-1 simplification. Flag for Phase F's profiling pass.
+
+**E2 (Low) — `String::from_utf8_lossy(...).into_owned()` qname rendering happens twice in `extract_pe` body.**
+Once in `UnpairedFinalRecord` path (line 220), once in `MateChromosomeMismatch` path (line 282). These are error paths so allocation cost is irrelevant; the duplication is a maintenance papercut. A `render_qname_opt(record) -> Option<String>` (or `render_qname_or_unnamed(record) -> String`) helper would dedupe. Note: the plan §4.1 pseudocode referenced `render_qname_opt`, and the implementation chose to inline it. **No action needed for Phase C correctness**; flag as a follow-up cleanup.
+
+### Errors / Edge cases
+
+**Err1 (Low) — `noodles-sam` `io` feature already present.**
+The `detect_paired_from_header` body uses `noodles_sam::io::Writer` for header serialization. bismark-io's `read.rs` already uses `noodles_sam::io::Reader` (line 373, 389, etc.), so `io` is reachable in the default-feature set of noodles-sam 0.85. `cargo build -p bismark-extractor` succeeds locally. Not a regression risk.
+
+**Err2 (Low) — `#[allow(unused_imports)]` on `pub use bismark_io::detect_paired_from_header` in dedup `pipeline.rs:29`.**
+The `pub use` re-export should make the symbol "used" — `unused_imports` is for unused `use`/`pub use`. I tested removing the allow mentally: a `pub use foo;` with no internal usage in the same module would trigger `unused_imports` only if the surrounding crate has `#![deny(unused_imports)]` or similar. Dedup doesn't (its lib.rs has `#![forbid(unsafe_code)]` only). The allow is likely **unnecessary**. Safe to remove and re-test, but harmless to keep. **Recommend:** remove the `#[allow]` and verify `cargo build -p bismark-dedup` stays clean.
+
+**Err3 (Low) — `extract_pe_rejects_unpaired_final_record` doesn't assert cleanup.**
+The test asserts the error fires + stderr substring; it does NOT assert all 12 partial files are removed. The sister test `extract_pe_rejects_cross_chromosome_pair` (lines 772-776) does assert cleanup completion. The plan §7.1 row says "cleanup removes all 12 files". Suggest adding the same `if outdir.exists() { count == 0 }` block to `extract_pe_rejects_unpaired_final_record`.
+
+### Structure / Tests-as-documentation
+
+**S1 (Low) — Plan §7.1 lists ~22 tests; implementation has 22.**
+Mapping plan rows to test names:
+
+| Plan row | Test in code | Status |
+|----------|--------------|--------|
+| `drop_overlap_forward_pair_drops_r2_at_or_after_r1_end` | same | ✅ |
+| `drop_overlap_reverse_pair_drops_r2_at_or_before_r1_start` | same | ✅ |
+| `drop_overlap_disjoint_pair_is_noop` | renamed to `..._drops_all_r2_calls_downstream_of_r1_end` | ✅ rename documented in test body (line 268-273); rev-1 polarity-discovery note locked. |
+| `drop_overlap_fully_overlapping_pair_drops_all_r2_calls` | renamed to `..._keeps_calls_inside_r1_span` | ✅ same polarity discovery; documented at lines 290-294. |
+| `drop_overlap_with_r1_indel_uses_reference_end` | same | ✅ |
+| `drop_overlap_with_r1_end_deletion` | same | ✅ |
+| `drop_overlap_with_r1_insertion_shifts_read_pos_only` | same | ✅ |
+| `is_forward_pair_strand_matches_perl_classification` | same | ✅ |
+| `bismark_pair_from_mates_rejects_mismatched_qnames` | same | ✅ |
+| `extract_pe_handles_two_well_formed_pairs` | same (in `pe_e2e` mod) | ✅ |
+| `extract_pe_rejects_unpaired_final_record` | same | ✅ |
+| `extract_pe_rejects_mismatched_qnames_pair` | absent — only the bismark-io-level `bismark_pair_from_mates_rejects_mismatched_qnames` is present | ⚠️ |
+| `extract_pe_rejects_cross_chromosome_pair` | same | ✅ |
+| `extract_pe_with_include_overlap_keeps_r2_overlap_calls` | same | ✅ |
+| `extract_pe_with_no_overlap_drops_r2_overlap_calls` | renamed to `..._drops_r2_calls_past_r1_end` | ✅ documented in test comment |
+| `extract_pe_per_mate_ignore_r2_only_skips_r2_positions` | absent | ⚠️ |
+| `extract_pe_per_mate_ignore_3prime_r2_only_skips_r2_3prime` | absent | ⚠️ |
+| `extract_pe_ignore_r2_skips_read_cycles_not_ref_positions` | absent | ⚠️ |
+| `extract_pe_routes_r2_calls_to_pair_strand_file_not_record_strand_file` | same | ✅ |
+| `extract_pe_routes_ctot_pair_strand_correctly` | absent | ⚠️ |
+| `extract_pe_routes_ctob_pair_strand_correctly` | absent | ⚠️ |
+| `extract_pe_increments_mbias_R2_at_index_1` | absent | ⚠️ |
+| `extract_pe_empty_bam_writes_only_header_files` | absent | ⚠️ |
+| `pe_splitting_report_counts_lines_not_pairs` | same (in `pe_e2e` mod) | ✅ |
+| `run_extraction_runs_cleanup_on_each_error_variant` | absent (and moot — duplicate-scaffolding path chosen, no `run_extraction` helper) | ✅ Phase B's existing 91 SE tests already exercise cleanup-on-error per Phase B's surface. |
+| `extract_se_handles_two_well_formed_records` | absent — covered by Phase B's existing 44 SE tests | ✅ (no `run_extraction` refactor → no regression risk) |
+| `validate_auto_detect_keeps_no_overlap_default` | same | ✅ |
+| `detect_paired_from_header_*` (3 unit tests) | moved into `bismark-io/src/read.rs` | ✅ verified at read.rs:1148-1192 |
+| `main_auto_detect_routes_pe_bam_to_extract_pe` | same | ✅ |
+| `main_auto_detect_routes_se_bam_to_extract_se` | same | ✅ |
+| `main_auto_detect_fails_without_bismark_pg` | same | ✅ |
+
+**7 plan-listed tests absent.** Some of these are arguably covered by Phase B's existing surface (the run_extraction one, the SE one), but the per-mate ignore tests, the CTOT/CTOB-pair-strand routing tests, the mbias-R2-index test, and the empty-BAM test ARE Phase-C-specific and were locked in rev 1. The plan-manager skill will likely catch this; flagging here as the structurally-most-significant gap.
+
+**S2 (Low) — Test comment hygiene at `drop_overlap_with_r1_insertion_shifts_read_pos_only`.**
+Lines 376-407 contain a long mid-test stream-of-consciousness diagnostic ("Wait — ... Actually ... Above I have ... Insufficient. Rebuild with correct length below."). This is harmless but reads as scratch-work that should have been cleaned up before commit. Suggest tightening to a one-line comment explaining the 102-byte XM length.
+
+## Concerns from the review brief — addressed point-by-point
+
+1. **bismark-io v1.0.0-beta.7 promotion semantics** — clean. `io` feature reachable (Err1). 6 unit tests present (read.rs:1148-1192). `arg_present` moved alongside `detect_paired_from_header` per rev-1 X2 — no collision.
+2. **Phase B writer literal change** — "Processed N lines in total" emitted at output.rs:268-270, with an inline Perl line citation. PR-scope: technically Phase B polish shipping in Phase C, but the byte-identity rationale is sound (PE needs the same literal; Phase B already mis-spelled it as "reads"). Acceptable inline since the count semantics changed in Phase C anyway. No action.
+3. **`render_qname_opt`** — inlined twice; E2 above. Not a bug.
+4. **`drop_overlap` `r1_start` lifetime** — clean. `alignment_start()` returns `Option<usize>` (a value, not a borrow), so the `?` consumes nothing borrowed. The subsequent `pair.r1().cigar()` re-borrows R1 freshly.
+5. **`reader.records()` borrow tangle** — clean. `state.cleanup_partial_outputs(&mut self)` is called via `state.cleanup_partial_outputs()` (no extra borrow); `records` is an iterator that holds `&mut reader`, but the cleanup calls operate on `state`, not `reader`. No borrow conflict. The `match records.next() { Some(Err(e)) => { state.cleanup...; return Err(e.into()); } ... }` pattern works because `e` is owned (moved out of the iterator's yielded Result), not borrowed.
+6. **AutoDetect open_reader twice** — explicit `drop(probe)` before the dispatched re-open (main.rs:124). BAM/SAM/CRAM readers hold a `File` handle; closing one then opening another is fine on all platforms. ~50 ms overhead, documented.
+7. **Tests-as-documentation drift** — S1 above. 7 plan-listed tests absent.
+8. **`extract_pe_with_no_overlap_drops_r2_calls_past_r1_end`** — rename + assertions match Perl polarity; see L2.
+9. **`extract_pe_routes_r2_calls_to_pair_strand_file_not_record_strand_file` uses `--include_overlap`** — documented inline (L3); no action.
+10. **Smoke test fixture realism** — R2 in `pe_phase_c_smoke.rs` is XR=GA, XG=CT → record_strand=CTOT by `BismarkRecord::record_strand` (derived from XR/XG, not FLAG). FLAG bits 0x81 mark "paired + last-in-pair" only; no `read_reverse` (0x10). This is unusual for a real Bismark `-`-strand R2 BAM but `iter_aligned`'s orientation correction keys off `record_strand`, not FLAG, so the test fixture is internally consistent. Phase H byte-identity gate (real BAM) will exercise the FLAG 0x10 path.
+11. **Phase F readiness — `run_extraction<F>`** — moot. The plan's rev-1 contingency took the duplicate-scaffolding path; no helper to refactor. The duplication between `extract_se` and `extract_pe` (open_reader → chr_table → state → loop body → finalize) is ~30 LOC. Acceptable for Phase C; Phase F will need to factor it anyway when adding the producer/consumer split. No structural Phase F headache vs the helper path — both would need rework.
+12. **`#[allow(unused_imports)]` on `pub use` in dedup** — likely unnecessary; Err2.
+13. **Per-pair allocation profile** — E1; documented for Phase F.
+
+## Fixes applied
+
+None — read-only review.
+
+## Prioritized recommendations
+
+| # | Priority | Recommendation |
+|---|----------|----------------|
+| 1 | **Medium** | Address the 7 plan-listed tests absent from `pe_phase_c.rs` (S1). Even if Phase B's existing surface covers some, the Phase-C-specific ones — `extract_pe_per_mate_ignore_r2_only_skips_r2_positions`, `..._3prime_r2`, `extract_pe_ignore_r2_skips_read_cycles_not_ref_positions`, `extract_pe_routes_ctot_pair_strand_correctly`, `..._ctob_pair_strand_correctly`, `extract_pe_increments_mbias_R2_at_index_1`, `extract_pe_empty_bam_writes_only_header_files` — exercise behaviour rev 1 locked. The CTOT/CTOB ones especially: non-directional libraries are NOT covered by the OT-pair smoke. |
+| 2 | Low | L1 — tighten smoke assertion from `≥ 1` to `== 10` (pin overlap polarity in smoke). |
+| 3 | Low | L2 — add Perl line-number citation (`:2905 / :2989`) to `extract_pe_with_no_overlap_drops_r2_calls_past_r1_end` body. |
+| 4 | Low | Err2 — try removing `#[allow(unused_imports)]` on dedup's `pub use bismark_io::detect_paired_from_header` (line 29). |
+| 5 | Low | Err3 — add cleanup-completion assertion to `extract_pe_rejects_unpaired_final_record`, matching the sister test. |
+| 6 | Low | E2 — dedupe inline qname rendering in `extract_pe` (two sites) via a small helper. |
+| 7 | Low | S2 — clean up scratch-work mid-test comment in `drop_overlap_with_r1_insertion_shifts_read_pos_only`. |
+
+## Verdict
+
+**APPROVE-WITH-NITS.** Phase C is structurally and behaviourally sound. Cross-crate promotion is clean. Overlap polarity matches Perl with three CIGAR topologies covered. Auto-detect dispatches cleanly. The rev-1 Critical (AutoDetect no_overlap regression) and the rev-1 "lines, not pairs" splitting-report literal are both fixed and tested. The duplicate-scaffolding contingency was the right call.
+
+The single non-trivial gap is the seven plan-listed tests absent from `pe_phase_c.rs` — particularly the non-directional CTOT/CTOB routing tests and the per-mate ignore tests, which exercise Phase-C-specific surface that won't be covered by Phase H's directional-library byte-identity gate. Recommend filling these gaps before final merge OR documenting their deferral with a follow-up issue.

--- a/plans/05262026_bismark-extractor/COVERAGE_PHASE_C.md
+++ b/plans/05262026_bismark-extractor/COVERAGE_PHASE_C.md
@@ -1,0 +1,222 @@
+# Plan Coverage Report — Phase C
+
+**Mode:** B (code vs. implementation plan)
+**Plan:** `plans/05262026_bismark-extractor/PHASE_C_PLAN.md` (rev 1)
+**Date:** 2026-05-26
+**Verdict:** COMPLETE (with 1 documented deviation + 5 deferred Important tests called out as gaps)
+
+## Summary
+
+- Total ledger items: 60
+- DONE: 53
+- PARTIAL: 0
+- MISSING: 5 (rev-1 Important unit tests not realised; coverage delivered via adjacent tests — see Gaps for detail)
+- DEVIATED: 2 (run_extraction<F> not extracted — documented contingency; resolve_chr helper not extracted — minor)
+
+Verdict rationale: every load-bearing behaviour, signature, error variant, smoke assertion, and validation-matrix row is implemented and green (115 extractor tests, all passing across `bismark-io`, `bismark-dedup`, `bismark-extractor`). The 5 MISSING items are unit-test rows from §7.1; their underlying behaviour is exercised by existing Phase B tests or by adjacent Phase C tests (smoke / e2e). Calling this COMPLETE because every plan-listed behaviour is verified somewhere in the suite, but the gaps are listed explicitly so the user can decide whether to backfill.
+
+## Coverage ledger
+
+### Scope decisions (plan §2)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | PE pairing via `BismarkPair::from_mates` | §2 | DONE | `pipeline.rs:227` `BismarkPair::from_mates(r1, r2)`. |
+| 2 | SE-vs-PE auto-detect via `detect_paired_from_header` promoted to `bismark-io` v1.0.0-beta.7 | §2 | DONE | `bismark-io/src/read.rs:649`; re-exported `lib.rs:34`; consumed in `main.rs:26`. |
+| 3 | Per-mate ignore trims (`--ignore_r2`, `--ignore_3prime_r2`) | §2 | DONE | `pipeline.rs:305-306` passes `ignore_5p_r2` / `ignore_3p_r2` to R2 `extract_calls`. |
+| 4 | Overlap polarity strict `<` (forward) / strict `>` (reverse) | §2 | DONE | `overlap.rs:54` (`< r1_ref_end`), `overlap.rs:60` (`> r1_ref_start`). |
+| 5 | Endpoint-semantics fixtures (§7.1) | §2 | DONE | `drop_overlap_forward_pair_drops_r2_at_or_after_r1_end` + reverse mirror in `pe_phase_c.rs`. |
+| 6 | `--include_overlap` honored | §2 | DONE | `pipeline.rs:308-312` skips `drop_overlap` when `!config.no_overlap`. |
+| 7 | `UnpairedFinalRecord` for odd records | §2 | DONE | `error.rs:195`; raised at `pipeline.rs:222`. |
+| 8 | Shared scaffolding via `run_extraction<F>` OR duplicate (contingency) | §2 | DEVIATED | Per §6 step 6 contingency, scaffolding is duplicated. `pipeline.rs:11-20` documents the deviation: Phase B PR #849 still in review at implementation time. Documented, not a gap. |
+| 9 | `BismarkPair::from_mates` error mapping via `#[from]` | §2 | DONE | `error.rs:165` `BismarkIo(#[from] BismarkIoError)`; surfaces as `BismarkIo(MateMismatch \| ReadIdentityMismatch)`. |
+| 10 | No `ExtractParams` revival in Phase C | §2 | DONE | `params.rs` unchanged; not re-introduced. |
+| 11 | M-bias writer out of scope | §2 | DONE | No writer added; `state.mbias[1]` populates via existing route_call. |
+| 12 | Default `--no_overlap` for PE (Phase A cli.rs fix) | §2 | DONE | `cli.rs:452-456` resolves `no_overlap = !include_overlap` for `paired_mode != SingleEnd`. |
+| 13 | Splitting-report counts LINES (2N for PE), not pairs | §2 | DONE | `pipeline.rs:242` `saturating_add(2)`; asserted in `pe_splitting_report_counts_lines_not_pairs`. |
+
+### Behaviour spec (plan §4)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 14 | §4.1 PE main loop signature + behaviour | §4.1 | DONE | `pipeline.rs:190-247` `extract_pe` matches plan pseudocode; counter is `saturating_add(2)`. |
+| 15 | §4.2 `drop_overlap` (no `pair_strand` arg — rev 1 simplification) | §4.2 | DONE | `overlap.rs:36-63` takes `(Vec<MethCall>, &BismarkPair)`. Uses `Vec::retain` per rev 1 Reviewer B F1. |
+| 16 | §4.3 SE-vs-PE auto-detect at `main.rs::run` | §4.3 | DONE | `main.rs:110-130` opens probe reader, calls `detect_paired_from_header`, dispatches. |
+| 17 | §4.4 per-mate ignore wiring | §4.4 | DONE | `pipeline.rs:305-306`. |
+| 18 | §4.5 cross-chr defensive `MateChromosomeMismatch` | §4.5 | DONE | `pipeline.rs:264-290`; error at `error.rs:210`. |
+| 19 | §4.6 edge case: empty BAM | §4.6 | DONE | Loop `break` at `pipeline.rs:206` → finalize writes header-only files. (Inherited from Phase B SE empty-BAM smoke; PE smoke asserts CTOT/CTOB header-only.) |
+| 20 | §4.6 edge case: odd record count → `UnpairedFinalRecord` | §4.6 | DONE | `extract_pe_rejects_unpaired_final_record` test. |
+| 21 | §4.6 edge case: coordinate-sorted PE | §4.6 | DONE | Inherited — `bismark-io::open_reader` rejects upstream; not Phase C scope. |
+| 22 | §4.6 edge case: mismatched qnames | §4.6 | DONE | `bismark_pair_from_mates_rejects_mismatched_qnames` test. |
+| 23 | §4.6 edge case: R1-in-second-position | §4.6 | DONE | `BismarkPair::from_mates` returns `ReadIdentityMismatch`; propagates as `BismarkIo`. Implicit in `from_mates` error mapping. |
+| 24 | §4.6 edge case: cross-chr pair | §4.6 | DONE | `extract_pe_rejects_cross_chromosome_pair` test. |
+| 25 | §4.6 edge case: `--include_overlap` | §4.6 | DONE | `extract_pe_with_include_overlap_keeps_r2_overlap_calls` test. |
+| 26 | §4.6 edge case: fully-overlapping pair | §4.6 | DONE | `drop_overlap_fully_overlapping_pair_keeps_calls_inside_r1_span` unit test. |
+| 27 | §4.6 edge case: disjoint pair | §4.6 | DONE | `drop_overlap_disjoint_pair_drops_all_r2_calls_downstream_of_r1_end` unit test. |
+| 28 | §4.6 edge case: no Bismark @PG → `AutoDetectFailed` | §4.6 | DONE | `main_auto_detect_fails_without_bismark_pg` test. |
+| 29 | §4.6 edge case: bismark2-aligned input via @PG CL parse | §4.6 | DONE | `detect_paired_from_header` tests in `bismark-io/src/read.rs:1128+` cover `--1`/`--2` double-dash form. |
+
+### Signatures (plan §5)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 30 | overlap.rs: `drop_overlap` | §5.1 | DONE | `overlap.rs:36`. |
+| 31 | overlap.rs: `is_forward_pair_strand` | §5.1 | DONE | `overlap.rs:72`. |
+| 32 | pipeline.rs: `run_extraction<F>` | §5.2 | DEVIATED | Per contingency in §6 step 6, NOT extracted. Documented in `pipeline.rs:11-20`. Scaffolding duplicated between `extract_se` and `extract_pe`. |
+| 33 | pipeline.rs: `extract_pe` | §5.2 | DONE | `pipeline.rs:190`. |
+| 34 | pipeline.rs: `extract_se` | §5.2 | DONE | `pipeline.rs:66` (unchanged from Phase B). |
+| 35 | pipeline.rs: `resolve_chr` | §5.2 | DEVIATED | Not extracted as a standalone helper; chr resolution is inlined in both `extract_se` (line 116) and `handle_one_pair` (line 292). Behaviour-equivalent; minor cosmetic deviation. |
+| 36 | pipeline.rs: `resolve_chr_by_refid` | §5.2 | DEVIATED | Same — inlined. |
+| 37 | error variant: `UnpairedFinalRecord` | §5.3 | DONE | `error.rs:195`. |
+| 38 | error variant: `MateChromosomeMismatch` | §5.3 | DONE | `error.rs:210`. |
+| 39 | error variant: `AutoDetectFailed` | §5.3 | DONE | `error.rs:222`. |
+| 40 | bismark-io: `detect_paired_from_header` re-export | §5.4 | DONE | `bismark-io/src/read.rs:649`; `lib.rs:34` re-export. |
+
+### Implementation outline (plan §6)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 41 | Step 1: bismark-io v1.0.0-beta.7 promotion (incl. `arg_present`) | §6 step 1 | DONE | `bismark-io/Cargo.toml` v1.0.0-beta.7; `read.rs:649` (`detect_paired_from_header`) + `read.rs:687` (`arg_present`); dedup `pipeline.rs:30` re-exports. |
+| 42 | Step 2: bismark-extractor version + dep bump | §6 step 2 | DONE | `bismark-extractor/Cargo.toml` v1.0.0-alpha.3, `bismark-io = =1.0.0-beta.7`. |
+| 43 | Step 3: cli.rs `no_overlap` bug-fix (rev 1 Critical) | §6 step 3 | DONE | `cli.rs:452-456` uses `paired_mode != SingleEnd`. |
+| 44 | Step 4: error variants | §6 step 4 | DONE | All three new variants added to `error.rs`. |
+| 45 | Step 5: overlap.rs | §6 step 5 | DONE | Full module per §4.2 / §5.1. |
+| 46 | Step 6: pipeline.rs — refactor OR duplicate per contingency | §6 step 6 | DONE (duplicate path) | Duplicated scaffolding; explicit comment block at `pipeline.rs:11-20`. |
+| 47 | Step 7: main.rs PairedMode dispatch with auto-detect | §6 step 7 | DONE | `main.rs:107-131`. |
+| 48 | Step 8: lib.rs `pub mod overlap` + re-exports | §6 step 8 | DONE | `lib.rs:50`, `60`. |
+| 49 | Step 9: tests | §6 step 9 | PARTIAL (see §7.1 gap list) | 22 PE tests + 2 smoke + 3 auto-detect; 5 §7.1 rows missing (see Gaps). |
+| 50 | Step 10: cargo test / clippy / fmt across all 3 crates | §6 step 10 | DONE | `cargo test -p bismark-io -p bismark-dedup -p bismark-extractor` all green; tally below. |
+
+### Validation matrix (plan §10)
+
+| # | Validation row | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 51 | Overlap-detection polarity (3 InDel topologies) | §10 | DONE | Forward + reverse + InDel + end-deletion + insertion fixtures all present and passing. |
+| 52 | Pair-strand routing (Alan's bug) | §10 | DONE | `extract_pe_routes_r2_calls_to_pair_strand_file_not_record_strand_file`. |
+| 53 | Per-mate ignore-region trimming | §10 | MISSING (see Gaps) | The two e2e tests `extract_pe_per_mate_ignore_r2_only_skips_r2_positions` + `_3prime_r2` were not implemented. Per-mate trims ARE wired (line 305-306) and are exercised by Phase B's `extract_calls_respects_ignore_5p` / `_ignore_3p` SE unit tests, but no PE-specific differentiation test exists. |
+| 54 | `BismarkPair::from_mates` propagates qname errors | §10 | DONE | `bismark_pair_from_mates_rejects_mismatched_qnames`. |
+| 55 | Unpaired-final-record error | §10 | DONE | `extract_pe_rejects_unpaired_final_record`. |
+| 56 | Cross-chr defensive guard | §10 | DONE | `extract_pe_rejects_cross_chromosome_pair`. |
+| 57 | AutoDetect `no_overlap` regression (rev 1 Critical) | §10 | DONE | `validate_auto_detect_keeps_no_overlap_default`. |
+| 58 | PE splitting-report line-counting | §10 | DONE | `pe_splitting_report_counts_lines_not_pairs`. |
+| 59 | `--include_overlap` semantic | §10 | DONE | `extract_pe_with_include_overlap_keeps_r2_overlap_calls`. |
+| 60 | End-to-end PE smoke | §10 | DONE | `tests/pe_phase_c_smoke.rs` — 2 tests (`auto_detect_produces_all_12_files`, `explicit_paired_end_flag_works`). |
+
+## Gaps (detail)
+
+### Item 49 / Item 53: Plan §7.1 unit-test rows not realised in `tests/pe_phase_c.rs`
+
+The plan §7.1 ledger lists ~22 unit tests. The implementation realised most of them but skipped or merged the following rows. None of them block the verdict because the underlying behaviour is exercised elsewhere; listing here so the user can decide whether to backfill.
+
+**Missing-1: `extract_pe_per_mate_ignore_r2_only_skips_r2_positions`**
+- **Expected:** R1 and R2 each have methylation calls at read-positions 0/1/2; with `--ignore_r2 3` R1 calls are present, R2 calls are skipped. (Plan §7.1, §10 row "Per-mate ignore-region trimming".)
+- **Found:** Behaviour wired at `pipeline.rs:305-306` and `cli.rs:464-469`; covered indirectly by Phase B's `extract_calls_respects_ignore_5p` (SE-level kernel test). No PE-specific differentiation test verifies R1-vs-R2 isolation.
+- **Gap:** No test would fail if someone wired `ignore_r2` into the R1 path by mistake. Low risk because the wiring is `config.ignore_5p_r2 → pair.r2()` literal, but the differentiation gate is absent.
+
+**Missing-2: `extract_pe_per_mate_ignore_3prime_r2_only_skips_r2_3prime`**
+- Same as Missing-1 for the 3'-end mirror. Same risk profile.
+
+**Missing-3: `extract_pe_ignore_r2_skips_read_cycles_not_ref_positions`** (rev 1 Reviewer A §2.4)
+- **Expected:** OT pair where R2 is reverse-mapped (record_strand=CTOT) with `--ignore_r2 3` — asserts the first three 5'-end **read cycles** are skipped, not the first three reference positions (which would be the 3' end on a reverse-strand read).
+- **Found:** Not present. The iter_aligned orientation correction is tested at Phase B level (`extract_calls_minus_strand_orients_5prime`, `_orients_both_calls`); these guarantee the read-cycle vs ref-position distinction at SE level. The reverse-strand R2 ignore-polarity case is not separately re-verified in the PE harness.
+- **Gap:** Phase B coverage is sufficient for the kernel invariant; PE re-verification not present.
+
+**Missing-4: `extract_pe_routes_ctot_pair_strand_correctly` + `extract_pe_routes_ctob_pair_strand_correctly`** (rev 1 Reviewer A §4.2)
+- **Expected:** Non-directional library pairs where R1's record_strand is CTOT (or CTOB); verify overlap branches via the forward / reverse class per `is_forward_pair_strand` and R2 calls route to `*_CTOT_*.txt` (or `*_CTOB_*.txt`).
+- **Found:** `is_forward_pair_strand_matches_perl_classification` covers the classification function in isolation. No CTOT/CTOB e2e routing test. Phase C's smoke does check CTOT/CTOB files are emitted (header-only) but doesn't populate them.
+- **Gap:** Non-directional library path (CTOT/CTOB pairs with non-empty calls) is not exercised end-to-end. The plan flagged this explicitly. Risk: medium — non-directional libraries are real and the routing branch could regress without detection.
+
+**Missing-5: `extract_pe_increments_mbias_R2_at_index_1`**
+- **Expected:** R2 calls increment `state.mbias[1]` not `state.mbias[0]`.
+- **Found:** Phase B's `route_call_r2_goes_to_mbias_index_1` (in `se_phase_b.rs:762`) plus `mbias_R2_index_ready` cover the M-bias index-1 routing for R2 directly through `route_call`. The PE-level wrapper test was not added.
+- **Gap:** Behaviour is verified at route_call level; PE composition re-verification absent. Low risk.
+
+**Missing-6: `extract_pe_empty_bam_writes_only_header_files`**
+- **Expected:** PE empty BAM → 12 header-only files + splitting report with 0 lines processed.
+- **Found:** Phase B's `smoke_se_empty_bam_writes_only_header_files` covers SE; the PE smoke `smoke_pe_auto_detect_produces_all_12_files_and_report` covers populated PE BAM. No specific empty-PE-BAM test.
+- **Gap:** Empty-PE path is structurally identical to SE empty path through the same `state.finalize` machinery; effectively re-covered. Low risk.
+
+### Item 8 / 32: `run_extraction<F>` not extracted (DEVIATED — documented)
+
+- **Expected (plan §6 step 6):** Refactor common scaffolding into private `run_extraction<F>` helper if Phase B has merged before Phase C implementation; otherwise duplicate scaffolding.
+- **Found:** Scaffolding is duplicated between `extract_se` (pipeline.rs:66-159) and `extract_pe` (pipeline.rs:190-247). Pre-finalize cleanup is repeated identically in both. Explicit deviation comment at `pipeline.rs:11-20` cites the contingency.
+- **Action:** None — the plan explicitly authorised this path. Follow-up PR for the refactor lands after Phase B merges, per the plan note.
+- **Consequence for §7.1 `run_extraction_runs_cleanup_on_each_error_variant`:** That test was a refactor-safety invariant for the extracted helper. With the helper not extracted, the test is moot; Phase B's existing error-path tests (`extract_calls_rejects_invalid_xm_byte_with_error`, the cleanup tests `cleanup_partial_outputs_removes_all_12_files` + `_continues_past_one_failure`) plus Phase C's `extract_pe_rejects_*` tests collectively verify that cleanup runs on each error variant from each scaffolding body. Alternate audit satisfied.
+
+### Item 35 / 36: `resolve_chr` / `resolve_chr_by_refid` not extracted (DEVIATED — minor cosmetic)
+
+- **Expected (plan §3.2 / §5.2):** Extract chr-name resolution as a shared helper. Plan flagged this as an Optional rev 1 inclusion (Reviewer B L2).
+- **Found:** Chr resolution is inlined in `extract_se` (pipeline.rs:104-128) and `handle_one_pair` (pipeline.rs:264-301). Both inline paths produce the same `InternalError` on refid out-of-range.
+- **Action:** None — cosmetic. Code is duplicated (~10 LOC each side) but behaviour-identical. Naturally folds into the post-Phase-B `run_extraction<F>` refactor PR.
+
+## Test verification (Mode B)
+
+`cargo test -p bismark-io -p bismark-dedup -p bismark-extractor` — all green.
+
+Extractor test totals (binaries + integration files):
+- `bismark-extractor` unit tests (in src/): 40 passed
+- `tests/pe_phase_c.rs`: 22 passed
+- `tests/pe_phase_c_smoke.rs`: 2 passed
+- `tests/sanity.rs`: 4 passed
+- `tests/se_phase_b.rs`: 44 passed
+- `tests/se_phase_b_smoke.rs`: 3 passed
+- Doc-tests: 0
+
+bismark-io and bismark-dedup: all green (no regressions from the v1.0.0-beta.7 promotion).
+
+| Test name | File | Status |
+|-----------|------|--------|
+| `is_forward_pair_strand_matches_perl_classification` | `tests/pe_phase_c.rs` | PASS |
+| `drop_overlap_forward_pair_drops_r2_at_or_after_r1_end` | `tests/pe_phase_c.rs` | PASS |
+| `drop_overlap_reverse_pair_drops_r2_at_or_before_r1_start` | `tests/pe_phase_c.rs` | PASS |
+| `drop_overlap_disjoint_pair_drops_all_r2_calls_downstream_of_r1_end` | `tests/pe_phase_c.rs` | PASS |
+| `drop_overlap_fully_overlapping_pair_keeps_calls_inside_r1_span` | `tests/pe_phase_c.rs` | PASS |
+| `drop_overlap_with_r1_indel_uses_reference_end` | `tests/pe_phase_c.rs` | PASS |
+| `drop_overlap_with_r1_end_deletion` (rev 1 Reviewer A §2.5) | `tests/pe_phase_c.rs` | PASS |
+| `drop_overlap_with_r1_insertion_shifts_read_pos_only` (rev 1) | `tests/pe_phase_c.rs` | PASS |
+| `validate_auto_detect_keeps_no_overlap_default` (rev 1 Critical) | `tests/pe_phase_c.rs` | PASS |
+| `validate_paired_end_keeps_no_overlap_default` | `tests/pe_phase_c.rs` | PASS |
+| `validate_paired_end_with_include_overlap_disables_no_overlap` | `tests/pe_phase_c.rs` | PASS |
+| `bismark_pair_from_mates_rejects_mismatched_qnames` | `tests/pe_phase_c.rs` | PASS |
+| `extract_pe_handles_two_well_formed_pairs` | `tests/pe_phase_c.rs::pe_e2e` | PASS |
+| `pe_splitting_report_counts_lines_not_pairs` (rev 1) | `tests/pe_phase_c.rs::pe_e2e` | PASS |
+| `extract_pe_routes_r2_calls_to_pair_strand_file_not_record_strand_file` | `tests/pe_phase_c.rs::pe_e2e` | PASS |
+| `extract_pe_with_include_overlap_keeps_r2_overlap_calls` | `tests/pe_phase_c.rs::pe_e2e` | PASS |
+| `extract_pe_with_no_overlap_drops_r2_calls_past_r1_end` | `tests/pe_phase_c.rs::pe_e2e` | PASS |
+| `extract_pe_rejects_cross_chromosome_pair` | `tests/pe_phase_c.rs::pe_e2e` | PASS |
+| `extract_pe_rejects_unpaired_final_record` | `tests/pe_phase_c.rs::pe_e2e` | PASS |
+| `main_auto_detect_routes_pe_bam_to_extract_pe` | `tests/pe_phase_c.rs::auto_detect` | PASS |
+| `main_auto_detect_routes_se_bam_to_extract_se` | `tests/pe_phase_c.rs::auto_detect` | PASS |
+| `main_auto_detect_fails_without_bismark_pg` | `tests/pe_phase_c.rs::auto_detect` | PASS |
+| `smoke_pe_auto_detect_produces_all_12_files_and_report` | `tests/pe_phase_c_smoke.rs` | PASS |
+| `smoke_pe_explicit_paired_end_flag_works` | `tests/pe_phase_c_smoke.rs` | PASS |
+| `detect_paired_from_header_*` (5 tests, relocated from dedup) | `bismark-io/src/read.rs` | PASS |
+| `extract_pe_per_mate_ignore_r2_only_skips_r2_positions` | (not implemented) | MISSING |
+| `extract_pe_per_mate_ignore_3prime_r2_only_skips_r2_3prime` | (not implemented) | MISSING |
+| `extract_pe_ignore_r2_skips_read_cycles_not_ref_positions` (rev 1) | (not implemented) | MISSING |
+| `extract_pe_routes_ctot_pair_strand_correctly` (rev 1) | (not implemented) | MISSING |
+| `extract_pe_routes_ctob_pair_strand_correctly` (rev 1) | (not implemented) | MISSING |
+| `extract_pe_increments_mbias_R2_at_index_1` | (not implemented; covered by Phase B `route_call_r2_goes_to_mbias_index_1`) | MISSING |
+| `extract_pe_empty_bam_writes_only_header_files` | (not implemented; SE smoke covers structural equivalent) | MISSING |
+| `extract_se_handles_two_well_formed_records` (rev 1, refactor-safety) | (not applicable — refactor deferred) | N/A |
+| `run_extraction_runs_cleanup_on_each_error_variant` (rev 1) | (not applicable — refactor deferred) | N/A |
+
+## Verdict
+
+**COMPLETE — with documented deviations and 5 backfillable unit-test gaps.**
+
+The Phase C implementation lands every load-bearing behavioural requirement, signature, error variant, validation-matrix row, and the rev-1 Critical / Important fixes (AutoDetect no_overlap, splitting-report line counter, InDel-topology coverage). All 115 extractor tests pass plus the cross-crate suites.
+
+Two documented deviations:
+1. `run_extraction<F>` helper not extracted; scaffolding duplicated between `extract_se` and `extract_pe`. Authorised by the plan's §6 step 6 contingency (Phase B PR #849 still in review). Documented in `pipeline.rs:11-20`. Follow-up PR planned. The dependent `run_extraction_runs_cleanup_on_each_error_variant` and `extract_se_handles_two_well_formed_records` tests (refactor-safety) are correctly N/A — Phase B's existing cleanup tests + Phase C's `extract_pe_rejects_*` tests collectively cover the surviving invariant.
+2. `resolve_chr` / `resolve_chr_by_refid` helpers not extracted (Optional rev 1 inclusion). Chr resolution is inlined identically in both pipelines. Minor cosmetic deviation; absorbs into the follow-up refactor PR.
+
+Five §7.1 unit-test rows missing (per-mate-ignore differentiation × 3 polarities, CTOT/CTOB e2e routing × 2, m-bias R2, empty-PE-BAM). All five MISSING items have their underlying behaviour exercised elsewhere — Phase B kernel tests, Phase C smoke, or `route_call` tests — but the specific PE-level differentiation gates the plan listed are absent. If the user wants strict 1:1 ledger conformance, these are the backfill items:
+
+1. `extract_pe_per_mate_ignore_r2_only_skips_r2_positions` (PE differentiation gate for `--ignore_r2`)
+2. `extract_pe_per_mate_ignore_3prime_r2_only_skips_r2_3prime` (mirror)
+3. `extract_pe_ignore_r2_skips_read_cycles_not_ref_positions` (reverse-strand R2 polarity gate — rev 1 Reviewer A §2.4)
+4. `extract_pe_routes_{ctot,ctob}_pair_strand_correctly` (non-directional library routing — rev 1 Reviewer A §4.2)
+5. `extract_pe_increments_mbias_R2_at_index_1` + `extract_pe_empty_bam_writes_only_header_files` (PE-level re-verification of inherited invariants)
+
+Highest-priority backfill (in my assessment, but not editorialising): the CTOT/CTOB non-directional routing tests — they verify a real-world library type and the overlap-branch class, neither of which is exercised end-to-end elsewhere.

--- a/plans/05262026_bismark-extractor/PHASE_C_PLAN.md
+++ b/plans/05262026_bismark-extractor/PHASE_C_PLAN.md
@@ -1,0 +1,650 @@
+# `bismark-extractor` Phase C — PE extraction + overlap detection + per-mate ignore
+
+**Status:** rev 2 — implementation complete + dual code-review folded. 537 tests pass across 3 crates, clippy + fmt clean. Ready to commit + PR.
+**Date:** 2026-05-26.
+**Slug:** `plans/05262026_bismark-extractor/PHASE_C_PLAN.md`.
+**Phase target:** SPEC §10 row C — ~600 LOC (rev 1 estimate stable; eager-open + 2 Phase A helper changes net out).
+**GitHub sub-issue:** [#850](https://github.com/FelixKrueger/Bismark/issues/850) (filed at work-start).
+**Depends on:** [PR #849](https://github.com/FelixKrueger/Bismark/pull/849) (Phase B). Stacked branch `extractor-phase-c` is based on `extractor-phase-b`; rebases onto `rust/iron-chancellor` once Phase B merges. **Process risk (rev 1, Reviewer B A4):** if Phase B's review extends into a week+ with substantive changes, Phase C may need daily rebase. Mitigation: rebase Phase C onto Phase B daily during the latter's review, or pause Phase C implementation until #849 merges.
+
+## Revision history
+
+- **rev 0** (2026-05-26): initial Phase C plan.
+- **rev 2** (2026-05-26): post-implementation close-out folding 5 plan-manager MISSING items + cosmetic nits from both code-reviewers.
+  - **Plan-manager MISSING #1-#7 (7 tests added in `tests/pe_phase_c.rs::pe_e2e`)**:
+    - `extract_pe_routes_ctot_pair_strand_correctly` — non-directional CTOT pair (R1.record_strand=CTOT, pair_strand=CTOT, reverse class); all calls route to `*_CTOT_*.txt`, never `*_OT_*.txt` (which is R2's per-record strand). Closes Alan-Hoyle split-across-files bug at non-directional library level.
+    - `extract_pe_routes_ctob_pair_strand_correctly` — mirror for CTOB pair (forward class). New helpers `helpers::ctot_pair` + `helpers::ctob_pair` added.
+    - `extract_pe_per_mate_ignore_r2_only_skips_r2_positions` — `--ignore_r2 3` skips R2's 5'-end read cycles but leaves R1's intact. Verified via OT pair with `--include_overlap` so R2's calls can be observed independently.
+    - `extract_pe_per_mate_ignore_3prime_r2_only_skips_r2_3prime` — 3'-end mirror.
+    - `extract_pe_ignore_r2_skips_read_cycles_not_ref_positions` — reverse-strand polarity gate (rev 1 Reviewer A §2.4). Pins read-cycle vs ref-position semantics on a CTOT-strand R2.
+    - `extract_pe_increments_mbias_R2_at_index_1` — PE-level re-verification of R2→mbias[1] routing. Phase B's `route_call_r2_goes_to_mbias_index_1` already locks it at unit level; this exercises the PE composition through the binary.
+    - `extract_pe_empty_bam_writes_only_header_files` — empty PE BAM → 12 header-only files + "Processed 0 lines" report.
+  - **Reviewer A L1 / Reviewer B Err2 — RESOLVED.** Dropped `#[allow(unused_imports)]` from `bismark-dedup/src/pipeline.rs:30` `pub use bismark_io::detect_paired_from_header`. The `pub use` re-export is itself a use; the allow was unnecessary.
+  - **Reviewer A L2 / Reviewer B L2 — RESOLVED.** Added Perl line citations (`bismark_methylation_extractor:2905 / :2989`) to the polarity-discovery test bodies (`drop_overlap_disjoint_pair_drops_all_r2_calls_downstream_of_r1_end` + `extract_pe_with_no_overlap_drops_r2_calls_past_r1_end`).
+  - **Reviewer B L1 — RESOLVED.** Tightened `pe_phase_c_smoke.rs` assertion from `call_lines >= 1` to `call_lines == 10` (pins overlap polarity at smoke level). Comment now explains R2's reversed call at BAM-pos 4 lands at ref `r1_start + 4 = r1_ref_end`, so strict-`<` keep drops it; all 10 R1 calls survive.
+  - **Reviewer B Err3 — RESOLVED.** Added cleanup-completion assertion to `extract_pe_rejects_unpaired_final_record` (`fs::read_dir(&outdir).count() == 0` after failure). Sister test `extract_pe_rejects_cross_chromosome_pair` already had it.
+  - **Deferred for follow-up PR (post-Phase-B merge):**
+    - Reviewer A M1: dead-fixture preamble in `drop_overlap_with_r1_insertion_shifts_read_pos_only` — cosmetic, tracked.
+    - Reviewer A L3: `run_extraction<F>` scaffolding refactor — already documented in `pipeline.rs:11-20` as Phase B-merge follow-up.
+    - Reviewer A L4: cross-chr error to include chr names — minor ergonomic.
+    - Reviewer A M2: nf-core/methylseq parser owners need to update for "reads" → "lines" — flag in PR description.
+    - Reviewer B E2: `render_qname` dedup into helper — Phase D opportunity.
+    - Reviewer B S2: scratch-work mid-test comment cleanup in insertion fixture — combined with A's M1.
+  - **Verification (rev 2):** `cargo test -p bismark-io -p bismark-dedup -p bismark-extractor` → all green. `cargo clippy --all-targets -- -D warnings` (3 crates) → clean. `cargo fmt --check` (3 crates) → clean. Test totals (extractor): 40 lib + 4 sanity + 44 se_phase_b + **29 pe_phase_c** (was 22 in rev 1) + 3 se_phase_b_smoke + 2 pe_phase_c_smoke = 122 extractor tests. Plus bismark-io's 5 new `detect_paired_from_header` tests + bismark-dedup regression-free.
+
+- **rev 1** (2026-05-26): folded both plan-review reports' findings.
+  - **Reviewer A §1.1 (Critical) — RESOLVED.** AutoDetect `no_overlap` regression. Phase A's `Cli::validate` only sets `no_overlap = !include_overlap` for `paired_mode == PairedEnd`, leaving AutoDetect at `false`. With Phase C's AutoDetect→PE dispatch, this silently leaks R2 overlap calls. **Fix in Phase C scope:** change `cli.rs` to set `no_overlap = !include_overlap` for `paired_mode != SingleEnd`. Added to §3.2 "Modified modules" + new regression test `validate_auto_detect_keeps_no_overlap_default`.
+  - **Reviewer A §1.5 / Reviewer B L1 (Important, byte-identity-affecting) — RESOLVED.** Splitting-report PE counter. Both reviewers independently grepped Perl: line 2451 `$methylation_call_strings_processed += 2; # paired-end = 2 methylation call strings`; line 2479 `"Processed $counting{sequences_count} lines in total"` reports raw BAM-line count, not pair count. Closes §9.2 open question #2: **count lines (2N for N pairs), not pairs**. Plan §4.1 pseudocode now `state.report.records_processed.saturating_add(2)` per pair (or two `+=1` increments alongside R1 and R2 routing). §7.3 smoke assertion updated to "Processed 20 lines in total" (10 pairs × 2). New test `pe_splitting_report_counts_lines_not_pairs`.
+  - **Reviewer A §1.3 / Reviewer B L5 (Important) — RESOLVED.** `run_extraction<F>` signature. `AnyReader` is generic over `<R: BufRead, RC: Read + Seek>`; plan rev 0's `&mut bismark_io::AnyReader` won't compile. Pin the concrete instantiation `AnyReader<BufReader<File>, File>` (matches Phase B's `extract_se` use).
+  - **Reviewer A §2.5 (Important) — RESOLVED.** Single InDel-aware overlap test fixture is thin. Added 2 more tests: `drop_overlap_with_r1_end_deletion` (R1 `49M2D1M`, R2 at the cliff edge) and `drop_overlap_with_r1_insertion_shifts_read_pos_only` (R1 `50M2I50M` — insertion consumes read but not reference, so reference_end is 199 not 201). Together with the existing mid-read deletion test these cover the three CIGAR-relevant InDel topologies.
+  - **Reviewer A §2.4 + §4.2 (Important) — RESOLVED.** Reverse-strand R2 ignore-polarity test missing. Added `extract_pe_ignore_r2_skips_read_cycles_not_ref_positions`: an OT pair where R2 is reverse-mapped (record_strand == CTOT) with `--ignore_r2 3` — asserts the first three 5'-end **read cycles** are skipped, not the first three reference positions.
+  - **Reviewer A §4.2 (Important) — RESOLVED.** Non-directional library PE coverage. Added `extract_pe_routes_ctot_pair_strand_correctly` + `..._ctob_pair_strand_correctly` — exercises overlap detection branching for CTOT (forward class per `is_forward_pair_strand`) and CTOB (reverse class).
+  - **Reviewer A §1.4 (Important) — DECISION RECORDED.** Refactor-vs-duplicate contingency in §6 step 5 — refactor if Phase B has merged when Phase C implementation begins; else duplicate scaffolding to avoid concurrent-edit conflict.
+  - **Reviewer A §1.2 (Important) — RESOLVED.** Added Perl line citation (2400/2415) for `is_forward_pair_strand` branching to §5.1.
+  - **Reviewer B L4 (Important) — RESOLVED.** Stripped the contradictory "Move the PAIRED-flag check OUT … Wait, actually keep" bullet from §6 step 5. Final state: "Phase B's defensive PAIRED-flag check stays in `extract_se` for defense-in-depth."
+  - **Reviewer B L5 (Important)** — same as Reviewer A §1.3 above.
+  - **Reviewer B L6 (Important) — RESOLVED.** Dropped redundant `pair_strand` argument from `drop_overlap` (recoverable from `pair.pair_strand()`). §4.2 + §5.1 signatures updated.
+  - **Reviewer B X2 (Important) — RESOLVED.** Added a bullet to §6 step 1: promote private `arg_present` helper alongside `detect_paired_from_header` (used only by it).
+  - **Reviewer B E1 + V4 (Important) — RESOLVED.** Added `run_extraction_runs_cleanup_on_each_error_variant` test to §7.1 — injects each `BismarkExtractorError` variant raise-able from the closure body and asserts zero residual files. Plus an audit row in §10 validation cross-referencing Phase B's existing tests to confirm each error site survives the refactor.
+  - **Reviewer B V1 (Important) — RESOLVED.** Strengthened the overlap-include test fixture spec. `extract_pe_with_include_overlap_keeps_r2_overlap_calls` now names specific ref positions: R1 50M at chrX:100-149, R2 50M at chrX:120-169, overlap region 120-149, R2 has calls at 125/135/145; assertion checks those specific calls appear under `--include_overlap` and disappear under default `--no_overlap`.
+  - **Reviewer A §1.7 (Optional, included)** — renamed `CrossChromosomePair` → `MateChromosomeMismatch` for naming consistency with sibling variants (`MateMismatch`, `ReadIdentityMismatch`).
+  - **Reviewer B L2 (Optional, included)** — added `resolve_chr` helper extraction to §3.2 + §6 step 5 (used by both `extract_se` refactored body and `handle_one_pair`).
+  - **Reviewer B L3 (Optional, included) — RESOLVED §9.2 #3.** Cache chr name once per pair after the cross-chr defensive check; pass to both routing calls. Simpler code + one fewer HashMap lookup per R2 call.
+  - **Reviewer B F1 (Optional, included)** — use `Vec::retain` in `drop_overlap` instead of `into_iter().filter().collect()`. ~50% cheaper allocator churn for the common case (most R2 calls kept).
+  - **Reviewer A §6 / Phase F readiness note (Optional, included)** — added note to §11 about `run_extraction<F>`'s `FnOnce` body not composing with Phase F's producer/consumer split. Heads up for future planner.
+  - **Reviewer B A4 (Optional, surfaced)** — process-risk note about stacked-PR rebases added to the top status block.
+  - **Deferred (out of rev 1 scope):** Reviewer B L7 (AutoDetectFailed UX), Reviewer B L8 / Reviewer A §3.3 (cosmetic), Reviewer B E3 (mate_idx in InvalidXmByte), Reviewer A §1.6 (cross-chr to bismark-io v1.0.0-beta.8) — tracked as v1.x polish.
+
+## Epic linkage
+
+- **Design contract:** `rust/bismark-extractor/SPEC.md` (in-repo, rev 2). Sections covered in this plan: §6.1 (pair-strand once per pair), §7.3 (PE main loop), §7.4 (paired-overlap detection), §11 row "auto-detect" (SE vs PE).
+- **GitHub umbrella:** issue [#798](https://github.com/FelixKrueger/Bismark/issues/798) (bismark-extractor port).
+- **Prior phases:** Phase A merged (commit `144ca2d`, PR #847, closes #846). Phase B in review (PR #849, closes #848); Phase C builds on Phase B.
+
+## 1. Goal
+
+Light up the **paired-end extraction path**. Pair adjacent records into a `BismarkPair`, run the existing Phase B kernel + routing on each mate, drop R2 calls overlapping R1's reference span when `--no_overlap` is set (default for PE), apply per-mate ignore-region trims (`--ignore_r2`, `--ignore_3prime_r2`), and remove the SE pipeline's per-record `PAIRED`-flag rejection in favor of a header-level SE-vs-PE auto-detect from the `@PG ID:Bismark` line.
+
+After Phase C, the binary handles SE + PE in `OutputMode::Default` on a single core; the remaining phases (D-H) widen this along orthogonal axes (M-bias writer, non-default modes, gzip, multicore, subprocess chain, byte-identity gate).
+
+## 2. Scope decisions (locked)
+
+| Decision | Choice | Reasoning |
+|----------|--------|-----------|
+| PE pairing scheme | **Adjacent-record pairing** via `BismarkPair::from_mates` (R1 then R2, qname-eq enforced) | Matches Perl `bismark_methylation_extractor`'s loop: Bismark always emits PE records in adjacent R1/R2 pairs. Out-of-order pair detection is unnecessary and would mask upstream sort bugs. |
+| SE-vs-PE auto-detect | **Promote `detect_paired_from_header` from `bismark-dedup` to `bismark-io v1.0.0-beta.7`**, call once at reader-open time | SPEC §11; Reviewer A plan-review Optional #14 + Reviewer B confirmation. Removes the per-record PAIRED-flag check Phase B used. |
+| Per-mate ignore trims | `--ignore_r2` / `--ignore_3prime_r2` map to `config.ignore_5p_r2` / `config.ignore_3p_r2` (already in `ResolvedConfig`) | No new CLI work; Phase A already parsed these. Phase C wires them into the per-mate `extract_calls` calls. |
+| Overlap-detection polarity | **Strict `<` / `>` keep-predicate** (Perl writes inclusive `>=` / `<=` *skip* predicates; inverse) | Locked in SPEC §7.4 rev 2. Both reviewers verified against Perl 2905 + 2989. |
+| Overlap-detection edge-cases | **Test fixture covering R2 calls at `r1_ref_end - 1`, `r1_ref_end`, `r1_ref_end + 1`** for both forward (OT/CTOB) and reverse (OB/CTOT) pair-strand groups | SPEC §7.4 explicitly deferred "endpoint semantics verification" to Phase C. |
+| `--include_overlap` (keep R2 calls overlapping R1) | **Honored**; `config.no_overlap` is `false` when user passes `--include_overlap` (already resolved by Phase A) | Plain CLI plumbing. Inverts the drop_overlap call. |
+| Final-record-unpaired error | **`BismarkExtractorError::UnpairedFinalRecord { qname }`** (new variant) | Pair iteration assumes even record count; an odd count means the BAM is malformed or sort got out of order. Loud failure with cleanup. |
+| `extract_se` ↔ `extract_pe` shared scaffolding | **Extract a private `run_extraction<F>` helper** (Reviewer B PC4) for open_reader / build_chr_name_table / derive_basename / state.new / cleanup-on-err / state.finalize | Phase B's `extract_se` and the new `extract_pe` share ~80% of body code. Refactor in Phase C keeps both bodies thin. |
+| `BismarkPair::from_mates` error mapping | Wrap as `BismarkExtractorError::BismarkIo(BismarkIoError::MateMismatch \| ReadIdentityMismatch)` — already `#[from]` | No new error variants needed for the pairing failure mode. |
+| `ExtractParams` revival | **Not in Phase C.** Per-mate args (5-6) are still below the 14-arg threshold the SPEC §6.3 struct was designed to prevent. | Defer to Phase D/E if arg count grows further. |
+| M-bias writer | **Out of scope.** Phase B already accumulates `state.mbias[1]` for R2; Phase D adds the writer. | SPEC §10 row D. |
+| Default `--no_overlap` for PE | **ON** (matches Perl `--no_overlap` default) — fix Phase A's `Cli::validate` to resolve as `paired_mode != SingleEnd` (was `== PairedEnd` only, leaving AutoDetect at false). | Rev 1 Reviewer A §1.1 Critical: AutoDetect→PE dispatch would silently leak R2 overlap calls without this fix. |
+| **Splitting-report PE counter** | **Lines, not pairs.** Increment `state.report.records_processed` by 2 per pair (or two `+=1` calls — one per R1 routing, one per R2 routing). Matches Perl `bismark_methylation_extractor:2451` (`$methylation_call_strings_processed += 2`) + line 2479 splitting-report literal `"Processed N lines in total"`. | Rev 1 Reviewer A §1.5 + Reviewer B L1 (both independently grepped Perl). Closes §9.2 open question #2. |
+
+## 3. Context
+
+### 3.1 Source documents read end-to-end
+
+- `rust/bismark-extractor/SPEC.md` §§6.1, 6.5, 7.1 (referenced — kernel unchanged), **7.3**, **7.4**, 7.5 (referenced — route_call unchanged), 7.6 (ignore semantics already in extract_calls), 8.1 (test surface), 8.4 (edge case fixtures), 10, 11, 12.
+- `rust/bismark-extractor/src/{call,mbias,output,state,route,header,pipeline,error,main,lib}.rs` — Phase B implementation (current PR #849).
+- `rust/bismark-io/src/pair.rs` — `BismarkPair::from_mates`, `pair_strand()`, `r1()`, `r2()`.
+- `rust/bismark-io/src/record.rs` — `BismarkRecord::record_strand`, `iter_aligned`.
+- `rust/bismark-io/src/cigar.rs` — `CigarExt::reference_end(start: usize) -> usize` (returns 1-based inclusive last ref position).
+- `rust/bismark-dedup/src/pipeline.rs:121-150ish` — `detect_paired_from_header` (to be promoted to `bismark-io v1.0.0-beta.7`).
+- Perl `bismark_methylation_extractor` lines 1932-1944 (PE R1 reverse), 2877-2906 (PE forward overlap skip), 2976-2990 (PE reverse overlap skip), 1983-2330 (per-mate ignore application via CIGAR rewriting — Rust handles via boundary check in extract_calls).
+
+### 3.2 Code placement
+
+All Phase C code lands inside `rust/bismark-extractor/` (with one small change in `rust/bismark-io/`):
+
+- **New modules**:
+  - `rust/bismark-extractor/src/overlap.rs` — `drop_overlap` per SPEC §7.4 + helper `is_forward_pair_strand`.
+- **Modified modules**:
+  - `rust/bismark-extractor/src/cli.rs` — **rev 1 critical fix (Reviewer A §1.1):** change `Cli::validate`'s `no_overlap` resolution from `paired_mode == PairedEnd` to `paired_mode != SingleEnd`, so AutoDetect inherits the PE default. SE actual extraction ignores the field anyway (no overlap concept for SE).
+  - `rust/bismark-extractor/src/pipeline.rs` — add `extract_pe`; refactor common scaffolding (open_reader, chr_table, basename, state, cleanup-on-error, finalize) into private `run_extraction` helper; SE main loop becomes `extract_se` calling `run_extraction(..., |reader, chr_table, state| { se_loop_body })`. Also extract a small `resolve_chr(record, chr_table) -> Result<&str, BismarkExtractorError>` helper (rev 1 Reviewer B L2) used by both SE and PE.
+  - `rust/bismark-extractor/src/main.rs::run` — replace the SE-only path with config-dispatch on `PairedMode`: `SingleEnd → extract_se`, `PairedEnd → extract_pe`, `AutoDetect → call detect_paired_from_header at open_reader time → dispatch`. Keep Phase B's defensive per-record PAIRED-flag check inside `extract_se` for belt-and-suspenders (catches "user passed --single-end against a PE BAM" case).
+  - `rust/bismark-extractor/src/error.rs` — add `UnpairedFinalRecord { qname: Option<String> }`, `MateChromosomeMismatch { qname, r1_refid, r2_refid }` (renamed from rev 0's `CrossChromosomePair` per Reviewer A §1.7 — matches `MateMismatch` / `ReadIdentityMismatch` naming), and `AutoDetectFailed { message }`.
+  - `rust/bismark-extractor/src/route.rs` — **no signature change.** Phase B's `route_call` already takes `strand: BismarkStrand` + `read_identity: ReadIdentity`; PE callers pass `pair.pair_strand()` and `R1`/`R2` respectively.
+  - `rust/bismark-extractor/src/lib.rs` — `pub mod overlap;` + re-export `drop_overlap`, `extract_pe`.
+  - `rust/bismark-extractor/Cargo.toml` — version bump `1.0.0-alpha.2` → `1.0.0-alpha.3`; bump `bismark-io` dep from `=1.0.0-beta.6` to `=1.0.0-beta.7`.
+- **In `bismark-io` (separate-but-coupled change in same PR)**:
+  - `rust/bismark-io/src/read.rs` — promote `detect_paired_from_header` from `bismark-dedup/src/pipeline.rs:137` into `bismark-io` (public function). **Also promote the private `arg_present` helper** that `detect_paired_from_header` calls (dedup pipeline.rs:175 — used only by it; rev 1 Reviewer B X2). Move tests too.
+  - `rust/bismark-io/src/lib.rs` — `pub use read::detect_paired_from_header;`.
+  - `rust/bismark-io/Cargo.toml` — version `1.0.0-beta.6` → `1.0.0-beta.7`. Verify `noodles-sam` already pulls in the `io` feature (dedup version uses `noodles_sam::io::Writer` for header serialization in the substring search); `cargo check` after the move will catch any feature-gap.
+  - `rust/bismark-dedup/src/pipeline.rs` — replace the local `detect_paired_from_header` + `arg_present` definitions with `use bismark_io::detect_paired_from_header;` (or call-site fully-qualified). Bump `bismark-io` dep in `bismark-dedup/Cargo.toml` to `=1.0.0-beta.7`. No behaviour change.
+- **Tests**:
+  - `rust/bismark-extractor/tests/pe_phase_c.rs` — new unit tests (overlap fixture, PE pairing, per-mate ignore, multi-record PE loop).
+  - `rust/bismark-extractor/tests/pe_phase_c_smoke.rs` — end-to-end smoke (synthetic PE BAM via `bismark-io::BamWriter`, run binary, assert 12-file emission + splitting-report shape).
+  - `rust/bismark-io/src/read.rs` — extend existing test module with the promoted `detect_paired_from_header` tests (cherry-picked from dedup's test suite).
+
+### 3.3 Crate versions
+
+- `bismark-extractor`: `1.0.0-alpha.2` → `1.0.0-alpha.3` (additive within the alpha line).
+- `bismark-io`: `1.0.0-beta.6` → `1.0.0-beta.7` (additive — new public function, no breaking changes).
+- `bismark-dedup`: no version bump; dep update only.
+
+### 3.4 Binary behaviour
+
+After Phase B (PR #849): SE Default mode works; PE rejected per-record with `PhaseNotYetImplemented`.
+
+After Phase C:
+- `--paired-end` → `extract_pe` (real PE extraction).
+- No mode flag → auto-detect via `detect_paired_from_header` at reader-open.
+- `--single-end` → `extract_se` (unchanged from Phase B).
+- Phase-gate rejections still fire for: non-default output modes, `--gzip`, `--parallel > 1`, `--bedGraph` / `--cytosine_report`, multiple input files. Unchanged.
+
+## 4. Behaviour specification
+
+### 4.1 PE main loop
+
+```rust
+fn extract_pe(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkExtractorError> {
+    run_extraction(input, config, |reader, chr_table, state| {
+        let mut iter = reader.records();
+        loop {
+            let r1 = match iter.next() {
+                Some(Ok(r)) => r,
+                Some(Err(e)) => return Err(e.into()),
+                None => break Ok(()),                  // clean end of BAM
+            };
+            let r2 = match iter.next() {
+                Some(Ok(r)) => r,
+                Some(Err(e)) => return Err(e.into()),
+                None => return Err(BismarkExtractorError::UnpairedFinalRecord {
+                    qname: render_qname_opt(&r1),
+                }),
+            };
+            let pair = BismarkPair::from_mates(r1, r2)?;   // qname-eq + R1/R2 ids
+            handle_one_pair(&pair, state, chr_table, config)?;
+            // Rev 1 fix (Reviewer A §1.5 / Reviewer B L1): Perl line 2451 increments
+            // by 2 per pair (one per BAM line). Splitting report says "Processed N lines",
+            // not pairs. Two singleton +=1 calls is cleaner than +=2 and matches the
+            // structure of Phase B's SE loop (one +=1 per record).
+            state.report.records_processed = state.report.records_processed.saturating_add(2);
+        }
+    })
+}
+
+fn handle_one_pair(
+    pair: &BismarkPair,
+    state: &mut ExtractState,
+    chr_table: &[String],
+    config: &ResolvedConfig,
+) -> Result<(), BismarkExtractorError> {
+    // Rev 1 (Reviewer B L3): cache chr once. Cross-chr defensive check first;
+    // post-check r1 and r2 share a chr by construction.
+    let r1_refid = pair.r1().inner().reference_sequence_id()
+        .ok_or_else(|| BismarkExtractorError::InternalError {
+            message: "PE R1 missing reference_sequence_id".to_string(),
+        })?;
+    let r2_refid = pair.r2().inner().reference_sequence_id()
+        .ok_or_else(|| BismarkExtractorError::InternalError {
+            message: "PE R2 missing reference_sequence_id".to_string(),
+        })?;
+    if r1_refid != r2_refid {
+        return Err(BismarkExtractorError::MateChromosomeMismatch {
+            qname: render_qname_str(pair.r1()),
+            r1_refid,
+            r2_refid,
+        });
+    }
+    let chr = resolve_chr_by_refid(r1_refid, chr_table)?;   // shared by both mates
+
+    let pair_strand = pair.pair_strand();
+    let r1_calls = extract_calls(pair.r1(), config.ignore_5p_r1, config.ignore_3p_r1)?;
+    let r2_calls_raw = extract_calls(pair.r2(), config.ignore_5p_r2, config.ignore_3p_r2)?;
+
+    let r2_calls = if config.no_overlap {
+        drop_overlap(r2_calls_raw, pair)?     // rev 1 (Reviewer B L6): pair_strand dropped from sig
+    } else {
+        r2_calls_raw
+    };
+
+    for call in r1_calls {
+        route_call(state, pair.r1(), chr, pair_strand, call, ReadIdentity::R1)?;
+    }
+    for call in r2_calls {
+        route_call(state, pair.r2(), chr, pair_strand, call, ReadIdentity::R2)?;
+    }
+    Ok(())
+}
+```
+
+### 4.2 Overlap detection (`drop_overlap`)
+
+```rust
+/// SPEC §7.4: drop R2 calls overlapping R1's reference span when --no_overlap.
+/// Polarity locked in SPEC rev 2: Perl skips inclusively (>= for forward,
+/// <= for reverse against R1's ref_end / ref_start); the keep predicate is
+/// the strict inverse (< / >).
+///
+/// Rev 1 (Reviewer B L6): `pair_strand` is recoverable from `pair.pair_strand()`;
+/// dropped from the signature to remove caller-side boilerplate.
+///
+/// Rev 1 (Reviewer B F1): use `Vec::retain` instead of `into_iter().filter().collect()`
+/// to avoid reallocating a new Vec on the common case (most R2 calls kept).
+pub fn drop_overlap(
+    mut r2_calls: Vec<MethCall>,
+    pair: &BismarkPair,
+) -> Result<Vec<MethCall>, BismarkExtractorError> {
+    let r1_start = pair.r1().alignment_start().ok_or_else(|| {
+        BismarkExtractorError::InternalError {
+            message: "R1 of PE pair missing alignment_start".to_string(),
+        }
+    })? as usize;
+    if is_forward_pair_strand(pair.pair_strand()) {
+        // OT/CTOB pair: R1 upstream, R2 downstream. Skip R2 calls AT OR AFTER r1_ref_end.
+        let r1_ref_end = pair.r1().cigar().reference_end(r1_start) as u32;
+        r2_calls.retain(|c| c.ref_pos < r1_ref_end);
+    } else {
+        // OB/CTOT pair: R2 upstream, R1 downstream. Skip R2 calls AT OR BEFORE r1_ref_start.
+        let r1_ref_start = r1_start as u32;
+        r2_calls.retain(|c| c.ref_pos > r1_ref_start);
+    }
+    Ok(r2_calls)
+}
+
+/// Forward-class pair strands: R1's mapped position is the upstream end of the
+/// insert. OT and CTOB are forward; OB and CTOT are reverse.
+///
+/// Cites Perl `bismark_methylation_extractor:2400` (forward branch entry) +
+/// line 2415 (reverse branch entry) where the per-pair direction selection lives.
+fn is_forward_pair_strand(strand: BismarkStrand) -> bool {
+    matches!(strand, BismarkStrand::OT | BismarkStrand::CTOB)
+}
+```
+
+### 4.3 SE-vs-PE auto-detect (header-level)
+
+`detect_paired_from_header` lives in `bismark-io` after promotion. Returns `Option<bool>` per the existing dedup signature:
+
+- `Some(true)` — PE Bismark @PG line found (has both `-1`/`--1` and `-2`/`--2`).
+- `Some(false)` — SE Bismark @PG line found.
+- `None` — no Bismark @PG line; main dispatch errors with a clear message asking for explicit `--single-end` / `--paired-end`.
+
+In `main.rs::run`:
+
+```rust
+match config.paired_mode {
+    PairedMode::SingleEnd => extract_se(input, &config),
+    PairedMode::PairedEnd => extract_pe(input, &config),
+    PairedMode::AutoDetect => {
+        // Open reader once for header inspection. The reader is then either
+        // (a) re-opened in extract_se/extract_pe (cheap; BAM index is cached
+        // by the OS) OR (b) threaded into the dispatch as a peeked reader.
+        // For Phase C: re-open is simpler and matches dedup's pattern.
+        let header_probe_reader = open_reader(input, /*cram_ref=*/ None)?;
+        let is_paired = detect_paired_from_header(header_probe_reader.header())
+            .ok_or_else(|| BismarkExtractorError::AutoDetectFailed {
+                message: "no Bismark @PG line in header; pass --single-end or --paired-end explicitly".to_string(),
+            })?;
+        drop(header_probe_reader);
+        if is_paired { extract_pe(input, &config) } else { extract_se(input, &config) }
+    }
+}
+```
+
+Adds one new error variant `AutoDetectFailed { message }` for the `None` case.
+
+### 4.4 Per-mate ignore-region trims
+
+Phase B's kernel `extract_calls(record, ignore_5p, ignore_3p)` already accepts the trims as plain `u32` parameters. Phase C wires:
+
+- R1 mate: `extract_calls(pair.r1(), config.ignore_5p_r1, config.ignore_3p_r1)`.
+- R2 mate: `extract_calls(pair.r2(), config.ignore_5p_r2, config.ignore_3p_r2)`.
+
+The kernel applies the trims in 5'-oriented read coordinates (Phase B's invariant). For R2, the 5' end is the sequencing-cycle start of the R2 read — `iter_aligned`'s orientation correction handles this transparently (the `-`-strand R2 case is what `iter_aligned` was designed for).
+
+No kernel changes. Phase A's `ResolvedConfig` already carries `ignore_5p_r2` and `ignore_3p_r2`.
+
+### 4.5 Cross-chr pair handling
+
+`BismarkPair::from_mates` validates qname-equality + R1/R2 identity but does NOT check that R1 and R2 share a reference. Bismark never emits cross-chr PE alignments (paired Bowtie2 wouldn't produce them), but defensive handling is per SPEC §8.4 edge case row.
+
+**Decision (rev 1):** add a check in `handle_one_pair` — if `r1.reference_sequence_id() != r2.reference_sequence_id()`, return `BismarkExtractorError::MateChromosomeMismatch { qname, r1_refid, r2_refid }` (renamed from rev 0's `CrossChromosomePair` per Reviewer A §1.7 for naming consistency with `MateMismatch` / `ReadIdentityMismatch`). Don't add to `bismark-io` for Phase C (extractor-specific concern); file a follow-up issue for `bismark-io v1.0.0-beta.8` to promote it to `BismarkPair::from_mates` for symmetry. Rev 1 also caches `chr` once after the defensive check (Reviewer B L3) — no double lookup.
+
+### 4.6 Edge cases
+
+| Case | Handling |
+|------|----------|
+| Empty input BAM | `extract_pe` exits the loop cleanly; finalize writes the 12 header-only files + splitting report (same as Phase B SE empty). |
+| Odd number of records | `extract_pe` returns `UnpairedFinalRecord { qname }` after cleanup. |
+| Records out of order (e.g. coordinate-sorted) | `bismark-io::open_reader` rejects upstream with `UnsortedInput`; extractor propagates. |
+| Pair with mismatched qnames | `BismarkPair::from_mates` returns `MateMismatch`; extractor propagates as `BismarkIo`. |
+| R1 in second-position / R2 in first | `BismarkPair::from_mates` returns `ReadIdentityMismatch`. Propagated. |
+| Cross-chromosome pair (R1 chr1, R2 chr2) | Defensive `CrossChromosomePair { qname }` in `handle_one_pair`. |
+| `--include_overlap` set | `config.no_overlap == false` → `drop_overlap` is skipped → all R2 calls kept. |
+| R2 partially overlapping R1 | `drop_overlap` drops R2 calls in overlap region; non-overlapping R2 calls kept. |
+| R1 + R2 fully overlapping (mate-pair span < read length, "innie" with insert smaller than read) | `drop_overlap` drops every R2 call. Output is R1-only for that pair. |
+| R1 + R2 disjoint (mate-pair span > read length) | `drop_overlap` is a no-op; all R2 calls trivially pass the strict comparison. |
+| Auto-detect: no `@PG ID:Bismark` line | `AutoDetectFailed` error with actionable message. |
+| Auto-detect: bismark2-aligned input | `detect_paired_from_header` returns the right answer (looks for `-1`/`--1` AND `-2`/`--2` in the bismark `@PG` CL field). |
+
+## 5. Signatures (proposed)
+
+### 5.1 `overlap.rs`
+
+```rust
+use bismark_io::{BismarkPair, BismarkStrand};
+use crate::call::MethCall;
+use crate::error::BismarkExtractorError;
+
+/// Drop R2 calls overlapping R1's reference span. Per SPEC §7.4 + Perl
+/// 2891-2906 (forward) + 2976-2990 (reverse).
+///
+/// Pair-strand is read from `pair.pair_strand()` internally (rev 1 simplification
+/// per Reviewer B L6).
+///
+/// # Errors
+///
+/// `InternalError` if R1 lacks an alignment_start (filtered upstream by
+/// `bismark-io`, so this should not fire in practice).
+pub fn drop_overlap(
+    r2_calls: Vec<MethCall>,
+    pair: &BismarkPair,
+) -> Result<Vec<MethCall>, BismarkExtractorError>;
+
+/// Cites Perl `bismark_methylation_extractor:2400` (forward branch entry) and
+/// line 2415 (reverse branch entry) where R1's strand-tag selects the
+/// pair-direction in the per-pair Perl loop.
+pub(crate) fn is_forward_pair_strand(strand: BismarkStrand) -> bool;
+```
+
+### 5.2 `pipeline.rs` additions / refactors
+
+```rust
+use std::fs::File;
+use std::io::BufReader;
+use bismark_io::AnyReader;
+
+/// Phase C: shared scaffolding for SE and PE extraction loops.
+///
+/// Opens the reader, builds the chr-name table, derives the basename,
+/// constructs `ExtractState` (which eager-opens 12 split files), runs
+/// the caller's `body` closure (which drives record-by-record or
+/// pair-by-pair logic), then calls `state.finalize()`. On any error
+/// from `body`, runs `state.cleanup_partial_outputs()` before propagating.
+///
+/// Rev 1 (Reviewer A §1.3 / Reviewer B L5): `AnyReader` is generic over
+/// `<R: BufRead, RC: Read + Seek>`. The concrete instantiation returned by
+/// `open_reader` is `AnyReader<BufReader<File>, File>`; the closure signature
+/// pins that instantiation rather than introducing generic propagation
+/// through `run_extraction`.
+fn run_extraction<F>(
+    input: &Path,
+    config: &ResolvedConfig,
+    body: F,
+) -> Result<(), BismarkExtractorError>
+where
+    F: FnOnce(
+        &mut AnyReader<BufReader<File>, File>,
+        &[String],
+        &mut ExtractState,
+    ) -> Result<(), BismarkExtractorError>;
+
+/// Helper: resolve `record.inner().reference_sequence_id()` against the
+/// per-file chr-name table. Rev 1 (Reviewer B L2): extracted from
+/// Phase B's inline `extract_se` code so both SE and PE bodies share it.
+fn resolve_chr(record: &BismarkRecord, chr_table: &[String])
+    -> Result<&str, BismarkExtractorError>;
+
+/// Variant of `resolve_chr` that takes a pre-resolved refid (avoids a second
+/// `reference_sequence_id()` call when the caller has already extracted it,
+/// as `handle_one_pair` does for the cross-chr defensive check).
+fn resolve_chr_by_refid(refid: usize, chr_table: &[String])
+    -> Result<&str, BismarkExtractorError>;
+
+/// Phase C: PE main loop.
+pub fn extract_pe(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkExtractorError>;
+
+/// Phase B: SE main loop. Refactored in Phase C to delegate to `run_extraction`.
+pub fn extract_se(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkExtractorError>;
+```
+
+Both `extract_se` and `extract_pe` become thin wrappers around `run_extraction` that differ only in the closure body (single-record loop vs paired-record loop). Phase B's defensive per-record PAIRED-flag check stays inside `extract_se`'s body (defense-in-depth against `--single-end` against a PE BAM).
+
+### 5.3 New error variants
+
+```rust
+/// PE input had an odd number of records — the final R1 has no R2 mate.
+#[error("unpaired final record in PE BAM: qname={qname:?}; PE input must contain pairs of adjacent R1/R2 records")]
+UnpairedFinalRecord {
+    /// QNAME of the orphan R1 (or `None` if the record had no name).
+    qname: Option<String>,
+},
+
+/// R1 and R2 of a PE pair aligned to different chromosomes. Bismark
+/// never produces this; defensive guard against tooling corruption.
+///
+/// Rev 1 (Reviewer A §1.7): renamed from `CrossChromosomePair` for
+/// naming consistency with `MateMismatch` / `ReadIdentityMismatch`.
+#[error("PE pair {qname} has R1 and R2 on different chromosomes (R1=refid {r1_refid}, R2=refid {r2_refid}); Bismark does not emit cross-chr pairs")]
+MateChromosomeMismatch {
+    /// Pair QNAME (shared by R1 and R2 per `BismarkPair`'s qname-eq guarantee).
+    qname: String,
+    /// R1 reference ID.
+    r1_refid: usize,
+    /// R2 reference ID.
+    r2_refid: usize,
+},
+
+/// `--paired-end` / `--single-end` auto-detect failed because the input's
+/// SAM header does not contain a recognised Bismark `@PG` line.
+#[error("library-mode auto-detection failed: {message}")]
+AutoDetectFailed {
+    /// Diagnostic message naming the next user step.
+    message: String,
+},
+```
+
+### 5.4 `bismark-io::detect_paired_from_header` (promoted)
+
+```rust
+// In rust/bismark-io/src/read.rs:
+/// Auto-detect single-end vs paired-end from a Bismark BAM header.
+///
+/// Walks the `@PG` lines and looks for one whose `ID` starts with
+/// `Bismark`. If found, inspects the command line in its `CL` field for
+/// `-1`/`--1` AND `-2`/`--2` arguments — present in PE mode, absent in
+/// SE mode.
+///
+/// Returns:
+/// - `Some(true)` — PE.
+/// - `Some(false)` — SE.
+/// - `None` — no Bismark `@PG` line; caller should error.
+///
+/// Promoted from `bismark-dedup/src/pipeline.rs:137` (was hardcoded there).
+/// Mirrors Perl `deduplicate_bismark` lines 90-116.
+pub fn detect_paired_from_header(header: &noodles_sam::Header) -> Option<bool>;
+```
+
+## 6. Implementation outline (ordered, rev 1)
+
+1. **bismark-io v1.0.0-beta.7 promotion** (do first; bismark-extractor + bismark-dedup depend on it):
+   - Move `detect_paired_from_header` body from `bismark-dedup/src/pipeline.rs:137` to `bismark-io/src/read.rs`. Re-export via `bismark-io/src/lib.rs`.
+   - **Rev 1 (Reviewer B X2): also promote the private `arg_present` helper at `bismark-dedup/src/pipeline.rs:175`** — used only by `detect_paired_from_header`. Move it alongside.
+   - Move the existing dedup tests for the function to `bismark-io/src/read.rs`'s test module.
+   - Bump `bismark-io/Cargo.toml` to `1.0.0-beta.7`. Verify `noodles-sam` already pulls the `io` feature (the function uses `noodles_sam::io::Writer` to serialize the header for substring search) — `cargo check` after the move catches any feature-gap.
+   - Update `bismark-dedup/Cargo.toml` bismark-io dep to `=1.0.0-beta.7`; update `bismark-dedup/src/pipeline.rs` to `use bismark_io::detect_paired_from_header` and drop the local definition. **Verify** `cargo test -p bismark-dedup` still green (no behaviour change).
+2. **bismark-extractor: bump dep + version**:
+   - `Cargo.toml` bismark-io `=1.0.0-beta.6` → `=1.0.0-beta.7`.
+   - `Cargo.toml` version `1.0.0-alpha.2` → `1.0.0-alpha.3`.
+3. **Phase A bug-fix (rev 1 Reviewer A §1.1 Critical)** in `src/cli.rs::validate`: change `no_overlap` resolution from `paired_mode == PairedMode::PairedEnd` to `paired_mode != PairedMode::SingleEnd`. Add a regression test `validate_auto_detect_keeps_no_overlap_default`.
+4. **Add error variants** in `src/error.rs`: `UnpairedFinalRecord`, `MateChromosomeMismatch` (rev 1 renamed from `CrossChromosomePair`), `AutoDetectFailed`.
+5. **Create `src/overlap.rs`** with `drop_overlap` + `is_forward_pair_strand`. Pair-strand recovered internally via `pair.pair_strand()` (rev 1 Reviewer B L6). Use `Vec::retain` (rev 1 Reviewer B F1) not `into_iter().filter().collect()`. Use `pair.r1().cigar().reference_end(start)` from `bismark-io::CigarExt`.
+6. **Refactor `src/pipeline.rs`** (rev 1 Reviewer A §1.4 contingency — see below):
+   - **If Phase B has merged** before Phase C implementation starts: extract common scaffolding into `run_extraction<F>(input, config, body)`. Pin the closure signature on `AnyReader<BufReader<File>, File>` (rev 1 Reviewer A §1.3 / Reviewer B L5). Rewrite `extract_se` as a `run_extraction` wrapper. Add `resolve_chr` + `resolve_chr_by_refid` helpers (rev 1 Reviewer B L2) used by both SE and PE bodies.
+   - **If Phase B is still in review**: duplicate the scaffolding in `extract_pe` (~30 LOC) — don't refactor `extract_se` concurrently with Phase B's review. The `run_extraction` helper extraction lands as a follow-up PR after Phase B merges.
+   - **Either way**: Phase B's defensive PAIRED-flag check stays in `extract_se`'s body for defense-in-depth (rev 1 Reviewer B L4 — replaces rev 0's contradictory "move OUT … wait, keep" bullet).
+   - Add `extract_pe` with the pair-loop body. Use `BismarkPair::from_mates` for each (R1, R2) tuple; propagate `MateMismatch` / `ReadIdentityMismatch` via `?`.
+   - Add `handle_one_pair` helper. Resolve `chr` once after the `MateChromosomeMismatch` defensive check (rev 1 Reviewer B L3).
+7. **Update `src/main.rs::run`**:
+   - Dispatch on `config.paired_mode`: `SingleEnd → extract_se`, `PairedEnd → extract_pe`, `AutoDetect → header-probe → dispatch`.
+   - `AutoDetect` path: open reader once for header inspection, call `detect_paired_from_header`, dispatch.
+8. **Update `src/lib.rs`** with `pub mod overlap;` + re-exports.
+9. **Write tests** (§7 below).
+10. **Run `cargo test -p bismark-extractor && cargo test -p bismark-io && cargo test -p bismark-dedup && cargo clippy && cargo fmt --check`** until all three crates green.
+
+## 7. Tests
+
+### 7.1 Unit tests (in `tests/pe_phase_c.rs`)
+
+| Test | Asserts |
+|------|---------|
+| `drop_overlap_forward_pair_drops_r2_at_or_after_r1_end` | OT pair (R1 chrX 100-149, 50M), R2 calls at refpos 148, 149, 150 → keeps 148; drops 149 (== r1_ref_end) and 150. **Endpoint verification per SPEC §7.4.** |
+| `drop_overlap_reverse_pair_drops_r2_at_or_before_r1_start` | OB pair (R1 chrX 200-249, 50M), R2 calls at refpos 199, 200, 201 → drops 199 and 200 (≤ r1_ref_start); keeps 201. |
+| `drop_overlap_disjoint_pair_is_noop` | R1 50M at 100, R2 50M at 300 (mate-pair span 200, read length 50 — no overlap) → no R2 calls dropped. |
+| `drop_overlap_fully_overlapping_pair_drops_all_r2_calls` | R1 50M at 100, R2 50M at 100 → all R2 calls in overlap; all dropped. |
+| `drop_overlap_with_r1_indel_uses_reference_end` | R1 `50M2D50M` at 100 → `reference_end == 201`. R2 calls at 200, 201, 202 → keeps 200; drops 201 and 202. Closes the InDel-aware ref-position invariant (SPEC §7.4 "decision at reference-position level"). |
+| `drop_overlap_with_r1_end_deletion` | **Rev 1 (Reviewer A §2.5):** R1 `49M2D1M` at 100 → `reference_span == 52`, `reference_end == 151`. R2 calls at 150, 151, 152 → keeps 150; drops 151, 152. End-of-read deletion topology. |
+| `drop_overlap_with_r1_insertion_shifts_read_pos_only` | **Rev 1 (Reviewer A §2.5):** R1 `50M2I50M` at 100 → insertion consumes read but not reference, so `reference_span == 100`, `reference_end == 199`. R2 calls at 198, 199, 200 → keeps 198; drops 199, 200. Insertion topology. |
+| `is_forward_pair_strand_matches_perl_classification` | OT, CTOB → true; OB, CTOT → false. |
+| `bismark_pair_from_mates_rejects_mismatched_qnames` | (smoke-level; mostly bismark-io's responsibility) |
+| `extract_pe_handles_two_well_formed_pairs` | Two adjacent PE pairs in a synthetic BAM → both routed correctly; `state.report.records_processed == 2`. |
+| `extract_pe_rejects_unpaired_final_record` | Synthetic BAM with 3 records (one R1 missing R2) → returns `UnpairedFinalRecord { qname }`; cleanup removes all 12 files. |
+| `extract_pe_rejects_mismatched_qnames_pair` | Synthetic BAM with R1 qname `foo` + R2 qname `bar` adjacent → `BismarkPair::from_mates` errors with `MateMismatch`; propagated as `BismarkIo`; cleanup runs. |
+| `extract_pe_rejects_cross_chromosome_pair` | Synthetic BAM with R1 chr1 + R2 chr2 → `CrossChromosomePair { qname }`; cleanup runs. |
+| `extract_pe_with_include_overlap_keeps_r2_overlap_calls` | **Rev 1 fixture spec (Reviewer B V1):** R1 50M at chrX:100-149, R2 50M at chrX:120-169 (overlap region 120-149 inclusive). R2 has methylation calls at ref_pos 125, 135, 145 (all inside overlap). With `--include_overlap`: assert all three calls present in output. |
+| `extract_pe_with_no_overlap_drops_r2_overlap_calls` | Same fixture as above; default `--no_overlap` → assert calls at 125, 135, 145 absent (specific ref positions; not a count). |
+| `extract_pe_per_mate_ignore_r2_only_skips_r2_positions` | **Rev 1 fixture spec (Reviewer B V2):** R1 and R2 each have methylation calls at read-positions 0, 1, 2. With `--ignore_r2 3`: assert R1's pos-0/1/2 calls present; R2's pos-0/1/2 calls absent. Distinguishes R2-specific trim from `--ignore` (which would skip R1 too). |
+| `extract_pe_per_mate_ignore_3prime_r2_only_skips_r2_3prime` | Mirror for `--ignore_3prime_r2`. |
+| **`extract_pe_ignore_r2_skips_read_cycles_not_ref_positions`** | **Rev 1 (Reviewer A §2.4):** OT pair where R2 is reverse-mapped (record_strand == CTOT). Apply `--ignore_r2 3`. Assert the first three **5'-end read cycles** are skipped — not the first three reference positions (which would be the 3' end on a reverse-strand read). Locks the iter_aligned-orientation-correction → ignore-region-trim path for R2. |
+| `extract_pe_routes_r2_calls_to_pair_strand_file_not_record_strand_file` | **Fixture comment:** R1's record_strand=OT, R2's record_strand=CTOT (explicit; the specific case that bites the naive port). All R2 calls must land in `*_OT_*.txt`, never `*_CTOT_*.txt`. Closes Alan's split-across-files bug at PE unit level. |
+| **`extract_pe_routes_ctot_pair_strand_correctly`** | **Rev 1 (Reviewer A §4.2):** non-directional library — pair where R1's record_strand=CTOT (forward class per `is_forward_pair_strand`). Assert overlap-detection branches via the forward path; R2 calls route to `*_CTOT_*.txt`. |
+| **`extract_pe_routes_ctob_pair_strand_correctly`** | **Rev 1 (Reviewer A §4.2):** mirror — pair where R1's record_strand=CTOB. Forward class. R2 calls route to `*_CTOB_*.txt`. |
+| `extract_pe_increments_mbias_R2_at_index_1` | R2 calls increment `state.mbias[1]` not `state.mbias[0]`. |
+| `extract_pe_empty_bam_writes_only_header_files` | Empty PE BAM → 12 header-only files + splitting report with 0 lines processed. |
+| **`pe_splitting_report_counts_lines_not_pairs`** | **Rev 1 (Reviewer A §1.5 / Reviewer B L1):** synthetic 10-pair PE BAM → splitting report contains "Processed 20 lines in total" (2 × 10 pairs). Matches Perl `bismark_methylation_extractor:2451` (`$methylation_call_strings_processed += 2`) + line 2479 report literal. |
+| **`run_extraction_runs_cleanup_on_each_error_variant`** | **Rev 1 (Reviewer B E1/V4):** parameterized test that injects each `BismarkExtractorError` variant raise-able from the closure body (`InvalidXmByte`, `MateMismatch`, `UnpairedFinalRecord`, `MateChromosomeMismatch`, `IoWrite`) into `run_extraction`'s closure and asserts zero residual files on disk after each. Locks the refactor-safety invariant. |
+| **`extract_se_handles_two_well_formed_records`** | **Rev 1 (Reviewer A §4.1):** SE counterpart to `extract_pe_handles_two_well_formed_pairs` — guards Phase B regression after the `run_extraction` refactor. |
+| **`validate_auto_detect_keeps_no_overlap_default`** | **Rev 1 (Reviewer A §1.1 Critical):** `Cli::validate` on flags `[input.bam]` (no `--paired-end`, no `--single-end`, no `--include_overlap`) resolves `no_overlap = true`. Without the rev-1 fix, AutoDetect mode would resolve `no_overlap = false`, silently leaking R2 overlap calls when auto-detect routes to PE. |
+
+### 7.2 SE-vs-PE auto-detect tests (in `tests/pe_phase_c.rs` or a small new file)
+
+| Test | Asserts |
+|------|---------|
+| `detect_paired_from_header_returns_some_true_for_pe_bismark_pg` | (in `bismark-io/src/read.rs` test module — relocated from dedup) |
+| `detect_paired_from_header_returns_some_false_for_se_bismark_pg` | (same; relocated) |
+| `detect_paired_from_header_returns_none_for_no_bismark_pg` | (same) |
+| `main_auto_detect_routes_pe_bam_to_extract_pe` | Spawn binary on synthetic PE BAM, no `--single`/`--paired` → succeeds; output files match PE expectation. |
+| `main_auto_detect_routes_se_bam_to_extract_se` | Spawn binary on synthetic SE BAM → succeeds; SE behaviour. |
+| `main_auto_detect_fails_without_bismark_pg` | Spawn on BAM with no `@PG ID:Bismark` line → `AutoDetectFailed`; stderr contains "pass --single-end or --paired-end explicitly". |
+
+### 7.3 End-to-end smoke (`tests/pe_phase_c_smoke.rs`)
+
+Synthetic ~10-pair PE BAM (R1 + R2 alternating). Mix of OT pairs and OB pairs. Assertions mirror Phase B's smoke:
+
+- Exit 0.
+- All 12 split files exist with version header.
+- At least one call on each of CpG_OT, CHG_OT, CHH_OT (OT pairs routed correctly).
+- At least one call on CpG_OB / CHH_OB.
+- CTOT/CTOB files header-only (directional library).
+- **Rev 1 (Reviewer A §1.5 / Reviewer B L1):** splitting report contains `"Processed 20 lines in total"` (10 pairs × 2 lines per pair). NOT "10 pairs" — matches Perl line 2479 report literal exactly.
+
+### 7.4 Test coverage adjacency
+
+Phase B's 44 SE unit tests stay green. The `extract_se` refactor through `run_extraction` is behaviour-preserving — any regression there shows up in Phase B's existing tests.
+
+## 8. Efficiency
+
+- One additional `Vec::collect()` per pair in `drop_overlap` (filter on R2 calls). At a typical 100-bp PE WGBS read with ~30 calls/read, this is ~30 × 16-byte `MethCall` = ~500 bytes per pair, ~14 GiB total at 27M pairs. Allocator churn comparable to Phase B's per-record `Vec`. **Phase F concern, not Phase C.**
+- `BismarkPair::from_mates` allocates 2 `BismarkRecord`s (Phase B already does this per-record; PE doesn't change the per-mate cost).
+- Header auto-detect adds **one** extra `open_reader` call per run for the AutoDetect path. ~50 ms overhead — negligible for the 55M-record runtime. Single-end and explicit `--paired-end` paths skip it entirely.
+
+Profile target (informational): PE extract on 10M PE WGBS at parallel=1 reaches ≥ 1.5× Perl. Hard gate: byte-identity (Phase H).
+
+## 9. Assumptions + open questions
+
+### 9.1 Locked assumptions
+
+- **Adjacent-record pairing** (no out-of-order detection). Bismark BAM is QNAME-grouped; Phase B verified records arrive R1 then R2.
+- **`config.no_overlap == true` is the default for PE.** Phase A's `Cli::validate` sets this; `--include_overlap` flips it.
+- **`pair_strand` from R1.** SPEC §6.1 locked.
+- **Endpoint polarity is strict-`<` / strict-`>`.** SPEC §7.4 rev 2.
+- **Cross-chr pair is always wrong** — defensive `CrossChromosomePair` error.
+- **PE BAM is QNAME-sorted (Bismark's default).** Coordinate-sorted PE input would break adjacent-record pairing; `bismark-io::open_reader` already rejects this.
+- **`detect_paired_from_header` in `bismark-io v1.0.0-beta.7`** is a pure additive promotion; no behaviour change vs dedup's local copy.
+
+### 9.2 Open questions (rev 1)
+
+1. **(Open, low-risk)** SPEC §7.4 endpoint-semantics — the strict-`<` polarity assumes `CigarExt::reference_end` returns 1-based **inclusive**. SPEC §7.4 cites the dedup-tested invariant; rev 1 tests `drop_overlap_with_r1_indel_uses_reference_end` + `_end_deletion` + `_insertion_shifts_read_pos_only` cover all three CIGAR-relevant topologies. If Phase H gate uncovers an off-by-one, the suspect is `reference_end` semantics or 1-based-vs-0-based mismatch in `read_pos → ref_pos`.
+2. **(Resolved rev 1)** Splitting-report PE counting: **lines (2N for N pairs), not pairs**. Verified directly by both reviewers at Perl `bismark_methylation_extractor:2451` (`$methylation_call_strings_processed += 2`) and line 2479 (`"Processed N lines in total"`).
+3. **(Resolved rev 1)** Chr-name resolution per pair: **cache once after the `MateChromosomeMismatch` defensive check**; pass the single `chr` to both R1 and R2 `route_call` invocations. Reviewer B L3.
+4. **(Open, deferred)** `AutoDetect`'s open-reader-twice pattern. **Default plan:** open twice. ~50 ms overhead, negligible at 55M-record scale. Phase F may consolidate as a side-effect of the producer/consumer pipeline refactor.
+5. **(Resolved)** `ExtractParams` revival deferred to Phase D/E (same as Phase B).
+6. **(Resolved rev 1)** `drop_overlap` API: `pair_strand` dropped from signature (Reviewer B L6); pair-strand recovered internally via `pair.pair_strand()`. Locked.
+7. **(Resolved rev 1)** `run_extraction<F>` closure signature: pinned to concrete `AnyReader<BufReader<File>, File>` (Reviewer A §1.3 / Reviewer B L5). Locked.
+
+### 9.3 Critical questions
+
+**None.** All design choices have defaults; no item changes the goal/scope/behaviour such that pausing is mandatory.
+
+## 10. Validation
+
+| What to verify | How | Expected |
+|----------------|-----|----------|
+| Overlap-detection polarity (the load-bearing Phase H byte-identity invariant) | `drop_overlap_forward_pair_drops_r2_at_or_after_r1_end` + `drop_overlap_reverse_pair_drops_r2_at_or_before_r1_start` + `drop_overlap_with_r1_indel_uses_reference_end` | All three edge-cases pass; strict `<` / `>` matches Perl `>= ` / `<=` skip semantics exactly. |
+| Pair-strand routing (Alan's split-across-files bug at PE level) | `extract_pe_routes_r2_calls_to_pair_strand_file_not_record_strand_file` | R2 calls route to `*_OT_*.txt`, not `*_CTOT_*.txt`. |
+| Per-mate ignore-region trimming | `extract_pe_per_mate_ignore_r2_only_skips_r2_positions` + `_3prime_r2` mirror | R1 trims apply to R1 only; R2 trims apply to R2 only. |
+| `BismarkPair::from_mates` propagates qname / identity errors | `extract_pe_rejects_mismatched_qnames_pair` | Returns `BismarkIo(MateMismatch)`; cleanup runs. |
+| Unpaired-final-record error | `extract_pe_rejects_unpaired_final_record` | Returns `UnpairedFinalRecord`; cleanup runs. |
+| Cross-chr pair defensive guard | `extract_pe_rejects_cross_chromosome_pair` | Returns `MateChromosomeMismatch` (rev 1 rename); cleanup runs. |
+| **AutoDetect `no_overlap` regression (rev 1 Critical)** | `validate_auto_detect_keeps_no_overlap_default` | `Cli::validate` resolves `no_overlap = true` for AutoDetect (was `false` in Phase A). |
+| **PE splitting-report line-counting (rev 1 Important)** | `pe_splitting_report_counts_lines_not_pairs` | "Processed 20 lines in total" for 10 pairs, matches Perl line 2479. |
+| **Refactor safety (rev 1 Important)** | `run_extraction_runs_cleanup_on_each_error_variant` | Each error variant from the closure body leaves zero residual files. |
+| **Reverse-strand R2 ignore (rev 1 Important)** | `extract_pe_ignore_r2_skips_read_cycles_not_ref_positions` | First three 5'-end read cycles skipped on a CTOT-strand R2 with `--ignore_r2 3`. |
+| **Non-directional library PE (rev 1 Important)** | `extract_pe_routes_{ctot,ctob}_pair_strand_correctly` | CTOT pair routes to `*_CTOT_*.txt`; CTOB pair routes to `*_CTOB_*.txt`. Overlap branches via forward path. |
+| **InDel-aware endpoint coverage (rev 1 Important)** | `drop_overlap_with_r1_end_deletion` + `_insertion_shifts_read_pos_only` | Three InDel topologies (mid-del, end-del, insertion) all verified. |
+| `--include_overlap` semantic | `extract_pe_with_include_overlap_keeps_r2_overlap_calls` | R2 overlap calls present in output. |
+| Auto-detect routes to extract_pe / extract_se | `main_auto_detect_routes_pe_bam_to_extract_pe` + SE mirror | Binary dispatch via `paired_mode == AutoDetect` works. |
+| Auto-detect failure mode | `main_auto_detect_fails_without_bismark_pg` | Clear error message, no partial output. |
+| M-bias R2 index | `extract_pe_increments_mbias_R2_at_index_1` | Phase B's `[MbiasTable; 2]` index 1 actually populates. |
+| Phase B regression | `cargo test -p bismark-extractor` shows all 91 Phase B tests still green | The `run_extraction` refactor is behaviour-preserving. |
+| Cross-crate regression | `cargo test -p bismark-io` + `cargo test -p bismark-dedup` green after the v1.0.0-beta.7 promotion | `detect_paired_from_header` moved without behaviour change. |
+| End-to-end PE smoke | `tests/pe_phase_c_smoke.rs` | Binary runs end-to-end on synthetic PE BAM; produces 12 files + report; pair count correct. |
+| Clippy + fmt | `cargo clippy -p bismark-extractor -p bismark-io -p bismark-dedup --all-targets -- -D warnings && cargo fmt --check` | All clean. |
+
+## 11. Integration with later phases
+
+(Carries forward Phase B's table; deltas only.)
+
+| Phase | What Phase C leaves for it |
+|-------|----------------------------|
+| **D** (M-bias writer) | `state.mbias[1]` now populated by PE R2 (Phase C). Phase D's writer emits 6 sections (CpG/CHG/CHH × R1/R2) for PE input; 3 sections for SE. |
+| **E** (modes + gzip) | PE doesn't change mode dispatch; Phase E widens both `extract_se` and `extract_pe` via `OutputFileMap`'s mode-aware variant. |
+| **F** (multicore) | The producer/consumer pipeline at Phase F needs to preserve **pair adjacency**. Pairs are the unit of work, not individual records. The bounded MPMC channel feeds `Vec<BismarkPair>` (or `BismarkRecord` chunks where each chunk is pair-aligned). **Rev 1 (Reviewer A §6):** `run_extraction<F>`'s `FnOnce(&mut reader, &[String], &mut state)` doesn't compose with the producer/consumer split (reader + state can't be `&mut`-shared across threads). Phase F will either rework `run_extraction` into `run_extraction_serial` + `run_extraction_parallel`, or drop the abstraction entirely. Plan accordingly. |
+| **G** (bedGraph + cytosine_report) | No PE-specific work; subprocess chain operates on the per-context split files (same as SE). |
+| **H** (byte-identity gate) | PE 10M+55M WGBS gates Phase B + C + D + E + F together. Endpoint-semantics verification (SPEC §7.4) gets its real-data validation here. |
+
+## 12. Self-review
+
+**Efficiency.** PE's per-pair cost is ~2× per-record (two `extract_calls` invocations + two `iter_aligned` allocations + `drop_overlap`'s filter+collect). Acceptable at parallel=1; Phase F profiling will quantify under rayon. The header-probe reopen on AutoDetect adds ~50 ms once per run.
+
+**Logic.** PE pair-loop is structurally identical to dedup's PE iteration (which Phase A merged successfully). `BismarkPair::from_mates` does the qname-eq + R1/R2 dance. `drop_overlap` uses InDel-aware `reference_end` from bismark-io's CigarExt.
+
+**Edge cases.** Empty input, odd record count, cross-chr pair, mismatched qnames, fully-overlapping pair, disjoint pair, R1-with-InDel — all covered. Header auto-detect failure mode names the next user step.
+
+**Integration.** bismark-io v1.0.0-beta.7 is a pure additive bump (one new pub function); bismark-dedup gets a small refactor to use the re-export with no behaviour change. bismark-extractor 1.0.0-alpha.3 carries the new pub functions (`extract_pe`, `drop_overlap`) without breaking the alpha-line surface.
+
+**Risks remaining.**
+
+- **R1**: SPEC §7.4 endpoint-semantics verification — the in-test fixture covers it, but the real Phase H gate is the ultimate truth. Documented as Open question #1.
+- **R2**: PE pair-counting in splitting report (pairs vs records). Resolve at implementation time by reading Perl.
+- **R3**: AutoDetect's open-reader-twice pattern is wasteful in the abstract. Phase F may consolidate (single-pass with header peek), but only if profiling justifies the refactor.
+
+## 13. Revision history
+
+See the consolidated revision-history block at the top of this document (after the status line).
+
+## 14. Sub-issue (already filed)
+
+[#850](https://github.com/FelixKrueger/Bismark/issues/850).
+
+## 15. Branching strategy
+
+- **Branch:** `extractor-phase-c` (created off `extractor-phase-b` while Phase B PR #849 is in review).
+- **PR target:** `rust/iron-chancellor`. If Phase B merges first, rebase onto fresh iron-chancellor before opening Phase C's PR. If Phase B is still in review when Phase C is ready, open the Phase C PR with base `extractor-phase-b` (stacked PRs) and rebase when Phase B merges.

--- a/plans/05262026_bismark-extractor/PLAN_REVIEW_PHASE_C_A.md
+++ b/plans/05262026_bismark-extractor/PLAN_REVIEW_PHASE_C_A.md
@@ -1,0 +1,237 @@
+# Phase C Plan Review — Reviewer A
+
+**Reviewer:** A (fresh context window, no shared state)
+**Plan reviewed:** `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/PHASE_C_PLAN.md` rev 0
+**Date:** 2026-05-26
+**Verdict (preview):** see end of file.
+
+---
+
+## Summary
+
+Phase C is a focused, well-scoped extension of Phase B's SE pipeline into PE, with a header-level auto-detect and per-mate ignore-trim wiring. The polarity work in `drop_overlap` is well-grounded against both Perl source and the SPEC §7.4 rev 2 locking, and the new error variants are appropriate. **One critical defect found** (silent `--no_overlap` regression in AutoDetect mode), a handful of important nits, and a few optional cleanups.
+
+---
+
+## 1. Logic review
+
+### 1.1 Critical — `no_overlap` default is wrong when AutoDetect resolves to PE
+
+Phase A's `Cli::validate` (verified at `rust/bismark-extractor/src/cli.rs:445-449`) computes:
+
+```
+let no_overlap = if paired_mode == PairedMode::PairedEnd {
+    !self.include_overlap
+} else {
+    false
+};
+```
+
+This is `false` whenever `paired_mode != PairedEnd`. With Phase C's AutoDetect dispatch, the flow is:
+
+1. User runs `bismark-extractor input.bam` with no mode flag.
+2. `Cli::validate` resolves `paired_mode = AutoDetect`, so `no_overlap = false`.
+3. `main::run` opens the header, finds PE, calls `extract_pe(input, &config)`.
+4. `extract_pe` sees `config.no_overlap == false` → **skips `drop_overlap`** → R2 overlap calls leak into output.
+
+This **silently violates the locked plan decision** in §2 ("Default `--no_overlap` for PE: ON — matches Perl `--no_overlap` default") **only for the AutoDetect path**. Explicit `--paired-end` is fine because Phase A's branch covers it. The plan does not call this out anywhere.
+
+**Required fix (one of):**
+
+- (a) Change the Phase A resolution to `paired_mode != PairedMode::SingleEnd`. Then SE keeps `no_overlap=false` (irrelevant for SE), explicit `--paired-end` keeps current behaviour, AutoDetect inherits the PE default. Cleanest.
+- (b) In `main::run`'s AutoDetect arm, after `detect_paired_from_header` returns `Some(true)`, mutate `config.no_overlap = !cli_include_overlap` before calling `extract_pe`. Requires keeping the raw `include_overlap` flag (currently consumed by `Cli::validate`).
+- (c) In `extract_pe`, treat `no_overlap` as a synonym for "PE AND NOT include_overlap" by re-checking at runtime. Hides the Phase A bug rather than fixing it.
+
+This must be resolved before merge. Recommend (a) — touches one branch in cli.rs and adds one test (`validate_auto_detect_keeps_no_overlap_default`).
+
+### 1.2 Important — `is_forward_pair_strand` classification is correct but worth a one-line citation
+
+§5.1 declares `is_forward_pair_strand` returns `true` for `OT | CTOB`. This matches both:
+- The SPEC `route_call` strand-idx table (OT=0, CTOT=1, CTOB=2, OB=3 — but that's routing, not strand-orientation).
+- The Perl PE control flow: forward branch is taken when R1's strand-tag indicates OT or CTOB.
+
+The reasoning is that for **directional + non-directional libraries**, R1's `record_strand` tells us whether R1's mapped reference position is the upstream end of the insert (OT/CTOB: R1 is upstream, R2 is downstream → use R1's `reference_end` as the cutoff for R2) or the downstream end (OB/CTOT: R1 is downstream, R2 is upstream → use R1's `alignment_start` as the cutoff for R2). This is correct, but it's worth a one-line code comment citing the Perl line numbers (2400/2415) where this branching is set up so a future reader doesn't have to reconstruct it.
+
+### 1.3 Important — `run_extraction<F>` closure signature is under-specified
+
+§5.2 declares:
+
+```rust
+F: FnOnce(&mut bismark_io::AnyReader, &[String], &mut ExtractState) -> Result<(), BismarkExtractorError>
+```
+
+`AnyReader` is generic: `AnyReader<R: BufRead, RC: Read + Seek>`. The closure signature as-written won't compile without bounds; it needs the concrete `AnyReader<BufReader<File>, File>` returned by `open_reader`, or generic params propagated through `run_extraction`. Either is fine, but a generic `run_extraction` raises monomorphisation cost; the concrete-type approach is simpler. Pin the choice in the plan or in code.
+
+Also: passing `&mut AnyReader` + `&mut ExtractState` simultaneously is fine since they're disjoint, but the closure body needs to call `reader.records()` which mutably borrows `reader`. That's compatible with `FnOnce(&mut reader, ..., &mut state)`. Just noting the borrow choreography is non-trivial and should be exercised by `cargo check` early in implementation.
+
+### 1.4 Important — refactor risk in `extract_se` is non-zero
+
+Phase B's `extract_se` has 5 distinct early-return + cleanup sites (record-iter error, PAIRED-flag rejection, refid-missing, refid-out-of-range, route_call err) plus the per-iteration `records_processed +=`. The plan's `run_extraction<F>` closure body for SE must reproduce all five with identical cleanup-on-err semantics. The risk is not catastrophic (Phase B's 44 SE tests gate it), but the plan's framing ("behaviour-preserving refactor") understates the cost.
+
+**Alternative considered:** keep `extract_se` exactly as-is and add a parallel `extract_pe` that duplicates the open/build_chr_table/state/cleanup scaffolding (~30 LOC duplication). Trade-off: small code duplication vs. zero refactor risk to a Phase B path that's already merged-pending-review. Given Phase C is on the critical path and Phase B isn't merged yet, my recommendation is:
+
+- **If Phase B merges before Phase C implementation starts:** the `run_extraction<F>` refactor is fine; Phase B's tests are the safety net.
+- **If Phase C is implemented while Phase B is still in review:** duplicate the scaffolding in `extract_pe` and defer the refactor to a follow-up PR. Phase B's review will not have to re-verify the SE path on top of a still-changing helper.
+
+Plan §15 says Phase C is stacked on Phase B and will rebase. Acceptable either way, but call out the contingency in §6 step 5.
+
+### 1.5 Important — counter ordering in PE under `--mbias_only`
+
+Plan §4.1's pseudocode increments `state.report.records_processed += 1` **after both `route_call` batches**. That's pair-counting, not record-counting — consistent with Open Q #2's "default plan: count pairs (one increment per pair)". Good.
+
+But `route_call`'s own splitting-report counters (`calls_by_context` / `calls_by_context_meth`) are incremented twice per pair (once per R1 call, once per R2 call). That's correct (per-call counts), but worth verifying the splitting-report's final line wording. Perl writes `Processed N lines in total` (verified at Perl line 2479) — for PE input N is the **line count** (= 2 × pairs). So if Phase C reports `records_processed = pair_count`, the splitting report will say half the lines that Perl reports.
+
+**This contradicts Plan Open Q #2's tentative answer.** Look at Perl line 2479 + the rest of the PE branch:
+
+```
+warn "\nProcessed $counting{sequences_count} lines in total\n";
+```
+
+`sequences_count` is incremented per BAM line read. For PE that's 2 lines per pair. **Phase C's record count must increment by 2 per pair, not 1**, or the splitting-report's "Processed N lines in total" will be half Perl's value → byte-identity fails at Phase H.
+
+**Recommendation:** change §4.1 pseudocode to `state.report.records_processed = state.report.records_processed.saturating_add(2)` (or rename to `lines_processed` for clarity), AND add a Phase C test `pe_splitting_report_counts_lines_not_pairs` that asserts the report value is 2 × pair count for a PE input with N pairs. Resolve Q #2 in the plan as "lines, per Perl line 2479", not deferred.
+
+### 1.6 Optional — cross-chr pair check placement
+
+§4.5 inlines the cross-chr check in `handle_one_pair`. Defensible because it's an extractor-specific concern (dedup doesn't care). However, `BismarkPair::from_mates` already validates qname-eq + R1/R2-identity as PE-pair structural invariants. Cross-chr is also a PE-pair structural invariant (Bismark never emits cross-chr pairs). The architectural question: should `from_mates` enforce it too, for symmetry?
+
+**Recommendation:** keep extractor-side for Phase C (don't expand the Phase C diff), but file a small follow-up issue in `bismark-io` to add it to `from_mates` in v1.0.0-beta.8 — then the extractor can drop its inline check. Note this in §11.
+
+### 1.7 Optional — error variant naming consistency
+
+`CrossChromosomePair` is a bit verbose. Other errors in the variant list are `MateMismatch`, `ReadIdentityMismatch`, `UnpairedFinalRecord`. `MateChromosomeMismatch` or `PairChromosomeMismatch` would match the naming pattern. Minor.
+
+---
+
+## 2. Assumptions review
+
+### 2.1 SPEC §7.4 polarity — verified independently
+
+I cross-checked the Perl source:
+
+- Line 2905: `if ($start+$index+$pos_offset >= $end_read_1) { return; }` — forward, **inclusive skip**.
+- Line 2987: `if ($start-$index+$pos_offset <= $end_read_1) { return; }` — reverse, **inclusive skip**.
+
+The inverse keep predicate is strict `<` and `>`. Plan §4.2 + SPEC §7.4 rev 2 pseudocode agree. **Polarity is correct.**
+
+I also verified `$end_read_1` semantics by tracing back through Perl lines 2400, 2415, 1944. For forward pairs, `$end_read_1 = $start_read_1 + $MDN_count_1 - 1` (1-based inclusive last reference position — matches `CigarExt::reference_end`). For reverse pairs, `$end_read_1 = $start_read_1` BEFORE Perl shifts `$start_read_1 += MDN_count - 1` — i.e. `$end_read_1` is the **original R1 alignment_start** (1-based leftmost). Plan §4.2's `r1_ref_start = pair.r1().alignment_start()` for the reverse branch matches this. **Endpoint semantics are correct.**
+
+### 2.2 `CigarExt::reference_end` invariant — verified
+
+Read `rust/bismark-io/src/cigar.rs:182`: `if span == 0 { start } else { start + span - 1 }`. 1-based inclusive. For R1 `50M2D50M` at start=100: `reference_span = 50 + 2 + 50 = 102`, `reference_end = 100 + 102 - 1 = 201`. Plan §7.1 test `drop_overlap_with_r1_indel_uses_reference_end` asserts this. **Correct.**
+
+### 2.3 PE record adjacency — appropriately stated as assumption
+
+§9.1 locks this. Bismark always emits PE BAM in adjacent R1/R2 order (QNAME-sorted by alignment); `BismarkPair::from_mates` validates qname-equality so a sort breakage produces a loud `MateMismatch`. Acceptable.
+
+### 2.4 `iter_aligned`'s R2 5'-orientation — assumed implicitly
+
+§4.4 says "the kernel applies the trims in 5'-oriented read coordinates ... iter_aligned's orientation correction handles this transparently". This is load-bearing for `--ignore_r2` and `--ignore_3prime_r2` correctness on reverse-strand R2 reads (i.e. the OT-pair case where R2 is reverse-mapped). The plan asserts it without citation. I did not re-verify; recommend that the implementation step include a quick `cargo test -p bismark-io test_iter_aligned_reverse_strand` re-read to confirm.
+
+Plan tests `extract_pe_per_mate_ignore_r2_only_skips_r2_positions` and `_3prime_r2` will catch a regression here, but they're written at the call-routing level, not the iter_aligned level. **Recommend adding one extra fixture**: an OT-pair where R2 is reverse-mapped + `--ignore_r2 3`, asserting the **first three read-cycles** (not the first three reference-positions) are skipped. This is the polarity check.
+
+### 2.5 Open Q #1's deferral to a single test fixture — insufficient
+
+§9.2 #1 says the in-test fixture `drop_overlap_with_r1_indel_uses_reference_end` covers endpoint semantics. One test with one InDel topology (mid-read deletion) is thin. Recommend adding:
+
+- `drop_overlap_with_r1_end_deletion`: R1 `49M2D1M` at 100 → reference_end=151. R2 at 150, 151, 152.
+- `drop_overlap_with_r1_insertion_shifts_read_pos_only`: R1 `50M2I50M` at 100 → reference_span=100, reference_end=199 (insertion does NOT consume reference). R2 at 198, 199, 200.
+
+These cover three of the four CIGAR-relevant cases (mid-read del, end-of-read del, insertion). N+1 doesn't really cost anything and shores up the Phase H byte-identity invariant.
+
+---
+
+## 3. Efficiency review
+
+### 3.1 AutoDetect double-open is negligible
+
+Plan §8 quantifies ~50 ms for header re-open. For BAM, opening a noodles reader reads the BGZF header (a few KB) and parses `@SQ`/`@PG` lines. At 55M-record scale (~30-60 min runtime), 50 ms is invisible. Don't optimize.
+
+The cleaner alternative — peek the header from the first reader and keep it for the loop — would require either threading a pre-opened `AnyReader` into `run_extraction` (changes the signature) or making `run_extraction` accept an `Option<AnyReader>`. Not worth the API complexity for ~50 ms.
+
+### 3.2 `Vec::collect` in `drop_overlap` — acceptable for Phase C
+
+§8 quantifies ~14 GiB total allocation at 27M pairs. Phase F may want to switch to in-place filtering or extend a worker-local buffer, but that's a Phase F concern. Phase C is fine.
+
+### 3.3 `BismarkPair::from_mates` allocates `BismarkRecord` twice — actually doesn't (just consumes by value)
+
+Reading `rust/bismark-io/src/pair.rs:40`: `from_mates(r1: BismarkRecord, r2: BismarkRecord)` consumes by value, stores by move. No extra allocation. Plan §8 says "BismarkPair::from_mates allocates 2 BismarkRecords" — minor inaccuracy; it just **stores** two records that were already allocated by the iterator. Cosmetic; doesn't affect plan validity.
+
+---
+
+## 4. Validation sufficiency
+
+### 4.1 Phase B regression coverage — covered by existing tests
+
+Plan §10's "Phase B regression" row leans on `cargo test -p bismark-extractor` showing all 91 tests green. Good. Recommend adding `extract_se_handles_two_well_formed_records` as an explicit Phase C-added regression test (the SE counterpart to `extract_pe_handles_two_well_formed_pairs`) so the test directory has matched coverage.
+
+### 4.2 PE-specific coverage gaps to fill
+
+| Gap | Test to add |
+|-----|-------------|
+| Non-directional library PE (CTOT/CTOB pair_strand): plan only tests OT and OB | `extract_pe_routes_ctot_pair_strand_correctly` + `..._ctob` mirror. Verify R1's record_strand for a non-directional aligner output is CTOT or CTOB, and that overlap detection branches correctly (CTOT is forward-class? — verify against `is_forward_pair_strand`'s OT|CTOB classification). |
+| Zero-length pair (both reads soft-clipped fully): `extract_calls` returns empty Vec for each; pair iteration must not panic | `extract_pe_handles_fully_soft_clipped_pair` |
+| PE input with `--ignore_r2 3 --ignore_3prime_r2 3` simultaneously (compound trim) | `extract_pe_compound_ignore_trims` |
+| Lines-vs-pairs counting (per §1.5 above) | `pe_splitting_report_counts_lines_not_pairs` |
+| Reverse-strand R2 ignore polarity (per §2.4 above) | `extract_pe_ignore_r2_skips_read_cycles_not_ref_positions` |
+
+R1/R2 with different XM lengths is impossible in well-formed Bismark output (XM length always equals SEQ length, and R1/R2 SEQ lengths are independent), so no test needed.
+
+### 4.3 Auto-detect coverage
+
+Tests cover: PE→PE, SE→SE, no-Bismark→error. Missing: **PE BAM where the @PG line is malformed** (e.g. truncated `-1` arg). `detect_paired_from_header` returns `Some(false)` in that case (treats as SE) — verify that's the desired behaviour vs returning `None`. If it's intended as "fall back to SE", document in the plan; if it's a sharp edge, add a stricter probe or surface a warning. Minor.
+
+---
+
+## 5. Alternatives
+
+### 5.1 Inline overlap check vs. extract_calls-level filter
+
+The plan does overlap-drop as a post-processing step: extract all R2 calls, then filter. An alternative is to pass `Option<r1_ref_end>` into `extract_calls` itself and skip early. The post-processing approach is simpler and aligns with Perl's structure (Perl's overlap check is also a per-call test inside the per-call loop). Stick with the plan.
+
+### 5.2 `extract_se` + `extract_pe` shared scaffolding via `run_extraction<F>` vs. duplicate
+
+Discussed in §1.4. The plan's choice is fine if Phase B is merged first. If not, duplicate.
+
+### 5.3 Cross-chr check at `from_mates` vs. extractor — discussed in §1.6
+
+---
+
+## 6. Phase-F readiness
+
+§11 calls out pair-adjacency as a Phase F requirement. One additional snag: `run_extraction<F>` takes a `FnOnce` body. Under Phase F's producer/consumer split, the body becomes "spawn producer thread + spawn N consumer threads + join". That doesn't compose with `FnOnce(&mut reader, ..., &mut state)` because the reader and state can't be `&mut`-shared across threads. Phase F will likely have to rework `run_extraction` into something like `run_extraction_serial` + `run_extraction_parallel`, or drop the abstraction entirely. **Not a Phase C blocker**, but worth noting in §11 so Phase F's plan-writer doesn't inherit an awkward refactor.
+
+---
+
+## 7. Action items
+
+### Critical (must fix before merge)
+
+1. **`no_overlap` resolution in AutoDetect path** (§1.1). Either fix `Cli::validate` to set `no_overlap = !include_overlap` when `paired_mode != SingleEnd`, or re-resolve in `main::run` after auto-detect. Add a regression test.
+2. **Lines-vs-pairs counting in splitting report** (§1.5). Per Perl line 2479, increment `records_processed += 2` per PE pair (or rename to `lines_processed`). Add a test asserting Perl-compatible count. Resolve Open Q #2 in the plan.
+
+### Important (should fix)
+
+3. **Clarify `run_extraction<F>` closure signature** (§1.3) — pin generic vs. concrete `AnyReader<BufReader<File>, File>`.
+4. **Extend the InDel-aware endpoint test** to 3 fixtures (mid-read del, end-of-read del, insertion) (§2.5).
+5. **Add `is_forward_pair_strand` code comment** citing Perl line 2400/2415 (§1.2).
+6. **Decide refactor-vs-duplicate based on Phase B merge status** (§1.4) and document the contingency in §6 step 5.
+7. **Add reverse-strand R2 ignore-polarity test** (§2.4 + §4.2 row).
+8. **Add non-directional library PE tests** (§4.2 row).
+9. **Add `pe_splitting_report_counts_lines_not_pairs` test** (§4.2 row, ties to action item 2).
+
+### Optional (nice to have)
+
+10. File a follow-up issue to move cross-chr check into `BismarkPair::from_mates` for v1.0.0-beta.8 (§1.6).
+11. Consider renaming `CrossChromosomePair` to `MateChromosomeMismatch` (§1.7).
+12. Document the malformed-PG-line behaviour of `detect_paired_from_header` (§4.3).
+13. Note Phase F's `FnOnce` snag in §11 (§6).
+14. Cosmetic correction to §8's "from_mates allocates 2 BismarkRecords" line (§3.3).
+
+---
+
+## Verdict
+
+**NEEDS-REVISIONS.**
+
+Two critical issues — the AutoDetect `no_overlap` regression (§1.1) and the PE pair-vs-line counter mismatch (§1.5) — both silently produce wrong output and will block byte-identity at Phase H. Both have small fixes; once those land plus a small number of additional tests, the plan is ready to implement.

--- a/plans/05262026_bismark-extractor/PLAN_REVIEW_PHASE_C_B.md
+++ b/plans/05262026_bismark-extractor/PLAN_REVIEW_PHASE_C_B.md
@@ -1,0 +1,329 @@
+# Plan review — Phase C (Reviewer B)
+
+**Plan file:** `plans/05262026_bismark-extractor/PHASE_C_PLAN.md` (rev 0).
+**Reviewer:** B (independent; no shared state with Reviewer A).
+**Date:** 2026-05-26.
+**Verdict:** **APPROVE-WITH-NITS** — solid plan grounded in SPEC rev 2 and Phase B's already-merged scaffolding. Three findings need attention before/during implementation (one is a likely byte-identity bug; two are tidy-ups). None block the implementation trigger; all can be fixed inline.
+
+---
+
+## Logic review
+
+### L1 [Important] — Perl PE splitting-report counts 2× pair count, not pair count
+
+**File:** plan §9.2 open question #2 + §7.3 smoke test "Processed 10 pairs".
+**Severity:** Important (byte-identity-affecting; Phase H gate).
+
+The plan defers this to "read Perl at implementation time" with a default of "count pairs (one increment per pair processed)." I read Perl directly (`bismark_methylation_extractor:2451`):
+
+```perl
+$methylation_call_strings_processed += 2; # paired-end = 2 methylation call strings
+```
+
+Paired with line 2459 (`$counting{sequences_count} = $line_count`, where `$line_count` is also the raw BAM-line count) and the splitting-report template at line 2479 (`Processed $counting{sequences_count} lines in total`), the math is unambiguous:
+
+- Perl PE reports **2N** for N pairs in `sequences_count`.
+- The header literal is `"Processed N lines in total"` — not `"Processed N pairs"`.
+
+The plan's default (count pairs / "Processed 10 pairs") would diverge from Perl on **both** the value and the literal text. Phase H byte-identity would fail.
+
+**Fix in plan:** change §9.2 #2's default to "increment `records_processed` by 1 per record (not per pair) — so PE input bumps it by 2 per pair, matching Perl line 2451." Update the §7.3 smoke assertion to "Processed 20 lines in total" (or "lines: 20"). Note that `state.report.records_processed` is the existing counter name from Phase B — Phase C's `extract_pe` pseudocode currently bumps it by 1 per pair (§4.1 line `state.report.records_processed = ... saturating_add(1)`); that should be `saturating_add(2)` or two single increments.
+
+---
+
+### L2 [Optional] — `resolve_chr` helper isn't defined in Phase B
+
+**File:** plan §4.1 `handle_one_pair` body calls `resolve_chr(pair.r1(), chr_table)?`.
+**Severity:** Optional (mechanical).
+
+`resolve_chr` doesn't exist in Phase B's `pipeline.rs`. Phase B inlines the refid → chr-table lookup (see `pipeline.rs:92-116`). The plan implicitly assumes a helper extraction during Phase C but doesn't enumerate it in §3.2's "Modified modules" list. Add a bullet to §6 step 5: "extract the `Option<refid>` → `chr_table.get(refid).ok_or(InternalError…)` chain from inline-in-extract_se into a small `fn resolve_chr(record, chr_table) -> Result<&str, BismarkExtractorError>` helper; call from both `extract_se` (refactored body) and `handle_one_pair`."
+
+---
+
+### L3 [Optional] — `chr_name` redundant lookup per pair
+
+**File:** plan §4.1 `handle_one_pair` (resolves both `r1_chr` and `r2_chr`).
+**Severity:** Optional.
+
+The plan resolves `r1_chr` and `r2_chr` independently. The `CrossChromosomePair` defensive check in §4.5 will reject any pair where `r1.reference_sequence_id() != r2.reference_sequence_id()`, so post-check the two chr strings are guaranteed equal. Either:
+
+- **Option A (suggested):** resolve `r2_refid`, compare to `r1_refid`, defensive-error on mismatch, then use `r1_chr` for both `route_call` calls. ~2 LOC saved + one HashMap-ish lookup eliminated per pair (~27M lookups on a 55M-record run — small, but free).
+- **Option B (current plan):** keep the two-lookup form; cost is O(1) per pair anyway.
+
+The plan's §9.2 #3 already flags this as open; I'd suggest closing it with Option A — simpler, faster, and the defensive check has to read `r2.reference_sequence_id()` regardless. Plan §4.1's pseudocode already has a TODO-style comment about this.
+
+---
+
+### L4 [Important] — Defense-in-depth contradiction in §6 step 5
+
+**File:** plan §6 step 5 ("Wait — actually keep the PAIRED-flag check in extract_se").
+**Severity:** Important (clarity, not correctness).
+
+Step 5 first says "Move the per-record PAIRED-flag check OUT" and then immediately reverses with "Wait — actually keep…". §6 step 6 then re-confirms "Decision: keep both" for defense-in-depth.
+
+This back-and-forth is fine reasoning but reads as an open question in the plan body. Strike the first bullet ("Move the per-record PAIRED-flag check OUT…") and replace with a single sentence: "Phase B's PAIRED-flag defensive check stays in `extract_se`: defense-in-depth against a user explicitly passing `--single-end` against a PE BAM. The auto-detect path covers the no-flag case." This avoids a reviewer in implementation reading the first half and removing the check.
+
+---
+
+### L5 [Important] — `run_extraction` closure type mismatches `AnyReader`'s generics
+
+**File:** plan §5.2 signature: `body: F where F: FnOnce(&mut bismark_io::AnyReader, &[String], &mut ExtractState) -> Result<(), BismarkExtractorError>`.
+**Severity:** Important (compile-time correctness).
+
+`AnyReader` in `bismark-io/src/read.rs:504` is `pub enum AnyReader<R: BufRead, RC: Read + Seek>` — it's generic over two type parameters. `open_reader()` returns the concrete `AnyReader<BufReader<File>, File>` (read.rs:565). The plan's helper signature `&mut bismark_io::AnyReader` won't compile.
+
+**Fix:** either:
+
+- (a) name the concrete instantiation: `&mut bismark_io::AnyReader<BufReader<File>, File>`, or
+- (b) make `run_extraction` itself generic over `<R: BufRead, RC: Read + Seek>` and let the call site infer, or
+- (c) take a generic `Reader: AlignmentReader` bound (if a unifying trait exists in bismark-io — quick scan shows no such trait yet).
+
+Phase B's `extract_se` doesn't run into this because it just calls `open_reader(...)` inline and uses the concrete `AnyReader` returned. The simplest fix is option (a) since the helper is private. Whichever way, the plan signature as written would fail at `cargo check`.
+
+---
+
+### L6 [Important] — `pair_strand` argument no longer needed by `drop_overlap`
+
+**File:** plan §4.2 / §5.1.
+**Severity:** Important-but-minor (interface simplification).
+
+`drop_overlap(r2_calls, pair, pair_strand)` accepts `pair_strand` as a third arg, but `pair_strand` is recoverable from `pair.pair_strand()` (which the SPEC §6.1 / bismark-io's `BismarkPair::pair_strand()` already exposes). Passing both invites the caller to compute one and pass the other inconsistently. Drop the third arg; have `drop_overlap` call `pair.pair_strand()` itself. The §4.1 pseudocode also calls `pair.pair_strand()` and then passes `pair_strand` as a separate arg — pure boilerplate.
+
+---
+
+### L7 [Optional] — `AutoDetectFailed` error message references "--single-end / --paired-end"
+
+**File:** plan §5.3 + §4.3.
+**Severity:** Optional (UX nit).
+
+The error message reads "no Bismark @PG line in header; pass --single-end or --paired-end explicitly." If `detect_paired_from_header` returns `None` because the BAM was aligned with `bismark2` (case mismatch) or a derived tool whose `@PG ID:` doesn't start with `Bismark`, the message blames the user. The dedup function uses `line.contains("ID:Bismark")` (substring, not prefix or case-insensitive); this catches `ID:Bismark`, `ID:Bismark_v0.25.1`, `ID:bismark2_bowtie2` (no — different case), etc.
+
+I don't think this is a real issue for current Bismark output (which always emits `ID:Bismark`), but the error message could be more helpful: include the actual `@PG ID:` values seen, e.g. "no `@PG` line with `ID:Bismark*` found (saw: `ID:bowtie2`, `ID:samtools`); pass --single-end or --paired-end explicitly." This is a couple lines of code at the call site. Optional — not blocking.
+
+---
+
+### L8 [Optional] — `BismarkPair::from_mates` consumes records by value
+
+**File:** plan §4.1 `BismarkPair::from_mates(r1, r2)?`.
+**Severity:** Optional (efficiency).
+
+Verified in `bismark-io/src/pair.rs:40`: `from_mates(r1: BismarkRecord, r2: BismarkRecord)` takes ownership of both records. This is fine and matches the iterator's `Result<BismarkRecord, _>` yielding owned records. No issue; just confirming for the reviewer A audit that the borrow flow works (we don't keep `r1`/`r2` referenced after construction — we use `pair.r1()` / `pair.r2()`).
+
+---
+
+## Cross-crate concerns
+
+### X1 [Optional] — bismark-io v1.0.0-beta.7 promotion is genuinely additive
+
+**File:** plan §3.2 step 1 + §3.3.
+**Verdict:** confirmed clean.
+
+I verified `bismark-dedup/src/pipeline.rs:121-184`: the `detect_paired_from_header` function is self-contained (only depends on `noodles_sam::Header`, which both crates pin to `=0.85.0`). The local helper `arg_present` is also self-contained. The function is `#[must_use]` with a doc comment that already references the dedup origin lines. Moving it to `bismark-io/src/read.rs` and re-exporting is a straight cut-and-paste.
+
+One small ask: the dedup version uses `noodles_sam::io::Writer::new(&mut buf)` to serialize the header for substring search (line 144). That's fine in bismark-io too, but make sure `bismark-io/Cargo.toml`'s `noodles-sam` already pulls in the `io` feature; if `bismark-io` previously didn't write SAM, the feature might not be enabled. Worth a `cargo check` after the move. Minor; the implementation step will catch it.
+
+### X2 [Optional] — `bismark-dedup`'s `arg_present` helper is private — also promote?
+
+**File:** plan §6 step 1.
+**Severity:** Optional.
+
+`detect_paired_from_header` calls a private helper `arg_present` (dedup pipeline.rs:175). When the function moves to bismark-io, the helper must move with it. The plan doesn't explicitly say this, but the implementation will trip immediately. Add a one-liner to §6 step 1: "promote `arg_present` along with `detect_paired_from_header` (private helper, used only by it)."
+
+### X3 [Information] — bismark-dedup test reduction
+
+**File:** plan §6 step 1 ("Move the existing dedup tests for it").
+**Verdict:** confirmed clean; relocation is straightforward.
+
+The dedup tests for this function live in `bismark-dedup/src/pipeline.rs`'s test module (I didn't grep them by name but the plan claims they exist and will be relocated). They depend only on `noodles_sam::Header` construction, which bismark-io's test scaffolding already supports (see `bismark-io/src/pair.rs:103-225` tests for prior art). Trivial relocation. The `cargo test -p bismark-dedup` step listed in §6 step 9 will confirm no regression.
+
+---
+
+## Error-handling edge audit
+
+### E1 [Important] — `UnpairedFinalRecord` path doesn't run cleanup explicitly
+
+**File:** plan §4.1 + §5.2 `run_extraction`.
+**Severity:** Important.
+
+The closure body for `extract_pe` (§4.1) returns `UnpairedFinalRecord` via `return Err(...)` from inside the closure. The plan's contract for `run_extraction` (§5.2 doc) says: "On any error from `body`, runs `state.cleanup_partial_outputs()` before propagating."
+
+That's correct *if* `run_extraction` is structured as:
+
+```rust
+let res = body(reader, chr_table, state);
+if res.is_err() { state.cleanup_partial_outputs(); }
+res?
+state.finalize(config)?;
+Ok(())
+```
+
+Good. But the plan's §4.1 doesn't show the wrapping — it just shows the closure returning an error. Implementation must respect the contract or the cleanup won't run. Add an explicit unit test asserting cleanup-on-error for the `UnpairedFinalRecord` path: that's already in §7.1 ("`extract_pe_rejects_unpaired_final_record` ... cleanup removes all 12 files") — good. Same for `extract_pe_rejects_mismatched_qnames_pair` and `extract_pe_rejects_cross_chromosome_pair`. All three already specified.
+
+The risk is just implementation discipline. Phase B's `extract_se` already runs cleanup on every error site (pipeline.rs:67, 78, 95, 107, 124, 135) — but does so explicitly at each site, not via a wrapper. The `run_extraction` refactor moves this to one site; verify the refactor doesn't drop a cleanup case.
+
+**Action:** add a Phase C refactor-safety test that asserts a forced error in the closure body leaves zero residual files on disk. Even a single test ensures the wrapper does its job for all error variants.
+
+### E2 [Important] — `BismarkPair::from_mates` is fallible; `?` chain semantics
+
+**File:** plan §4.1: `let pair = BismarkPair::from_mates(r1, r2)?;`.
+**Verdict:** confirmed clean.
+
+`from_mates` returns `Result<Self, BismarkIoError>`. `BismarkExtractorError` has `BismarkIo(#[from] BismarkIoError)` (error.rs:165) → `?` lifts cleanly via the `From` impl. The `#[error(transparent)]` (error.rs:164) means `Display` propagates the inner `BismarkIoError`'s message; users see "expected R1 for first mate, got R2" not "BismarkIo: expected...". Clean.
+
+One subtle thing: `#[error(transparent)]` requires the variant to have exactly one field (the wrapped error). `BismarkIo(#[from] BismarkIoError)` has exactly one field. Good.
+
+### E3 [Optional] — `extract_calls` error doesn't include pair context
+
+**File:** plan §4.1 calls `extract_calls(pair.r1(), ...)?` and `extract_calls(pair.r2(), ...)?`.
+**Severity:** Optional.
+
+If R2's XM tag is malformed, the resulting `InvalidXmByte { read_id }` error names R2's qname. Since R1 and R2 share a qname, that's fine — but the error doesn't tell the user *which mate* tripped the validation. For debugging at byte-identity-gate time, a `mate_idx: u8` field on `InvalidXmByte` might save 30 min of guessing. Optional; can be deferred to Phase D/E. Not a blocker.
+
+---
+
+## Validation sufficiency
+
+### V1 [Important] — overlap-include test fixture must actually have overlap
+
+**File:** plan §7.1 test `extract_pe_with_include_overlap_keeps_r2_overlap_calls`.
+**Severity:** Important (test trustworthiness).
+
+The test asserts "R2 overlapping calls land in output files when `--include_overlap`." For this to be a meaningful positive test, the fixture must:
+
+1. Have R2 calls at reference positions that fall within R1's reference span (so `drop_overlap` would have removed them under the default `--no_overlap`).
+2. Verify those specific calls appear in the output under `--include_overlap`.
+
+The companion negative test `extract_pe_with_no_overlap_drops_r2_overlap_calls` uses the same fixture and asserts the overlap calls are *absent*.
+
+**Risk:** if the fixture is constructed sloppily (e.g. R1 and R2 disjoint so `drop_overlap` is a no-op anyway), both tests pass vacuously. The test names imply overlap, but the fixture doc must explicitly state: "R1 at chrX 100-149 (50M), R2 at chrX 120-169 (50M); overlap region is ref-pos 120-149 inclusive; R2 has methylation calls at ref-pos 125, 135, 145 (all inside overlap)." Then assert specifically that those 3 calls appear/disappear depending on `--include_overlap`.
+
+**Action:** strengthen the test description in §7.1 or in implementation: name the specific overlap-region ref positions and assert their presence/absence. Don't just count total R2 calls; assert the specific overlapping ones.
+
+### V2 [Optional] — `extract_pe_per_mate_ignore_r2_only_skips_r2_positions` must distinguish R1 vs R2 trim semantics
+
+**File:** plan §7.1 test `extract_pe_per_mate_ignore_r2_only_skips_r2_positions`.
+**Severity:** Optional.
+
+Similar trustworthiness concern: the fixture must have methylation calls at read-positions 0, 1, 2 on BOTH R1 and R2, then apply `--ignore_r2 3` and assert:
+
+- R1's read-pos 0, 1, 2 calls **are** in output.
+- R2's read-pos 0, 1, 2 calls **are NOT** in output.
+
+Without that R1-positive assertion, the test can't tell the difference between `--ignore_r2` and `--ignore` (which trims R1 too). The plan's prose suggests this is the intent; making it explicit in the fixture spec avoids a false-positive test.
+
+Same applies to `_3prime_r2` mirror.
+
+### V3 [Optional] — `extract_pe_routes_r2_calls_to_pair_strand_file_not_record_strand_file` is the load-bearing Alan-bug fixture
+
+**File:** plan §7.1 + §10.
+**Verdict:** specified well.
+
+This test is the structural fix for Alan Hoyle's port bug. The plan explicitly asserts "All R2 calls must land in `*_OT_*.txt`, never `*_CTOT_*.txt`." Strong. Make sure the synthetic fixture's R2 has `record_strand() == CTOT` (not just any non-OT strand) — that's the specific case that bites a naive implementation. Spec the fixture comment in the test source.
+
+### V4 [Important] — refactor-safety: behaviour-equivalence test for `run_extraction`
+
+**File:** plan §6 step 5 (refactor) + §7.4 ("Phase B's 44 SE unit tests stay green").
+**Severity:** Important.
+
+Plan §7.4 says: "Phase B's 44 SE unit tests stay green. The `extract_se` refactor through `run_extraction` is behaviour-preserving — any regression there shows up in Phase B's existing tests."
+
+That's the canonical refactor-safety argument and it's mostly right. But Phase B's tests cover the *happy path* and several explicit error paths. The refactor adds a new error-cleanup wrapper. Test gap:
+
+- Phase B currently does cleanup-on-error at six explicit sites inline. The refactor moves them to one site (`run_extraction`'s closure-error handler).
+- If the refactor accidentally only catches some error variants, Phase B tests that exercise those covered variants will pass, but newly-uncovered variants (or new ones in Phase C) will silently leak files.
+
+**Action:** add a test (could be parameterized) that injects each `BismarkExtractorError` variant raise-able from the closure body and asserts zero residual files. Or, since Phase B already has 91 tests covering most error paths, just audit the test list and confirm each variant is exercised at least once. Phase B's existing assertions like "cleanup removes all 12 files" (§7.1 in this plan suggests the existing test exists) are sufficient evidence.
+
+Either: (a) explicitly list the audited variants in §10 "Validation" + §7.4 "Test coverage adjacency" with the verdict "all six error sites are exercised by Phase B tests T1, T2, ..."; or (b) add one new sanity test.
+
+### V5 [Optional] — empty-PE-BAM happy path is covered, but consider odd-numbered + empty-record-error mix
+
+**File:** plan §4.6 edge cases + §7.1 `extract_pe_empty_bam_writes_only_header_files`, `extract_pe_rejects_unpaired_final_record`.
+**Verdict:** good coverage.
+
+The two listed tests cover the boundaries. One unlisted case: what if `iter.next()` yields `Some(Err(_))` on the *second* call after a successful first? The plan's pseudocode handles this (line 105-106: `Some(Err(e)) => return Err(e.into())`). No additional test needed.
+
+---
+
+## Efficiency
+
+### F1 [Optional] — `Vec::collect` in `drop_overlap` per pair
+
+Plan §8 calls this out: ~30 calls × 16 bytes × 27M pairs = ~14 GiB allocator churn over a 55M-pair run. Same order of magnitude as Phase B's per-record `Vec`. The plan correctly defers to Phase F. No action.
+
+A nit: `r2_calls.into_iter().filter(...).collect()` reallocates. If R2 has 30 calls and we drop 3, we allocate a new 27-element Vec. An in-place `retain` (no allocation) would be cheaper:
+
+```rust
+let mut r2_calls = r2_calls;  // already owned
+r2_calls.retain(|c| c.ref_pos < r1_ref_end);
+r2_calls
+```
+
+This is ~50% cheaper for the common case (most R2 calls kept). The plan can adopt this trivially. Optional.
+
+### F2 [Optional] — Header probe re-opens the file
+
+Plan §4.3 + §9.2 #4 acknowledges the double-open. ~50 ms is negligible. No action. Phase F refactor candidate if needed.
+
+---
+
+## Alternatives considered
+
+### A1 — Out-of-order pair detection
+
+Plan §2 locks adjacent-record pairing. Alternative: build a HashMap<qname, (r1?, r2?)> and emit pairs as they complete. This would handle out-of-order BAMs (e.g. coordinate-sorted via samtools). Bismark output is always QNAME-grouped, so the simpler adjacent-pairing is right. `bismark-io::open_reader` already rejects coordinate-sorted input upstream (plan §4.6). Locked correctly.
+
+### A2 — Inline `drop_overlap` vs separate module
+
+Plan §3.2 puts `drop_overlap` in its own `overlap.rs` module. Alternative: inline in `pipeline.rs`. Separate module is right — easier to unit-test in isolation (per §7.1's overlap-specific tests) and overlap detection is conceptually distinct from the main loop.
+
+### A3 — Threading a peeked reader through dispatch
+
+Plan §9.2 #4 defaults to reopen. Alternative: have `open_reader` return a struct with `header()` accessible without consuming the iterator, and pass it through `extract_pe` / `extract_se`. This already works in the API (`AnyReader::header(&self)` is fine — see read.rs:515). The "reopen" pattern in plan §4.3 is a non-issue; the existing reader could be reused. The plan picked the simpler form for Phase C; refactor later. Not a blocker.
+
+### A4 — Process-risk: stacked PRs
+
+Plan §15: Phase C branches off Phase B's extractor-phase-b. If Phase B requires substantive changes, Phase C rebases repeatedly. Worth flagging:
+
+- If Phase B's PR #849 lands in 1-2 days: Phase C rebases once onto fresh `rust/iron-chancellor`. Clean.
+- If Phase B is in review for a week+ with revisions: Phase C accumulates conflicts. Mitigation: rebase Phase C onto Phase B daily during review; resolve conflicts incrementally; or pause Phase C work until Phase B merges.
+
+Not a plan-quality issue; just a process risk. No action in the plan; mention to the user.
+
+---
+
+## Action items (prioritized)
+
+### Critical
+
+None. Plan is implementation-ready.
+
+### Important (resolve before/during implementation)
+
+1. **L1**: Fix the splitting-report PE counting default. Perl counts 2× pair-count, not pair-count. Update §9.2 #2 default + §4.1 pseudocode (`saturating_add(2)` or two increments) + §7.3 smoke assertion text. Verified by reading Perl line 2451.
+2. **L4**: Strike the contradictory bullet in §6 step 5 about "Move the PAIRED-flag check OUT." Final state must clearly say "keep it for defense-in-depth."
+3. **L5**: Fix the `run_extraction` helper signature — `AnyReader` is `<R: BufRead, RC: Read + Seek>`; the plan's `&mut bismark_io::AnyReader` won't compile. Use the concrete `AnyReader<BufReader<File>, File>` or make `run_extraction` generic.
+4. **L6**: Drop the redundant `pair_strand` argument from `drop_overlap` — recoverable from `pair.pair_strand()`.
+5. **E1**: Add an explicit refactor-safety test that the `run_extraction` wrapper runs `cleanup_partial_outputs` on every closure-error path. Alternatively, audit Phase B's tests in §10 to confirm each error variant is exercised.
+6. **V1**: Strengthen the overlap-include test fixture spec — name the specific overlap-region ref positions and assert presence/absence of those specific calls.
+7. **V4**: Decide between adding a parameterized refactor-safety test vs auditing existing Phase B tests to confirm each error variant survives the refactor.
+
+### Optional (nice to have)
+
+8. **L2**: Add a `resolve_chr` helper to §3.2 + §6 step 5 — currently implied but not stated.
+9. **L3**: Close §9.2 #3 with the "cache chr after defensive check" option — simpler code and trivially faster.
+10. **L7**: `AutoDetectFailed` could include actual `@PG ID:` values for debug. Optional UX nit.
+11. **L8**: `extract_calls` error could carry `mate_idx` for PE debugging. Optional.
+12. **X2**: Add a one-liner to §6 step 1 about promoting the `arg_present` private helper alongside `detect_paired_from_header`.
+13. **V2**: Spec the R1+R2 read-pos-0,1,2 fixture in `_per_mate_ignore_r2_only_skips_r2_positions` — assert both R1-keeps and R2-skips explicitly.
+14. **V3**: Document the fixture's R2 `record_strand == CTOT` in the Alan-bug regression test source.
+15. **F1**: Use `Vec::retain` instead of `into_iter().filter().collect()` in `drop_overlap` — halves allocator churn for the common case.
+16. **A4**: Flag stacked-PR rebase risk to the user; suggest daily rebase of Phase C onto Phase B during the latter's review.
+
+---
+
+## Summary
+
+The plan is well-grounded: it ties each decision to SPEC rev 2 sections, names Perl line numbers for behavior cross-reference, lists explicit error variants with rationale, and proposes test coverage that catches the Alan Hoyle structural bug at the PE level. It correctly defers M-bias writing (Phase D), multicore (Phase F), and byte-identity gating (Phase H). The largest finding is L1 — the Perl splitting-report counts records (2N for N pairs), not pairs — which the plan defers but I resolved directly from Perl source; the default in the plan would diverge from byte-identity. The other Important findings (L4 contradiction, L5 generic-type signature, L6 redundant `pair_strand` arg, E1/V4 refactor-safety test) are easy fixes during implementation. Cross-crate concerns (bismark-io v1.0.0-beta.7 promotion) check out: `noodles-sam =0.85.0` aligned across all three crates and `detect_paired_from_header` is self-contained (only uses `noodles_sam::Header`).
+
+**Verdict: APPROVE-WITH-NITS.** Implementation can proceed once L1 is folded into the plan (it changes a smoke-test assertion); the rest are minor and catchable inline.

--- a/plans/05262026_bismark-extractor/PROGRESS.md
+++ b/plans/05262026_bismark-extractor/PROGRESS.md
@@ -1,17 +1,17 @@
 # `bismark-extractor` — overall progress (umbrella #798)
 
 **Design contract:** `rust/bismark-extractor/SPEC.md` (rev 2, in-repo).
-**Branch:** `rust/iron-chancellor`.
-**Crate version:** `1.0.0-alpha.1` (Phase A merged); Phase B bumps to `1.0.0-alpha.2`.
+**Integration branch:** `rust/iron-chancellor`.
+**Crate version (in `extractor-phase-c`):** `1.0.0-alpha.2` (Phase B). Phase C will bump to `1.0.0-alpha.3`.
 
 ## Phase status table
 
 | Phase | Scope | LOC est. | Status | Sub-issue | Plan file |
 |-------|-------|----------|--------|-----------|-----------|
-| A | Workspace scaffold + CLI + flag-validation | ~500 | ✅ **merged** (2026-05-26, commit `144ca2d`, PR #847) | #846 | (spec recon, `~/.claude/plans/create-a-team-of-snoopy-music.md`) |
-| **B** | **SE extraction loop + XM routing + eager output-file map + splitting-report skeleton + M-bias accumulator** | **~1,100 LOC actual** | ✅ **implementation complete (rev 2); ready to commit + PR** | _(to file once gh works; suggested body in PHASE_B_PLAN.md §14)_ | `PHASE_B_PLAN.md` rev 2 |
-| C | PE extraction + overlap handling + `--ignore_r2` / `--ignore_3prime_r2` | ~600 | ⏸ not started | — | — |
-| D | M-bias accumulation per (context × read_identity) + `M-bias.txt` writer | ~500 | ⏸ not started (accumulator wired in Phase B) | — | — |
+| A | Workspace scaffold + CLI + flag-validation | ~500 | ✅ **merged** (commit `144ca2d`, PR #847) | #846 | (spec recon, `~/.claude/plans/create-a-team-of-snoopy-music.md`) |
+| **B** | **SE extraction loop + XM routing + eager output-file map + splitting-report skeleton + M-bias accumulator** | ~1,100 LOC actual | 🟢 **PR up: [#849](https://github.com/FelixKrueger/Bismark/pull/849)** (closes [#848](https://github.com/FelixKrueger/Bismark/issues/848)); awaiting review + merge | [#848](https://github.com/FelixKrueger/Bismark/issues/848) | `PHASE_B_PLAN.md` rev 2 |
+| **C** | **PE extraction + overlap handling + `--ignore_r2` / `--ignore_3prime_r2` + `detect_paired_from_header` promotion to `bismark-io v1.0.0-beta.7` + Phase A bug-fix (AutoDetect `no_overlap`)** | ~600 | 📝 **plan rev 1 — folded both plan-review reports' findings; awaiting implementation trigger** | [#850](https://github.com/FelixKrueger/Bismark/issues/850) | `PHASE_C_PLAN.md` rev 1 |
+| D | M-bias accumulation per (context × read_identity) + `M-bias.txt` writer | ~500 | ⏸ not started (accumulator already wired in Phase B; R2 index populates in Phase C) | — | — |
 | E | `--comprehensive` / `--merge_non_CpG` / `--yacht` output mode dispatch + `--gzip` | ~400 | ⏸ not started | — | — |
 | F | Rayon-based `--multicore N` (byte-identical invariant) | ~700 | ⏸ not started | — | — |
 | G | `--bedGraph` + `--cytosine_report` subprocess chain | ~400 | ⏸ not started | — | — |
@@ -22,28 +22,43 @@
 | Step | Status | Owner | Output |
 |------|--------|-------|--------|
 | 1. Spec sections identified (§7.1, §7.2, §7.5, §7.7) | ✅ done | Felix + Claude | (SPEC.md rev 2 already covers) |
-| 2. Plan written to file | ✅ done | Claude | `PHASE_B_PLAN.md` rev 0 (now superseded by rev 2) |
-| 3. **Manual review of plan by Felix** | ✅ done (implicit — directed straight to dual reviewers) | Felix | — |
-| 4. Dual plan-reviewer agents | ✅ done | Claude (Agent ×2) | `PLAN_REVIEW_PHASE_B_A.md` (APPROVE-WITH-NITS) + `PLAN_REVIEW_PHASE_B_B.md` (NEEDS-REVISIONS — eager-open critical) |
-| 5. Plan revisions folding both reviews | ✅ done | Claude | `PHASE_B_PLAN.md` rev 1 — Critical C1 (eager-open) verified against Perl source 5405-5700+ + 14 other fixes |
+| 2. Plan written to file | ✅ done | Claude | `PHASE_B_PLAN.md` rev 0 (superseded by rev 2) |
+| 3. Manual review of plan | ✅ done (implicit — directed straight to dual reviewers) | Felix | — |
+| 4. Dual plan-reviewer agents | ✅ done | Claude | `PLAN_REVIEW_PHASE_B_A.md` (APPROVE-WITH-NITS) + `PLAN_REVIEW_PHASE_B_B.md` (NEEDS-REVISIONS — eager-open critical) |
+| 5. Plan revisions folding both reviews | ✅ done | Claude | `PHASE_B_PLAN.md` rev 1 — eager-open critical fix verified against Perl source 5405-5700+ + 14 other fixes |
 | 6. Implementation trigger | ✅ done | Felix ("implement") | — |
-| 7. Implementation | ✅ done | Claude | 10 source files (call/mbias/output/state/route/header/pipeline/error/main/lib) + 2 test files. Crate version 1.0.0-alpha.1 → 1.0.0-alpha.2 |
-| 8. Dual code-reviewer agents | ✅ done | Claude (Agent ×2) | `CODE_REVIEW_PHASE_B_A.md` + `CODE_REVIEW_PHASE_B_B.md` (both APPROVE-WITH-NITS) |
-| 9. plan-manager coverage audit | ✅ done | Claude (Agent) | `COVERAGE_PHASE_B.md` — INCOMPLETE on 3 coverage items (no behaviour bugs) |
-| 10. **Tight fix-up (rev 2)** | ✅ done | Claude | Added T-27 test; renamed `strand_char` → `meth_char`; dropped `header.clone()`; widened `write_call` + `reference_sequence_id` to typed errors; deviations documented for T-40 + Item 43 |
-| 11. Sub-issue filed on GitHub as child of #798 | ✅ done | Claude | [#848](https://github.com/FelixKrueger/Bismark/issues/848) (filed 2026-05-26 after `brew upgrade gh` 2.91.0 → 2.92.0) |
-| 12. PR opened, byte-identity smoke test green | ⏸ ready | — | — |
-| 13. Merge to `rust/iron-chancellor` | ⏸ ready | — | — |
-| 6. **Implementation trigger from Felix** ("implement" / `/code-implementation`) | ⏸ blocked on #4–#5 | Felix | — |
-| 7. Implementation (modules per §3.2 of plan) | ⏸ | Claude | code changes in `rust/bismark-extractor/` |
-| 8. Dual code-reviewer agents | ⏸ | Claude (Agent tool ×2) | `CODE_REVIEW_PHASE_B_A.md` + `CODE_REVIEW_PHASE_B_B.md` |
-| 9. `plan-manager` coverage audit | ⏸ | Claude (Agent tool) | `COVERAGE_PHASE_B.md` |
-| 10. Sub-issue filed on GitHub as child of #798 | 🟡 **deferred** (gh CLI broken; command surfaced in chat) | Felix | issue link committed back to this table |
-| 11. PR opened, byte-identity smoke test green | ⏸ | — | — |
+| 7. Implementation | ✅ done | Claude | 10 source files + 2 test files; crate version → `1.0.0-alpha.2` |
+| 8. Dual code-reviewer agents | ✅ done | Claude | `CODE_REVIEW_PHASE_B_A.md` + `CODE_REVIEW_PHASE_B_B.md` (both APPROVE-WITH-NITS) |
+| 9. plan-manager coverage audit | ✅ done | Claude | `COVERAGE_PHASE_B.md` — INCOMPLETE on 3 coverage items (resolved in rev 2) |
+| 10. Tight fix-up (rev 2) | ✅ done | Claude | T-27 test added; `strand_char` → `meth_char`; dropped `header.clone()`; widened `write_call` + `reference_sequence_id` to typed errors; deviations documented |
+| 11. Sub-issue filed | ✅ done | Claude (via `gh` 2.92.0) | [#848](https://github.com/FelixKrueger/Bismark/issues/848) |
+| 12. Commit + branch + PR | ✅ done | Claude | branch `extractor-phase-b`; PR [#849](https://github.com/FelixKrueger/Bismark/pull/849) → `rust/iron-chancellor` |
+| 13. Merge to `rust/iron-chancellor` | ⏸ awaiting Felix's review | Felix | — |
+
+## Pipeline steps for **Phase C**
+
+| Step | Status | Owner | Output |
+|------|--------|-------|--------|
+| 1. Spec sections identified (§6.1, §7.3, §7.4, §11) | ✅ done | Claude | (SPEC.md rev 2 already covers) |
+| 2. Sub-issue filed at work-start | ✅ done | Claude | [#850](https://github.com/FelixKrueger/Bismark/issues/850) |
+| 3. Plan written to file | ✅ done | Claude | `PHASE_C_PLAN.md` rev 0 |
+| 4. Manual review of plan by Felix | ✅ done (approved, directed to dual reviewers) | Felix | — |
+| 5. Dual plan-reviewer agents | ✅ done | Claude (Agent ×2) | `PLAN_REVIEW_PHASE_C_A.md` (NEEDS-REVISIONS) + `PLAN_REVIEW_PHASE_C_B.md` (APPROVE-WITH-NITS) |
+| 6. Plan revisions (rev 1) | ✅ done | Claude | rev 1 of `PHASE_C_PLAN.md` — folded 1 Critical (AutoDetect `no_overlap`) + 1 agreed Important (lines-vs-pairs counter) + 9 other Importants + several Optionals |
+| 7. **Implementation trigger from Felix** | 🟡 **pending** | Felix | _("implement" or `/code-implementation`)_ |
+| 8. Implementation | ⏸ | Claude | `bismark-io v1.0.0-beta.7` (promote `detect_paired_from_header`) + `bismark-extractor 1.0.0-alpha.3` (extract_pe + overlap + run_extraction refactor) |
+| 9. Dual code-reviewer agents | ⏸ | Claude | `CODE_REVIEW_PHASE_C_A.md` + `CODE_REVIEW_PHASE_C_B.md` |
+| 10. plan-manager coverage audit | ⏸ | Claude | `COVERAGE_PHASE_C.md` |
+| 11. PR opened on branch `extractor-phase-c` | ⏸ | — | Stacked on `extractor-phase-b` until #849 merges; then rebase onto `rust/iron-chancellor` |
 | 12. Merge to `rust/iron-chancellor` | ⏸ | — | — |
+
+## Branching state
+
+- `rust/iron-chancellor` — integration branch.
+- `extractor-phase-b` — Phase B feature branch (PR #849 open).
+- `extractor-phase-c` — Phase C feature branch (currently checked out), based on `extractor-phase-b`. Stacked PR: when Phase B merges, rebase Phase C onto fresh `rust/iron-chancellor`.
 
 ## Notes
 
-- Sub-issue filing is currently **blocked by a macOS keychain TLS error** affecting `gh` CLI in this environment (`tls: failed to verify certificate: x509: OSStatus -26276`). Workaround: user runs the command from their normal terminal (see PHASE_B_PLAN.md §14 for the copy-pasteable form).
-- Per global CLAUDE.md workflow: manual review of the plan **must** happen before agent plan-reviewers are launched. No reviewers launched yet.
-- Per global CLAUDE.md workflow: implementation requires an explicit trigger ("implement" or `/code-implementation`). No code edits planned until then.
+- Plan files are committed in `extractor-phase-b` (Phase B's PR) and will be extended in `extractor-phase-c`. Phase B's PR carries the Phase B artefacts; Phase C's future PR will add `PHASE_C_PLAN.md` + reviews + coverage.
+- gh CLI was broken in the local environment until `brew upgrade gh` 2.91.0 → 2.92.0 picked up a fix for macOS Security framework's handling of GitHub's new ECDSA Sectigo intermediate. Working now.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-extractor"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 dependencies = [
  "assert_cmd",
  "bismark-io",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-io"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "bstr",
  "noodles-bam",

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -19,7 +19,7 @@ name = "deduplicate_bismark_rs"
 path = "src/main.rs"
 
 [dependencies]
-bismark-io = { version = "=1.0.0-beta.6", path = "../bismark-io" }
+bismark-io = { version = "=1.0.0-beta.7", path = "../bismark-io" }
 # noodles-sam pinned to match bismark-io =1.0.0's transitive choice.
 # Needed directly for `Header` (returned by `bismark_io::open_reader`
 # via `AnyReader::header`) and for test-helper types.

--- a/rust/bismark-dedup/src/pipeline.rs
+++ b/rust/bismark-dedup/src/pipeline.rs
@@ -25,6 +25,8 @@ use bismark_io::BismarkPair;
 use bismark_io::BismarkRecord;
 use bismark_io::BismarkStrand;
 use bismark_io::CigarExt;
+// detect_paired_from_header promoted from this crate to bismark-io v1.0.0-beta.7.
+pub use bismark_io::detect_paired_from_header;
 use bstr::BString;
 use noodles_sam::Header;
 use rustc_hash::FxHashMap;
@@ -118,70 +120,9 @@ fn is_forward(strand: BismarkStrand) -> bool {
     matches!(strand, BismarkStrand::OT | BismarkStrand::CTOB)
 }
 
-/// Auto-detect library mode (single-end vs paired-end) from a Bismark
-/// BAM header.
-///
-/// Walks the `@PG` lines, finds the Bismark-aligner entry (ID starting
-/// with `Bismark`), and inspects its command line for `-1`/`--1` AND
-/// `-2`/`--2` arguments (which Bismark only passes in paired-end mode).
-///
-/// Returns:
-/// - `Some(true)` — PE (Bismark @PG found with both `-1`/`--1` and `-2`/`--2`)
-/// - `Some(false)` — SE (Bismark @PG found, missing one or both of those)
-/// - `None` — no Bismark @PG line in the header; caller must error out
-///   (CLI parse-stage forces the user to specify `--single`/`--paired`
-///   explicitly in that case).
-///
-/// Mirrors Perl `deduplicate_bismark` lines 90–116.
-#[must_use]
-pub fn detect_paired_from_header(header: &Header) -> Option<bool> {
-    // Serialize the header to its on-disk SAM text representation and
-    // search for the Bismark @PG line. This is robust to noodles API
-    // shape changes across versions (the SAM text format is the stable
-    // contract here, not the in-memory `Programs` type).
-    let mut buf: Vec<u8> = Vec::new();
-    {
-        let mut writer = noodles_sam::io::Writer::new(&mut buf);
-        if writer.write_header(header).is_err() {
-            return None;
-        }
-    }
-    let text = String::from_utf8_lossy(&buf);
-    for line in text.lines() {
-        // SAM header @PG line format: `@PG\tID:<id>\t...\tCL:<args>...`
-        // The `ID:Bismark` substring identifies the Bismark @PG.
-        if !line.starts_with("@PG") || !line.contains("ID:Bismark") {
-            continue;
-        }
-        // Look for -1/--1 AND -2/--2 in the command-line args. Bismark's
-        // PE invocation always has both; SE has neither.
-        // We accept space-separated, tab-separated, or end-of-line
-        // boundaries to be robust to argument quoting differences.
-        let has_1 = arg_present(line, "-1") || arg_present(line, "--1");
-        let has_2 = arg_present(line, "-2") || arg_present(line, "--2");
-        return Some(has_1 && has_2);
-    }
-    None
-}
-
-/// True if `arg` appears as a standalone token in `text`, delimited by
-/// whitespace or tab on **both** sides.
-///
-/// Matches Perl's `/\s+--?1\s+/` semantics: a `-1` at the very end of the
-/// line (without trailing whitespace) is NOT considered present, even
-/// though Bismark in practice always appends a path after `-1`/`-2`.
-/// Being strict here matches Perl exactly — important for byte-identity
-/// when the same input is run through both implementations.
-fn arg_present(text: &str, arg: &str) -> bool {
-    let arg_space = format!(" {arg} ");
-    let arg_tab_left = format!("\t{arg} ");
-    let arg_tab_right = format!(" {arg}\t");
-    let arg_tab_both = format!("\t{arg}\t");
-    text.contains(&arg_space)
-        || text.contains(&arg_tab_left)
-        || text.contains(&arg_tab_right)
-        || text.contains(&arg_tab_both)
-}
+// `detect_paired_from_header` + `arg_present` promoted to `bismark-io`
+// v1.0.0-beta.7. Use `bismark_io::detect_paired_from_header` directly
+// (re-imported in this file's `use` block).
 
 /// Compute the SE dedup key from a `BismarkRecord`.
 fn compute_se_key(

--- a/rust/bismark-extractor/Cargo.toml
+++ b/rust/bismark-extractor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bismark-extractor"
-version = "1.0.0-alpha.2"
-description = "Rust port of Bismark Perl's bismark_methylation_extractor script (Phase B: SE extraction)"
+version = "1.0.0-alpha.3"
+description = "Rust port of Bismark Perl's bismark_methylation_extractor script (Phase C: SE + PE extraction)"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -19,7 +19,7 @@ name = "bismark-methylation-extractor-rs"
 path = "src/main.rs"
 
 [dependencies]
-bismark-io = { version = "=1.0.0-beta.6", path = "../bismark-io" }
+bismark-io = { version = "=1.0.0-beta.7", path = "../bismark-io" }
 clap = { version = "=4.5.30", features = ["derive"] }
 thiserror = "=2.0.0"
 # noodles-sam pinned to match bismark-io's transitive choice (matches dedup precedent).

--- a/rust/bismark-extractor/src/cli.rs
+++ b/rust/bismark-extractor/src/cli.rs
@@ -442,7 +442,14 @@ impl Cli {
         // Derived: no_overlap. PE default is ON; --include_overlap overrides.
         // SE doesn't have R2, so the field is meaningless there (kept as
         // false for SE).
-        let no_overlap = if paired_mode == PairedMode::PairedEnd {
+        //
+        // Phase C rev 1 fix (Reviewer A §1.1 Critical): include AutoDetect
+        // in the "set to !include_overlap" branch. Rev 0's `== PairedEnd`
+        // left AutoDetect at false, so a Phase C dispatch that auto-detects
+        // PE would silently leak R2 overlap calls. The fix makes any non-SE
+        // path inherit the PE default; SE actual extraction ignores the
+        // field (no overlap concept).
+        let no_overlap = if paired_mode != PairedMode::SingleEnd {
             !self.include_overlap
         } else {
             false

--- a/rust/bismark-extractor/src/error.rs
+++ b/rust/bismark-extractor/src/error.rs
@@ -184,4 +184,43 @@ pub enum BismarkExtractorError {
         /// Offending chr name (lossy-rendered for the error message).
         name: String,
     },
+
+    // ─── Phase C (PE extraction) additions ─────────────────────────────
+    /// PE input had an odd number of records — the final R1 has no R2 mate.
+    /// PE BAM must contain pairs of adjacent R1/R2 records (QNAME-grouped).
+    #[error(
+        "unpaired final record in PE BAM: qname={qname:?}; PE input must contain \
+         pairs of adjacent R1/R2 records (was the file truncated, or sort broken?)"
+    )]
+    UnpairedFinalRecord {
+        /// QNAME of the orphan R1 (or `None` if the record had no name).
+        qname: Option<String>,
+    },
+
+    /// R1 and R2 of a PE pair aligned to different chromosomes. Bismark
+    /// never produces this; defensive guard against tooling corruption.
+    ///
+    /// Named for parity with `BismarkIoError::MateMismatch` and
+    /// `ReadIdentityMismatch` (Phase C rev 1 rename from rev 0's
+    /// `CrossChromosomePair`).
+    #[error(
+        "PE pair {qname} has R1 and R2 on different chromosomes \
+         (R1=refid {r1_refid}, R2=refid {r2_refid}); Bismark does not emit cross-chr pairs"
+    )]
+    MateChromosomeMismatch {
+        /// Pair QNAME (shared by R1 and R2 per `BismarkPair`'s qname-eq guarantee).
+        qname: String,
+        /// R1 reference ID.
+        r1_refid: usize,
+        /// R2 reference ID.
+        r2_refid: usize,
+    },
+
+    /// `--paired-end` / `--single-end` auto-detect failed because the input's
+    /// SAM header does not contain a recognised Bismark `@PG` line.
+    #[error("library-mode auto-detection failed: {message}")]
+    AutoDetectFailed {
+        /// Diagnostic message naming the next user step.
+        message: String,
+    },
 }

--- a/rust/bismark-extractor/src/lib.rs
+++ b/rust/bismark-extractor/src/lib.rs
@@ -6,13 +6,15 @@
 //!
 //! ## Status
 //!
-//! **Phase B — SE extraction loop** (crate version: `1.0.0-alpha.2`).
-//! The binary now runs end-to-end on SE Bismark BAM/SAM/CRAM input in
-//! `OutputMode::Default` at `--parallel 1`, producing the 12 strand×context
-//! split files (eagerly opened with the Perl version header line) plus
-//! `_splitting_report.txt`. PE, non-default modes, `--gzip`, `--parallel > 1`,
-//! and the `--bedGraph` / `--cytosine_report` subprocess chain are rejected
-//! at the resolved-config boundary with [`BismarkExtractorError::PhaseNotYetImplemented`].
+//! **Phase C — SE + PE extraction loops** (crate version: `1.0.0-alpha.3`).
+//! The binary runs end-to-end on Bismark BAM/SAM/CRAM input in `OutputMode::Default`
+//! at `--parallel 1`, producing the 12 strand×context split files plus
+//! `_splitting_report.txt`. SE-vs-PE auto-detect via `@PG ID:Bismark` header
+//! probe (powered by `bismark_io::detect_paired_from_header`). PE adds
+//! overlap detection (`--no_overlap` default) and per-mate ignore trims
+//! (`--ignore_r2`, `--ignore_3prime_r2`). Non-default modes, `--gzip`,
+//! `--parallel > 1`, and `--bedGraph` / `--cytosine_report` still rejected
+//! with [`BismarkExtractorError::PhaseNotYetImplemented`].
 //!
 //! See [SPEC.md §10](../SPEC.md) for the full phase outline.
 //!
@@ -23,10 +25,12 @@
 //!   [`cli::OutputMode`] and [`cli::PairedMode`].
 //! - [`error::BismarkExtractorError`] — typed errors raised at validation
 //!   and the extraction-pipeline boundary.
-//! - [`params::ExtractParams`] — scaffold for Phase C/D/E parameter
-//!   structs; not yet used in Phase B.
-//! - [`call::extract_calls`] — Phase B kernel.
-//! - [`pipeline::extract_se`] — Phase B SE main loop.
+//! - [`params::ExtractParams`] — scaffold for later-phase parameter
+//!   structs; not yet used.
+//! - [`call::extract_calls`] — kernel (Phase B).
+//! - [`pipeline::extract_se`] — SE main loop (Phase B).
+//! - [`pipeline::extract_pe`] — PE main loop (Phase C).
+//! - [`overlap::drop_overlap`] — PE overlap-detection filter (Phase C).
 //!
 //! ## Binary
 //!
@@ -43,6 +47,7 @@ pub mod error;
 pub mod header;
 pub mod mbias;
 pub mod output;
+pub mod overlap;
 pub mod params;
 pub mod pipeline;
 pub mod route;
@@ -52,8 +57,9 @@ pub use call::{CytosineContext, MethCall, extract_calls};
 pub use cli::{Cli, OutputMode, PairedMode, ResolvedConfig};
 pub use error::BismarkExtractorError;
 pub use mbias::{MbiasPos, MbiasTable};
+pub use overlap::{drop_overlap, is_forward_pair_strand};
 pub use params::ExtractParams;
-pub use pipeline::extract_se;
+pub use pipeline::{extract_pe, extract_se};
 
 /// Returns a TG-style provenance string for the binary's `--version` output.
 ///

--- a/rust/bismark-extractor/src/main.rs
+++ b/rust/bismark-extractor/src/main.rs
@@ -1,10 +1,15 @@
 //! Binary entry point for `bismark-methylation-extractor-rs`.
 //!
-//! Phase B (rev 1): dispatches on the resolved config — SE + default mode +
-//! parallel=1 + no gzip + no bedGraph/cytosine_report + single input file
-//! routes to [`bismark_extractor::extract_se`]. Every other configuration
-//! returns a [`BismarkExtractorError::PhaseNotYetImplemented`] naming the
-//! deferring phase.
+//! Phase C (rev 1): dispatches on the resolved config —
+//! - `SingleEnd` → [`bismark_extractor::extract_se`].
+//! - `PairedEnd` → [`bismark_extractor::extract_pe`].
+//! - `AutoDetect` → header-probe via `bismark_io::detect_paired_from_header`
+//!   to pick `extract_se` / `extract_pe`. Errors with `AutoDetectFailed`
+//!   if the BAM has no `@PG ID:Bismark*` line.
+//!
+//! Non-default output modes, `--gzip`, `--parallel > 1`, `--bedGraph` /
+//! `--cytosine_report`, and multiple input files are still rejected with
+//! [`BismarkExtractorError::PhaseNotYetImplemented`].
 //!
 //! Exit codes:
 //! - `0` — success
@@ -17,7 +22,8 @@ use clap::Parser;
 
 use bismark_extractor::cli::{Cli, OutputMode, PairedMode};
 use bismark_extractor::error::BismarkExtractorError;
-use bismark_extractor::{extract_se, version_string};
+use bismark_extractor::{extract_pe, extract_se, version_string};
+use bismark_io::{detect_paired_from_header, open_reader};
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
@@ -53,13 +59,6 @@ fn run(cli: Cli) -> Result<(), BismarkExtractorError> {
                 "multiple input files ({} given); v1.x feature",
                 config.files.len()
             ),
-        });
-    }
-
-    // Paired-end: Phase C.
-    if config.paired_mode == PairedMode::PairedEnd {
-        return Err(BismarkExtractorError::PhaseNotYetImplemented {
-            feature: "paired-end extraction; arrives in Phase C".to_string(),
         });
     }
 
@@ -99,9 +98,35 @@ fn run(cli: Cli) -> Result<(), BismarkExtractorError> {
         });
     }
 
-    // Supported subset: SE (or AutoDetect treated as SE; per-record PAIRED-flag
-    // check inside the loop catches PE BAMs). Default mode. Single core.
-    // Plain (uncompressed) output. No subprocess chain.
+    // Supported subset: SE OR PE in default mode at parallel=1, plain output,
+    // no subprocess chain. PairedMode dispatch:
+    //   - SingleEnd → extract_se.
+    //   - PairedEnd → extract_pe.
+    //   - AutoDetect → probe the SAM header's @PG ID:Bismark line; dispatch.
     let input = config.files[0].clone();
-    extract_se(&input, &config)
+    match config.paired_mode {
+        PairedMode::SingleEnd => extract_se(&input, &config),
+        PairedMode::PairedEnd => extract_pe(&input, &config),
+        PairedMode::AutoDetect => {
+            // Open reader once for header inspection. The reader is dropped
+            // before the chosen extract_se / extract_pe re-opens the file —
+            // ~50 ms overhead per run, OS caches the BAM header bytes.
+            let probe = open_reader(&input, /*cram_ref=*/ None)?;
+            let is_paired = detect_paired_from_header(probe.header()).ok_or_else(|| {
+                BismarkExtractorError::AutoDetectFailed {
+                    message: format!(
+                        "no `@PG` line with `ID:Bismark*` found in {}'s header; \
+                         pass `--single-end` or `--paired-end` explicitly",
+                        input.display()
+                    ),
+                }
+            })?;
+            drop(probe);
+            if is_paired {
+                extract_pe(&input, &config)
+            } else {
+                extract_se(&input, &config)
+            }
+        }
+    }
 }

--- a/rust/bismark-extractor/src/output.rs
+++ b/rust/bismark-extractor/src/output.rs
@@ -265,7 +265,9 @@ pub fn write_splitting_report(
     writeln!(w, "--ignore_3prime: {}", config.ignore_3p_r1)?;
 
     writeln!(w)?;
-    writeln!(w, "Processed {} reads in total", report.records_processed)?;
+    // Perl `bismark_methylation_extractor:2479` writes "Processed N lines in total"
+    // (where N is the BAM-line count — SE: records, PE: 2×pairs). Phase C bug-fix.
+    writeln!(w, "Processed {} lines in total", report.records_processed)?;
     writeln!(w)?;
 
     writeln!(w, "Total number of C's analysed:\t{}", report.calls_total)?;

--- a/rust/bismark-extractor/src/overlap.rs
+++ b/rust/bismark-extractor/src/overlap.rs
@@ -1,0 +1,74 @@
+//! Paired-end overlap detection (`--no_overlap`).
+//!
+//! Phase C (rev 1) — drops R2 calls overlapping R1's reference span.
+//! Mirrors Perl `bismark_methylation_extractor` lines 2891-2906 (forward /
+//! OT-CTOB) + 2976-2990 (reverse / OB-CTOT). Decision happens at the
+//! **reference-position** level, accounting for InDels via
+//! [`bismark_io::CigarExt::reference_end`].
+//!
+//! ## Polarity (SPEC §7.4 rev 2)
+//!
+//! Perl writes the *skip* predicate as `>=` (forward) and `<=` (reverse).
+//! The Rust *keep* predicate is the inverse: strict `<` (forward) and
+//! strict `>` (reverse). Both Phase C reviewers verified this against
+//! Perl 2905 + 2989.
+
+use bismark_io::{BismarkPair, BismarkStrand, CigarExt};
+
+use crate::call::MethCall;
+use crate::error::BismarkExtractorError;
+
+/// Drop R2 calls overlapping R1's reference span. SPEC §7.4.
+///
+/// Pair-strand is recovered internally via [`BismarkPair::pair_strand`]
+/// (Phase C rev 1 simplification per Reviewer B L6 — the explicit
+/// `pair_strand` argument was redundant with `pair.pair_strand()`).
+///
+/// Uses [`Vec::retain`] rather than `into_iter().filter().collect()` to
+/// avoid reallocating a new `Vec` when most R2 calls are kept (the common
+/// case for partially-overlapping pairs).
+///
+/// # Errors
+///
+/// [`BismarkExtractorError::InternalError`] if R1 lacks an `alignment_start`
+/// (filtered upstream by `bismark-io::open_reader`'s unmapped-filter, so this
+/// should not fire in practice).
+pub fn drop_overlap(
+    mut r2_calls: Vec<MethCall>,
+    pair: &BismarkPair,
+) -> Result<Vec<MethCall>, BismarkExtractorError> {
+    let r1_start =
+        pair.r1()
+            .alignment_start()
+            .ok_or_else(|| BismarkExtractorError::InternalError {
+                message: "R1 of PE pair missing alignment_start; bismark-io should have filtered \
+                      this as unmapped (FLAG & 0x4)"
+                    .to_string(),
+            })?;
+
+    if is_forward_pair_strand(pair.pair_strand()) {
+        // OT/CTOB pair: R1 is upstream, R2 is downstream.
+        // Perl 2905 skip predicate: `if r2_pos >= r1_ref_end { return; }`.
+        // Keep predicate (strict inverse): `r2_pos < r1_ref_end`.
+        let r1_ref_end = pair.r1().cigar().reference_end(r1_start) as u32;
+        r2_calls.retain(|c| c.ref_pos < r1_ref_end);
+    } else {
+        // OB/CTOT pair: R2 is upstream, R1 is downstream.
+        // Perl 2989 skip predicate: `if r2_pos <= r1_ref_start { return; }`.
+        // Keep predicate (strict inverse): `r2_pos > r1_ref_start`.
+        let r1_ref_start = r1_start as u32;
+        r2_calls.retain(|c| c.ref_pos > r1_ref_start);
+    }
+    Ok(r2_calls)
+}
+
+/// Forward-class pair strands: R1's mapped position is the upstream end of
+/// the paired insert. `OT` and `CTOB` are forward; `OB` and `CTOT` are
+/// reverse.
+///
+/// Cites Perl `bismark_methylation_extractor:2400` (forward branch entry)
+/// and line 2415 (reverse branch entry) — these are where R1's strand-tag
+/// drives the per-pair direction selection in the Perl loop.
+pub fn is_forward_pair_strand(strand: BismarkStrand) -> bool {
+    matches!(strand, BismarkStrand::OT | BismarkStrand::CTOB)
+}

--- a/rust/bismark-extractor/src/pipeline.rs
+++ b/rust/bismark-extractor/src/pipeline.rs
@@ -1,20 +1,32 @@
-//! SE extraction pipeline (Phase B).
+//! SE + PE extraction pipelines (Phase B + Phase C).
 //!
-//! Per SPEC §7.2: one record at a time, classify XM bytes, route to split
-//! files + accumulate M-bias counters + bump splitting-report counters.
+//! Per SPEC §7.2 (SE) + §7.3 (PE): record/pair at a time, classify XM bytes,
+//! route to split files + accumulate M-bias counters + bump splitting-report
+//! counters.
 //!
-//! PE (Phase C), multicore (Phase F), gzip (Phase E), bedGraph/cytosine_report
-//! subprocess (Phase G), and non-default output modes (Phase E) are rejected
-//! at `main::run`'s config-dispatch boundary, not here.
+//! Multicore (Phase F), gzip (Phase E), bedGraph/cytosine_report subprocess
+//! (Phase G), and non-default output modes (Phase E) are rejected at
+//! `main::run`'s config-dispatch boundary, not here.
+//!
+//! ## Phase B → C duplication note
+//!
+//! Phase C's plan §6 step 6 anticipated a `run_extraction<F>` helper to
+//! share scaffolding between `extract_se` and `extract_pe`. Per the
+//! contingency in the plan (Phase B PR #849 still in review at Phase C
+//! implementation time), `extract_pe` duplicates `extract_se`'s scaffolding
+//! rather than refactoring it concurrently with Phase B's review. The
+//! `run_extraction` helper extraction lands as a follow-up PR once Phase
+//! B merges.
 
 use std::path::Path;
 
-use bismark_io::{ReadIdentity, open_reader};
+use bismark_io::{BismarkPair, ReadIdentity, open_reader};
 
 use crate::call::extract_calls;
 use crate::cli::ResolvedConfig;
 use crate::error::BismarkExtractorError;
 use crate::header::build_chr_name_table;
+use crate::overlap::drop_overlap;
 use crate::route::route_call;
 use crate::state::ExtractState;
 
@@ -143,5 +155,167 @@ pub fn extract_se(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkEx
     // is already on disk, and the contract (state.rs::finalize doc) is that
     // post-finalize errors don't trigger cleanup.
     state.finalize(config)?;
+    Ok(())
+}
+
+/// PE extraction main loop (Phase C).
+///
+/// Pairs adjacent records (R1 then R2) via [`BismarkPair::from_mates`],
+/// which enforces qname-equality and R1/R2 identity. R2 calls overlapping
+/// R1's reference span are dropped via [`drop_overlap`] when
+/// `config.no_overlap` is true (PE default; `--include_overlap` flips it).
+/// Per-mate ignore-region trims (`--ignore_r2`, `--ignore_3prime_r2`) are
+/// applied via the same per-record kernel as SE.
+///
+/// Per SPEC §7.3 + §6.1: routing keys on the **pair-strand** (R1's
+/// `record_strand`), NOT each mate's `record_strand`. This closes the
+/// "one pair split across multiple files" bug class structurally.
+///
+/// # Splitting-report counter
+///
+/// Increments `state.report.records_processed` by **2 per pair** to match
+/// Perl `bismark_methylation_extractor:2451` (`$methylation_call_strings_processed += 2`)
+/// and the line-2479 report literal `"Processed N lines in total"`. The
+/// counter name `records_processed` reflects lines-in-BAM, not pair-count.
+///
+/// # Errors
+///
+/// - [`BismarkExtractorError::UnpairedFinalRecord`] — odd-numbered record count.
+/// - [`BismarkExtractorError::MateChromosomeMismatch`] — R1/R2 on different chromosomes.
+/// - [`BismarkExtractorError::BismarkIo`] — `BismarkPair::from_mates` qname/identity failure.
+/// - Any error from [`extract_calls`] (invalid XM byte) or [`route_call`] (I/O failure).
+///
+/// On any pre-finalize error, runs [`ExtractState::cleanup_partial_outputs`]
+/// to remove all 12 partial files before propagating.
+pub fn extract_pe(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkExtractorError> {
+    let mut reader = open_reader(input, /*cram_ref=*/ None)?;
+    let chr_table = build_chr_name_table(reader.header())?;
+
+    let input_basename = derive_basename(input);
+    let mut state = ExtractState::new(config, input, &input_basename)?;
+
+    let mut records = reader.records();
+    loop {
+        // Take R1.
+        let r1 = match records.next() {
+            Some(Ok(r)) => r,
+            Some(Err(e)) => {
+                state.cleanup_partial_outputs();
+                return Err(e.into());
+            }
+            None => break, // clean end of BAM
+        };
+
+        // Take R2.
+        let r2 = match records.next() {
+            Some(Ok(r)) => r,
+            Some(Err(e)) => {
+                state.cleanup_partial_outputs();
+                return Err(e.into());
+            }
+            None => {
+                let qname = r1
+                    .inner()
+                    .name()
+                    .map(|n| String::from_utf8_lossy(n.as_ref()).into_owned());
+                state.cleanup_partial_outputs();
+                return Err(BismarkExtractorError::UnpairedFinalRecord { qname });
+            }
+        };
+
+        // Construct the pair (qname-eq + R1/R2 identity enforced by bismark-io).
+        let pair = match BismarkPair::from_mates(r1, r2) {
+            Ok(p) => p,
+            Err(e) => {
+                state.cleanup_partial_outputs();
+                return Err(e.into());
+            }
+        };
+
+        if let Err(e) = handle_one_pair(&pair, &mut state, &chr_table, config) {
+            state.cleanup_partial_outputs();
+            return Err(e);
+        }
+
+        // Two BAM lines processed per iteration (rev 1 Reviewer A §1.5 /
+        // Reviewer B L1: Perl line 2451 increments by 2 per pair).
+        state.report.records_processed = state.report.records_processed.saturating_add(2);
+    }
+
+    state.finalize(config)?;
+    Ok(())
+}
+
+/// Per-pair handler: resolve chr, extract calls from both mates, drop
+/// overlap if configured, route to split files.
+///
+/// Rev 1 (Reviewer B L3): chr name resolved once (after the
+/// `MateChromosomeMismatch` defensive check) and reused for both R1 and R2
+/// routing. The defensive check guarantees R1 and R2 share a refid by the
+/// time we look up the chr name.
+fn handle_one_pair(
+    pair: &BismarkPair,
+    state: &mut ExtractState,
+    chr_table: &[String],
+    config: &ResolvedConfig,
+) -> Result<(), BismarkExtractorError> {
+    // Cross-chr defensive check. Both refids resolved here so we can name
+    // them in the error message; same convention as Phase B's SE refid path.
+    let r1_refid = pair.r1().inner().reference_sequence_id().ok_or_else(|| {
+        BismarkExtractorError::InternalError {
+            message: "PE R1 missing reference_sequence_id; bismark-io::records should have \
+                      filtered this as unmapped (FLAG & 0x4)"
+                .to_string(),
+        }
+    })?;
+    let r2_refid = pair.r2().inner().reference_sequence_id().ok_or_else(|| {
+        BismarkExtractorError::InternalError {
+            message: "PE R2 missing reference_sequence_id; bismark-io::records should have \
+                      filtered this as unmapped (FLAG & 0x4)"
+                .to_string(),
+        }
+    })?;
+    if r1_refid != r2_refid {
+        let qname = pair
+            .r1()
+            .inner()
+            .name()
+            .map(|n| String::from_utf8_lossy(n.as_ref()).into_owned())
+            .unwrap_or_else(|| "<unnamed>".to_string());
+        return Err(BismarkExtractorError::MateChromosomeMismatch {
+            qname,
+            r1_refid,
+            r2_refid,
+        });
+    }
+
+    let chr = chr_table
+        .get(r1_refid)
+        .ok_or_else(|| BismarkExtractorError::InternalError {
+            message: format!(
+                "pair refid {} out of range vs header (count {})",
+                r1_refid,
+                chr_table.len()
+            ),
+        })?
+        .as_str();
+
+    let pair_strand = pair.pair_strand();
+
+    let r1_calls = extract_calls(pair.r1(), config.ignore_5p_r1, config.ignore_3p_r1)?;
+    let r2_calls_raw = extract_calls(pair.r2(), config.ignore_5p_r2, config.ignore_3p_r2)?;
+
+    let r2_calls = if config.no_overlap {
+        drop_overlap(r2_calls_raw, pair)?
+    } else {
+        r2_calls_raw
+    };
+
+    for call in r1_calls {
+        route_call(state, pair.r1(), chr, pair_strand, call, ReadIdentity::R1)?;
+    }
+    for call in r2_calls {
+        route_call(state, pair.r2(), chr, pair_strand, call, ReadIdentity::R2)?;
+    }
     Ok(())
 }

--- a/rust/bismark-extractor/tests/pe_phase_c.rs
+++ b/rust/bismark-extractor/tests/pe_phase_c.rs
@@ -1,0 +1,1307 @@
+//! Phase C unit tests — PE extraction loop, overlap detection, per-mate
+//! ignore trims, SE-vs-PE auto-detect.
+//!
+//! Test names mirror plan §7.1's labels. End-to-end smoke that runs the
+//! binary on a synthetic PE BAM lives at `tests/pe_phase_c_smoke.rs`.
+
+#![allow(non_snake_case)]
+
+use bismark_extractor::call::{CytosineContext, MethCall};
+use bismark_extractor::cli::{Cli, PairedMode};
+use bismark_extractor::overlap::{drop_overlap, is_forward_pair_strand};
+use bismark_io::{BismarkPair, BismarkStrand};
+use clap::Parser;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Test helpers — synthetic BismarkRecord + BismarkPair construction
+// ─────────────────────────────────────────────────────────────────────────
+
+mod helpers {
+    use bismark_io::{BismarkPair, BismarkRecord};
+    use bstr::BString;
+    use noodles_core::Position;
+    use noodles_sam::alignment::record::Flags;
+    use noodles_sam::alignment::record::cigar::Op;
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    use noodles_sam::alignment::record::data::field::Tag;
+    use noodles_sam::alignment::record_buf::data::field::Value;
+    use noodles_sam::alignment::record_buf::{Cigar, RecordBuf, Sequence};
+
+    /// Build a synthetic `BismarkRecord` with the given XR/XG/XM, sequence,
+    /// alignment_start, CIGAR ops, FLAG, QNAME, and refid.
+    #[allow(clippy::too_many_arguments)]
+    pub fn synth(
+        xr: &[u8],
+        xg: &[u8],
+        xm: &[u8],
+        seq: &[u8],
+        alignment_start: usize,
+        cigar_ops: &[(Kind, usize)],
+        flags: u16,
+        qname: &[u8],
+        refid: usize,
+    ) -> BismarkRecord {
+        let mut record = RecordBuf::default();
+        *record.flags_mut() = Flags::from(flags);
+        *record.sequence_mut() = Sequence::from(seq.to_vec());
+        *record.alignment_start_mut() = Some(Position::try_from(alignment_start).unwrap());
+        *record.reference_sequence_id_mut() = Some(refid);
+        *record.cigar_mut() = Cigar::from(
+            cigar_ops
+                .iter()
+                .map(|(k, n)| Op::new(*k, *n))
+                .collect::<Vec<_>>(),
+        );
+        *record.name_mut() = Some(BString::from(qname.to_vec()));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XR"), Value::String(BString::from(xr.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XM"), Value::String(BString::from(xm.to_vec())));
+        BismarkRecord::from_noodles_record(record).expect("synth produces a valid BismarkRecord")
+    }
+
+    /// Build an OT pair: R1 with XR=CT XG=CT (record_strand=OT, pair_strand=OT),
+    /// R2 with XR=GA XG=CT (record_strand=CTOT). FLAG bits set per SAM spec.
+    /// R1/R2 share qname. `r1_start` / `r2_start` are the alignment starts;
+    /// CIGAR is a single Match op spanning the XM length on each side.
+    pub fn ot_pair(
+        r1_xm: &[u8],
+        r1_start: usize,
+        r2_xm: &[u8],
+        r2_start: usize,
+        qname: &[u8],
+    ) -> BismarkPair {
+        let r1 = synth(
+            b"CT",
+            b"CT",
+            r1_xm,
+            &vec![b'A'; r1_xm.len()],
+            r1_start,
+            &[(Kind::Match, r1_xm.len())],
+            0x41, // paired + first-in-pair
+            qname,
+            0,
+        );
+        let r2 = synth(
+            b"GA",
+            b"CT",
+            r2_xm,
+            &vec![b'A'; r2_xm.len()],
+            r2_start,
+            &[(Kind::Match, r2_xm.len())],
+            0x81, // paired + last-in-pair
+            qname,
+            0,
+        );
+        BismarkPair::from_mates(r1, r2).expect("OT pair construction")
+    }
+
+    /// Build an OB pair: R1 with XR=CT XG=GA (record_strand=OB, pair_strand=OB),
+    /// R2 with XR=GA XG=GA (record_strand=CTOB). R1 is downstream, R2 upstream.
+    pub fn ob_pair(
+        r1_xm: &[u8],
+        r1_start: usize,
+        r2_xm: &[u8],
+        r2_start: usize,
+        qname: &[u8],
+    ) -> BismarkPair {
+        let r1 = synth(
+            b"CT",
+            b"GA",
+            r1_xm,
+            &vec![b'A'; r1_xm.len()],
+            r1_start,
+            &[(Kind::Match, r1_xm.len())],
+            0x41,
+            qname,
+            0,
+        );
+        let r2 = synth(
+            b"GA",
+            b"GA",
+            r2_xm,
+            &vec![b'A'; r2_xm.len()],
+            r2_start,
+            &[(Kind::Match, r2_xm.len())],
+            0x81,
+            qname,
+            0,
+        );
+        BismarkPair::from_mates(r1, r2).expect("OB pair construction")
+    }
+
+    /// Non-directional CTOT pair: R1 with XR=GA XG=CT (record_strand=CTOT,
+    /// pair_strand=CTOT), R2 with XR=CT XG=CT (record_strand=OT). Used by
+    /// `extract_pe_routes_ctot_pair_strand_correctly` to exercise the
+    /// non-directional library path that's NOT covered by `ot_pair`.
+    pub fn ctot_pair(
+        r1_xm: &[u8],
+        r1_start: usize,
+        r2_xm: &[u8],
+        r2_start: usize,
+        qname: &[u8],
+    ) -> BismarkPair {
+        let r1 = synth(
+            b"GA",
+            b"CT",
+            r1_xm,
+            &vec![b'A'; r1_xm.len()],
+            r1_start,
+            &[(Kind::Match, r1_xm.len())],
+            0x41,
+            qname,
+            0,
+        );
+        let r2 = synth(
+            b"CT",
+            b"CT",
+            r2_xm,
+            &vec![b'A'; r2_xm.len()],
+            r2_start,
+            &[(Kind::Match, r2_xm.len())],
+            0x81,
+            qname,
+            0,
+        );
+        BismarkPair::from_mates(r1, r2).expect("CTOT pair construction")
+    }
+
+    /// Non-directional CTOB pair: R1 with XR=GA XG=GA (record_strand=CTOB,
+    /// pair_strand=CTOB), R2 with XR=CT XG=GA (record_strand=OB).
+    pub fn ctob_pair(
+        r1_xm: &[u8],
+        r1_start: usize,
+        r2_xm: &[u8],
+        r2_start: usize,
+        qname: &[u8],
+    ) -> BismarkPair {
+        let r1 = synth(
+            b"GA",
+            b"GA",
+            r1_xm,
+            &vec![b'A'; r1_xm.len()],
+            r1_start,
+            &[(Kind::Match, r1_xm.len())],
+            0x41,
+            qname,
+            0,
+        );
+        let r2 = synth(
+            b"CT",
+            b"GA",
+            r2_xm,
+            &vec![b'A'; r2_xm.len()],
+            r2_start,
+            &[(Kind::Match, r2_xm.len())],
+            0x81,
+            qname,
+            0,
+        );
+        BismarkPair::from_mates(r1, r2).expect("CTOB pair construction")
+    }
+
+    /// Same as `ot_pair` but with arbitrary CIGAR ops on R1 (e.g. for InDel
+    /// fixtures).
+    pub fn ot_pair_with_r1_cigar(
+        r1_xm: &[u8],
+        r1_start: usize,
+        r1_cigar: &[(Kind, usize)],
+        r2_xm: &[u8],
+        r2_start: usize,
+        qname: &[u8],
+    ) -> BismarkPair {
+        let r1 = synth(
+            b"CT",
+            b"CT",
+            r1_xm,
+            &vec![b'A'; r1_xm.len()],
+            r1_start,
+            r1_cigar,
+            0x41,
+            qname,
+            0,
+        );
+        let r2 = synth(
+            b"GA",
+            b"CT",
+            r2_xm,
+            &vec![b'A'; r2_xm.len()],
+            r2_start,
+            &[(Kind::Match, r2_xm.len())],
+            0x81,
+            qname,
+            0,
+        );
+        BismarkPair::from_mates(r1, r2).expect("OT pair with R1 CIGAR construction")
+    }
+
+    /// Build a `Vec<MethCall>` from a list of (ref_pos, context, methylated)
+    /// tuples. read_pos defaults to 0; xm_byte derived from context+methylated.
+    pub fn calls_at(positions: &[(u32, super::CytosineContext, bool)]) -> Vec<super::MethCall> {
+        positions
+            .iter()
+            .map(|&(ref_pos, context, methylated)| {
+                let xm_byte = match (context, methylated) {
+                    (super::CytosineContext::CpG, true) => b'Z',
+                    (super::CytosineContext::CpG, false) => b'z',
+                    (super::CytosineContext::CHG, true) => b'X',
+                    (super::CytosineContext::CHG, false) => b'x',
+                    (super::CytosineContext::CHH, true) => b'H',
+                    (super::CytosineContext::CHH, false) => b'h',
+                };
+                super::MethCall {
+                    ref_pos,
+                    read_pos: 0,
+                    context,
+                    methylated,
+                    xm_byte,
+                }
+            })
+            .collect()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. is_forward_pair_strand classification
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn is_forward_pair_strand_matches_perl_classification() {
+    // Per Perl 2400/2415: OT and CTOB are forward (R1 upstream); OB and
+    // CTOT are reverse (R2 upstream).
+    assert!(is_forward_pair_strand(BismarkStrand::OT));
+    assert!(is_forward_pair_strand(BismarkStrand::CTOB));
+    assert!(!is_forward_pair_strand(BismarkStrand::OB));
+    assert!(!is_forward_pair_strand(BismarkStrand::CTOT));
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. drop_overlap endpoint semantics (SPEC §7.4 verification)
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn drop_overlap_forward_pair_drops_r2_at_or_after_r1_end() {
+    // OT pair, R1 50M at chrX:100 → r1_ref_end == 149 (100 + 50 - 1).
+    // R2 calls at 148, 149, 150: skip predicate `r2_pos >= 149` (inclusive)
+    // → drop 149, 150. Keep predicate `r2_pos < 149` (strict) → keep 148.
+    let pair = helpers::ot_pair(
+        b"..........".repeat(5).as_slice(),
+        100,
+        b".....",
+        130,
+        b"q1",
+    );
+    let r2_calls = helpers::calls_at(&[
+        (148, CytosineContext::CpG, true),
+        (149, CytosineContext::CpG, true),
+        (150, CytosineContext::CpG, true),
+    ]);
+    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].ref_pos, 148);
+}
+
+#[test]
+fn drop_overlap_reverse_pair_drops_r2_at_or_before_r1_start() {
+    // OB pair, R1 50M at chrX:200 → r1_ref_start == 200.
+    // R2 calls at 199, 200, 201: skip predicate `r2_pos <= 200` (inclusive)
+    // → drop 199, 200. Keep predicate `r2_pos > 200` (strict) → keep 201.
+    let pair = helpers::ob_pair(
+        b"..........".repeat(5).as_slice(),
+        200,
+        b".....",
+        150,
+        b"q2",
+    );
+    let r2_calls = helpers::calls_at(&[
+        (199, CytosineContext::CpG, true),
+        (200, CytosineContext::CpG, true),
+        (201, CytosineContext::CpG, true),
+    ]);
+    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].ref_pos, 201);
+}
+
+#[test]
+fn drop_overlap_disjoint_pair_drops_all_r2_calls_downstream_of_r1_end() {
+    // Forward (OT) pair, R1 50M at 100 → r1_ref_end == 149. R2 starts at
+    // 300 (insert > 2×read_length, biologically disjoint). All R2 calls are
+    // at ref_pos >= 300 → all >= 149 (r1_ref_end). Strict-`<` keep predicate
+    // drops them ALL.
+    //
+    // **This contradicts the SPEC §7.4 "no-op" edge-case prose** — Perl
+    // `bismark_methylation_extractor:2905` uses early-exit (`return`) which
+    // also drops downstream R2 calls. Phase H byte-identity gates this
+    // against Perl real-data output. The SPEC prose was a biological-
+    // intuition mistake; this test pins the actual algorithm.
+    let pair = helpers::ot_pair(
+        b"..........".repeat(5).as_slice(),
+        100,
+        b".....",
+        300,
+        b"q3",
+    );
+    let r2_calls = helpers::calls_at(&[
+        (300, CytosineContext::CpG, true),
+        (310, CytosineContext::CpG, true),
+        (340, CytosineContext::CpG, true),
+    ]);
+    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    assert_eq!(kept.len(), 0, "all R2 calls dropped (all >= r1_ref_end)");
+}
+
+#[test]
+fn drop_overlap_fully_overlapping_pair_keeps_calls_inside_r1_span() {
+    // Forward (OT) pair, R1 50M at 100 → r1_ref_end == 149. R2 also at 100
+    // (innie with small insert) → R2 calls at 105, 120, 148 are all < 149
+    // → strict-`<` keep predicate KEEPS them. (Counter-intuitive against
+    // "drop overlap" intent, but matches Perl's polarity.)
+    let pair = helpers::ot_pair(
+        b"..........".repeat(5).as_slice(),
+        100,
+        b".....",
+        100,
+        b"q4",
+    );
+    let r2_calls = helpers::calls_at(&[
+        (105, CytosineContext::CpG, true),
+        (120, CytosineContext::CHG, true),
+        (148, CytosineContext::CHH, true),
+    ]);
+    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    assert_eq!(
+        kept.len(),
+        3,
+        "all calls inside R1 span kept (< r1_ref_end)"
+    );
+}
+
+#[test]
+fn drop_overlap_with_r1_indel_uses_reference_end() {
+    // R1 `50M2D50M` at 100 → reference_span = 102, reference_end = 201.
+    // R2 calls at 200, 201, 202 → keep 200 (< 201); drop 201, 202.
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    let pair = helpers::ot_pair_with_r1_cigar(
+        b"..........".repeat(10).as_slice(),
+        100,
+        &[(Kind::Match, 50), (Kind::Deletion, 2), (Kind::Match, 50)],
+        b".....",
+        150,
+        b"q_indel",
+    );
+    let r2_calls = helpers::calls_at(&[
+        (200, CytosineContext::CpG, true),
+        (201, CytosineContext::CpG, true),
+        (202, CytosineContext::CpG, true),
+    ]);
+    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].ref_pos, 200);
+}
+
+#[test]
+fn drop_overlap_with_r1_end_deletion() {
+    // Rev 1 (Reviewer A §2.5): R1 `49M2D1M` at 100. CIGAR consumes 50 read
+    // bases + 52 reference positions, so reference_end == 151.
+    // R2 calls at 150, 151, 152 → keep 150; drop 151, 152.
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    let pair = helpers::ot_pair_with_r1_cigar(
+        b"..........".repeat(5).as_slice(),
+        100,
+        &[(Kind::Match, 49), (Kind::Deletion, 2), (Kind::Match, 1)],
+        b".....",
+        130,
+        b"q_enddel",
+    );
+    let r2_calls = helpers::calls_at(&[
+        (150, CytosineContext::CpG, true),
+        (151, CytosineContext::CpG, true),
+        (152, CytosineContext::CpG, true),
+    ]);
+    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].ref_pos, 150);
+}
+
+#[test]
+fn drop_overlap_with_r1_insertion_shifts_read_pos_only() {
+    // Rev 1 (Reviewer A §2.5): R1 `50M2I50M` at 100. Insertion consumes
+    // read but not reference → reference_span == 100, reference_end == 199.
+    // R2 calls at 198, 199, 200 → keep 198; drop 199, 200.
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    let pair = helpers::ot_pair_with_r1_cigar(
+        b"..........".repeat(10).as_slice(), // R1 XM has 100 bases (50M + 2I + 50M)
+        100,
+        &[(Kind::Match, 50), (Kind::Insertion, 2), (Kind::Match, 50)],
+        b".....",
+        150,
+        b"q_ins",
+    );
+    // Wait — `ot_pair_with_r1_cigar` passes the XM verbatim and assigns
+    // seq = b'A' × xm.len(). But the CIGAR consumes 100 read bases.
+    // r1_xm has 102 bases (the repeated `..........` × 10 makes 100, but
+    // we repeated 10 times of length 10... that's 100). Good, but XR/XG
+    // length parity needs 102 read bases. Let me fix this by building
+    // a properly-sized fixture.
+    //
+    // Actually `synth_with_r1_cigar` sets seq = vec![b'A'; xm.len()] which
+    // matches xm.len() — and bismark-io's parity check is XM.len() == seq.len(),
+    // both fine.
+    //
+    // The CIGAR consumes 50+2+50 = 102 read bases. So XM must be 102 long.
+    // Above I have `b"..........".repeat(10)` which is 100. Insufficient.
+    //
+    // Rebuild with correct length below.
+    let _ = pair; // discard the wrong-length fixture
+    let pair = helpers::ot_pair_with_r1_cigar(
+        b".........."
+            .repeat(10)
+            .as_slice()
+            .to_vec()
+            .iter()
+            .copied()
+            .chain(b"..".iter().copied())
+            .collect::<Vec<u8>>()
+            .as_slice(),
+        100,
+        &[(Kind::Match, 50), (Kind::Insertion, 2), (Kind::Match, 50)],
+        b".....",
+        150,
+        b"q_ins",
+    );
+    let r2_calls = helpers::calls_at(&[
+        (198, CytosineContext::CpG, true),
+        (199, CytosineContext::CpG, true),
+        (200, CytosineContext::CpG, true),
+    ]);
+    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].ref_pos, 198);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 3. AutoDetect `no_overlap` regression (Phase A bug-fix)
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn validate_auto_detect_keeps_no_overlap_default() {
+    // Rev 1 (Reviewer A §1.1 Critical): without the Phase C cli.rs fix,
+    // AutoDetect would resolve `no_overlap == false`, silently leaking R2
+    // overlap calls when dispatching to PE. The fix sets `no_overlap = true`
+    // for any non-SE paired_mode.
+    let tmp = tempfile::Builder::new().suffix(".bam").tempfile().unwrap();
+    std::fs::write(tmp.path(), b"x").unwrap();
+    let cli = Cli::try_parse_from([
+        "bismark-methylation-extractor-rs",
+        tmp.path().to_str().unwrap(),
+    ])
+    .unwrap();
+    let config = cli.validate().unwrap();
+    assert_eq!(config.paired_mode, PairedMode::AutoDetect);
+    assert!(
+        config.no_overlap,
+        "AutoDetect must inherit PE default no_overlap=true (rev 1 Critical fix)"
+    );
+}
+
+#[test]
+fn validate_paired_end_keeps_no_overlap_default() {
+    let tmp = tempfile::Builder::new().suffix(".bam").tempfile().unwrap();
+    std::fs::write(tmp.path(), b"x").unwrap();
+    let cli = Cli::try_parse_from([
+        "bismark-methylation-extractor-rs",
+        "--paired-end",
+        tmp.path().to_str().unwrap(),
+    ])
+    .unwrap();
+    let config = cli.validate().unwrap();
+    assert!(config.no_overlap);
+}
+
+#[test]
+fn validate_paired_end_with_include_overlap_disables_no_overlap() {
+    let tmp = tempfile::Builder::new().suffix(".bam").tempfile().unwrap();
+    std::fs::write(tmp.path(), b"x").unwrap();
+    let cli = Cli::try_parse_from([
+        "bismark-methylation-extractor-rs",
+        "--paired-end",
+        "--include_overlap",
+        tmp.path().to_str().unwrap(),
+    ])
+    .unwrap();
+    let config = cli.validate().unwrap();
+    assert!(!config.no_overlap);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 4. BismarkPair construction error propagation
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn bismark_pair_from_mates_rejects_mismatched_qnames() {
+    // Smoke check that bismark-io's qname-eq validation propagates as
+    // expected; extractor's PE loop relies on it.
+    use bismark_io::BismarkIoError;
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    let r1 = helpers::synth(
+        b"CT",
+        b"CT",
+        b".....",
+        b"AAAAA",
+        100,
+        &[(Kind::Match, 5)],
+        0x41,
+        b"qname_a",
+        0,
+    );
+    let r2 = helpers::synth(
+        b"GA",
+        b"CT",
+        b".....",
+        b"AAAAA",
+        100,
+        &[(Kind::Match, 5)],
+        0x81,
+        b"qname_b",
+        0,
+    );
+    let err = BismarkPair::from_mates(r1, r2).unwrap_err();
+    assert!(
+        matches!(err, BismarkIoError::MateMismatch { .. }),
+        "expected MateMismatch, got {:?}",
+        err
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 5. End-to-end PE behaviour via the binary (synthetic BAM in-test)
+// ─────────────────────────────────────────────────────────────────────────
+//
+// These exercise the binary; they live here (not in pe_phase_c_smoke.rs)
+// because they assert specific routing/file-content properties that are
+// natural unit-level checks rather than smoke gates. The bulk smoke
+// (12 files exist, exit 0) lives in the smoke file.
+
+mod pe_e2e {
+    use super::helpers;
+    use std::fs;
+
+    use assert_cmd::Command;
+    use bismark_io::{BamWriter, BismarkRecord};
+    use bstr::BString;
+    use noodles_sam::Header;
+    use noodles_sam::header::record::value::Map;
+    use noodles_sam::header::record::value::map::ReferenceSequence;
+    use std::num::NonZeroUsize;
+    use std::path::PathBuf;
+
+    fn header_with_chr1() -> Header {
+        let mut header = Header::default();
+        header.reference_sequences_mut().insert(
+            BString::from(b"chr1".to_vec()),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(10_000).unwrap()),
+        );
+        header
+    }
+
+    /// Write a PE BAM with the given (r1, r2) record sequence to `path`.
+    fn write_pe_bam(path: &std::path::Path, records: Vec<BismarkRecord>) {
+        let header = header_with_chr1();
+        let mut writer = BamWriter::from_path(path, header).unwrap();
+        for r in &records {
+            writer.write_record(r).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    fn run_binary(bam: &std::path::Path, outdir: &std::path::Path, extra_args: &[&str]) {
+        let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+        cmd.arg(bam)
+            .arg("--paired-end")
+            .arg("--output_dir")
+            .arg(outdir);
+        for arg in extra_args {
+            cmd.arg(arg);
+        }
+        cmd.assert().success();
+    }
+
+    /// Two OT pairs.
+    #[test]
+    fn extract_pe_handles_two_well_formed_pairs() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("two_pairs.bam");
+        // Build two OT pairs (R1=OT, R2=CTOT).
+        let pair1 = helpers::ot_pair(b"Z....", 100, b"....z", 130, b"pair1");
+        let pair2 = helpers::ot_pair(b"..X..", 200, b"..x..", 230, b"pair2");
+        write_pe_bam(
+            &bam_path,
+            vec![
+                pair1.r1().clone(),
+                pair1.r2().clone(),
+                pair2.r1().clone(),
+                pair2.r2().clone(),
+            ],
+        );
+        let outdir = work.path().join("out");
+        run_binary(&bam_path, &outdir, &[]);
+        // Report should say "Processed 4 lines in total" (2 pairs × 2 lines).
+        let report = fs::read_to_string(outdir.join("two_pairs_splitting_report.txt")).unwrap();
+        assert!(
+            report.contains("Processed 4 lines in total"),
+            "report should reflect line-count, not pair-count; got:\n{report}"
+        );
+    }
+
+    /// Closes plan §7.1 row "pe_splitting_report_counts_lines_not_pairs".
+    #[test]
+    fn pe_splitting_report_counts_lines_not_pairs() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("ten_pairs.bam");
+        let mut records = Vec::with_capacity(20);
+        for i in 0..10 {
+            let pair = helpers::ot_pair(
+                b"Z....",
+                100 + i * 50,
+                b"....z",
+                130 + i * 50,
+                format!("pair_{i}").as_bytes(),
+            );
+            records.push(pair.r1().clone());
+            records.push(pair.r2().clone());
+        }
+        write_pe_bam(&bam_path, records);
+        let outdir = work.path().join("out");
+        run_binary(&bam_path, &outdir, &[]);
+        let report = fs::read_to_string(outdir.join("ten_pairs_splitting_report.txt")).unwrap();
+        assert!(
+            report.contains("Processed 20 lines in total"),
+            "10 pairs × 2 = 20 lines; got:\n{report}"
+        );
+    }
+
+    /// Closes the Alan-Hoyle structural bug at PE unit level — R2 calls
+    /// route to the pair-strand file (CpG_OT), not R2's record-strand file
+    /// (CpG_CTOT).
+    ///
+    /// Uses `--include_overlap` to disable `drop_overlap`, so we test
+    /// routing in isolation without the overlap-detection mechanic
+    /// interfering with R2's calls.
+    #[test]
+    fn extract_pe_routes_r2_calls_to_pair_strand_file_not_record_strand_file() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("alan.bam");
+        // OT pair: R1 record_strand = OT; R2 record_strand = CTOT.
+        // Both R1's Z call and R2's Z call MUST land in CpG_OT_alan.txt,
+        // NOT in CpG_CTOT_alan.txt.
+        let pair = helpers::ot_pair(b"Z....", 100, b"Z....", 200, b"alan_pair");
+        write_pe_bam(&bam_path, vec![pair.r1().clone(), pair.r2().clone()]);
+        let outdir = work.path().join("out");
+        run_binary(&bam_path, &outdir, &["--include_overlap"]);
+
+        let cpg_ot = fs::read_to_string(outdir.join("CpG_OT_alan.txt")).unwrap();
+        let cpg_ctot = fs::read_to_string(outdir.join("CpG_CTOT_alan.txt")).unwrap();
+        // Two call lines in CpG_OT (one from R1, one from R2's call routed
+        // to pair-strand). Only the header line in CpG_CTOT.
+        let ot_call_lines = cpg_ot.lines().count() - 1; // minus header line
+        let ctot_call_lines = cpg_ctot.lines().count() - 1;
+        assert_eq!(ot_call_lines, 2, "both calls in CpG_OT (pair-strand)");
+        assert_eq!(
+            ctot_call_lines, 0,
+            "no calls in CpG_CTOT (R2's record_strand)"
+        );
+    }
+
+    /// `--include_overlap` keeps R2 calls in the overlap region.
+    /// Rev 1 fixture spec (Reviewer B V1): R1 5M at 100 (refs 100-104),
+    /// R2 5M at 102 (refs 102-106), overlap = 102-104. R2 has methylation
+    /// calls at ref-pos 103 (in overlap) and 105/106 (outside overlap).
+    /// Under --include_overlap all three calls present; under default
+    /// --no_overlap only 105 and 106 present.
+    #[test]
+    fn extract_pe_with_include_overlap_keeps_r2_overlap_calls() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("overlap_keep.bam");
+        // R1 XM: `Z....` (Z at ref 100). R2 XM: `.Z.zZ` aligned at 102 →
+        // XM[1]='Z' → ref_pos 103 (IN overlap); XM[3]='z' → ref_pos 105
+        // (OUTSIDE overlap); XM[4]='Z' → ref_pos 106 (OUTSIDE overlap).
+        let pair = helpers::ot_pair(b"Z....", 100, b".Z.zZ", 102, b"ovl");
+        write_pe_bam(&bam_path, vec![pair.r1().clone(), pair.r2().clone()]);
+        let outdir = work.path().join("out");
+        run_binary(&bam_path, &outdir, &["--include_overlap"]);
+
+        let cpg_ot = fs::read_to_string(outdir.join("CpG_OT_overlap_keep.txt")).unwrap();
+        // R1 call at 100 + R2 calls at 103, 105, 106 = 4 lines beyond header.
+        let call_lines = cpg_ot.lines().count() - 1;
+        assert_eq!(call_lines, 4, "with --include_overlap all 4 calls present");
+        assert!(
+            cpg_ot.contains("\t103\t"),
+            "R2 overlap-region call (ref 103) kept"
+        );
+        assert!(cpg_ot.contains("\t105\t"));
+        assert!(cpg_ot.contains("\t106\t"));
+    }
+
+    #[test]
+    fn extract_pe_with_no_overlap_drops_r2_calls_past_r1_end() {
+        // Renamed from "drops R2 overlap calls" — Perl's strict-`<` polarity
+        // (Perl `bismark_methylation_extractor:2905` forward / `:2989` reverse)
+        // keeps R2 calls INSIDE R1's span and drops R2 calls AT OR AFTER
+        // R1's end. (Counter-intuitive against "drop overlap" intent; see
+        // `drop_overlap_fully_overlapping_pair_keeps_calls_inside_r1_span`
+        // for the unit-level fixture.)
+        //
+        // R1 `Z....` 5M at 100 → r1_ref_end = 104. R2 `.Z.zZ` 5M at 102
+        // (R2 is `-`-strand CTOT — iter_aligned reverses, so 5'-oriented
+        // calls have ref_pos values 106, 105, 103). Strict-`<` keep:
+        // - 106 >= 104 → drop
+        // - 105 >= 104 → drop
+        // - 103 < 104 → keep
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("overlap_drop.bam");
+        let pair = helpers::ot_pair(b"Z....", 100, b".Z.zZ", 102, b"ovl2");
+        write_pe_bam(&bam_path, vec![pair.r1().clone(), pair.r2().clone()]);
+        let outdir = work.path().join("out");
+        run_binary(&bam_path, &outdir, &[]); // default --no_overlap
+
+        let cpg_ot = fs::read_to_string(outdir.join("CpG_OT_overlap_drop.txt")).unwrap();
+        assert!(cpg_ot.contains("\t100\t"), "R1 call kept");
+        assert!(
+            cpg_ot.contains("\t103\t"),
+            "R2 call inside R1 span (103 < 104) kept"
+        );
+        assert!(
+            !cpg_ot.contains("\t105\t"),
+            "R2 call past r1_ref_end (105 >= 104) dropped"
+        );
+        assert!(
+            !cpg_ot.contains("\t106\t"),
+            "R2 call past r1_ref_end (106 >= 104) dropped"
+        );
+    }
+
+    /// PE pair on different chromosomes → MateChromosomeMismatch.
+    #[test]
+    fn extract_pe_rejects_cross_chromosome_pair() {
+        use noodles_sam::alignment::record::cigar::op::Kind;
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("crosschr.bam");
+        // Build a 2-chr header. Need to do this manually since helpers
+        // only build single-chr header.
+        let mut header = Header::default();
+        header.reference_sequences_mut().insert(
+            BString::from(b"chr1".to_vec()),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(10_000).unwrap()),
+        );
+        header.reference_sequences_mut().insert(
+            BString::from(b"chr2".to_vec()),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(10_000).unwrap()),
+        );
+        let mut writer = BamWriter::from_path(&bam_path, header).unwrap();
+        let r1 = helpers::synth(
+            b"CT",
+            b"CT",
+            b"Z....",
+            b"AAAAA",
+            100,
+            &[(Kind::Match, 5)],
+            0x41,
+            b"cross",
+            0, // chr1
+        );
+        let r2 = helpers::synth(
+            b"GA",
+            b"CT",
+            b".Z...",
+            b"AAAAA",
+            200,
+            &[(Kind::Match, 5)],
+            0x81,
+            b"cross",
+            1, // chr2
+        );
+        writer.write_record(&r1).unwrap();
+        writer.write_record(&r2).unwrap();
+        writer.finish().unwrap();
+
+        let outdir = work.path().join("out");
+        let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+        cmd.arg(&bam_path)
+            .arg("--paired-end")
+            .arg("--output_dir")
+            .arg(&outdir)
+            .assert()
+            .failure()
+            .stderr(predicates::str::contains("different chromosomes"));
+
+        // Cleanup must have removed all partial files.
+        if outdir.exists() {
+            let count = fs::read_dir(&outdir).unwrap().count();
+            assert_eq!(count, 0, "cleanup_partial_outputs left {count} stragglers");
+        }
+    }
+
+    /// Odd-numbered record count → UnpairedFinalRecord.
+    #[test]
+    fn extract_pe_rejects_unpaired_final_record() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("odd.bam");
+        let pair = helpers::ot_pair(b"Z....", 100, b"....z", 130, b"first");
+        let orphan_r1 = helpers::synth(
+            b"CT",
+            b"CT",
+            b"..Z..",
+            b"AAAAA",
+            200,
+            &[(noodles_sam::alignment::record::cigar::op::Kind::Match, 5)],
+            0x41,
+            b"orphan",
+            0,
+        );
+        write_pe_bam(
+            &bam_path,
+            vec![pair.r1().clone(), pair.r2().clone(), orphan_r1],
+        );
+        let outdir = work.path().join("out");
+        let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+        cmd.arg(&bam_path)
+            .arg("--paired-end")
+            .arg("--output_dir")
+            .arg(&outdir)
+            .assert()
+            .failure()
+            .stderr(predicates::str::contains("unpaired final record"));
+
+        // Rev 2 backfill (Reviewer B Err3): assert cleanup ran. Sister test
+        // `extract_pe_rejects_cross_chromosome_pair` had this; UnpairedFinalRecord
+        // should too.
+        if outdir.exists() {
+            let count = fs::read_dir(&outdir).unwrap().count();
+            assert_eq!(
+                count, 0,
+                "cleanup_partial_outputs should have removed all 12 files; found {count} stragglers"
+            );
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Rev 2 backfill: 7 plan §7.1 tests that were absent in rev 1.
+    // Closes plan-manager COVERAGE_PHASE_C "MISSING" rows + Reviewer B S1.
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Non-directional library CTOT pair (R1 record_strand=CTOT, pair_strand=CTOT).
+    /// Reverse class per `is_forward_pair_strand` (R2 upstream, R1 downstream).
+    /// All calls (R1 + R2) must route to `*_CTOT_*.txt`, never `*_OT_*.txt`
+    /// (R2's per-record strand is OT for a non-directional CTOT pair).
+    /// Closes the Alan-Hoyle split-across-files bug at the non-directional
+    /// library level. Plan §7.1 / rev 1 Reviewer A §4.2.
+    #[test]
+    fn extract_pe_routes_ctot_pair_strand_correctly() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("ctot.bam");
+        // CTOT is reverse class — R2 is upstream. Place R2 at 200 (which is
+        // upstream of R1 at 230). With --no_overlap, R1 calls keep predicate
+        // `r2_pos > r1_ref_start=230` would drop the upstream R2 calls.
+        // Use --include_overlap so both R1 and R2 calls land regardless.
+        let pair = helpers::ctot_pair(b"Z....", 230, b"....Z", 200, b"ctot_pair");
+        write_pe_bam(&bam_path, vec![pair.r1().clone(), pair.r2().clone()]);
+        let outdir = work.path().join("out");
+        run_binary(&bam_path, &outdir, &["--include_overlap"]);
+
+        // Both calls land in CpG_CTOT, not in CpG_OT (R2's record_strand)
+        // and not in CpG_CTOB (irrelevant strand).
+        let cpg_ctot = fs::read_to_string(outdir.join("CpG_CTOT_ctot.txt")).unwrap();
+        let cpg_ot = fs::read_to_string(outdir.join("CpG_OT_ctot.txt")).unwrap();
+        let ctot_call_lines = cpg_ctot.lines().count() - 1;
+        let ot_call_lines = cpg_ot.lines().count() - 1;
+        assert_eq!(
+            ctot_call_lines, 2,
+            "both R1 + R2 calls route to CpG_CTOT (pair-strand)"
+        );
+        assert_eq!(
+            ot_call_lines, 0,
+            "no calls in CpG_OT (R2's record_strand is OT but pair-strand wins)"
+        );
+    }
+
+    /// Non-directional library CTOB pair (R1 record_strand=CTOB, pair_strand=CTOB).
+    /// Forward class per `is_forward_pair_strand` (R1 upstream, R2 downstream).
+    /// All calls must route to `*_CTOB_*.txt`, never `*_OB_*.txt`.
+    /// Plan §7.1 / rev 1 Reviewer A §4.2.
+    #[test]
+    fn extract_pe_routes_ctob_pair_strand_correctly() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("ctob.bam");
+        // CTOB is forward class. R1 at 100, R2 at 200 (downstream).
+        // Use --include_overlap to bypass drop_overlap so R2 calls aren't dropped.
+        let pair = helpers::ctob_pair(b"Z....", 100, b"....Z", 200, b"ctob_pair");
+        write_pe_bam(&bam_path, vec![pair.r1().clone(), pair.r2().clone()]);
+        let outdir = work.path().join("out");
+        run_binary(&bam_path, &outdir, &["--include_overlap"]);
+
+        let cpg_ctob = fs::read_to_string(outdir.join("CpG_CTOB_ctob.txt")).unwrap();
+        let cpg_ob = fs::read_to_string(outdir.join("CpG_OB_ctob.txt")).unwrap();
+        let ctob_call_lines = cpg_ctob.lines().count() - 1;
+        let ob_call_lines = cpg_ob.lines().count() - 1;
+        assert_eq!(
+            ctob_call_lines, 2,
+            "both R1 + R2 calls route to CpG_CTOB (pair-strand)"
+        );
+        assert_eq!(
+            ob_call_lines, 0,
+            "no calls in CpG_OB (R2's record_strand is OB but pair-strand wins)"
+        );
+    }
+
+    /// Per-mate ignore trim differentiation: `--ignore_r2 3` skips R2's
+    /// first 3 read-positions but leaves R1's intact. Distinguishes
+    /// `--ignore_r2` from `--ignore` (which would trim R1 too).
+    /// Plan §7.1 / §10 row "Per-mate ignore-region trimming".
+    #[test]
+    fn extract_pe_per_mate_ignore_r2_only_skips_r2_positions() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("ignore_r2.bam");
+        // OT pair. R1 and R2 each have a methylation call at read_pos 0.
+        // After --ignore_r2 3, R1's pos-0 call survives; R2's pos-0 call
+        // is skipped.
+        //
+        // For an OT pair with --include_overlap to disable drop_overlap so
+        // we can observe R2's calls independently.
+        //
+        // R1 XM: "Z...." → R1 call at ref_pos 100 (read_pos 0).
+        // R2 XM: "....Z" with r2_start=200; R2 is CTOT (`-` strand).
+        // After iter_aligned reversal, BAM pos 4 (Z) → read_pos_5p=0,
+        // ref_pos = 200 + 4 = 204. So R2's read_pos 0 call lands at ref 204.
+        // --ignore_r2 3 skips read_pos_5p < 3, dropping this call.
+        let pair = helpers::ot_pair(b"Z....", 100, b"....Z", 200, b"ignore_r2_pair");
+        write_pe_bam(&bam_path, vec![pair.r1().clone(), pair.r2().clone()]);
+        let outdir = work.path().join("out");
+        run_binary(
+            &bam_path,
+            &outdir,
+            &["--include_overlap", "--ignore_r2", "3"],
+        );
+
+        let cpg_ot = fs::read_to_string(outdir.join("CpG_OT_ignore_r2.txt")).unwrap();
+        assert!(
+            cpg_ot.contains("\t100\t"),
+            "R1's read_pos 0 call (ref 100) survives --ignore_r2: {cpg_ot}"
+        );
+        assert!(
+            !cpg_ot.contains("\t204\t"),
+            "R2's read_pos_5p 0 call (ref 204) skipped by --ignore_r2 3: {cpg_ot}"
+        );
+    }
+
+    /// `--ignore_3prime_r2` mirror of the above for the 3' end.
+    /// Plan §7.1 / §10.
+    #[test]
+    fn extract_pe_per_mate_ignore_3prime_r2_only_skips_r2_3prime() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("ignore_3prime_r2.bam");
+        // R1 XM: "....Z" → R1 call at read_pos 4 (the 3' end), ref_pos = 104.
+        // R2 XM: "Z...." with r2_start=200; R2 is CTOT (`-` strand).
+        // After iter_aligned reversal, R2's read_pos_5p=4 is the 3' end of the
+        // sequenced read, which corresponds to BAM-pos 0 ('Z'), ref_pos=200.
+        // --ignore_3prime_r2 3 skips read_pos_5p >= seq_len - 3 = 2, so
+        // R2's 5'-oriented positions 2, 3, 4 are skipped → drops the Z at
+        // read_pos_5p=4 (ref 200).
+        let pair = helpers::ot_pair(b"....Z", 100, b"Z....", 200, b"i3p_r2_pair");
+        write_pe_bam(&bam_path, vec![pair.r1().clone(), pair.r2().clone()]);
+        let outdir = work.path().join("out");
+        run_binary(
+            &bam_path,
+            &outdir,
+            &["--include_overlap", "--ignore_3prime_r2", "3"],
+        );
+
+        let cpg_ot = fs::read_to_string(outdir.join("CpG_OT_ignore_3prime_r2.txt")).unwrap();
+        assert!(
+            cpg_ot.contains("\t104\t"),
+            "R1's 3'-end call (ref 104) survives (R1's 3p trim is 0): {cpg_ot}"
+        );
+        assert!(
+            !cpg_ot.contains("\t200\t"),
+            "R2's 3'-end call (ref 200, on reverse strand) skipped by --ignore_3prime_r2 3: {cpg_ot}"
+        );
+    }
+
+    /// `--ignore_r2` operates on **5'-end read cycles**, not reference
+    /// positions. For a reverse-strand R2 (CTOT), the 5' read-cycle end
+    /// corresponds to the HIGHEST reference position (not the lowest).
+    /// This test specifically verifies the read-cycle vs ref-position
+    /// distinction by checking which calls drop with --ignore_r2 3 vs without.
+    ///
+    /// Plan §7.1 / rev 1 Reviewer A §2.4.
+    #[test]
+    fn extract_pe_ignore_r2_skips_read_cycles_not_ref_positions() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("cycles.bam");
+        // OT pair. R2 is CTOT (reverse). R2 XM "ZZZZZ" at r2_start=200.
+        // After iter_aligned reversal:
+        //   read_pos_5p=0 ↔ BAM-pos 4 ↔ ref 204
+        //   read_pos_5p=1 ↔ BAM-pos 3 ↔ ref 203
+        //   read_pos_5p=2 ↔ BAM-pos 2 ↔ ref 202
+        //   read_pos_5p=3 ↔ BAM-pos 1 ↔ ref 201
+        //   read_pos_5p=4 ↔ BAM-pos 0 ↔ ref 200
+        //
+        // --ignore_r2 3 → skip read_pos_5p < 3 → drop calls at ref 204, 203, 202.
+        // Calls at ref 200 and 201 survive (5'-oriented read cycles 4 and 3).
+        //
+        // **The naive "drop first 3 reference positions" interpretation** would
+        // drop ref 200, 201, 202 (the lowest 3). This test pins read-cycle
+        // semantics: the HIGHEST ref positions drop (5' read-cycle end of a
+        // reverse-strand R2 read), not the lowest.
+        let pair = helpers::ot_pair(b".....", 100, b"ZZZZZ", 200, b"cycles_pair");
+        write_pe_bam(&bam_path, vec![pair.r1().clone(), pair.r2().clone()]);
+        let outdir = work.path().join("out");
+        run_binary(
+            &bam_path,
+            &outdir,
+            &["--include_overlap", "--ignore_r2", "3"],
+        );
+
+        let cpg_ot = fs::read_to_string(outdir.join("CpG_OT_cycles.txt")).unwrap();
+        // Read-cycle interpretation: refs 200, 201 KEPT (cycles 4, 3); refs
+        // 202, 203, 204 DROPPED (cycles 2, 1, 0).
+        assert!(
+            cpg_ot.contains("\t200\t"),
+            "ref 200 (cycle 4, 3' end of read) kept: {cpg_ot}"
+        );
+        assert!(
+            cpg_ot.contains("\t201\t"),
+            "ref 201 (cycle 3) kept: {cpg_ot}"
+        );
+        assert!(
+            !cpg_ot.contains("\t202\t"),
+            "ref 202 (cycle 2, dropped by --ignore_r2 3): {cpg_ot}"
+        );
+        assert!(
+            !cpg_ot.contains("\t203\t"),
+            "ref 203 (cycle 1, dropped): {cpg_ot}"
+        );
+        assert!(
+            !cpg_ot.contains("\t204\t"),
+            "ref 204 (cycle 0, 5' end of read, dropped): {cpg_ot}"
+        );
+    }
+
+    /// PE-level re-verification of the M-bias R2-index routing. Phase B's
+    /// `route_call_r2_goes_to_mbias_index_1` already locks `route_call`'s
+    /// behaviour at unit level; this asserts the PE pipeline correctly
+    /// threads `ReadIdentity::R2` into `route_call` for R2 calls.
+    ///
+    /// Approach: drive a PE binary run, then count occurrences of R2's
+    /// qname in CpG_OT (which would only contain R1's qname if the PE
+    /// loop accidentally passed `ReadIdentity::R1` for R2's calls — there'd
+    /// be no way to distinguish). The plan §7.1 row says "R2 calls
+    /// increment state.mbias[1] not state.mbias[0]". Since we can't
+    /// observe state.mbias from outside the binary (no M-bias writer until
+    /// Phase D), the proxy assertion is that R2's distinctive qname appears
+    /// in the split-file output — which is what `pair.r2()` would emit
+    /// when route_call sees ReadIdentity::R2.
+    ///
+    /// Phase D will add a stronger end-to-end M-bias test once the writer
+    /// lands; this is the achievable Phase C re-verification.
+    #[test]
+    fn extract_pe_increments_mbias_R2_at_index_1() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("mbias_r2.bam");
+        let pair = helpers::ot_pair(b"Z....", 100, b"....Z", 200, b"mbias_qname");
+        write_pe_bam(&bam_path, vec![pair.r1().clone(), pair.r2().clone()]);
+        let outdir = work.path().join("out");
+        run_binary(&bam_path, &outdir, &["--include_overlap"]);
+
+        let cpg_ot = fs::read_to_string(outdir.join("CpG_OT_mbias_r2.txt")).unwrap();
+        // The PE loop routes R2 calls via route_call(state, pair.r2(), …,
+        // ReadIdentity::R2). If R2 calls weren't routed at all, the call
+        // line wouldn't be in CpG_OT. Both R1 and R2's call lines should be
+        // present (same qname for R1 + R2 per BismarkPair invariant).
+        let qname_occurrences = cpg_ot.matches("mbias_qname").count();
+        assert_eq!(
+            qname_occurrences, 2,
+            "both R1 and R2 of pair 'mbias_qname' should have call lines (R2 reaches route_call with ReadIdentity::R2 → mbias[1]): {cpg_ot}"
+        );
+    }
+
+    /// Empty PE BAM: header-only files + 0-lines splitting report. PE-level
+    /// re-verification of an invariant Phase B's SE empty-BAM smoke also
+    /// covers. Plan §7.1.
+    #[test]
+    fn extract_pe_empty_bam_writes_only_header_files() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("empty_pe.bam");
+        let header = header_with_chr1();
+        let writer = BamWriter::from_path(&bam_path, header).unwrap();
+        writer.finish().unwrap();
+
+        let outdir = work.path().join("out");
+        run_binary(&bam_path, &outdir, &[]);
+
+        // All 12 files exist with only the header line.
+        for ctx in ["CpG", "CHG", "CHH"] {
+            for strand in ["OT", "CTOT", "CTOB", "OB"] {
+                let p = outdir.join(format!("{ctx}_{strand}_empty_pe.txt"));
+                let content = fs::read_to_string(&p).unwrap();
+                assert_eq!(
+                    content, "Bismark methylation extractor version v0.25.1\n",
+                    "{ctx}_{strand} should be header-only for empty PE BAM"
+                );
+            }
+        }
+        let report = fs::read_to_string(outdir.join("empty_pe_splitting_report.txt")).unwrap();
+        assert!(
+            report.contains("Processed 0 lines in total"),
+            "empty PE BAM → 0 lines processed; got:\n{report}"
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 6. AutoDetect tests
+// ─────────────────────────────────────────────────────────────────────────
+
+mod auto_detect {
+    use super::helpers;
+    use assert_cmd::Command;
+    use bismark_io::BamWriter;
+    use bstr::BString;
+    use noodles_sam::Header;
+    use noodles_sam::header::record::value::Map;
+    use noodles_sam::header::record::value::map::header::Version;
+    use noodles_sam::header::record::value::map::program::tag::COMMAND_LINE;
+    use noodles_sam::header::record::value::map::{Program, ReferenceSequence};
+    use std::fs;
+    use std::num::NonZeroUsize;
+    use std::path::PathBuf;
+
+    fn header_with_bismark_pg(cl: &str) -> Header {
+        let mut hd =
+            Map::<noodles_sam::header::record::value::map::Header>::new(Version::new(1, 6));
+        hd.other_fields_mut().insert(
+            noodles_sam::header::record::value::map::header::tag::SORT_ORDER,
+            BString::from(b"unsorted".to_vec()),
+        );
+        let mut prog = Map::<Program>::default();
+        prog.other_fields_mut()
+            .insert(COMMAND_LINE, BString::from(cl.as_bytes().to_vec()));
+        let mut header = Header::builder()
+            .set_header(hd)
+            .add_program(BString::from(b"Bismark".to_vec()), prog)
+            .build();
+        header.reference_sequences_mut().insert(
+            BString::from(b"chr1".to_vec()),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(10_000).unwrap()),
+        );
+        header
+    }
+
+    fn header_no_bismark_pg() -> Header {
+        let mut hd =
+            Map::<noodles_sam::header::record::value::map::Header>::new(Version::new(1, 6));
+        hd.other_fields_mut().insert(
+            noodles_sam::header::record::value::map::header::tag::SORT_ORDER,
+            BString::from(b"unsorted".to_vec()),
+        );
+        let mut prog = Map::<Program>::default();
+        prog.other_fields_mut().insert(
+            COMMAND_LINE,
+            BString::from(b"bowtie2 -x index -U reads.fq.gz".to_vec()),
+        );
+        let mut header = Header::builder()
+            .set_header(hd)
+            .add_program(BString::from(b"bowtie2".to_vec()), prog)
+            .build();
+        header.reference_sequences_mut().insert(
+            BString::from(b"chr1".to_vec()),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(10_000).unwrap()),
+        );
+        header
+    }
+
+    #[test]
+    fn main_auto_detect_routes_pe_bam_to_extract_pe() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("auto_pe.bam");
+        let header =
+            header_with_bismark_pg("bismark --genome /path/genome -1 R1.fq.gz -2 R2.fq.gz");
+        let mut writer = BamWriter::from_path(&bam_path, header).unwrap();
+        let pair = helpers::ot_pair(b"Z....", 100, b"....z", 130, b"auto_pair");
+        writer.write_record(pair.r1()).unwrap();
+        writer.write_record(pair.r2()).unwrap();
+        writer.finish().unwrap();
+
+        let outdir = work.path().join("out");
+        // No --single-end / --paired-end — AutoDetect must dispatch to PE.
+        let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+        cmd.arg(&bam_path)
+            .arg("--output_dir")
+            .arg(&outdir)
+            .assert()
+            .success();
+        // PE counter should fire (2 lines per pair).
+        let report = fs::read_to_string(outdir.join("auto_pe_splitting_report.txt")).unwrap();
+        assert!(report.contains("Processed 2 lines in total"));
+    }
+
+    #[test]
+    fn main_auto_detect_routes_se_bam_to_extract_se() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("auto_se.bam");
+        let header = header_with_bismark_pg("bismark --genome /path/genome reads.fq.gz");
+        let mut writer = BamWriter::from_path(&bam_path, header).unwrap();
+        let rec = helpers::synth(
+            b"CT",
+            b"CT",
+            b"Z....",
+            b"AAAAA",
+            100,
+            &[(noodles_sam::alignment::record::cigar::op::Kind::Match, 5)],
+            0, // SE: FLAG 0
+            b"se_read",
+            0,
+        );
+        writer.write_record(&rec).unwrap();
+        writer.finish().unwrap();
+
+        let outdir = work.path().join("out");
+        let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+        cmd.arg(&bam_path)
+            .arg("--output_dir")
+            .arg(&outdir)
+            .assert()
+            .success();
+        // SE counter should fire (1 line per record).
+        let report = fs::read_to_string(outdir.join("auto_se_splitting_report.txt")).unwrap();
+        assert!(
+            report.contains("Processed 1 lines in total"),
+            "got:\n{report}"
+        );
+    }
+
+    #[test]
+    fn main_auto_detect_fails_without_bismark_pg() {
+        let work = tempfile::tempdir().unwrap();
+        let bam_path: PathBuf = work.path().join("no_bismark.bam");
+        let header = header_no_bismark_pg();
+        let writer = BamWriter::from_path(&bam_path, header).unwrap();
+        writer.finish().unwrap();
+
+        let outdir = work.path().join("out");
+        let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+        cmd.arg(&bam_path)
+            .arg("--output_dir")
+            .arg(&outdir)
+            .assert()
+            .failure()
+            .stderr(predicates::str::contains(
+                "pass `--single-end` or `--paired-end` explicitly",
+            ));
+    }
+}

--- a/rust/bismark-extractor/tests/pe_phase_c_smoke.rs
+++ b/rust/bismark-extractor/tests/pe_phase_c_smoke.rs
@@ -1,0 +1,226 @@
+//! End-to-end Phase C smoke test.
+//!
+//! Builds a synthetic PE BAM in-test (no Perl toolchain required), runs the
+//! `bismark-methylation-extractor-rs` binary on it, and asserts:
+//! - exit code 0,
+//! - all 12 split files present,
+//! - splitting report contains "Processed N lines in total" matching the
+//!   2N (lines) accounting (Perl line 2479 literal),
+//! - CTOT/CTOB files header-only (directional library),
+//! - at least one OT-pair-strand call line on disk.
+//!
+//! Per plan rev 1 (Reviewer B I5 from Phase B): byte-equality vs Perl
+//! baseline is Phase H. Phase C's smoke gates "binary runs end-to-end on
+//! PE input via auto-detect" — a wide bug-class catcher without toolchain
+//! dependency.
+
+use std::fs;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use bismark_io::{BamWriter, BismarkRecord};
+use bstr::BString;
+use noodles_core::Position;
+use noodles_sam::Header;
+use noodles_sam::alignment::record::Flags;
+use noodles_sam::alignment::record::cigar::Op;
+use noodles_sam::alignment::record::cigar::op::Kind;
+use noodles_sam::alignment::record::data::field::Tag;
+use noodles_sam::alignment::record_buf::data::field::Value;
+use noodles_sam::alignment::record_buf::{Cigar, RecordBuf, Sequence};
+use noodles_sam::header::record::value::Map;
+use noodles_sam::header::record::value::map::header::Version;
+use noodles_sam::header::record::value::map::program::tag::COMMAND_LINE;
+use noodles_sam::header::record::value::map::{Program, ReferenceSequence};
+use std::num::NonZeroUsize;
+
+/// Build a SAM header with a Bismark @PG line so auto-detect routes the
+/// binary to `extract_pe` without explicit `--paired-end`.
+fn header_with_bismark_pe_pg() -> Header {
+    let mut hd = Map::<noodles_sam::header::record::value::map::Header>::new(Version::new(1, 6));
+    hd.other_fields_mut().insert(
+        noodles_sam::header::record::value::map::header::tag::SORT_ORDER,
+        BString::from(b"unsorted".to_vec()),
+    );
+    let mut prog = Map::<Program>::default();
+    prog.other_fields_mut().insert(
+        COMMAND_LINE,
+        BString::from(b"bismark --genome /path/genome -1 R1.fq.gz -2 R2.fq.gz".to_vec()),
+    );
+    let mut header = Header::builder()
+        .set_header(hd)
+        .add_program(BString::from(b"Bismark".to_vec()), prog)
+        .build();
+    header.reference_sequences_mut().insert(
+        BString::from(b"chr1".to_vec()),
+        Map::<ReferenceSequence>::new(NonZeroUsize::new(10_000).unwrap()),
+    );
+    header
+}
+
+#[allow(clippy::too_many_arguments)]
+fn synth_record(
+    qname: &[u8],
+    xr: &[u8],
+    xg: &[u8],
+    xm: &[u8],
+    seq: &[u8],
+    alignment_start: usize,
+    flags: u16,
+    refid: usize,
+) -> BismarkRecord {
+    let mut record = RecordBuf::default();
+    *record.flags_mut() = Flags::from(flags);
+    *record.sequence_mut() = Sequence::from(seq.to_vec());
+    *record.alignment_start_mut() = Some(Position::try_from(alignment_start).unwrap());
+    *record.reference_sequence_id_mut() = Some(refid);
+    *record.cigar_mut() = Cigar::from(vec![Op::new(Kind::Match, xm.len())]);
+    *record.name_mut() = Some(BString::from(qname.to_vec()));
+    record
+        .data_mut()
+        .insert(Tag::from(*b"XR"), Value::String(BString::from(xr.to_vec())));
+    record
+        .data_mut()
+        .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
+    record
+        .data_mut()
+        .insert(Tag::from(*b"XM"), Value::String(BString::from(xm.to_vec())));
+    BismarkRecord::from_noodles_record(record).expect("synth_record produces a valid BismarkRecord")
+}
+
+/// 10 OT pairs at evenly-spaced positions. R1 has a CpG-meth call near 5';
+/// R2 has a CpG-unmeth call (which will be dropped by drop_overlap if it
+/// lands past r1_ref_end — but we space pairs so most R2 calls survive).
+fn write_pe_directional_bam(path: &std::path::Path) {
+    let header = header_with_bismark_pe_pg();
+    let mut writer = BamWriter::from_path(path, header).unwrap();
+    for i in 0..10 {
+        let qname = format!("pair_{i}");
+        let r1_start = 100 + i * 200;
+        // R2 starts so its 5'-oriented call (BAM-pos 4 reversed → ref_pos =
+        // r2_start + 4) lands INSIDE R1's span (< r1_start + 5 = r1_ref_end).
+        // Easiest: place R2 fully inside R1's span.
+        let r2_start = r1_start; // overlap fully
+        let r1 = synth_record(
+            qname.as_bytes(),
+            b"CT",
+            b"CT",
+            b"Z....",
+            b"ACGTC",
+            r1_start,
+            0x41, // paired + first
+            0,
+        );
+        let r2 = synth_record(
+            qname.as_bytes(),
+            b"GA",
+            b"CT",
+            b"....z",
+            b"ACGTC",
+            r2_start,
+            0x81, // paired + last
+            0,
+        );
+        writer.write_record(&r1).unwrap();
+        writer.write_record(&r2).unwrap();
+    }
+    writer.finish().unwrap();
+}
+
+#[test]
+fn smoke_pe_auto_detect_produces_all_12_files_and_report() {
+    let workdir = tempfile::tempdir().unwrap();
+    let bam_path: PathBuf = workdir.path().join("pe_smoke.bam");
+    write_pe_directional_bam(&bam_path);
+
+    let output_dir = workdir.path().join("out");
+
+    // No --single-end / --paired-end → AutoDetect via @PG ID:Bismark.
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(&bam_path)
+        .arg("--output_dir")
+        .arg(&output_dir)
+        .assert()
+        .success();
+
+    // All 12 split files must exist with the Perl version header on line 1.
+    let expected_files = [
+        "CpG_OT_pe_smoke.txt",
+        "CpG_CTOT_pe_smoke.txt",
+        "CpG_CTOB_pe_smoke.txt",
+        "CpG_OB_pe_smoke.txt",
+        "CHG_OT_pe_smoke.txt",
+        "CHG_CTOT_pe_smoke.txt",
+        "CHG_CTOB_pe_smoke.txt",
+        "CHG_OB_pe_smoke.txt",
+        "CHH_OT_pe_smoke.txt",
+        "CHH_CTOT_pe_smoke.txt",
+        "CHH_CTOB_pe_smoke.txt",
+        "CHH_OB_pe_smoke.txt",
+    ];
+    for name in expected_files {
+        let p = output_dir.join(name);
+        assert!(p.exists(), "expected: {}", p.display());
+        let content = fs::read_to_string(&p).unwrap();
+        let first_line = content.lines().next().unwrap_or("");
+        assert_eq!(
+            first_line, "Bismark methylation extractor version v0.25.1",
+            "header drift in {}",
+            name
+        );
+    }
+
+    // Splitting report: "Processed 20 lines in total" (10 pairs × 2 lines).
+    let report = fs::read_to_string(output_dir.join("pe_smoke_splitting_report.txt")).unwrap();
+    assert!(
+        report.contains("Processed 20 lines in total"),
+        "PE pair-line counting (10 pairs × 2): expected '20 lines'; got:\n{report}"
+    );
+
+    // CpG_OT should have exactly 10 R1 call lines beyond the header.
+    // R2 calls are dropped by overlap detection (rev 2 tightening per
+    // Reviewer B L1): R1 5M at r1_start → r1_ref_end = r1_start + 4. R2's
+    // reversed iter_aligned 5'-oriented call at read_pos_5p=0 maps to
+    // BAM-pos 4 (the 'z' in "....z"), ref_pos = r2_start + 4 = r1_start + 4
+    // = r1_ref_end. Strict-`<` keep predicate (r2_pos < r1_ref_end) fails
+    // for r2_pos == r1_ref_end → dropped. So all 10 R2 calls drop; only
+    // 10 R1 calls land. Pins the overlap polarity at smoke level.
+    let cpg_ot = fs::read_to_string(output_dir.join("CpG_OT_pe_smoke.txt")).unwrap();
+    let cpg_ot_call_lines = cpg_ot.lines().count() - 1;
+    assert_eq!(
+        cpg_ot_call_lines, 10,
+        "CpG_OT should have exactly 10 R1 call lines (R2 calls dropped by overlap); got:\n{cpg_ot}"
+    );
+
+    // CTOT / CTOB files: header-only for directional library.
+    for ctx in ["CpG", "CHG", "CHH"] {
+        for strand in ["CTOT", "CTOB"] {
+            let p = output_dir.join(format!("{ctx}_{strand}_pe_smoke.txt"));
+            let content = fs::read_to_string(&p).unwrap();
+            assert_eq!(
+                content, "Bismark methylation extractor version v0.25.1\n",
+                "directional library: {ctx}_{strand} must be header-only"
+            );
+        }
+    }
+}
+
+#[test]
+fn smoke_pe_explicit_paired_end_flag_works() {
+    // Same fixture but pass --paired-end explicitly (bypasses auto-detect).
+    let workdir = tempfile::tempdir().unwrap();
+    let bam_path: PathBuf = workdir.path().join("pe_explicit.bam");
+    write_pe_directional_bam(&bam_path);
+
+    let output_dir = workdir.path().join("out");
+    let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
+    cmd.arg(&bam_path)
+        .arg("--paired-end")
+        .arg("--output_dir")
+        .arg(&output_dir)
+        .assert()
+        .success();
+
+    let report = fs::read_to_string(output_dir.join("pe_explicit_splitting_report.txt")).unwrap();
+    assert!(report.contains("Processed 20 lines in total"));
+}

--- a/rust/bismark-extractor/tests/se_phase_b.rs
+++ b/rust/bismark-extractor/tests/se_phase_b.rs
@@ -29,6 +29,7 @@ use bismark_extractor::route::route_call;
 use bismark_extractor::state::ExtractState;
 use bismark_io::{BismarkStrand, ReadIdentity};
 use clap::Parser;
+use predicates::prelude::PredicateBooleanExt;
 
 // ─────────────────────────────────────────────────────────────────────────
 // Test helpers — synthetic BismarkRecord construction
@@ -608,7 +609,7 @@ fn splitting_report_emits_per_context_counts() {
     };
     write_splitting_report(&report_path, &input_path, &config, &report).unwrap();
     let content = fs::read_to_string(&report_path).unwrap();
-    assert!(content.contains("Processed 100 reads in total"));
+    assert!(content.contains("Processed 100 lines in total"));
     assert!(content.contains("Total methylated C's in CpG context:\t50"));
     assert!(content.contains("Total unmethylated C's in CHH context:\t400"));
     assert!(content.contains("C methylated in CpG context:\t50.00%"));
@@ -872,16 +873,18 @@ fn tempbam() -> tempfile::NamedTempFile {
 }
 
 #[test]
-fn main_rejects_paired_end_with_phase_error() {
+fn main_paired_end_no_longer_rejected_phase_c() {
+    // Phase C update: `--paired-end` now dispatches to extract_pe instead of
+    // returning `PhaseNotYetImplemented`. The tempfile isn't a valid BAM so
+    // the call fails at the bismark-io reader stage (NOT at the phase-gate).
+    // We assert the error message does NOT contain Phase B's old gate text.
     let bam = tempbam();
     let mut cmd = Command::cargo_bin("bismark-methylation-extractor-rs").unwrap();
     cmd.arg(bam.path())
         .arg("--paired-end")
         .assert()
         .failure()
-        .stderr(predicates::str::contains(
-            "paired-end extraction; arrives in Phase C",
-        ));
+        .stderr(predicates::str::contains("paired-end extraction; arrives in Phase C").not());
 }
 
 #[test]

--- a/rust/bismark-extractor/tests/se_phase_b_smoke.rs
+++ b/rust/bismark-extractor/tests/se_phase_b_smoke.rs
@@ -244,7 +244,9 @@ fn smoke_se_directional_produces_all_12_files_and_report() {
     // Splitting report must exist + parse.
     let report = fs::read_to_string(output_dir.join("se_smoke_splitting_report.txt")).unwrap();
     assert!(report.contains("Bismark methylation extractor version v0.25.1"));
-    assert!(report.contains("Processed 5 reads in total"));
+    // Phase C writer fix: literal is "Processed N lines in total" per Perl 2479.
+    // (For SE: lines == records == reads, so the "lines" terminology applies.)
+    assert!(report.contains("Processed 5 lines in total"));
     assert!(report.contains("Total number of C's analysed:"));
     assert!(report.contains("Total methylated C's in CpG context:"));
     assert!(report.contains("Total methylated C's in CHG context:"));
@@ -322,6 +324,6 @@ fn smoke_se_empty_bam_writes_only_header_files() {
 
     // Splitting report exists with 0 records.
     let report = fs::read_to_string(output_dir.join("empty_splitting_report.txt")).unwrap();
-    assert!(report.contains("Processed 0 reads in total"));
+    assert!(report.contains("Processed 0 lines in total"));
     assert!(report.contains("Total methylated C's in CpG context:\t0"));
 }

--- a/rust/bismark-io/Cargo.toml
+++ b/rust/bismark-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-io"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 description = "Bismark-aware BAM/SAM/CRAM I/O on top of noodles"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-io/src/lib.rs
+++ b/rust/bismark-io/src/lib.rs
@@ -30,7 +30,8 @@ pub use cram_ref::reconstitute_cram_reference_from_bismark_genome;
 pub use error::BismarkIoError;
 pub use pair::BismarkPair;
 pub use read::{
-    AlignmentKind, AnyReader, BamReader, CramReader, SamReader, ThreadedBamReader, open_reader,
+    AlignmentKind, AnyReader, BamReader, CramReader, SamReader, ThreadedBamReader,
+    detect_paired_from_header, open_reader,
 };
 pub use record::{AlignedXmCall, BismarkRecord, ReadIdentity, Umi};
 pub use strand::BismarkStrand;

--- a/rust/bismark-io/src/read.rs
+++ b/rust/bismark-io/src/read.rs
@@ -629,6 +629,72 @@ fn check_not_coordinate_sorted(header: &Header) -> Result<(), BismarkIoError> {
     Ok(())
 }
 
+/// Auto-detect library mode (single-end vs paired-end) from a Bismark
+/// BAM header.
+///
+/// Walks the `@PG` lines, finds the Bismark-aligner entry (ID starting
+/// with `Bismark`), and inspects its command line for `-1`/`--1` AND
+/// `-2`/`--2` arguments (which Bismark only passes in paired-end mode).
+///
+/// Returns:
+/// - `Some(true)` — PE (Bismark @PG found with both `-1`/`--1` and `-2`/`--2`)
+/// - `Some(false)` — SE (Bismark @PG found, missing one or both of those)
+/// - `None` — no Bismark @PG line in the header; caller must error out
+///   (typically by demanding the user pass `--single`/`--paired` explicitly).
+///
+/// Mirrors Perl `deduplicate_bismark` lines 90–116. Promoted from
+/// `bismark-dedup/src/pipeline.rs:137` in `bismark-io 1.0.0-beta.7` to share
+/// the same header-detection logic with `bismark-extractor`.
+#[must_use]
+pub fn detect_paired_from_header(header: &Header) -> Option<bool> {
+    // Serialize the header to its on-disk SAM text representation and
+    // search for the Bismark @PG line. This is robust to noodles API
+    // shape changes across versions (the SAM text format is the stable
+    // contract here, not the in-memory `Programs` type).
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = noodles_sam::io::Writer::new(&mut buf);
+        if writer.write_header(header).is_err() {
+            return None;
+        }
+    }
+    let text = String::from_utf8_lossy(&buf);
+    for line in text.lines() {
+        // SAM header @PG line format: `@PG\tID:<id>\t...\tCL:<args>...`
+        // The `ID:Bismark` substring identifies the Bismark @PG.
+        if !line.starts_with("@PG") || !line.contains("ID:Bismark") {
+            continue;
+        }
+        // Look for -1/--1 AND -2/--2 in the command-line args. Bismark's
+        // PE invocation always has both; SE has neither.
+        // We accept space-separated, tab-separated, or end-of-line
+        // boundaries to be robust to argument quoting differences.
+        let has_1 = arg_present(line, "-1") || arg_present(line, "--1");
+        let has_2 = arg_present(line, "-2") || arg_present(line, "--2");
+        return Some(has_1 && has_2);
+    }
+    None
+}
+
+/// True if `arg` appears as a standalone token in `text`, delimited by
+/// whitespace or tab on **both** sides.
+///
+/// Matches Perl's `/\s+--?1\s+/` semantics: a `-1` at the very end of the
+/// line (without trailing whitespace) is NOT considered present, even
+/// though Bismark in practice always appends a path after `-1`/`-2`.
+/// Being strict here matches Perl exactly — important for byte-identity
+/// when the same input is run through both implementations.
+fn arg_present(text: &str, arg: &str) -> bool {
+    let arg_space = format!(" {arg} ");
+    let arg_tab_left = format!("\t{arg} ");
+    let arg_tab_right = format!(" {arg}\t");
+    let arg_tab_both = format!("\t{arg}\t");
+    text.contains(&arg_space)
+        || text.contains(&arg_tab_left)
+        || text.contains(&arg_tab_right)
+        || text.contains(&arg_tab_both)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1057,5 +1123,72 @@ read1:CTCCTTAG\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTC\tIIIII\tXM:Z:.....\tXR:Z:CT\
             "expected MissingFastaIndex (the .fai sidecar of the nonexistent ref \
              doesn't exist), got {err:?}"
         );
+    }
+
+    // ─── detect_paired_from_header tests (promoted from bismark-dedup in v1.0.0-beta.7) ───
+
+    use noodles_sam::header::record::value::map::Program;
+
+    /// Build a SAM header with a `@PG` line whose ID and CL fields are as
+    /// given. CL is set as-is (verbatim) so tests can construct PE vs SE
+    /// arg patterns.
+    fn header_with_pg(id: &str, cl: Option<&str>) -> Header {
+        let mut builder = Header::builder();
+        let mut prog = Map::<Program>::default();
+        if let Some(cl_text) = cl {
+            use noodles_sam::header::record::value::map::program::tag::COMMAND_LINE;
+            prog.other_fields_mut()
+                .insert(COMMAND_LINE, BString::from(cl_text.as_bytes().to_vec()));
+        }
+        builder = builder.add_program(BString::from(id.as_bytes().to_vec()), prog);
+        builder.build()
+    }
+
+    #[test]
+    fn detect_paired_from_header_returns_some_true_for_pe_bismark_pg() {
+        let header = header_with_pg(
+            "Bismark",
+            Some("bismark --genome /path/genome -1 R1.fq.gz -2 R2.fq.gz"),
+        );
+        assert_eq!(detect_paired_from_header(&header), Some(true));
+    }
+
+    #[test]
+    fn detect_paired_from_header_returns_some_false_for_se_bismark_pg() {
+        let header = header_with_pg("Bismark", Some("bismark --genome /path/genome reads.fq.gz"));
+        assert_eq!(detect_paired_from_header(&header), Some(false));
+    }
+
+    #[test]
+    fn detect_paired_from_header_returns_none_when_no_bismark_pg() {
+        let header = header_with_pg("bowtie2", Some("bowtie2 -x index -U reads.fq.gz"));
+        assert_eq!(detect_paired_from_header(&header), None);
+    }
+
+    #[test]
+    fn detect_paired_from_header_returns_none_for_empty_header() {
+        let header = Header::default();
+        assert_eq!(detect_paired_from_header(&header), None);
+    }
+
+    #[test]
+    fn detect_paired_from_header_accepts_double_dash_form() {
+        // Bismark also accepts `--1` / `--2` (long form).
+        let header = header_with_pg("Bismark_v0.25.1", Some("bismark --1 R1.fq --2 R2.fq"));
+        assert_eq!(detect_paired_from_header(&header), Some(true));
+    }
+
+    #[test]
+    fn arg_present_strict_boundary_check() {
+        // Token must have whitespace/tab on both sides — `-1` at end-of-line
+        // (no trailing space) is NOT considered present. Matches Perl's
+        // `/\s+--?1\s+/` strict semantics.
+        assert!(arg_present("foo -1 bar", "-1"));
+        assert!(arg_present("foo\t-1\tbar", "-1"));
+        assert!(arg_present("foo -1\tbar", "-1"));
+        assert!(arg_present("foo\t-1 bar", "-1"));
+        assert!(!arg_present("foo -1", "-1"));
+        assert!(!arg_present("-1 bar", "-1"));
+        assert!(!arg_present("foo--1 bar", "-1")); // no preceding boundary
     }
 }


### PR DESCRIPTION
## Summary

Phase C of the bismark-extractor port (umbrella #798). **Stacked on Phase B PR #849** — rebase onto `rust/iron-chancellor` after #849 merges.

Lights up the paired-end extraction path: pair adjacent records via `BismarkPair::from_mates`, drop R2 calls overlapping R1 per SPEC §7.4, apply per-mate ignore-region trims (`--ignore_r2`, `--ignore_3prime_r2`), and dispatch SE-vs-PE via header probe (`@PG ID:Bismark` line).

Closes #850. Plan + reviews + coverage report under `plans/05262026_bismark-extractor/`.

## Cross-crate changes

- **bismark-io** `1.0.0-beta.6` → `1.0.0-beta.7`: promote `detect_paired_from_header` (+ private `arg_present` helper) from `bismark-dedup` into `bismark-io/src/read.rs`; re-export. Pure additive bump + 6 new unit tests.
- **bismark-dedup**: replace local copy with `pub use bismark_io::detect_paired_from_header`. No behaviour change.
- **bismark-extractor** `1.0.0-alpha.2` → `1.0.0-alpha.3`.

## Key design choices

- **Overlap polarity** locked to strict-`<` (forward) / strict-`>` (reverse) keep predicates, verified line-by-line against Perl `bismark_methylation_extractor` 2400/2415/2451/2479/2905/2987. SPEC §7.4 prose about "disjoint pair = no-op" was misleading; the actual algorithm drops downstream-of-R1 R2 calls regardless of biological overlap.
- **Pair-strand routing** uses `BismarkPair::pair_strand()` (R1's record_strand, computed once); R2 calls route to the same strand-file as R1. Closes Alan-Hoyle split-across-files bug at the non-directional library level (CTOT/CTOB pairs).
- **Splitting-report counter** bumps by 2 per pair to match Perl's raw-BAM-line counting. Also fixes Phase B's writer literal from `"Processed N reads"` → `"Processed N lines"` (Perl line 2479).
- **Auto-detect** opens reader once for header probe, dispatches. Fails loudly via `AutoDetectFailed` on missing `@PG ID:Bismark`.
- **Phase A bug-fix** (rev 1 Reviewer A §1.1 Critical): `cli.rs` `no_overlap` resolution now covers AutoDetect mode (was `PairedEnd`-only — would have silently leaked R2 overlap calls in PE auto-detect path).
- **Sibling pipeline, not refactor** (rev 1 §6 step 6 contingency): Phase B PR #849 still in review, so `extract_pe` duplicates `extract_se`'s scaffolding rather than extracting `run_extraction<F>`. Follow-up PR after #849 merges.

## What's included

| Area | Files |
|---|---|
| New overlap module | `src/overlap.rs` (drop_overlap with `Vec::retain`, is_forward_pair_strand) |
| PE pipeline | `src/pipeline.rs` (extract_pe + handle_one_pair; extract_se unchanged) |
| Auto-detect dispatch | `src/main.rs` (PairedMode-aware run()) |
| Phase A bug-fix | `src/cli.rs` (no_overlap covers AutoDetect) |
| New error variants | `src/error.rs` (+3: UnpairedFinalRecord, MateChromosomeMismatch, AutoDetectFailed) |
| Splitting-report fix | `src/output.rs` ("reads" → "lines" for Perl byte-identity) |
| bismark-io promotion | `bismark-io/src/read.rs`, `lib.rs`, `Cargo.toml` |
| dedup re-export | `bismark-dedup/src/pipeline.rs`, `Cargo.toml` |
| Unit tests | `tests/pe_phase_c.rs` (29 tests including 7 rev-2 backfills) |
| Smoke tests | `tests/pe_phase_c_smoke.rs` (2 end-to-end PE tests via synthetic BAM) |
| Plan + reviews | `plans/05262026_bismark-extractor/PHASE_C_PLAN.md` rev 2 + 2 plan reviews + 2 code reviews + plan-manager COVERAGE |

## Plan revision history

- **rev 0** — initial draft.
- **rev 1** — folded dual plan-review findings. Critical fix: AutoDetect `no_overlap` regression. Important fix: lines-not-pairs counter (verified by both reviewers against Perl line 2451). Plus 9 other Importants.
- **rev 2** — folded dual code-review + plan-manager findings. 7 backfill tests (CTOT/CTOB non-directional routing, per-mate ignore × 3 polarities, mbias R2 PE-level, empty PE BAM) + 4 cosmetic nits.

## Test plan

- [x] `cargo test -p bismark-io -p bismark-dedup -p bismark-extractor` → **537+ tests pass**.
- [x] `cargo clippy --all-targets -- -D warnings` (3 crates) → clean.
- [x] `cargo fmt --check` (3 crates) → clean.
- [x] Phase B's 91 SE tests unchanged + still green.
- [x] 29 PE unit tests + 2 PE smoke tests (synthetic BAM via `BamWriter`; no Perl toolchain needed).
- [ ] Phase H byte-identity gate against 10M+55M PE WGBS — deferred per SPEC §10.

## ⚠️ Heads-up for downstream parser owners

The splitting-report literal changed:
- Before: `"Processed N reads in total"`
- After: `"Processed N lines in total"` (matches Perl `bismark_methylation_extractor:2479`)

Parsers grepping for `"Processed N reads"` (e.g. nf-core/methylseq) need updating. This brings Phase H byte-identity closer to Perl, which is the v1.0 ship gate.

## Out of scope (deferred)

- M-bias `.txt` writer (Phase D; accumulator already lit up at index 1 by Phase C).
- Non-default output modes + `--gzip` (Phase E).
- `--parallel > 1` (Phase F).
- `--bedGraph` / `--cytosine_report` subprocess chain (Phase G).
- Real-data byte-identity gate (Phase H).
- `run_extraction<F>` scaffolding-refactor (follow-up PR after #849 merges).