### PR TITLE
polish(extractor): back-port count_mbias_rows awk fix to SE driver

### DIFF
--- a/scripts/phase_h_se_matrix.sh
+++ b/scripts/phase_h_se_matrix.sh
@@ -387,8 +387,19 @@ ROW_COUNT_DETAIL=""
 count_mbias_rows() {
   local f="$1"
   if [[ ! -f "$f" ]]; then echo "0"; return; fi
-  # Data rows start with `<position>\t` where position is a digit
-  grep -cE '^[0-9]+	' "$f" 2>/dev/null || echo "0"
+  # Data rows start with `<position>\t` where position is a digit.
+  # Back-port from PE driver #874 rev-3 absorption (consensus code-review
+  # finding B-H1 ≡ A-M1): use awk instead of `grep -cE ... || echo "0"`.
+  # The grep pattern fail-opens: grep -c prints "0" AND exits 1 when 0
+  # matches, triggering the || echo "0" fallback. Result is two lines
+  # "0\n0" — downstream integer compare `[[ N -ge D ]]` hits "bad math
+  # expression" (swallowed by 2>/dev/null inside if-test), the violation
+  # goes unrecorded, PASS_FLAG stays 1, and the matrix emits a false PASS.
+  # Latent on the canonical 10M SE BAM (D cell always has rows) but real
+  # fail-open in a check whose entire purpose (rev 3 absorption) is
+  # fail-closed. The awk form emits a single integer (including 0) on
+  # stdout, exits 0, and parses cleanly.
+  awk '/^[0-9]+\t/ { c++ } END { print c+0 }' "$f"
 }
 
 get_cell_mbias_file() {


### PR DESCRIPTION
## Summary

Back-ports the rev-3 absorption from #874 (PE driver) to `scripts/phase_h_se_matrix.sh`. SE driver inherited the same `count_mbias_rows` fail-open bug when #871/#873 shipped; both code-reviewers on #874 independently flagged this.

**No user-facing changes; release-harness only. v1.0 release path unaffected (latent on the canonical 10M SE BAM).**

## The bug

`grep -cE '...' || echo "0"` fail-opens when M-bias has 0 data rows. `grep -c` prints `0` to stdout AND exits 1 on 0 matches, triggering the `|| echo "0"` fallback. Result is two-line `"0\n0"` output; downstream integer compare `[[ N -ge D ]]` hits `bad math expression` (silently swallowed by `2>/dev/null` inside the if-test), the violation goes unrecorded, `PASS_FLAG` stays 1, and the matrix emits a false PASS.

Fail-open in a check whose entire purpose (M-bias row-count differential, the §3.4 #4 PARTIAL absorption in SE rev 3 / Coverage audit) is fail-closed.

## The fix

```bash
awk '/^[0-9]+\t/ { c++ } END { print c+0 }' "$f"
```

Single-integer stdout (including `0`), exit 0, parses cleanly. Same recipe applied in #874 post rev-3.

## Why "latent" not "blocking"

The canonical 10M SE BAM has data rows at all positions in the D cell, so the 0-row case never fires on the release-gate run. But: future edge-case BAMs (very short reads, `--ignore` exceeds read length on all positions) would hit it. Worth fixing pre-v1.0 for symmetry with the PE driver.

## Test plan

- [x] `bash -n scripts/phase_h_se_matrix.sh` clean
- [x] `cargo test -p bismark-extractor` → 303 passed / 0 failed / 0 ignored (post-#874 baseline preserved bit-for-bit)
- [ ] Real validation on colossal — RELEASE_CHECKLIST.md SE matrix walk (release-gate, post-merge)

## Co-found by

- Phase H PE code-reviewer A (M1, graded Medium)
- Phase H PE code-reviewer B (H1, graded High — verdict wins per CLAUDE.md dual-reviewer pattern)
- Both reviewers independently flagged the SE-driver inheritance, recommending lockstep back-port.