### PR TITLE
fix(extractor): #879 drop_overlap respects --ignore_3prime via CIGAR-trim primitive

### DIFF
--- a/plans/05262026_bismark-extractor/BUG_879_FIXES_PLAN.md
+++ b/plans/05262026_bismark-extractor/BUG_879_FIXES_PLAN.md
@@ -1,0 +1,240 @@
+# Plan — fix #879 (PE byte-identity FAIL with `--ignore_3prime` on R1)
+
+**Status**: rev 1 — dual-reviewer findings absorbed, awaiting re-review (Felix-approved revision, 2026-05-28)
+**Scope**: closes #879 by fixing `drop_overlap`'s R1-boundary calculation to mirror Perl's CIGAR-adjustment behavior under `--ignore_3prime`
+**Workflow stage**: Plan (per CLAUDE.md mandatory plan → manual review → agent review → implement)
+**Branch**: new branch `extractor-fix-879` off `rust/iron-chancellor` HEAD `45b4c61` (post-#876)
+
+## Revision history
+
+- **rev 0**: proposed two strand-specific CigarExt methods (`reference_end_clipping_right` + `reference_start_clipping_left`) that walk CIGAR from one end consuming read positions, return the boundary.
+- **rev 1** (this version): both plan-reviewers independently raised THREE Critical correctness gaps in rev 0:
+  - **C1 (both)** — rev 0 missed Perl's **trailing D/N strip** at L1760-1764. After the read-position pop loop completes, Perl strips any trailing D/N ops WITHOUT decrementing the clip counter. For CIGAR `90M5D` with `--ignore_3prime 5`: Perl removes 5M + 5D → ref_end shifts by 10 ref positions; rev 0 would only shift by 5.
+  - **C2 (both)** — rev 0's full-clip return value `start.saturating_sub(1)` is inconsistent with existing `reference_end_with_empty_cigar_returns_start` convention at `cigar.rs:276-278` (returns `start`).
+  - **C3 (Reviewer B unique)** — rev 0's OB-strand handling didn't explicitly account for Perl's L1803 composite shift `$start += $ignore_3prime + $D_count + $N_count - $I_count`. The single-helper formulation might not capture both contributions correctly without a CIGAR-trim primitive.
+- Both reviewers' convergent **Important** recommendation: pivot the API to a **CIGAR-trim primitive** that returns a trimmed `Cigar` object, then reuse the existing `reference_end()` / `reference_span()` on it. This encapsulates D/N/I trailing-strip in one place; mirrors Perl's "rewrite the CIGAR then use existing end-calc" pattern at L1807-1828; sidesteps the directional/positional naming confusion in rev 0.
+- Rev 1 adopts the CIGAR-trim primitive + two thin caller-facing helpers + adds 4 new tests covering trailing D/N + full-clip boundary + OB InDel-in-prefix case. Also cites `call.rs:179-182` for the §2.4 R2-3p-clip claim (Reviewer A I-citation).
+
+## 1. Context
+
+PE Phase H matrix on merged HEAD `45b4c61` FAILed at cell `r1r2_3p` (`--ignore_3prime 5 --ignore_3prime_r2 5`) with **all 8 files differing** — methylation data files (not just metadata). Rust emitted ~0.54% fewer total Cs than Perl (174,039,426 vs 174,982,585).
+
+Isolation smokes:
+- `--ignore_3prime 5` alone: **FAIL** 8/8 files
+- `--ignore_3prime_r2 5` alone: **PASS** 8/8 files
+
+**Root cause** (located in `overlap.rs:101`, full audit trail at [#879 comment](https://github.com/FelixKrueger/Bismark/issues/879#issuecomment-4567351382)): `drop_overlap()` computes the R1 overlap boundary from R1's **un-clipped** CIGAR, while Perl `bismark_methylation_extractor:1726-1782` **adjusts the CIGAR** when `--ignore_3prime N` fires THEN recomputes `$end_read_1`.
+
+Symmetry confirmation across all 4 ignore flags is in #879 and rev 0; unchanged in rev 1.
+
+## 2. Fix shape — CIGAR-trim primitive + two helpers + drop_overlap update
+
+The fix lives across two crates:
+1. **bismark-io** — add one CIGAR-trim primitive + two reference-boundary helpers to `CigarExt`
+2. **bismark-extractor** — wire those into `drop_overlap` and pass `ignore_3p_r1` through
+
+### 2.1 Bismark-io: CIGAR-trim primitive + 2 helpers
+
+File: `rust/bismark-io/src/cigar.rs` (extend the existing `CigarExt` trait + `impl CigarExt for Cigar`)
+
+**The primitive** (the actual CIGAR-trim logic, Perl-faithful):
+
+```rust
+/// Return a new `Cigar` with `n_read_positions` of read-consuming ops
+/// trimmed from one end. After the read-position trim loop completes,
+/// also strips any now-exposed trailing D/N ops (which consume reference
+/// but no read positions) — mirrors Perl `bismark_methylation_extractor:
+/// 1760-1764` `while ($op eq 'D' or eq 'N')` post-pop loops.
+///
+/// - `from_left=false` mirrors Perl `pop @comp_cigar` (forward-strand R1).
+/// - `from_left=true` mirrors Perl `shift @comp_cigar` (reverse-strand R1).
+///
+/// Read-consuming ops: `M`, `I`, `S`, `=`, `X`. Ref-consuming ops:
+/// `M`, `D`, `N`, `=`, `X`. `H` is ignored (consumes neither).
+///
+/// Edge cases:
+/// - `n_read_positions == 0` returns the CIGAR unchanged (no-op fast-path).
+/// - `n_read_positions >= total_read_consuming_positions` returns an
+///   empty `Cigar` (degenerate "everything clipped").
+fn trim_3p_read_positions(&self, n_read_positions: u32, from_left: bool) -> Cigar;
+```
+
+**The two caller-facing helpers** (thin wrappers, what `drop_overlap` will call):
+
+```rust
+/// Reference-end of the CIGAR's reference span AFTER trimming
+/// `n_read_positions` from the read's 3' end via CIGAR's RIGHT side
+/// (forward-strand R1 under `--ignore_3prime`). Returns the new
+/// 1-based inclusive ref-end on the original `start` coordinate.
+///
+/// Implementation: `self.trim_3p_read_positions(n, false).reference_end(start)`.
+/// Returns `start` when the trimmed CIGAR has zero reference span
+/// (matching the existing `reference_end_with_empty_cigar_returns_start`
+/// convention at `cigar.rs:276-278`).
+fn reference_end_after_3p_trim(&self, start: usize, n_read_positions: u32) -> usize;
+
+/// Reference-start AFTER trimming `n_read_positions` from the read's 3' end
+/// via CIGAR's LEFT side (reverse-strand R1 under `--ignore_3prime`).
+/// Returns the new 1-based ref position where the trimmed CIGAR begins
+/// (the original `start` shifted right by the ref-positions consumed by
+/// the trimmed-off prefix).
+///
+/// Implementation: trim from left, compute `start + (original_ref_span
+/// - trimmed_ref_span)`. Equivalent to Perl L1803's composite shift
+/// `$start += $ignore_3prime + $D_count + $N_count - $I_count` (where
+/// the deltas are computed from the dropped prefix; D/N add to ref shift,
+/// I subtracts; M is implicit in the ignore_3prime count).
+fn reference_start_after_3p_trim(&self, start: usize, n_read_positions: u32) -> usize;
+```
+
+**Implementation notes**:
+- The primitive's loop structure mirrors Perl L1756-1770: in the same iteration sweep, after the read-consuming op is popped, immediately strip any adjacent D/N ops at the trimmed boundary (Perl's `while ($op eq 'D' or eq 'N')` inner loops). This is a SINGLE sweep that combines read-position counting with trailing-D/N stripping — not two separate loops. **D/N ops in the MIDDLE of the CIGAR (not adjacent to the trim boundary) are NEVER stripped** — they're left untouched in the returned CIGAR. This fixes C1 (Round 1 critical: trailing-D/N strip missing) while NOT over-stripping middle ops.
+- The two helpers are thin wrappers (3-5 lines each); the primitive does the actual work.
+- The primitive returns a `Cigar` (owned), so the caller can chain `.reference_end(start)` or `.reference_span()` as needed. `Cigar` is internally a `Vec<Op>` (noodles-sam), so the allocation is small (typical CIGAR is <10 ops).
+
+### 2.2 Bismark-extractor: drop_overlap signature + impl
+
+File: `rust/bismark-extractor/src/overlap.rs` (lines 83-112)
+
+**Proposed signature** (add `ignore_3p_r1` parameter):
+```rust
+pub fn drop_overlap(
+    mut r2_calls: Vec<MethCall>,
+    pair: &BismarkPair,
+    ignore_3p_r1: u32,
+) -> Result<Vec<MethCall>, BismarkExtractorError>
+```
+
+**Updated implementation** (replaces the inline ref calc at L101 + L108):
+```rust
+if is_forward_pair_strand(pair.pair_strand()) {
+    // OT/CTOB pair: clip R1's 3' end = pop CIGAR RIGHT side (Perl L1729+).
+    let r1_ref_end = pair.r1().cigar()
+        .reference_end_after_3p_trim(r1_start, ignore_3p_r1) as u32;
+    r2_calls.retain(|c| c.ref_pos > r1_ref_end);
+} else {
+    // OB/CTOT pair: clip R1's 3' end = shift CIGAR LEFT side (Perl L1781+).
+    let r1_ref_start = pair.r1().cigar()
+        .reference_start_after_3p_trim(r1_start, ignore_3p_r1) as u32;
+    r2_calls.retain(|c| c.ref_pos < r1_ref_start);
+}
+```
+
+When `ignore_3p_r1 == 0` (the common case), the helpers' no-op fast-path returns the same value as the existing `reference_end(start)` / `r1_start` — no perf regression on the default-cell path.
+
+### 2.3 Call site updates
+
+Two callers of `drop_overlap`:
+- `rust/bismark-extractor/src/pipeline.rs:354` → `drop_overlap(r2_calls_raw, pair, config.ignore_3p_r1)?`
+- `rust/bismark-extractor/src/parallel.rs:711` → `drop_overlap(r2_calls_raw, pair, config.ignore_3p_r1)?`
+
+Both have `config: &ResolvedConfig` in scope already.
+
+### 2.4 Why NOT also pass `ignore_3p_r2` (citations added per Reviewer A)
+
+R2's 3'-clip is correctly handled by `extract_calls`'s position filter at **`call.rs:179-182`**:
+```rust
+for aligned in record.iter_aligned() {
+    if aligned.read_pos_5p < lo || aligned.read_pos_5p >= hi {
+        continue;
+    }
+    ...
+}
+```
+where `hi = xm_len.saturating_sub(ignore_3p)`. R2 calls at the clipped read positions are FILTERED OUT before they reach `drop_overlap`. The R2 `MethCall` values that DO reach `drop_overlap` already have correct `ref_pos` (the reference coordinate is unaffected by which read-positions emit calls — only the SET of emitting positions changes).
+
+`drop_overlap` reads R1's CIGAR (not R2's) to compute the R1 overlap boundary. R2's 3'-clip never affects R1's CIGAR. The iso_r2_3p PASS confirms this empirically: `--ignore_3prime_r2 5` alone produces byte-identical 8/8 output.
+
+## 3. Test coverage (expanded from rev 0)
+
+### 3.1 bismark-io unit tests (`rust/bismark-io/src/cigar.rs` test module)
+
+**Primitive tests** (for `trim_3p_read_positions`):
+
+1. **`trim_3p_zero_is_identity_right`**: `n_read_positions=0, from_left=false` → returned Cigar equals input.
+2. **`trim_3p_zero_is_identity_left`**: `n_read_positions=0, from_left=true` → returned Cigar equals input.
+3. **`trim_3p_simple_match_right`**: `100M`, trim 5 from right → returned Cigar is `95M`.
+4. **`trim_3p_simple_match_left`**: `100M`, trim 5 from left → returned Cigar is `95M`.
+5. **`trim_3p_with_trailing_deletion_strips_D` (C1 regression guard)**: `90M5D`, trim 5 from right → returned Cigar is `85M`. The 5 read-positions of M are removed PLUS the now-trailing 5D is stripped. Critical: validates the Perl L1760-1764 trailing-D loop.
+6. **`trim_3p_with_trailing_skip_strips_N` (C1 regression guard)**: `90M5N`, trim 5 from right → returned Cigar is `85M`. Validates the Perl L1764 `while ($op eq 'N')` loop.
+7. **`trim_3p_with_leading_deletion_strips_D_when_from_left` (C3 regression guard)**: `5D90M`, trim 5 from left → returned Cigar is `85M`. The 5 read-positions of M are removed from the front PLUS the now-leading 5D is stripped.
+8. **`trim_3p_clipping_into_insertion_no_ref_impact`**: `95M5I`, trim 5 from right → returned Cigar is `95M` (the 5 read positions of I are removed). Existing `reference_end()` on `95M` returns `start + 95 - 1` = same as on original `95M5I` (because I doesn't consume ref). The reference_end is unchanged.
+9. **`trim_3p_full_clip_returns_empty_cigar`**: `100M`, trim 100 → empty Cigar. Existing `reference_end_with_empty_cigar_returns_start` covers what happens next.
+9a. **`trim_3p_middle_D_is_NOT_stripped` (Reviewer A R2 negative-regression guard)**: `90M5D5M`, trim 5 from right → returned Cigar is `90M5D` (NOT `85M`). Validates that the 5M at the trailing end clips, but the 5D in the MIDDLE remains. Guards against an over-aggressive strip loop that would walk past a non-boundary D.
+9b. **`trim_3p_left_with_soft_clip_prefix` (Reviewer B R2 OB-soft-clip guard)**: `5S95M`, trim 5 from left → returned Cigar is `95M`. The 5 read-positions of S are removed from the front. Since S doesn't consume reference, `original_ref_span (95) − trimmed_ref_span (95) = 0`, so `reference_start_after_3p_trim(start, 5)` returns `start` unchanged. This is the OB R1 BAM-5'-end edge case where the read's sequenced 3' is the CIGAR's left and starts with a soft-clip — verified by Reviewer B as correct under spec.
+
+**Helper tests** (for the wrappers):
+
+10. **`reference_end_after_3p_trim_zero_is_existing_reference_end`**: with `n=0`, result equals existing `reference_end(start)`.
+11. **`reference_end_after_3p_trim_simple`**: CIGAR `100M`, `start=100`, `n=5` → returns `start + 95 - 1 = 194` (was `199` un-clipped).
+12. **`reference_start_after_3p_trim_zero_is_start`**: with `n=0`, returns `start`.
+13. **`reference_start_after_3p_trim_simple`**: CIGAR `100M`, `start=100`, `n=5` → returns `start + 5 = 105` (reference-shifted right by the 5 ref-positions of trimmed prefix M).
+14. **`reference_start_after_3p_trim_with_leading_D` (C3 regression guard for OB composite shift)**: `5D90M`, `start=100`, `n=5` → trimmed CIGAR is `85M`, shift = original `95` − trimmed `85` = `10` ref positions → `start + 10 = 110`. Validates Perl L1803's `$start += $ignore_3prime + $D_count` mechanism.
+15. **`reference_end_after_3p_trim_full_clip_returns_start` (C2 regression guard)**: `100M`, `n=100` → trimmed empty Cigar, `reference_end` returns `start` (matches `cigar.rs:276-278` convention).
+
+(17 unit tests in bismark-io. Each tightly scoped, each FAILable independently if its specific edge case regresses.)
+
+### 3.2 bismark-extractor integration tests
+
+16. **`drop_overlap_with_ignore_3p_r1_forward_pair`** (new test in a new `overlap.rs` test module): synthetic forward (OT) pair, R1 CIGAR `100M` start=100. R2 has calls at ref_pos 195, 197, 200. Without fix (un-clipped `r1_ref_end=199`): predicate `> 199` keeps only call at 200 (drops 195, 197). With fix (`ignore_3p_r1=5` → clipped `r1_ref_end=194`): predicate `> 194` keeps 195, 197, 200. Assert keep-set is `{195, 197, 200}`.
+17. **`drop_overlap_with_ignore_3p_r1_reverse_pair`** (C3 regression guard): synthetic reverse (OB) pair, R1 CIGAR `100M` start=100 → `r1_ref_start=100` un-clipped, `=105` with `ignore_3p_r1=5`. R2 has calls at ref_pos 99, 103, 107. Without fix (predicate `< 100`): keeps only 99. With fix (predicate `< 105`): keeps 99, 103. Assert keep-set is `{99, 103}`.
+18. **`drop_overlap_ignore_3p_r1_zero_is_no_op`**: regression guard — with `ignore_3p_r1=0`, behavior is byte-identical to pre-fix `drop_overlap`. Run side-by-side on identical input as test 16 with `ignore_3p_r1=0`; assert keep-set is `{200}` (the old buggy behavior — but now correctly representing "no clip applied").
+19. **`drop_overlap_with_ignore_3p_r1_at_boundary` (Reviewer B I3 regression guard)**: same as test 16 but with R2 call exactly at `ref_pos = r1_ref_end + 1` (just inside the keep zone) and `ref_pos = r1_ref_end` (just outside) under both un-clipped and clipped boundaries. Asserts the predicate's strict-greater-than semantics are preserved through the fix.
+
+(4 integration tests in bismark-extractor's `overlap.rs`.)
+
+### 3.3 Integration check on colossal (manual, post-merge)
+
+20. Re-run `iso_r1_3p` smoke (`--ignore_3prime 5` alone) on a fresh `--out` dir. Expect PASS 8/8 (was FAIL 8/8 pre-fix). Wall ~12 min.
+21. Re-run the full Phase H PE matrix on the merged HEAD. Expect all 10 cells (including `r1r2_3p` × N=1+N=4) to PASS. Wall ~2-2.5 h.
+
+### 3.4 What we are NOT adding to this plan
+
+- Parallel.rs synthetic worker tests for the R1×R2 dispatch (tracked at #878).
+- OB-strand SE test fixture (tracked at #878).
+- N=4 perf collapse investigation (#876 Finding #4).
+- Perl edge_clip hang workaround (#876 Finding #3).
+
+## 4. Implementation order
+
+Per CLAUDE.md TDD default:
+
+1. **Tests-first commit** (`bismark-io`): unit tests 1-15 + 9a + 9b in `cigar.rs` (17 total). They MUST fail (compile error) on current HEAD — methods don't exist yet. Verify via `cargo check`.
+2. **bismark-io fix commit**: implement `trim_3p_read_positions` + `reference_end_after_3p_trim` + `reference_start_after_3p_trim` in `cigar.rs`. Re-run unit tests 1-15 → expect PASS. **Verify bismark-io version FIRST** (V1 below); bump if Felix-approved.
+3. **Tests-first commit** (`bismark-extractor`): integration tests 16-19 in a new `overlap.rs` test module. They MUST fail because the new signature isn't in place.
+4. **bismark-extractor fix commit**: update `drop_overlap` signature + impl. Update 2 call sites (`pipeline.rs:354`, `parallel.rs:711`). Bump bismark-io path-dep version if applicable. Full test suite expected to be 310 (existing) + 17 (bismark-io) + 4 (extractor) = 331 passing.
+5. **PR** against `rust/iron-chancellor`. Title: `fix(extractor): #879 drop_overlap respects --ignore_3prime via CIGAR-trim primitive`. Body links #879 + plan + dual-reviewer audit trail (PLAN_REVIEW_879_{A,B}.md + this rev 1).
+6. **Post-merge on colossal**: tests 20-21 above. If both PASS, proceed to v1.0 release walk continuation.
+
+## 5. Out of scope
+
+Same as rev 0 — unchanged.
+
+## 6. Assumptions / open decisions (rev 1)
+
+| # | Question | Resolution | Source |
+|---|---|---|---|
+| A1 | API design — two strand-specific helpers OR CIGAR-trim primitive + helpers? | **CIGAR-trim primitive + 2 helpers** (rev 1 redirect). Both reviewers' I1 recommendation. Mirrors Perl L1807-1828; encapsulates D/N/I in one place. | Both reviewers (I1) |
+| A2 | Helpers on `CigarExt` trait or free fns? | Trait methods (rev 0 unchanged) | Both reviewers OK |
+| A3 | Full-clip return value: `start.saturating_sub(1)` or `start`? | **`start`** (rev 1 fix per C2) — matches existing `cigar.rs:276-278` convention | Both reviewers (C2) |
+| A4 | Pass `ignore_3p_r2` to drop_overlap? | NO — R2 3'-clip handled by `call.rs:179-182` filter (citation added per Reviewer A I-citation request) | Both reviewers confirmed |
+| A5 | Branch base | `rust/iron-chancellor` HEAD `45b4c61` | unchanged |
+| V1 | Verify current `bismark-io` Cargo.toml version before bumping | **Run `git show 45b4c61:rust/bismark-io/Cargo.toml \| grep version` first**; the plan assumes `1.0.0-beta.7` but Reviewer A flagged uncertainty. If different, adjust the bump target. Bump cadence (every internal bismark-io change → version bump) confirmed by Reviewer B from git log. | Reviewer A V1 |
+| V2 | Verify no other test in `tests/` directly calls `drop_overlap` with the 2-arg signature | grep first at commit time | Reviewer B V-style item |
+| T1 (NEW per Reviewer B I3) | Boundary-case tests — assert `ref_pos == r1_ref_end` (drop) vs `== r1_ref_end + 1` (keep) under both un-clipped and clipped boundaries | Test #19 added | Reviewer B I3 |
+
+## 7. Self-review (rev 1)
+
+- [x] Bug root cause precisely identified — unchanged from rev 0, validated by both reviewers
+- [x] **C1 absorbed**: trailing D/N strip explicitly described in primitive § 2.1 + 2 dedicated regression tests (#5, #6, #7)
+- [x] **C2 absorbed**: full-clip returns `start` (matching `cigar.rs:276-278`) + dedicated regression test #15
+- [x] **C3 absorbed**: OB composite shift covered by `reference_start_after_3p_trim`'s "original_ref_span − trimmed_ref_span" formula + dedicated regression test #14
+- [x] **I1 absorbed**: CIGAR-trim primitive design (one primitive + 2 thin helpers) — Perl-faithful, encapsulates D/N/I in one place
+- [x] **I2 absorbed**: naming pivoted from positional (`_clipping_right/_left`) to semantic (`_after_3p_trim`)
+- [x] **I3 absorbed**: boundary-case test #19 added
+- [x] **§2.4 citation absorbed**: `call.rs:179-182` cited explicitly to substantiate "R2 3'-clip doesn't need drop_overlap parameter" claim
+- [x] No source edits performed — plan only
+- [x] V1 verification flagged as commit-time implementer task
+- [x] Out-of-scope items unchanged (no scope creep)
+- [x] Plan-reviewer round 2 re-run on rev 1 — **both reviewers APPROVED**, 0 Critical, 2 Important refinements absorbed into rev 1.1 (tests 9a + 9b + §2.1 prose clarification on D/N strip interleaving)
+- [ ] Implement trigger from Felix — pending

--- a/plans/05262026_bismark-extractor/CODE_REVIEW_879_A.md
+++ b/plans/05262026_bismark-extractor/CODE_REVIEW_879_A.md
@@ -1,0 +1,39 @@
+# Code Review A — PR #880 (`extractor-fix-879`)
+
+Reviewer: A (independent, fresh context)
+Scope: 4-commit diff vs `rust/iron-chancellor`; 8 files, +605/-19.
+
+## Summary
+
+Verdict: **APPROVE with one Medium finding and minor Low cleanups.** The CIGAR-trim primitive is correct in all hand-traced cases (including the round-2 `5D90M5D5M` middle-D fixture), Perl L1726-1782 semantics are faithfully mirrored, both production call sites and all 12 existing test call sites are updated, `cargo test --no-fail-fast` reports 0 failures across the workspace (178 bismark-io tests, all extractor suites), and the version bumps + dep updates are consistent (only bismark-extractor + bismark-dedup depend on bismark-io). The single-sweep "walk past D/N for free" formulation in `walk_trim_from_{left,right}` is a clean, correct simplification of the Perl per-base loop and the regression for the "phase 2 over-stripped middle D" gotcha is locked down by the named test.
+
+## Findings by area
+
+### Logic
+- Hand-traced `90M5D` n=1, n=5, n=7; `90M5D5M` n=5; `5D90M5D5M` n=5; `5M5D5M` n=5/n=6; `5I90M` n=5; `5D5I90M` n=5; `5I5D90M` n=5; `5S95M` n=5 — every case matches Perl's `for (1..$ignore_3prime) { pop; while D; while N; if I I_count++ }` semantics. The "inner D/N loop only fires when outer pop yielded D/N" subtlety is correctly preserved.
+- `reference_start_after_3p_trim`'s `original_ref_span - trimmed_ref_span` formulation is algebraically equivalent to Perl L1803's `$ignore_3prime + $D_count + $N_count - $I_count` (verified against `5D5I90M` n=5 where I and D interact: both give shift=5).
+- `reference_end_after_3p_trim` correctly delegates to `reference_end` which already has the `span == 0 → start` empty-CIGAR convention (cigar.rs:248), so the full-clip case returns `start` as documented.
+- Both production call sites (`pipeline.rs:354`, `parallel.rs:711`) pass `config.ignore_3p_r1`. `grep` shows no other callers in src/.
+
+### Efficiency
+- `n == 0` fast-path in `trim_3p_read_positions` (cigar.rs:259) returns a fresh `Cigar::from(self.as_ref().to_vec())` — an allocation per default-cell record. The docstring acknowledges this but it is still a per-record `Vec` clone on the hot path. Since `drop_overlap` only consumes `ref_span` / `reference_end`, the wrapper helpers `reference_end_after_3p_trim` / `reference_start_after_3p_trim` could short-circuit *before* calling `trim_3p_read_positions` when `n_read_positions == 0`. `reference_start_after_3p_trim` already has the `n == 0 → start` short-circuit (cigar.rs:301), but `reference_end_after_3p_trim` (cigar.rs:295-298) does not — it always calls `trim_3p_read_positions(0, false)` then `.reference_end(start)`, paying for a CIGAR clone on every default-cell forward pair. **See Medium recommendation below.**
+
+### Errors
+- `trim_3p_read_positions` can return a CIGAR with a *leading D* (e.g., `5I5D90M` n=5 → `[5D, 90M]`). That is technically an invalid SAM CIGAR. Current call sites only consume `reference_span` / `reference_end` from the result, so correctness is preserved, but the public `CigarExt::trim_3p_read_positions` could be misused in future. Docstring does not warn. (Low.)
+- No new panics. `usize` arithmetic in `reference_start_after_3p_trim` uses unchecked subtraction `original_ref_span - trimmed_ref_span`; trimmed span ≤ original span by construction so it cannot underflow. (Defensive: a `saturating_sub` would document intent for free.)
+
+### Structure
+- API naming: `reference_end_after_3p_trim` / `reference_start_after_3p_trim` parallel the existing `reference_end` / `reference_span` shape — good fit.
+- The `from_left: bool` boolean argument on `trim_3p_read_positions` is slightly hard to read at call sites (e.g., `trim_3p_read_positions(n, false)`). A `TrimSide::{Left, Right}` enum would be more legible — but only 1 production-equivalent call exists (both helpers internal), so this is Low priority.
+- 17 unit tests + 4 integration tests = 21 total, all 21 present in diff (including round-2 `trim_3p_middle_D_is_NOT_stripped` at cigar.rs:692 and `trim_3p_left_with_soft_clip_prefix` at cigar.rs:716). Plan §3 coverage is complete.
+
+## Recommendations
+
+| Priority | File:Line | Suggestion |
+|---|---|---|
+| Medium | cigar.rs:295-298 | Short-circuit `reference_end_after_3p_trim` when `n_read_positions == 0` to avoid per-record `Cigar` clone on the default cell. Mirrors the existing pattern in `reference_start_after_3p_trim` (cigar.rs:301). |
+| Low | cigar.rs:53-66 | Docstring for `trim_3p_read_positions` should note that the returned CIGAR may begin with `D/N` when the trimmed prefix contains insertions but the next op is D/N (e.g., `5I5D90M` n=5 → `5D90M`). Recommend callers consume only `reference_span` / `reference_end` from the result, not re-emit it. |
+| Low | cigar.rs:306 | `start + (original_ref_span - trimmed_ref_span)`: consider `saturating_sub` for self-documentation (cannot underflow today, but cheap insurance). |
+| Low | cigar.rs (API) | Consider `TrimSide::{Left, Right}` enum vs `from_left: bool` in a future revision — purely ergonomic. |
+
+Report path: `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/CODE_REVIEW_879_A.md`

--- a/plans/05262026_bismark-extractor/CODE_REVIEW_879_B.md
+++ b/plans/05262026_bismark-extractor/CODE_REVIEW_879_B.md
@@ -1,0 +1,98 @@
+# Code Review B — PR #880 (closes #879)
+
+**Reviewer:** B (independent of A)
+**Branch:** `extractor-fix-879` @ `f96f9c6` off `rust/iron-chancellor` @ `45b4c61`
+**Scope:** 4 commits, 8 files (+605 / -19). Verified via `git diff rust/iron-chancellor..extractor-fix-879`.
+
+---
+
+## Summary
+
+The fix correctly addresses #879: `drop_overlap` no longer uses R1's un-clipped CIGAR end/start when `--ignore_3prime N` shifts R1's effective boundary inward. The new CIGAR-trim primitive at `bismark-io/src/cigar.rs:255-308` plus the two helpers (`reference_end_after_3p_trim`, `reference_start_after_3p_trim`) faithfully mirror Perl `bismark_methylation_extractor:1756-1803`. By hand I traced 5 representative CIGARs (`90M5D` n=5, `90M5D5M` n=5, `5D90M` n=5, `5S95M` n=5, `90M5N5M` n=10) — all match Perl's expanded-@comp_cigar pop/shift semantics including the "D/N stripped only when adjacent to trimmed boundary post-pop" rule. fmt + check clean. All 178 bismark-io tests + full workspace test suite pass (0 failures, 0 ignored except 9 pre-existing).
+
+**Verdict: APPROVE.** No Critical or High findings. One Medium and three Low items below.
+
+---
+
+## Issues by area
+
+### Logic — no defects found
+
+- **`walk_trim_from_right` / `walk_trim_from_left`** (cigar.rs:325-393): single-sweep semantics correctly absorb D/N at the trimmed boundary while preserving middle D/N. The exit condition `while remaining > 0` correctly stops without over-stripping when the boundary lands exactly on a read-consuming op (e.g., `90M5D5M` n=5 → `90M5D`, matching Perl which only fires the inner D-strip when an outer pop returned D).
+- **`reference_start_after_3p_trim`** (cigar.rs:300-308): the `original_ref_span - trimmed_ref_span` formula is algebraically equivalent to Perl L1803's `ignore_3prime + D + N - I`. Verified for the `5I90M` (pure-insertion prefix → 0 shift), `5D90M` (D-only prefix → 10 shift), and `5S95M` (soft-clip prefix → 0 shift) cases.
+- **`drop_overlap`** signature change (overlap.rs:84) + both call sites (pipeline.rs:354, parallel.rs:711) consistently pass `config.ignore_3p_r1`. `grep -rn drop_overlap rust/bismark-extractor/src/` confirms no third call site exists.
+- The Strict-`>` (OT) and Strict-`<` (OB) keep predicates are preserved; the fix only changes the boundary value, not the predicate polarity (Phase C.1 polarity fix from #862 stays intact).
+
+### Efficiency
+
+- **Allocation on no-op fast-path** (cigar.rs:259-261): when `n == 0`, `trim_3p_read_positions` clones the ops vec via `to_vec()`, then wraps in `Cigar::from`. For the default cell (no `--ignore_3prime`), this is an unnecessary heap allocation per record. **However** — and this saves the day — `reference_end_after_3p_trim` calls the trim before `reference_end`, but `reference_start_after_3p_trim` (overlap.rs OB branch) does have an `n == 0 → return start` short-circuit at cigar.rs:301-303. The OT branch (`reference_end_after_3p_trim`) does NOT short-circuit at the helper level — it always trims. The docstring acknowledges this with "the allocation cost is irrelevant since this branch is hit on every default-cell record" but I'd flag this as a real (if small) perf concern: ~55M PE reads × one extra `Vec<Op>` clone per record. See Medium-1.
+
+### Errors — no defects found
+
+- Full-clip case (`n >= read_span`): `walk_trim_from_right` returns `(0, 0, None)`, producing an empty Cigar. `reference_end` of empty Cigar returns `start` per the pre-existing convention at cigar.rs:248. Test `reference_end_after_3p_trim_full_clip_returns_start` guards this.
+- Empty-CIGAR input: outer `while kept_end > 0` immediately exits, returning an empty Cigar — graceful.
+- `boundary_remaining` with `surviving_len == 0`: not reachable, because the branch is only taken when `op_len > remaining`, i.e., `surviving_len ≥ 1`.
+
+### Structure / API
+
+- The new trait methods follow the existing `CigarExt` naming (`reference_end` → `reference_end_after_3p_trim`); signatures consistent (`start: usize, n_read_positions: u32` matches the `start` parameter style of `reference_end`).
+- Docstrings accurately describe the post-fix single-sweep semantics. The earlier "Phase 2" wording is absent. Cross-references to Perl line numbers + the issue # are present and accurate.
+- The 12 existing call-site updates (`drop_overlap(r2_calls, &pair) → drop_overlap(r2_calls, &pair, 0)`) all preserve original test intent (`0` = no clipping = same boundary as before). Spot-checked `drop_overlap_with_r1_indel_uses_reference_end`, `drop_overlap_r1_with_n_skip_op`, `drop_overlap_r1_with_5prime_soft_clip` — all still test what their names claim.
+
+---
+
+## Recommendations
+
+### Medium
+
+1. **Skip the clone on `n == 0` in `reference_end_after_3p_trim`** (cigar.rs:295-298). Add an early return:
+   ```rust
+   fn reference_end_after_3p_trim(&self, start: usize, n_read_positions: u32) -> usize {
+       if n_read_positions == 0 { return self.reference_end(start); }
+       self.trim_3p_read_positions(n_read_positions, false).reference_end(start)
+   }
+   ```
+   Mirrors `reference_start_after_3p_trim`'s existing short-circuit and removes a `Vec<Op>` allocation per record on the default cell (~55M allocations/run on the full PE dataset). Optional but cheap and symmetric.
+
+### Low
+
+2. **Test naming inconsistency** (pe_phase_c.rs:1505-1656): the new module is `ignore_3prime_879` but the existing call-site-updated tests live in the top-level scope. Mostly stylistic. If you want all `--ignore_3prime` tests in one module, move them — but this isn't worth churning the 12-line-update diff.
+
+3. **`read_consumes` naming** (cigar.rs:397) returns `usize` but only ever returns 0 or 1. Could just return `bool`. Tiny readability nit.
+
+4. **Missing edge-case test: I+D+N mixed prefix** for `reference_start_after_3p_trim`. Current tests cover M-only, D-only, S-only, and zero. A mixed prefix like `3I2D90M` (with n=3 from left) would exercise the I-vs-D-vs-N interaction in one test. The math works (`original_ref_span = 92`, `trimmed_ref_span = 90`, shift = 2; Perl: `3 + 0 + 0 - 3 + ... wait`) — actually this case is non-trivial because Perl's L1781-1793 walks I via op_len=1-per-iter while D is absorbed for free. Verify by trace, then add the test. Optional defensive cover.
+
+---
+
+## What I verified by hand
+
+| CIGAR | n | side | Rust result | Perl trace result | Match |
+|---|---|---|---|---|---|
+| `90M5D` | 5 | right | `85M` | `85M` | ✓ |
+| `90M5D5M` | 5 | right | `90M5D` | `90M5D` | ✓ |
+| `90M5D5M` | 10 | right | `85M` | `85M` | ✓ |
+| `5D90M` | 5 | left | `85M` | `85M` | ✓ |
+| `5S95M` | 5 | left | `95M` (no shift) | matches | ✓ |
+| `5I90M` | 5 | left | `90M` (no shift) | matches | ✓ |
+| `90M5N5M` | 10 | right | `85M` | `85M` | ✓ |
+| `100M` | 100 | right | empty Cigar, end=start | matches | ✓ |
+
+---
+
+## Tests claim verification
+
+- 17 `cigar.rs` unit tests for new methods (lines 608-770): ✓ counted.
+- 4 integration tests in `pe_phase_c.rs::ignore_3prime_879` (forward_pair, reverse_pair, zero_is_no_op, at_boundary): ✓ present.
+- `trim_3p_middle_D_is_NOT_stripped` (R2 finding): ✓ present at cigar.rs:688.
+- `trim_3p_left_with_soft_clip_prefix` (R2 finding): ✓ present at cigar.rs:702.
+- Workspace test run: `test result: ok. 178 passed; 0 failed` for bismark-io + all extractor/dedup suites green. ✓
+
+---
+
+## Cross-crate dep audit
+
+`grep -l bismark-io rust/*/Cargo.toml` → only `bismark-extractor` and `bismark-dedup`. Both Cargo.tomls bumped to `=1.0.0-beta.8`. No other dependents (verified by `Cargo.lock` semantics via the workspace inheritance; the two listed crates are the only consumers of `bismark-io` workspace path). ✓
+
+---
+
+**Report path:** `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/CODE_REVIEW_879_B.md`

--- a/plans/05262026_bismark-extractor/PLAN_COVERAGE_879.md
+++ b/plans/05262026_bismark-extractor/PLAN_COVERAGE_879.md
@@ -1,0 +1,92 @@
+# Plan Coverage Report — #879 (PR #880)
+
+**Mode:** B (code vs. design plan)
+**Plan:** `plans/05262026_bismark-extractor/BUG_879_FIXES_PLAN.md` (rev 1.1)
+**Branch:** `extractor-fix-879` HEAD `f96f9c6` off `rust/iron-chancellor`
+**Date:** 2026-05-28
+**Verdict:** COMPLETE
+
+## Summary
+
+- Total in-PR items audited: 30 (21 tests + 5 production-code items + 4 process items)
+- DONE: 30
+- PARTIAL / MISSING / DEVIATED: 0
+- Out-of-scope items (tests 20/21 colossal smokes): correctly deferred per plan §3.3.
+
+## Coverage ledger
+
+### Production code (plan §2)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| P1 | `trim_3p_read_positions` primitive on `CigarExt` | Plan §2.1 / cigar.rs lines 81-86, 254-292 | DONE | Returns owned `Cigar`; no-op fast-path on `n==0`; delegates to `walk_trim_from_right`/`walk_trim_from_left`. |
+| P2 | `reference_end_after_3p_trim` helper | Plan §2.1 / cigar.rs:294-297 | DONE | 3-line wrapper as specified. |
+| P3 | `reference_start_after_3p_trim` helper | Plan §2.1 / cigar.rs:299-306 | DONE | Uses `original_ref_span − trimmed_ref_span` formula per Perl L1803 algebra. |
+| P4 | `drop_overlap` signature gains `ignore_3p_r1: u32` | Plan §2.2 / overlap.rs:83-86 | DONE | Parameter wired through both branches. |
+| P5 | OT branch uses `reference_end_after_3p_trim` | Plan §2.2 / overlap.rs:108-112 | DONE | |
+| P6 | OB branch uses `reference_start_after_3p_trim` | Plan §2.2 / overlap.rs:121-127 | DONE | Replaces the prior `r1_ref_start = r1_start as u32` shortcut. |
+| P7 | Call site update `pipeline.rs:354` | Plan §2.3 / pipeline.rs:354 | DONE | Passes `config.ignore_3p_r1`. |
+| P8 | Call site update `parallel.rs:711` | Plan §2.3 / parallel.rs:711 | DONE | Passes `config.ignore_3p_r1`. |
+
+### Semantics: D/N absorption at boundary, NEVER in the middle (Plan §2.1)
+
+`walk_trim_from_right` (cigar.rs:323-360) and `walk_trim_from_left` (cigar.rs:366-389) each loop while `remaining > 0`, walking past `read_consumes(kind) == 0` ops (D/N/H/P) for free and decrementing `remaining` only on M/I/S/=/X. The loop exits as soon as `remaining == 0`, which is what protects middle D/N from being stripped — once the final read-consuming op completes the count, the next iteration condition is false and the walker stops. The phase-2 over-stripping bug the implementer discovered is fixed by THIS exact structure (single sweep, exit on count exhausted), and is regression-guarded by test 9a `trim_3p_middle_D_is_NOT_stripped` which asserts `90M5D5M` trim 5 from right yields `90M5D` (not `85M`). **Matches plan §2.1 semantics exactly.**
+
+### bismark-io unit tests (plan §3.1, all in `rust/bismark-io/src/cigar.rs` test module)
+
+All 17 expected tests present (verified by grep — 17 new `#[test]` additions in the diff):
+
+| # | Test name | Status |
+|---|-----------|--------|
+| 1 | `trim_3p_zero_is_identity_right` | DONE |
+| 2 | `trim_3p_zero_is_identity_left` | DONE |
+| 3 | `trim_3p_simple_match_right` | DONE |
+| 4 | `trim_3p_simple_match_left` | DONE |
+| 5 | `trim_3p_with_trailing_deletion_strips_D` | DONE — C1 guard |
+| 6 | `trim_3p_with_trailing_skip_strips_N` | DONE — C1 guard |
+| 7 | `trim_3p_with_leading_deletion_strips_D_when_from_left` | DONE — C3 guard |
+| 8 | `trim_3p_clipping_into_insertion_no_ref_impact` | DONE |
+| 9 | `trim_3p_full_clip_returns_empty_cigar` | DONE |
+| 9a | `trim_3p_middle_D_is_NOT_stripped` | DONE — Reviewer A R2 negative guard |
+| 9b | `trim_3p_left_with_soft_clip_prefix` | DONE — Reviewer B R2 OB soft-clip guard |
+| 10 | `reference_end_after_3p_trim_zero_is_existing_reference_end` | DONE |
+| 11 | `reference_end_after_3p_trim_simple` (asserts 194) | DONE |
+| 12 | `reference_start_after_3p_trim_zero_is_start` | DONE |
+| 13 | `reference_start_after_3p_trim_simple` (asserts 105) | DONE |
+| 14 | `reference_start_after_3p_trim_with_leading_D` (asserts 110) | DONE — C3 guard |
+| 15 | `reference_end_after_3p_trim_full_clip_returns_start` | DONE — C2 guard |
+
+Spot-checked assertions for #11 (194), #13 (105), #14 (110), #15 (returns `start=100`) — all match the plan's specified numeric results.
+
+### bismark-extractor integration tests (plan §3.2)
+
+All in new `mod ignore_3prime_879` at `tests/pe_phase_c.rs:1485-1656`:
+
+| # | Test name | Status |
+|---|-----------|--------|
+| 16 | `drop_overlap_with_ignore_3p_r1_forward_pair` (assert {195, 197, 200}) | DONE |
+| 17 | `drop_overlap_with_ignore_3p_r1_reverse_pair` (assert {99, 103}) | DONE — C3 integration guard |
+| 18 | `drop_overlap_ignore_3p_r1_zero_is_no_op` (assert {200}) | DONE — default-cell guard |
+| 19 | `drop_overlap_with_ignore_3p_r1_at_boundary` (assert {195}, drops 194) | DONE — Reviewer B I3 |
+
+### §2.4 — R2 3'-clip does NOT need `drop_overlap` parameter
+
+Verified: `call.rs:163` `hi = xm_len.saturating_sub(ignore_3p)` and `call.rs:179` `if aligned.read_pos_5p < lo || aligned.read_pos_5p >= hi { continue }` filter R2 ignore_3p calls before they ever reach `drop_overlap`. `drop_overlap` reads R1's CIGAR only. No code change needed and none was made. Plan §2.4 assumption holds.
+
+### Process / pipeline items
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| O1 | Implementation order tests-first → fix (×2 crates) | Plan §4 | DONE | Commit graph: `41d48cf` test(bismark-io), `efaa274` fix(bismark-io), `559aa1a` test(extractor), `f96f9c6` fix(extractor). Exact 4-commit cadence the plan specified. |
+| O2 | bismark-io version bump | Plan §4 step 2 + §6 V1 | DONE | `1.0.0-beta.7` → `1.0.0-beta.8` in all three Cargo.tomls (io, extractor, dedup). |
+| O3 | Existing-tests signature update | Plan §4 step 4 implicit | DONE | All 13 existing `drop_overlap(..., &pair).unwrap()` callers in pe_phase_c.rs updated to `(..., &pair, 0).unwrap()`. |
+| O4 | V2 grep for other `drop_overlap` callers | Plan §6 V2 | DONE | Audit reproduced the grep: only callers are pipeline.rs:354, parallel.rs:711 (both updated), and the 13 in-test callers (all updated to pass `0`). Doc-comments in lib.rs/pipeline.rs/parallel.rs/cigar.rs are non-invocation references. |
+| O5 | Out-of-scope discipline | Plan §6 | DONE | `git diff --stat` shows only the 8 expected production/test/Cargo files plus the 5 plan/review markdown files. No drift into #876 follow-ups, #878 parallel tests, edge_clip, or N=4 collapse. |
+
+## Test verification
+
+Did not execute `cargo test`. All 21 expected tests are present in the diff at the expected paths with assertions matching the plan's stated numeric expectations. Test execution is for the user's CI / verify step.
+
+## Verdict
+
+**COMPLETE.** Every task, test, edge case, and semantic constraint specified in `BUG_879_FIXES_PLAN.md` rev 1.1 is implemented in branch `extractor-fix-879`. The implementer's discovered "phase-2 over-stripping" mid-implementation bug is fixed by the as-shipped single-sweep walker design and explicitly regression-guarded by test 9a. Both V1 (version bump) and V2 (grep callers) verification items from plan §6 are executed and resolved. Out-of-scope discipline holds. Ready for code-review and merge.

--- a/plans/05262026_bismark-extractor/PLAN_REVIEW_879_A.md
+++ b/plans/05262026_bismark-extractor/PLAN_REVIEW_879_A.md
@@ -1,0 +1,55 @@
+# Plan Review A — `BUG_879_FIXES_PLAN.md`
+
+**Reviewer**: A (independent, fresh context)
+**Target**: `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/BUG_879_FIXES_PLAN.md` rev 0
+**Verdict**: Sound fix; ship after addressing one Critical (test #5 off-by-one) and three Important issues (API shape, D-op walk semantics on test #4 / #8, plan §2.4 missing R2 trace).
+
+---
+
+## Logic review
+
+The root cause is correctly identified: `overlap.rs:101` uses `reference_end` on R1's un-clipped CIGAR, while Perl L1726-1804 trims `@comp_cigar_1` THEN recomputes `$end_read_1 = $start_read_1 + $MDN_count_1 - 1` (L2400) or shifts `$start_read_1 += $MDN_count_1 - 1` from the trimmed CIGAR (L2415-2416). The asymmetry table (`§1`) is accurate: R1 5p / R2 5p / R2 3p don't touch R1's drop_overlap boundary; only R1 3p does, on both forward (right-pop) and reverse (left-shift) branches.
+
+The OB reverse-strand semantics are correct. Perl L2406 reverses `@comp_cigar_1` BEFORE counting MDN, so the BAM-stored CIGAR's **left** side is the read's **3' end** when strand is `-`. Perl L1803 `$start += $ignore_3prime + $D_count + $N_count - $I_count` advances the alignment_start, which equals "ref-positions consumed by the dropped prefix" (M+D+N count, since `ignore_3prime` counts read-positions = M+I+S and subtracts back I). The plan's `reference_start_clipping_left → start + ref-positions of dropped prefix` matches.
+
+## Assumptions / open questions
+
+- **A1 (naming) — Important.** `reference_end_clipping_right` / `reference_start_clipping_left` is positional w.r.t. CIGAR storage. The OB branch wires "right-positional clip" to "5' BAM-storage / 3' read-orientation," which is exactly the confusion the table at `§1` is trying to dispel. Suggest `reference_end_after_clip_3p_storage_right` / `reference_start_after_clip_3p_storage_left`, or — cleaner — a single `cigar_with_trailing_read_clipped(n)` / `cigar_with_leading_read_clipped(n)` returning a trimmed `Cigar`, on which the caller calls existing `reference_end(start)`. The latter is **more Perl-faithful** (Perl literally rewrites the CIGAR, L1807-1828) and would let the new helpers be reused for any future code path that needs the trimmed CIGAR (e.g. an SE write path that revisits per-call CIGAR). Recommend pivoting to the trimming variant. Tests stay almost identical — they'd assert on `cigar.reference_end(start)` after trim.
+- **D-op walk semantics — Important.** Test #4 (`90M5D10M`, clip 5) is correct: the 5D is BEFORE the 10M block being clipped, so it stays. But the plan never tests `100M5D` (D at the very tail). Perl L1760-1764 says: AFTER popping a non-D/N op from the end, if the NEW tail is D or N, keep popping D/N (the `while ($op eq 'D')` loop). This means a trailing D run **is consumed** without decrementing the clip counter, and the reference_end MUST move past those D ops. The plan's "D doesn't consume read" framing in `§2.1` is true but misses Perl's extra rule that **trailing D/N after the last read-consuming op are also stripped**. Add a test: `90M5D` clip 5 → reference_end loses 5 (from M) AND 5 (from trailing D) = 10. Same for `90M5D5M` clip 5 → strips 5M, then while-loop strips the 5D, then stops — reference_end loses 10. The current plan would compute "lose 5" and silently produce wrong results on reads with trailing deletions.
+- **Test #5 (full clip) — Critical inconsistency.** Plan asserts `start.saturating_sub(1)` for clip-everything. Existing convention at `cigar.rs:276-278` returns `start` for empty CIGAR (and the existing `reference_end` impl at L185-186 returns `start` when `span==0`). Returning `start - 1` here is a new convention that will surprise readers and may interact badly with `r2_calls.retain(|c| c.ref_pos > r1_ref_end)` if `r1_start` is 1 (saturating_sub yields 0, every R2 with ref_pos>0 is kept — which happens to be wrong because "everything clipped" means no overlap and we should keep ALL R2 calls). With the trimming variant, this degenerates naturally to "trimmed CIGAR is empty → reference_end returns start → predicate `c.ref_pos > start` drops R2 calls AT R1's start." That's still arguably wrong, but at least matches existing convention. Either way, **the plan's chosen sentinel and the predicate's interaction with it must be jointly tested.** Currently no integration test exercises `ignore_3p_r1 ≥ read_span`.
+
+## Efficiency
+
+`drop_overlap` runs once per pair, hot path. Both new helpers are O(ops), same as `reference_span`. Zero-clip degenerates to identical work as today (the early-return `if n_read_positions == 0 { return reference_end(start); }` should be explicit in the impl — the plan implies it but the test #1 / #6 are the only enforcement). No regression. If the trimming variant is chosen, allocating a new `Cigar` per pair when `ignore_3p_r1>0` is a minor cost — acceptable given the flag is rare.
+
+## Validation sufficiency
+
+Gaps:
+- **No test for trailing-D semantics** (Perl L1760-1764 while-loop). See above.
+- **No test for full clip predicate behavior** (only the helper return value). Add an integration test: R1 with `ignore_3p_r1 = read_span`, assert all R2 calls kept (or whatever the correct biological semantic is — needs Felix sign-off).
+- **Plan §2.4 is asserted, not traced.** "R2's 3'-clip is handled by `extract_calls` filter" — true for R2's own call set, but the claim that `drop_overlap` doesn't need to know about it depends on R2's `ref_pos` values being **independent of `ignore_3p_r2`**. Verify: `extract_calls` at `call.rs:179-182` filters by `read_pos`, leaving `ref_pos` untouched. Good — but the iso_r2_3p PASS only proves no regression in that one scenario. The combined cell `r1r2_3p` (the failing one) is what proves drop_overlap doesn't need `ignore_3p_r2`. The plan should cite the iso_r2_3p PASS plus the post-fix expectation that `r1r2_3p` PASSes once R1-side is fixed.
+- **No test combining R1 3p clip with R1 having soft-clip + insertion + deletion**. The unit tests are each one-op-class. A `5S90M3I2D` style test would catch interaction bugs.
+
+## Efficiency / version-bump nit (Important)
+
+Git log shows bismark-io bumps tied to externally-visible feature work (`-beta.2` threaded readers #827, `-beta.3` magic-byte #831, `-beta.4` UMI #835, `-beta.6` iter_aligned #845). Adding two new public trait methods is genuinely API-visible → bump is justified. Note however that `-beta.7` is not in the log shown; confirm current Cargo.toml shows `-beta.7` before bumping to `-beta.8`. If current is `-beta.6` the plan's premise (`-beta.7 → -beta.8`) is off-by-one.
+
+## Action items
+
+**Critical**
+1. Resolve test #5 off-by-one vs `reference_end_with_empty_cigar_returns_start` convention; add integration test for full-clip predicate behavior.
+
+**Important**
+2. Add trailing-D/N tests (`90M5D` clip 5, `90M5D5M` clip 5) and verify the impl mirrors Perl L1760-1764 / L1765-1769 while-loops.
+3. Reconsider API shape: prefer `cigar_with_trailing_read_clipped(n) -> Cigar` (Perl-faithful) over the two boundary-returning helpers; rename to non-positional terms if keeping current shape.
+4. Trace `§2.4` claim explicitly with code refs (`call.rs:179-182` for R2 filter, parallel.rs:704-714 for the order).
+5. Confirm current `bismark-io` version in `rust/bismark-io/Cargo.toml` matches plan §4 step 2's `-beta.7` starting point.
+
+**Optional**
+6. Add a combined-op CIGAR test (`5S90M3I2D` style).
+7. Update `overlap.rs` module docs to mention the new behavior under `--ignore_3prime`.
+8. Consider whether SPEC §7.4 rev 4 should formalize the `ignore_3p_r1` parameter (plan §5 defers — fine, but ticket it).
+
+---
+
+Report written to `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/PLAN_REVIEW_879_A.md`.

--- a/plans/05262026_bismark-extractor/PLAN_REVIEW_879_B.md
+++ b/plans/05262026_bismark-extractor/PLAN_REVIEW_879_B.md
@@ -1,0 +1,83 @@
+# Plan review — fix #879 (Reviewer B)
+
+**Plan**: `plans/05262026_bismark-extractor/BUG_879_FIXES_PLAN.md` (rev 0)
+**Reviewer**: B (independent, fresh context)
+**Verdict**: **Conditional GO** — root cause is correct and the localized fix shape is right, but there are three correctness issues in the helper semantics and tests that should be resolved before implementation.
+
+## Logic review
+
+The diagnosis at `overlap.rs:101` is precise and the Perl contract at `bismark_methylation_extractor:1726-1804` + `:2400/:2415-2416` is faithfully cited. The symmetry table in §1 correctly explains why `iso_r1_3p` FAILs while the other three flags PASS. Quantitative deficit (-943k calls, OT direction) is consistent with the predicate flip story.
+
+However, the helper specification has a load-bearing gap on the **reverse-strand (OB) branch**. Perl L1803 explicitly adds three terms: `$start += $ignore_3prime + $D_count + $N_count - $I_count`. This is then *followed* by the L2416 recomputation `$start_read_1 += $MDN_count_1 - 1` over the already-shortened CIGAR. The plan's `reference_start_clipping_left` collapses these into a single "ref positions of the dropped prefix" calc. That formulation is morally equivalent **only if** the helper treats D/N ops in the clipped prefix as contributing to ref-positions-consumed while NOT decrementing the read-position counter (mirroring the Perl `while $op eq 'D' shift @comp_cigar` loop on L1783-1790). The plan text in §2.1 says "D/N skip" the read-position counter, which is consistent, but the **prose is ambiguous about whether D/N ops in the clipped span are REMOVED from the CIGAR (Perl: yes — `shift`) or RETAINED**. The result differs.
+
+## Critical findings
+
+### C1. No test exercises clip crossing a D/N op in the clipped region
+Test #4 (`90M5D10M`, clip 5) deliberately keeps the clip inside the trailing 10M and never reaches the 5D. Walk through `90M5D5M` with clip=10: trailing 5M consumed (counter 5/10), then 5D — D doesn't decrement the read counter but is *popped* by Perl (L1760-1764), then 5 more of the 90M block consumed (counter 10/10). Final remaining ref-span: 85 (not 90). The ref_end shifts by 15 ref positions while only 10 read positions were clipped. **Add a test for this case** — `100M_clip_traversing_D` and the OB-mirror `100M_clip_traversing_D_left`. Without it, the helper can silently keep or drop the D ops with no test signal.
+
+### C2. Degenerate-empty return value contradicts existing convention
+Plan §2.1 specifies `reference_end_clipping_right` returns `start.saturating_sub(1)` when fully clipped. But the existing convention at `cigar.rs:276-278` (`reference_end_with_empty_cigar_returns_start`) returns `start` for an empty CIGAR with span=0. Two adjacent functions in the same trait disagreeing on the "nothing aligned" return value is a footgun for the `drop_overlap` predicate. If `ignore_3p_r1` clips the entire R1, then `r1_ref_end = start - 1` means **all R2 calls with `ref_pos > start - 1` are kept** — i.e., almost everything, including the original overlap region. Is that the desired behavior? Plausibly yes (no R1, no overlap-zone), but it needs to be explicit. Recommendation: align with existing convention OR document explicitly why this case diverges, and assert the chosen behavior in a test that walks through what drop_overlap actually returns. Currently no integration test covers `ignore_3p_r1 >= read_span`.
+
+### C3. OB-strand helper may not fully mirror Perl L1803's `+ ignore_3prime - I_count` adjustment
+Perl L1803 adds `$ignore_3prime` (one count per clipped position) PLUS `$D_count` (extras) MINUS `$I_count`. Then L2416 re-derives `$start_read_1` from the trimmed CIGAR's MDN count. The plan's helper does the second step but the first step's `+ $ignore_3prime - $I_count` is subtle: it means each clipped M contributes 1 ref-position, each clipped I contributes −1 (so net 0, since the I never consumed a ref position), each clipped D contributes 1+1=2. Walking the Perl through `5M2I5M` clip 5 from left: 5 M's clipped → +5 ignore_3prime, 0 D, 0 N, 0 I → start += 5. CIGAR becomes `2I5M`. Then L2416: MDN_count = 5 → start += 4. Total shift from `$start_read_1`: 5 + 4 = 9. The plan's helper would compute "ref positions in clipped prefix" = 5 (just the M), then `start + 5`. The L2416 transform is the caller's responsibility (it doesn't happen in drop_overlap). **Verify the math matches by hand on a non-trivial OB R1 fixture before declaring victory.** Test #7 (`100M` clip 5) and test #8 (`5S95M` clip 5) don't exercise this.
+
+## Important findings
+
+### I1. API shape: `cigar_with_3p_clipped(n) -> Cigar` would be more Perl-faithful
+The Perl algorithm is unambiguous: trim the CIGAR, then run the existing end/start arithmetic on the trimmed CIGAR. A helper that returns a trimmed `Cigar` and lets the caller use the existing `reference_end(start)` would (a) reduce surface area to one method instead of two, (b) match Perl's semantic exactly, and (c) make the D-pop policy fall out naturally (rebuild the CIGAR without the popped ops). Downside: an extra allocation per overlap pair. Quantify: on 55.7M PE reads with `--ignore_3prime` set, that's ~55.7M small `Vec<Op>` allocations. Probably negligible compared to BAM decode, but worth measuring. **At minimum, document why the two-helper approach was chosen over the trim-and-reuse approach.**
+
+### I2. Naming — `_clipping_right` / `_clipping_left` is positional, not semantic
+`right`/`left` refers to CIGAR-array position, but for OB pairs the **read 3'-end** is at the CIGAR's left side (because the BAM stores reads in reference orientation). A reader of `drop_overlap` will see "this is the `--ignore_3prime` case, so I want the 3' clipping helper" — and then have to remember "but for OB R1, 3' is left." Recommend `clip_3p_cigar_right` / `clip_3p_cigar_left` if the two-method shape stays, OR a single `clip_3p_read_end(n, strand)` that internally branches. The current names will confuse the next maintainer.
+
+### I3. Tests #9-#11 are under-specified
+Test #9's narrative ("Actually simpler: synthetic pair where un-clipped R1 ends at ref 199...") shows the plan author derived the predicate on the fly while drafting. That's a yellow flag — the test as written assumes the helper produces `r1_ref_end = 194` for `100M` clip 5 start 100. Confirm: 100M clipped by 5 → ref_span = 95 → reference_end = 100 + 95 − 1 = 194. ✅ correct. But the test doesn't pin which R2 call positions should be dropped vs kept across multiple boundary cases (192, 194, 195, 199). Add boundary tests at `r2_pos == r1_ref_end` (drop), `r2_pos == r1_ref_end + 1` (keep), `r2_pos == r1_ref_end - 1` (drop) — current text only covers a single intermediate position.
+
+### I4. No integration assertion that #872's matrix passes
+Plan §3.3 says "expect all 10 cells (including r1r2_3p × N=1+N=4) to PASS." That's the actual ground-truth signal — but it's framed as manual post-merge work. The dev-loop should ideally have a fast `iso_r1_3p` subset that runs in CI on every push. Out of scope for this fix, but flag it for the work-queue.
+
+## Assumptions
+
+- **A1 (naming)**: not OK — see I2.
+- **A2 (trait methods)**: OK, consistent with existing `CigarExt`.
+- **A3 (u32, not Option)**: OK, matches existing config field types.
+- **A4 (no `ignore_3p_r2`)**: **traced and confirmed**. R2 3p-clip filters R2 calls' `ref_pos` upstream at `call.rs:179-182`, and `drop_overlap` only consults R1's CIGAR. The R2 calls that survive to `drop_overlap` already have the clipped tail removed from consideration. No code path in `drop_overlap` reads R2's CIGAR. The `iso_r2_3p` PASS empirically confirms this. ✅
+- **A5 (target branch)**: OK.
+- **Cross-crate version bump (§4 step 2)**: history shows every prior bismark-io change bumped the version (beta.1 → .2 → .3 → .4 → .6 → .7). Plan's `.7 → .8` matches that precedent. ✅
+
+## Efficiency
+
+The fix is O(CIGAR ops) per pair (typically <10 ops), guarded by a zero-cost path when `ignore_3p_r1 == 0`. No allocation, no extra iteration of `r2_calls`. No concerns. The two-helper vs trim-CIGAR alternative (I1) trades allocation for clarity — measure if uncertain.
+
+## Validation sufficiency
+
+**Insufficient as drafted**. Specific gaps:
+1. No test where clipping crosses a D/N op (C1).
+2. No test where the helper input is empty / fully-clipped + assertion on `drop_overlap` behavior (C2).
+3. No boundary-edge tests for `drop_overlap` keep/drop predicate (I3).
+4. No OB-strand test with InDels in the clipped prefix that verifies the Perl L1803 + L2416 composite shift (C3).
+5. Plan mentions `cargo check` to verify compile-fail tests but no `cargo nextest` or `cargo test --workspace` invocation; OK but be explicit in §4.
+
+## Alternatives
+
+1. **Trim-CIGAR helper** (`clip_3p_cigar(n, from_left: bool) -> Cigar`) + reuse existing `reference_end`. See I1. Single API surface, exactly Perl-shaped, slight allocation cost.
+2. **Inline the algorithm in `drop_overlap`** without adding `CigarExt` methods. Rejected — same reasoning as the plan (testability + reuse). Plan choice is correct here.
+3. **Pre-compute clipped boundaries in `extract_calls`** and stash them on the pair. Rejected — couples extract_calls to overlap concerns, wrong layer.
+
+## Action items
+
+### Critical (block implementation)
+- **[C1]** Add unit tests for `reference_end_clipping_right` and `reference_start_clipping_left` that traverse a D or N op in the clipped region. Document explicitly: do D/N ops in the clipped region get REMOVED from the trimmed CIGAR (Perl: yes)?
+- **[C2]** Reconcile the degenerate "everything clipped" return convention with existing `reference_end_with_empty_cigar_returns_start` at `cigar.rs:276-278`. Either align (return `start`) or document why divergence is correct; add a `drop_overlap` test for `ignore_3p_r1 >= read_span`.
+- **[C3]** Add an OB-strand test fixture with InDels in the first 5 CIGAR ops; hand-derive the expected `r1_ref_start` from the Perl L1803 + L2416 composite math and assert.
+
+### Important (resolve in plan, before implement)
+- **[I1]** Document why the two-helper approach was chosen over `clip_3p_cigar(n, from_left) -> Cigar`; quantify the allocation overhead vs the API-clarity win.
+- **[I2]** Rename to `clip_3p_cigar_right` / `_left` or to a single strand-aware helper. `_clipping_right/_left` reads as positional in a context where "3'" already carries directional meaning.
+- **[I3]** Pin the boundary cases in tests #9 and #10 explicitly (exact predicate, exact ref_pos at boundary ±1).
+
+### Optional
+- **[O1]** Add a fast `iso_r1_3p` smoke harness for CI (out of #879 scope; file separately).
+- **[O2]** Confirm test #11 ("`ignore_3p_r1=0` is no-op") asserts byte-equality with the pre-fix output, not just "non-zero overlap dropped." Plan text is loose.
+
+---
+File written: `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/PLAN_REVIEW_879_B.md`

--- a/plans/05262026_bismark-extractor/PLAN_REVIEW_879_REV1_A.md
+++ b/plans/05262026_bismark-extractor/PLAN_REVIEW_879_REV1_A.md
@@ -1,0 +1,92 @@
+# Plan Review A — `BUG_879_FIXES_PLAN.md` rev 1 (round 2)
+
+**Reviewer**: A (independent, fresh context — round 2)
+**Target**: `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/BUG_879_FIXES_PLAN.md` rev 1
+**Verdict**: **GO** with one Important clarification on D/N strip semantics. Round-1 Critical findings (C1/C2/C3) are correctly absorbed at the algorithmic level. One subtle test description is misleading; the underlying primitive is still correct.
+
+---
+
+## C1 absorption — Trailing D/N strip (verified against Perl L1756-1770)
+
+The plan §2.1 primitive description and test #5 (`90M5D` clip 5 → `85M`) are **correct** but the plan's prose framing ("After the read-position trim loop completes, also strips any now-exposed trailing D/N ops") is **subtly misleading** about where the strip happens.
+
+Reading Perl L1756-1770 literally: the `while ($op eq 'D')` and `while ($op eq 'N')` loops are **INSIDE** the `for (1..$ignore_3prime)` body. Each for-iteration pops one op; if that op is D/N, the while-loop pops until a non-D/N op surfaces; that non-D/N op counts as the iteration's read-position. There is NO post-loop strip in Perl.
+
+The behavioral consequence:
+- `90M5D` clip 5: iter 1 pops `D` → while pops 4 more D's → pops `M` (1 read-pos). Iters 2-5 pop M (4 more read-pos). Result: `85M`. ✓ (matches test #5)
+- `90M5D5M` clip 5: iter 1 pops `M`, iter 2 pops `M`, ..., iter 5 pops `M`. Five M's gone. Trailing `5D` remains. Result: `90M5D`, **NOT** `85M`. Reviewer B round-1 wrote `100M_clip_traversing_D` with `90M5D5M` clip 10 expecting "85M"; under correct Perl semantics this would be `85M` only because the 10th iteration pops a D from the now-exposed 5D, triggering the inner while loop. So Reviewer B's example was right for clip=10, not clip=5.
+
+**Action**: rephrase the primitive's docstring (plan §2.1, lines 43-60) from "After the read-position trim loop completes, also strips any now-exposed trailing D/N ops" to "Within each read-position consumed, if the popped op is D or N, continue popping D/N until a read-consuming op surfaces (that op counts as the read-position)". This matches Perl exactly and prevents a future maintainer from implementing a post-loop strip that would diverge on `90M5D5M` clip 5.
+
+Test #5 / #6 / #7 are correct as written. Recommend adding a **negative regression** test: `90M5D5M` clip 5 → `90M5D` (NOT `85M`), to lock in the Perl-faithful semantic and prevent the post-loop-strip implementation drift.
+
+## C2 absorption — Full-clip return convention (verified)
+
+Plan A3, §2.1 docstring for `reference_end_after_3p_trim`, and test #15 all align: trimmed empty CIGAR → `reference_end` returns `start` per `cigar.rs:185-186` (`if span == 0 { start }`) and the existing `reference_end_with_empty_cigar_returns_start` test at L276-278. ✓ Clean absorption.
+
+## C3 absorption — OB composite shift (algebraically verified)
+
+Plan §2.1's `reference_start_after_3p_trim` formula `start + (original_ref_span - trimmed_ref_span)` is **algebraically equivalent** to Perl L1803's `$start += $ignore_3prime + $D_count + $N_count - $I_count`:
+- Dropped prefix ref-positions = M_dropped + D_dropped + N_dropped (reference_span counts M+D+N+=+X).
+- Perl: ignore_3prime = M+I+S read-positions; plus extra D + extra N (which are popped but don't count toward ignore_3prime); minus I (I consumes read but no ref, but ignore_3prime already counted it). Net: M + D + N. ✓
+- Test #14 (`5D90M` clip 5 left → trimmed `85M`, shift=10, start+10=110) validates this directly.
+
+## I1 absorption — CIGAR-trim primitive (good shape, mild redundancy concern)
+
+The primitive + 2 helpers shape is right. One small efficiency note: the 2 helpers are 3-5 line wrappers that the call sites in `overlap.rs` could just as well inline (`pair.r1().cigar().trim_3p_read_positions(n, false).reference_end(start)`). Keeping the helpers buys: (a) named call-site semantics, (b) one place to enforce the full-clip return convention. Worth the keep, but consider documenting the helpers as "thin wrappers, may be inlined at call site if needed" so future refactors don't see them as load-bearing.
+
+## I2 absorption — Naming (acceptable, mild concern)
+
+`_after_3p_trim` is semantic and clearer than `_clipping_right/_left`. Minor concern: "trim" overlaps with Trim Galore terminology (the upstream read-trimming tool, often a step before Bismark). Risk is low because this lives in `bismark-io::CigarExt`, not at a user-facing layer. Optional: `_after_3p_clip` would be unambiguous in the Bismark/methylation domain (`--ignore_3prime` is a clip). Not blocking.
+
+## I3 absorption — Boundary tests (partially absorbed)
+
+Test #19 description (plan §3.2 lines 180-181) covers boundary cases under "both un-clipped and clipped boundaries" but the test is described in prose. To pin Reviewer B's I3 intent, the test should explicitly assert FOUR values:
+- `r2_pos == r1_ref_end` → DROP (un-clipped)
+- `r2_pos == r1_ref_end + 1` → KEEP (un-clipped)
+- `r2_pos == clipped_r1_ref_end` → DROP (clipped)
+- `r2_pos == clipped_r1_ref_end + 1` → KEEP (clipped)
+
+The plan text says "the predicate's strict-greater-than semantics are preserved through the fix" which captures the intent but the implementer might write a one-sided boundary check. Recommend pinning the 4 assertions explicitly in the plan.
+
+## §2.4 citation absorption (verified)
+
+`call.rs:179-182` (verified): `if aligned.read_pos_5p < lo || aligned.read_pos_5p >= hi { continue; }`. Matches the plan claim. ✓
+
+## V1 verification (done now)
+
+`git show 45b4c61:rust/bismark-io/Cargo.toml | grep version` → `version = "1.0.0-beta.7"`. The plan's assumed starting point is correct. Bump target `-beta.8` is justified (new public trait methods = API-visible change). V1 can stay as a commit-time check; no plan blocker.
+
+## V2 (Reviewer B) — `drop_overlap` callers
+
+Plan §2.3 cites `pipeline.rs:354` and `parallel.rs:711` as the only callers. V2's grep-at-commit-time is fine. No plan blocker.
+
+## New issues introduced by rev 1
+
+Examined the API restructure for new bugs:
+- **Test #8 semantics check**: `5S95M` trim 5 from LEFT → "ref unchanged at start". S consumes read but not ref. From-left trim consumes 5 read-positions of S; the M block is untouched; trimmed CIGAR `95M`; original_ref_span = 95, trimmed_ref_span = 95; shift = 0; start unchanged. ✓ Correct. But this is the OB-strand path where R1's BAM-stored 5'-side maps to the read's 3' end. For OB R1 with leading soft-clip, this means: "5S at BAM-position 0 = soft-clipped 3' read end" — the soft-clip is ALREADY removed from the read's effective end. Clipping further by `--ignore_3prime 5` should clip 5 MORE bases beyond the soft-clip — which the test doesn't quite express. Worth adding a test like `5S95M` clip 5 left where the expected semantic is "consume the 5S, then the next clip would need to dip into 95M" — but the primitive as specced only consumes 5 read-positions total. **Verify**: does Perl's `pop/shift @comp_cigar` include S ops? Yes — S is in `@comp_cigar`. So Perl `5S95M` clip 5 from left would consume the 5S and stop. The primitive matches Perl. ✓
+
+## Round-1 findings cross-check
+
+All round-1 Critical (C1, C2, C3) and Important (I1, I2, I3) items appear in §7 self-review and have corresponding plan-text changes + tests. Optional items O1/O2 not absorbed — fine, those are scope-deferred (CI smoke harness, byte-equality check). Reviewer A's I4/V1 absorbed.
+
+---
+
+## Action items
+
+### Critical
+None. Rev 1 absorbs C1/C2/C3 correctly at the algorithmic level.
+
+### Important
+1. **Reword §2.1 primitive docstring** to put the D/N strip INSIDE the per-read-position loop (matches Perl L1756-1770 literally). Current "After the read-position trim loop completes, also strips" phrasing risks implementer drift on `90M5D5M` clip 5.
+2. **Add negative-regression test**: `90M5D5M` clip 5 from right → `90M5D` (NOT `85M`). Locks in the Perl-faithful "strip happens only when the popped op IS D/N, not after" semantic.
+3. **Pin test #19's 4 boundary assertions explicitly** in plan §3.2 (un-clipped DROP/KEEP × clipped DROP/KEEP).
+
+### Optional
+4. Consider `_after_3p_clip` over `_after_3p_trim` to avoid Trim Galore terminology overlap.
+5. Document the 2 helpers as "thin wrappers, callers may inline if preferred" to signal they're not load-bearing.
+6. After implementation, run `cargo bench` (or hand-time) `drop_overlap` on a 100k-pair sample to confirm the `ignore_3p_r1=0` no-op fast-path actually short-circuits (the plan says it does; verify).
+
+---
+
+File written: `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/PLAN_REVIEW_879_REV1_A.md`.

--- a/plans/05262026_bismark-extractor/PLAN_REVIEW_879_REV1_B.md
+++ b/plans/05262026_bismark-extractor/PLAN_REVIEW_879_REV1_B.md
@@ -1,0 +1,134 @@
+# Plan Review — `BUG_879_FIXES_PLAN.md` rev 1 (Round 2, Reviewer B)
+
+**Reviewer**: B round 2 (independent, fresh context — NOT same agent as PLAN_REVIEW_879_B.md round 1)
+**Target**: `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/BUG_879_FIXES_PLAN.md` rev 1
+**Verdict**: **APPROVED for implementation.** All three round-1 Criticals (C1/C2/C3) are correctly absorbed and verifiable by hand against the Perl reference. Important items I1/I2/I3 and Reviewer A's §2.4 citation are absorbed. V1 can be marked resolved now (verified below). One minor naming clarification noted as Optional.
+
+---
+
+## Logic review — verifying each round-1 finding is genuinely fixed
+
+### C1 (trailing D/N strip) — ABSORBED
+
+§2.1 explicitly describes the post-pop trailing D/N loop and cites Perl `bismark_methylation_extractor:1760-1764`. I verified the Perl source at L1760-1769: after `pop @comp_cigar` consumes a non-D/N op, two `while ($op eq 'D')` / `while ($op eq 'N')` loops keep popping without decrementing the for-loop counter `(1..$ignore_3prime)`. Rev 1's primitive description ("continue with a trailing-D/N strip loop that drops adjacent D/N ops at the trimmed boundary without decrementing the read-position counter") is the correct mirror.
+
+Hand-trace test #5 (`90M5D`, n=5 from right):
+- Read-position loop pops 5M-positions off the 90M → leaves `85M5D`.
+- The strip loop sees trailing 5D → strips it → `85M`. ✓
+- `reference_end(85M, start=100)` via existing impl = 100 + 85 − 1 = **184**. ✓
+- Pre-fix bug would have computed 100 + 95 − 1 = 194 (because the un-clipped `90M5D` has ref_span 95). Fix shifts the boundary by 10 ref positions, matching Perl's `M_count + D_count`.
+
+Test #6 (`90M5N`) is symmetric. Test #7 (`5D90M` from left) is the OB-direction analog — also correct.
+
+### C2 (full-clip return value) — ABSORBED
+
+§A3 commits to `start` (matching `cigar.rs:185-187` and the existing test at L276-278). The helper impl `self.trim_3p_read_positions(n, false).reference_end(start)` naturally yields `start` when the trimmed CIGAR is empty, because `reference_end` returns `start` when `span == 0`. Test #15 asserts this directly. No new convention is being introduced. ✓
+
+### C3 (OB composite shift) — ABSORBED, with one note
+
+§2.1's `reference_start_after_3p_trim` formula is `start + (original_ref_span − trimmed_ref_span)`. I verified the algebra against Perl L1803:
+
+- Perl: `$start += $ignore_3prime + $D_count + $N_count − $I_count`.
+- Perl `$ignore_3prime` counts read positions consumed = M + I in the dropped prefix.
+- So Perl shift = `(M + I) + D + N − I = M + D + N` (ref-consuming ops in the dropped prefix).
+- Rev 1's `original_ref_span − trimmed_ref_span` = sum of ref-consuming ops dropped = `M + D + N` (since `reference_span` already excludes I).
+- **Identical.** ✓
+
+Test #14 (`5D90M` start=100, n=5) hand-trace: from-left trim of 5 read-positions consumes 5M, then strip loop swallows the leading 5D (but wait — the trim is from the LEFT, so D comes BEFORE the M in CIGAR order; the strip after pop would target the new leftmost element). Reading the plan again: in the from-left case, Perl L1782-1790 `shift @comp_cigar` then `while ($op eq 'D') { $D_count++; $op = shift @comp_cigar }` — so D-strip happens BEFORE the M-consume? No: the `while` is entered when the shifted op IS D. The order is: shift one op; if it's D, keep shifting D's; if it's N, keep shifting N's; if it's I, count I and continue. So for `5D90M` n=5: shift 5D (D-loop swallows it, doesn't decrement); now shift 5 of the 90M one at a time → end with `85M`. Shift count = D-loop iterations + 5 for-loop iterations.
+
+Hand-trace: trimmed CIGAR = `85M`, ref_span trimmed = 85, original ref_span (5D+90M) = 95, shift = 10, start = 110. ✓ Matches plan's expected test #14 outcome.
+
+**Note**: the plan's primitive description says "after the read-position trim loop completes, also strips any now-exposed trailing D/N ops" — this phrasing is right for from-right but slightly misleading for from-left, where Perl actually strips D/N BEFORE consuming the next read-position op on each iteration. The end-state CIGAR is the same (D/N ops between/around the trimmed read-positions are stripped), but an implementer reading only §2.1's English description might code it wrong. **Optional**: clarify in §2.1 that the strip-D/N behavior applies symmetrically on both ends and is interleaved with read-position consumption per iteration (per Perl L1760-1769 for from-right and L1783-1793 for from-left).
+
+### I1 (CIGAR-trim primitive) — ABSORBED, well-shaped
+
+The primitive `trim_3p_read_positions(n, from_left) -> Cigar` plus two thin helpers is the right shape. The helpers are not strictly redundant — they hide the `from_left` boolean and the `reference_span` subtraction from call sites, giving `drop_overlap` clean semantics. Keeping them is worth the ~10 lines.
+
+### I2 (semantic naming) — ABSORBED
+
+`_after_3p_trim` is clearer than `_clipping_right/_left`. Slight risk of confusion with Trim Galore's read-trimming, but the `3p` qualifier and trait location (`CigarExt`) make the scope unambiguous. ✓
+
+### I3 (boundary tests) — ABSORBED
+
+Test #19 covers both `ref_pos == r1_ref_end + 1` (kept) and `ref_pos == r1_ref_end` (dropped) under both clipped and un-clipped boundaries — sufficient to guard against off-by-one in the predicate. ✓
+
+### Reviewer A §2.4 citation — ABSORBED
+
+`call.rs:179-182` cited and accurate. I verified the lines: the filter is `if aligned.read_pos_5p < lo || aligned.read_pos_5p >= hi { continue; }`, which is read-position-based and never touches `ref_pos`. ✓
+
+### V1 (bismark-io version) — RESOLVED NOW
+
+`git show 45b4c61:rust/bismark-io/Cargo.toml` shows `version = "1.0.0-beta.7"`. Plan §4 step 2's `-beta.7 → -beta.8` premise is correct. **Recommend striking V1 from "commit-time tasks" and marking it resolved in the table — one fewer thing for the implementer to forget.**
+
+---
+
+## New issues introduced by rev 1
+
+### Question 9 (soft-clip prefix on OB) — verified safe
+
+Test #8 (`95M5I` from right): trim 5 read positions of trailing I → returns `95M`; reference_end unchanged. ✓ But the question asked about `5S95M` from the LEFT (OB R1 BAM-stored 5' = read's sequenced 3'). The plan doesn't include this test. Tracing: from-left trim of 5 read-positions on `5S95M` consumes the 5S (S consumes read positions), then the strip-D/N loop is a no-op (next op is M, not D/N), leaving `95M`. Ref-span original = 95 (S doesn't consume ref), trimmed = 95, shift = 0, start unchanged. **This is correct biologically**: a soft-clip at the BAM-storage 5' (= read 3' under OB) means those bases were already unaligned, so clipping them shouldn't shift the alignment start. Adding a test for `5S95M` from-left would be a low-cost belt-and-braces. **Important**.
+
+### Combined-op CIGAR test (Reviewer A round-1 Optional #6) — still missing
+
+`5S90M3I2D` (or similar combined) is not in the test list. Each rev 1 test is one-op-class. **Optional** — but cheap to add and would catch state-machine interaction bugs the unit tests don't.
+
+### V2 not actioned
+
+The plan flags V2 ("grep for other `drop_overlap` callers") as a commit-time task. This is fine, but a 5-second grep before implementation start would be cheaper than discovering a third caller mid-implement. **Optional**.
+
+---
+
+## Round-1 items still unaddressed
+
+Cross-checking §7 self-review against both round-1 reports:
+
+- Round-1 Reviewer A Optional #6 (combined-op CIGAR test) — not addressed. **Optional**.
+- Round-1 Reviewer A Optional #7 (overlap.rs module doc update) — not addressed. **Optional**, low value.
+- Round-1 Reviewer B I4 ("integration assertion that #872's matrix passes") — covered implicitly by §3.3 tests 20-21 (post-merge Phase H matrix). ✓
+
+No Critical/Important from round 1 leaked through. The round-1 → rev 1 absorption is thorough.
+
+---
+
+## Efficiency
+
+`drop_overlap` is hot-path (once per pair). The CIGAR-trim primitive allocates a new `Cigar` (Vec<Op>, typically <10 ops) when `ignore_3p_r1 > 0`. With the no-op fast-path on `n == 0`, the default-cell allocation is zero. ✓ No regression risk.
+
+---
+
+## Validation sufficiency
+
+15 unit tests + 4 integration tests is generous coverage. Gaps:
+1. `5S95M` from-left soft-clip-at-BAM-5p test (Important above).
+2. Combined-op CIGAR test (Optional).
+
+Otherwise, every Critical and Important from round 1 has at least one regression test.
+
+---
+
+## Alternatives
+
+The CIGAR-trim primitive + 2 helpers shape is the right call. Alternative shapes considered (and correctly rejected):
+- Inline in `drop_overlap` — worse testability.
+- Free fns instead of trait methods — inconsistent with existing `CigarExt`.
+- Single helper that takes a from_left bool at the boundary level — loses Perl-faithfulness; current primitive+helpers is cleaner.
+
+---
+
+## Action items
+
+### Critical
+*(none — all round-1 Criticals are absorbed)*
+
+### Important
+1. Add test: `5S95M` trim 5 from left → trimmed `95M`, start unchanged. Validates soft-clip-at-BAM-5p doesn't shift the OB start.
+2. Mark V1 resolved in §6 (verified `1.0.0-beta.7` at HEAD `45b4c61`). One fewer commit-time gotcha.
+
+### Optional
+3. Clarify §2.1's English: trailing-D/N strip is interleaved per iteration in Perl (not a separate post-pass), symmetric on both ends. Algebra is the same; just clearer for the implementer.
+4. Add a combined-op CIGAR unit test (`5S90M3I2D` trim 5 from right) for state-machine interaction coverage.
+5. Run `rg 'drop_overlap\\(' rust/` before starting to confirm only 2 callers (V2).
+
+---
+
+Report written to `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/PLAN_REVIEW_879_REV1_B.md`.

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -19,7 +19,7 @@ name = "deduplicate_bismark_rs"
 path = "src/main.rs"
 
 [dependencies]
-bismark-io = { version = "=1.0.0-beta.7", path = "../bismark-io" }
+bismark-io = { version = "=1.0.0-beta.8", path = "../bismark-io" }
 # noodles-sam pinned to match bismark-io =1.0.0's transitive choice.
 # Needed directly for `Header` (returned by `bismark_io::open_reader`
 # via `AnyReader::header`) and for test-helper types.

--- a/rust/bismark-extractor/Cargo.toml
+++ b/rust/bismark-extractor/Cargo.toml
@@ -19,7 +19,7 @@ name = "bismark-methylation-extractor-rs"
 path = "src/main.rs"
 
 [dependencies]
-bismark-io = { version = "=1.0.0-beta.7", path = "../bismark-io" }
+bismark-io = { version = "=1.0.0-beta.8", path = "../bismark-io" }
 clap = { version = "=4.5.30", features = ["derive"] }
 thiserror = "=2.0.0"
 # noodles-sam pinned to match bismark-io's transitive choice (matches dedup precedent).

--- a/rust/bismark-extractor/src/overlap.rs
+++ b/rust/bismark-extractor/src/overlap.rs
@@ -83,6 +83,7 @@ use crate::error::BismarkExtractorError;
 pub fn drop_overlap(
     mut r2_calls: Vec<MethCall>,
     pair: &BismarkPair,
+    ignore_3p_r1: u32,
 ) -> Result<Vec<MethCall>, BismarkExtractorError> {
     let r1_start =
         pair.r1()
@@ -98,14 +99,35 @@ pub fn drop_overlap(
         // Perl 3826 drop predicate (post-transformation): `if r2_pos <= r1_ref_end { return; }`.
         // Keep predicate (strict inverse): `r2_pos > r1_ref_end`.
         // (Pre-C.1 had the polarity reversed — see SPEC §7.4 rev 3.)
-        let r1_ref_end = pair.r1().cigar().reference_end(r1_start) as u32;
+        //
+        // #879 fix: when `--ignore_3prime N` is set, Perl L1726-1782 adjusts
+        // R1's CIGAR by popping the last N read-positions (plus any adjacent
+        // D/N) BEFORE computing `$end_read_1`. Use `reference_end_after_3p_trim`
+        // which encapsulates that adjustment via the bismark-io CIGAR-trim
+        // primitive. With `ignore_3p_r1 == 0` the helper is a no-op fast-path
+        // — no perf regression on the default cell.
+        let r1_ref_end = pair
+            .r1()
+            .cigar()
+            .reference_end_after_3p_trim(r1_start, ignore_3p_r1) as u32;
         r2_calls.retain(|c| c.ref_pos > r1_ref_end);
     } else {
         // OB/CTOT pair: R2 is upstream, R1 is downstream.
         // Perl 3745 drop predicate (post-transformation): `if r2_pos >= r1_ref_start { return; }`.
         // Keep predicate (strict inverse): `r2_pos < r1_ref_start`.
         // (Pre-C.1 had the polarity reversed — see SPEC §7.4 rev 3.)
-        let r1_ref_start = r1_start as u32;
+        //
+        // #879 fix: when `--ignore_3prime N` is set on OB R1, Perl L1781-1789
+        // adjusts R1's CIGAR by shifting the first N read-positions from the
+        // LEFT (with adjacent-D/N absorption) and then `$start_read_1`
+        // advances by the ref-positions consumed in the trimmed prefix
+        // (Perl L1803's composite shift formula). Use
+        // `reference_start_after_3p_trim` which computes the same shift via
+        // `original_ref_span - trimmed_ref_span`.
+        let r1_ref_start =
+            pair.r1()
+                .cigar()
+                .reference_start_after_3p_trim(r1_start, ignore_3p_r1) as u32;
         r2_calls.retain(|c| c.ref_pos < r1_ref_start);
     }
     Ok(r2_calls)

--- a/rust/bismark-extractor/src/parallel.rs
+++ b/rust/bismark-extractor/src/parallel.rs
@@ -708,7 +708,7 @@ fn process_pe(
         mbias_only_silence,
     )?;
     let r2_calls = if config.no_overlap {
-        drop_overlap(r2_calls_raw, pair)?
+        drop_overlap(r2_calls_raw, pair, config.ignore_3p_r1)?
     } else {
         r2_calls_raw
     };

--- a/rust/bismark-extractor/src/pipeline.rs
+++ b/rust/bismark-extractor/src/pipeline.rs
@@ -351,7 +351,7 @@ fn handle_one_pair(
     )?;
 
     let r2_calls = if config.no_overlap {
-        drop_overlap(r2_calls_raw, pair)?
+        drop_overlap(r2_calls_raw, pair, config.ignore_3p_r1)?
     } else {
         r2_calls_raw
     };

--- a/rust/bismark-extractor/tests/pe_phase_c.rs
+++ b/rust/bismark-extractor/tests/pe_phase_c.rs
@@ -302,7 +302,7 @@ fn drop_overlap_forward_pair_drops_r2_at_or_before_r1_end() {
         (149, CytosineContext::CpG, true),
         (150, CytosineContext::CpG, true),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(kept.len(), 1);
     assert_eq!(kept[0].ref_pos, 150);
 }
@@ -325,7 +325,7 @@ fn drop_overlap_reverse_pair_drops_r2_at_or_after_r1_start() {
         (200, CytosineContext::CpG, true),
         (201, CytosineContext::CpG, true),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(kept.len(), 1);
     assert_eq!(kept[0].ref_pos, 199);
 }
@@ -355,7 +355,7 @@ fn drop_overlap_disjoint_forward_pair_keeps_all_r2_calls() {
         (310, CytosineContext::CpG, true),
         (340, CytosineContext::CpG, true),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(
         kept.len(),
         3,
@@ -388,7 +388,7 @@ fn drop_overlap_fully_overlapping_pair_drops_all_r2_calls() {
         (120, CytosineContext::CHG, true),
         (148, CytosineContext::CHH, true),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(
         kept.len(),
         0,
@@ -415,7 +415,7 @@ fn drop_overlap_with_r1_indel_uses_reference_end() {
         (201, CytosineContext::CpG, true),
         (202, CytosineContext::CpG, true),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(kept.len(), 1);
     assert_eq!(kept[0].ref_pos, 202);
 }
@@ -439,7 +439,7 @@ fn drop_overlap_with_r1_end_deletion() {
         (151, CytosineContext::CpG, true),
         (152, CytosineContext::CpG, true),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(kept.len(), 1);
     assert_eq!(kept[0].ref_pos, 152);
 }
@@ -468,7 +468,7 @@ fn drop_overlap_with_r1_insertion_shifts_read_pos_only() {
     ]);
     // C.1 polarity fix (#862): R1 `50M2I50M` at 100 → reference_end = 199.
     // Strict-`>` keep → drop 198, 199 (≤ 199); keep 200 (R2's unique region).
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(kept.len(), 1);
     assert_eq!(kept[0].ref_pos, 200);
 }
@@ -496,7 +496,7 @@ fn drop_overlap_real_data_fr_pair_with_gap_keeps_all_r2_calls() {
         (220, CytosineContext::CHG, true),
         (235, CytosineContext::CHH, false),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(
         kept.len(),
         4,
@@ -524,7 +524,7 @@ fn drop_overlap_partial_overlap_reverse_pair() {
         (200, CytosineContext::CpG, true),
         (201, CytosineContext::CpG, true),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(kept.len(), 2);
     assert_eq!(kept[0].ref_pos, 195, "R2 unique upstream call kept");
     assert_eq!(
@@ -563,7 +563,7 @@ fn drop_overlap_r1_with_n_skip_op() {
         (1199, CytosineContext::CpG, true),
         (1200, CytosineContext::CpG, true),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(kept.len(), 1);
     assert_eq!(
         kept[0].ref_pos, 1200,
@@ -593,7 +593,7 @@ fn drop_overlap_r1_with_5prime_soft_clip() {
         (199, CytosineContext::CpG, true),
         (200, CytosineContext::CpG, true),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(kept.len(), 1);
     assert_eq!(
         kept[0].ref_pos, 200,
@@ -622,7 +622,7 @@ fn drop_overlap_r1_with_3prime_soft_clip() {
         (199, CytosineContext::CpG, true),
         (200, CytosineContext::CpG, true),
     ]);
-    let kept = drop_overlap(r2_calls, &pair).unwrap();
+    let kept = drop_overlap(r2_calls, &pair, 0).unwrap();
     assert_eq!(kept.len(), 1);
     assert_eq!(
         kept[0].ref_pos, 200,
@@ -1510,7 +1510,12 @@ mod ignore_3prime_879 {
     /// - With fix (ignore_3p_r1=5, boundary 194): keep 195, 197, 200.
     #[test]
     fn drop_overlap_with_ignore_3p_r1_forward_pair() {
-        let pair = helpers::ot_pair(b"ZZZ", 100, b"ZZZ", 195, b"pair1");
+        // 100-char XM → R1 CIGAR = 100M; ot_pair's synth builds the CIGAR
+        // from XM length so we need the full ~100bp R1 to assert against
+        // r1_ref_end = 199 (un-clipped) / 194 (clipped n=5).
+        let xm100 = vec![b'Z'; 100];
+        let r2xm = vec![b'Z'; 100];
+        let pair = helpers::ot_pair(&xm100, 100, &r2xm, 195, b"pair1");
         let r2_calls = vec![
             MethCall {
                 ref_pos: 195,
@@ -1549,7 +1554,9 @@ mod ignore_3prime_879 {
     /// - With fix (ignore_3p_r1=5, boundary 105): keep 99, 103.
     #[test]
     fn drop_overlap_with_ignore_3p_r1_reverse_pair() {
-        let pair = helpers::ob_pair(b"ZZZ", 100, b"ZZZ", 95, b"pair2");
+        let xm100 = vec![b'Z'; 100];
+        let r2xm = vec![b'Z'; 100];
+        let pair = helpers::ob_pair(&xm100, 100, &r2xm, 95, b"pair2");
         let r2_calls = vec![
             MethCall {
                 ref_pos: 99,
@@ -1585,7 +1592,9 @@ mod ignore_3prime_879 {
     /// 200.
     #[test]
     fn drop_overlap_ignore_3p_r1_zero_is_no_op() {
-        let pair = helpers::ot_pair(b"ZZZ", 100, b"ZZZ", 195, b"pair3");
+        let xm100 = vec![b'Z'; 100];
+        let r2xm = vec![b'Z'; 100];
+        let pair = helpers::ot_pair(&xm100, 100, &r2xm, 195, b"pair3");
         let r2_calls = vec![
             MethCall {
                 ref_pos: 195,
@@ -1621,7 +1630,9 @@ mod ignore_3prime_879 {
     /// the clipped boundary.
     #[test]
     fn drop_overlap_with_ignore_3p_r1_at_boundary() {
-        let pair = helpers::ot_pair(b"ZZ", 100, b"ZZ", 194, b"pair4");
+        let xm100 = vec![b'Z'; 100];
+        let r2xm = vec![b'Z'; 100];
+        let pair = helpers::ot_pair(&xm100, 100, &r2xm, 194, b"pair4");
         let r2_calls = vec![
             MethCall {
                 ref_pos: 194, // == boundary → drop (predicate is strict `>`)

--- a/rust/bismark-extractor/tests/pe_phase_c.rs
+++ b/rust/bismark-extractor/tests/pe_phase_c.rs
@@ -1485,3 +1485,161 @@ mod auto_detect {
             ));
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// 7. #879 — drop_overlap respects --ignore_3prime on R1
+// ─────────────────────────────────────────────────────────────────────────
+mod ignore_3prime_879 {
+    use super::helpers;
+    use bismark_extractor::call::{CytosineContext, MethCall};
+    use bismark_extractor::overlap::drop_overlap;
+
+    // ─── #879 — drop_overlap respects --ignore_3prime on R1 ────────────
+    //
+    // These tests guard the new `ignore_3p_r1` argument to `drop_overlap`.
+    // The bug: pre-#879, drop_overlap used R1's un-clipped CIGAR end as
+    // the boundary, so R2 calls that should be kept (because R1's
+    // effective end shifted INWARD by `--ignore_3prime N`) were dropped
+    // instead. Fix: use the CIGAR-trim primitive (added in bismark-io)
+    // to compute the trimmed R1 boundary.
+
+    /// Forward pair (OT/CTOB): R1 upstream, R2 downstream. R1 CIGAR=100M
+    /// at start=100 → un-clipped r1_ref_end=199, trimmed r1_ref_end=194
+    /// with ignore_3p_r1=5. R2 calls at ref_pos 195, 197, 200:
+    /// - Without fix (ignore_3p_r1=0, boundary 199): keep only 200.
+    /// - With fix (ignore_3p_r1=5, boundary 194): keep 195, 197, 200.
+    #[test]
+    fn drop_overlap_with_ignore_3p_r1_forward_pair() {
+        let pair = helpers::ot_pair(b"ZZZ", 100, b"ZZZ", 195, b"pair1");
+        let r2_calls = vec![
+            MethCall {
+                ref_pos: 195,
+                read_pos: 0,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+            MethCall {
+                ref_pos: 197,
+                read_pos: 2,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+            MethCall {
+                ref_pos: 200,
+                read_pos: 5,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+        ];
+        let kept = drop_overlap(r2_calls, &pair, /*ignore_3p_r1=*/ 5).unwrap();
+        let positions: Vec<u32> = kept.iter().map(|c| c.ref_pos).collect();
+        assert_eq!(positions, vec![195, 197, 200]);
+    }
+
+    /// Reverse pair (OB/CTOT): R2 upstream, R1 downstream. R1 CIGAR=100M
+    /// at start=100 → un-clipped r1_ref_start=100, trimmed
+    /// r1_ref_start=105 with ignore_3p_r1=5 (R1's 3'-end on OB = CIGAR
+    /// left side; the 5-base clip removes 5M from prefix, ref_start
+    /// shifts to 105).
+    /// R2 calls at ref_pos 99, 103, 107:
+    /// - Without fix (ignore_3p_r1=0, boundary 100): keep only 99.
+    /// - With fix (ignore_3p_r1=5, boundary 105): keep 99, 103.
+    #[test]
+    fn drop_overlap_with_ignore_3p_r1_reverse_pair() {
+        let pair = helpers::ob_pair(b"ZZZ", 100, b"ZZZ", 95, b"pair2");
+        let r2_calls = vec![
+            MethCall {
+                ref_pos: 99,
+                read_pos: 0,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+            MethCall {
+                ref_pos: 103,
+                read_pos: 4,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+            MethCall {
+                ref_pos: 107,
+                read_pos: 8,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+        ];
+        let kept = drop_overlap(r2_calls, &pair, /*ignore_3p_r1=*/ 5).unwrap();
+        let positions: Vec<u32> = kept.iter().map(|c| c.ref_pos).collect();
+        assert_eq!(positions, vec![99, 103]);
+    }
+
+    /// Regression guard for default-cell behavior: with `ignore_3p_r1=0`,
+    /// `drop_overlap` must behave byte-identically to the pre-#879
+    /// signature. Same fixture as `drop_overlap_with_ignore_3p_r1_forward_pair`
+    /// but ignore_3p_r1=0 → un-clipped boundary 199 → keep only ref_pos
+    /// 200.
+    #[test]
+    fn drop_overlap_ignore_3p_r1_zero_is_no_op() {
+        let pair = helpers::ot_pair(b"ZZZ", 100, b"ZZZ", 195, b"pair3");
+        let r2_calls = vec![
+            MethCall {
+                ref_pos: 195,
+                read_pos: 0,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+            MethCall {
+                ref_pos: 197,
+                read_pos: 2,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+            MethCall {
+                ref_pos: 200,
+                read_pos: 5,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+        ];
+        let kept = drop_overlap(r2_calls, &pair, /*ignore_3p_r1=*/ 0).unwrap();
+        let positions: Vec<u32> = kept.iter().map(|c| c.ref_pos).collect();
+        assert_eq!(positions, vec![200]);
+    }
+
+    /// Boundary regression guard (Reviewer B R2 I3): assert strict-`>`
+    /// semantics of the OT predicate are preserved through the fix.
+    /// R1 CIGAR=100M at start=100 → with ignore_3p_r1=5, boundary=194.
+    /// R2 calls at ref_pos 194 (drop) and 195 (keep) — exactly bracketing
+    /// the clipped boundary.
+    #[test]
+    fn drop_overlap_with_ignore_3p_r1_at_boundary() {
+        let pair = helpers::ot_pair(b"ZZ", 100, b"ZZ", 194, b"pair4");
+        let r2_calls = vec![
+            MethCall {
+                ref_pos: 194, // == boundary → drop (predicate is strict `>`)
+                read_pos: 0,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+            MethCall {
+                ref_pos: 195, // > boundary → keep
+                read_pos: 1,
+                context: CytosineContext::CpG,
+                methylated: true,
+                xm_byte: b'Z',
+            },
+        ];
+        let kept = drop_overlap(r2_calls, &pair, /*ignore_3p_r1=*/ 5).unwrap();
+        let positions: Vec<u32> = kept.iter().map(|c| c.ref_pos).collect();
+        assert_eq!(positions, vec![195]);
+    }
+}

--- a/rust/bismark-io/Cargo.toml
+++ b/rust/bismark-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-io"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 description = "Bismark-aware BAM/SAM/CRAM I/O on top of noodles"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-io/src/cigar.rs
+++ b/rust/bismark-io/src/cigar.rs
@@ -370,4 +370,180 @@ mod tests {
         let c = cigar_from_ops(&[]);
         assert_eq!(c.aligned_positions().count(), 0);
     }
+
+    // ─── #879 — CIGAR-trim primitive + ref-boundary helpers ──────────────
+    //
+    // These tests guard `trim_3p_read_positions` and the two thin caller
+    // helpers (`reference_end_after_3p_trim`, `reference_start_after_3p_trim`)
+    // that drop_overlap uses to mirror Perl's `--ignore_3prime` CIGAR
+    // adjustment at bismark_methylation_extractor:1726-1782. See plan
+    // file plans/05262026_bismark-extractor/BUG_879_FIXES_PLAN.md for
+    // context + the two rounds of dual plan-review.
+
+    // Helper: round-trip a Cigar through a Vec<(Kind, usize)> shape so test
+    // assertions stay readable.
+    fn ops_of(cigar: &Cigar) -> Vec<(Kind, usize)> {
+        cigar.as_ref().iter().map(|op| (op.kind(), op.len())).collect()
+    }
+
+    #[test]
+    fn trim_3p_zero_is_identity_right() {
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        let trimmed = c.trim_3p_read_positions(0, false);
+        assert_eq!(ops_of(&trimmed), ops_of(&c));
+    }
+
+    #[test]
+    fn trim_3p_zero_is_identity_left() {
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        let trimmed = c.trim_3p_read_positions(0, true);
+        assert_eq!(ops_of(&trimmed), ops_of(&c));
+    }
+
+    #[test]
+    fn trim_3p_simple_match_right() {
+        // 100M trim 5 from right → 95M
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        let trimmed = c.trim_3p_read_positions(5, false);
+        assert_eq!(ops_of(&trimmed), vec![(Kind::Match, 95)]);
+    }
+
+    #[test]
+    fn trim_3p_simple_match_left() {
+        // 100M trim 5 from left → 95M
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        let trimmed = c.trim_3p_read_positions(5, true);
+        assert_eq!(ops_of(&trimmed), vec![(Kind::Match, 95)]);
+    }
+
+    #[test]
+    fn trim_3p_with_trailing_deletion_strips_D() {
+        // C1 regression guard: 90M5D, trim 5 from right.
+        // The 5 read-positions of M are removed PLUS the now-trailing 5D is
+        // stripped per Perl L1760-1764 `while ($op eq 'D')` loop.
+        // Result: 85M.
+        let c = cigar_from_ops(&[(Kind::Match, 90), (Kind::Deletion, 5)]);
+        let trimmed = c.trim_3p_read_positions(5, false);
+        assert_eq!(ops_of(&trimmed), vec![(Kind::Match, 85)]);
+    }
+
+    #[test]
+    fn trim_3p_with_trailing_skip_strips_N() {
+        // C1 regression guard: 90M5N, trim 5 from right.
+        // Same as the trailing-D case but with Skip (N) ops.
+        let c = cigar_from_ops(&[(Kind::Match, 90), (Kind::Skip, 5)]);
+        let trimmed = c.trim_3p_read_positions(5, false);
+        assert_eq!(ops_of(&trimmed), vec![(Kind::Match, 85)]);
+    }
+
+    #[test]
+    fn trim_3p_with_leading_deletion_strips_D_when_from_left() {
+        // C3 regression guard: 5D90M, trim 5 from left.
+        // The 5 read-positions of M (from the front of the M block) are
+        // removed PLUS the now-leading 5D is stripped (Perl reverse-strand
+        // `shift @comp_cigar` + adjacent-D strip).
+        // Result: 85M.
+        let c = cigar_from_ops(&[(Kind::Deletion, 5), (Kind::Match, 90)]);
+        let trimmed = c.trim_3p_read_positions(5, true);
+        assert_eq!(ops_of(&trimmed), vec![(Kind::Match, 85)]);
+    }
+
+    #[test]
+    fn trim_3p_clipping_into_insertion_no_ref_impact() {
+        // 95M5I trim 5 from right → 95M (the 5 read positions of I are
+        // removed; I doesn't consume ref so reference_end is unchanged).
+        let c = cigar_from_ops(&[(Kind::Match, 95), (Kind::Insertion, 5)]);
+        let trimmed = c.trim_3p_read_positions(5, false);
+        assert_eq!(ops_of(&trimmed), vec![(Kind::Match, 95)]);
+    }
+
+    #[test]
+    fn trim_3p_full_clip_returns_empty_cigar() {
+        // 100M trim 100 from right → empty Cigar.
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        let trimmed = c.trim_3p_read_positions(100, false);
+        assert_eq!(ops_of(&trimmed), vec![]);
+    }
+
+    #[test]
+    fn trim_3p_middle_D_is_NOT_stripped() {
+        // Reviewer A R2 negative-regression guard: 90M5D5M, trim 5 from right.
+        // The 5M at the trailing end clips. The 5D in the MIDDLE must NOT be
+        // stripped — only adjacent-to-trimmed-boundary D/N ops are stripped
+        // per Perl L1760-1764. Result: 90M5D.
+        let c = cigar_from_ops(&[(Kind::Match, 90), (Kind::Deletion, 5), (Kind::Match, 5)]);
+        let trimmed = c.trim_3p_read_positions(5, false);
+        assert_eq!(ops_of(&trimmed), vec![(Kind::Match, 90), (Kind::Deletion, 5)]);
+    }
+
+    #[test]
+    fn trim_3p_left_with_soft_clip_prefix() {
+        // Reviewer B R2 OB-soft-clip guard: 5S95M, trim 5 from left.
+        // The 5 read-positions of S are removed. S doesn't consume ref so
+        // the trimmed CIGAR's ref_span (95) == original ref_span (95);
+        // reference_start_after_3p_trim(start, 5) therefore returns start
+        // unchanged. This is the OB R1 BAM-5'-with-soft-clip edge case.
+        let c = cigar_from_ops(&[(Kind::SoftClip, 5), (Kind::Match, 95)]);
+        let trimmed = c.trim_3p_read_positions(5, true);
+        assert_eq!(ops_of(&trimmed), vec![(Kind::Match, 95)]);
+    }
+
+    #[test]
+    fn reference_end_after_3p_trim_zero_is_existing_reference_end() {
+        // With n=0, the helper returns the same value as the existing
+        // reference_end. Regression guard for default-cell behavior.
+        let c = cigar_from_ops(&[
+            (Kind::Match, 50),
+            (Kind::Deletion, 5),
+            (Kind::Match, 50),
+        ]);
+        assert_eq!(c.reference_end_after_3p_trim(100, 0), c.reference_end(100));
+    }
+
+    #[test]
+    fn reference_end_after_3p_trim_simple() {
+        // 100M from start=100, n=5: trimmed to 95M, reference_end = 194
+        // (vs un-clipped 199).
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        assert_eq!(c.reference_end_after_3p_trim(100, 5), 194);
+    }
+
+    #[test]
+    fn reference_start_after_3p_trim_zero_is_start() {
+        // With n=0, no shift applied; helper returns start unchanged.
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        assert_eq!(c.reference_start_after_3p_trim(100, 0), 100);
+    }
+
+    #[test]
+    fn reference_start_after_3p_trim_simple() {
+        // 100M, start=100, n=5 from left: 5 ref positions consumed from
+        // prefix → start shifts to 105.
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        assert_eq!(c.reference_start_after_3p_trim(100, 5), 105);
+    }
+
+    #[test]
+    fn reference_start_after_3p_trim_with_leading_D() {
+        // C3 regression guard for OB composite shift.
+        // 5D90M, start=100, n=5 from left:
+        //   - 5 M clipped (read positions)
+        //   - 5 D adjacent stripped (ref-consuming)
+        //   → trimmed CIGAR is 85M with ref_span 85
+        //   → shift = 95 (original) - 85 (trimmed) = 10
+        //   → result = 100 + 10 = 110
+        // Equivalent to Perl L1803 `$start += $ignore_3prime + $D_count
+        // + $N_count - $I_count` = 5 + 5 + 0 - 0 = 10.
+        let c = cigar_from_ops(&[(Kind::Deletion, 5), (Kind::Match, 90)]);
+        assert_eq!(c.reference_start_after_3p_trim(100, 5), 110);
+    }
+
+    #[test]
+    fn reference_end_after_3p_trim_full_clip_returns_start() {
+        // C2 regression guard: full-clip returns `start` (matching the
+        // existing reference_end_with_empty_cigar_returns_start convention
+        // at cigar.rs:276-278). 100M, start=100, n=100 → returns 100.
+        let c = cigar_from_ops(&[(Kind::Match, 100)]);
+        assert_eq!(c.reference_end_after_3p_trim(100, 100), 100);
+    }
 }

--- a/rust/bismark-io/src/cigar.rs
+++ b/rust/bismark-io/src/cigar.rs
@@ -642,7 +642,7 @@ mod tests {
     }
 
     #[test]
-    fn trim_3p_with_trailing_deletion_strips_D() {
+    fn trim_3p_with_trailing_deletion_strips_d() {
         // C1 regression guard: 90M5D, trim 5 from right.
         // The 5 read-positions of M are removed PLUS the now-trailing 5D is
         // stripped per Perl L1760-1764 `while ($op eq 'D')` loop.
@@ -653,7 +653,7 @@ mod tests {
     }
 
     #[test]
-    fn trim_3p_with_trailing_skip_strips_N() {
+    fn trim_3p_with_trailing_skip_strips_n() {
         // C1 regression guard: 90M5N, trim 5 from right.
         // Same as the trailing-D case but with Skip (N) ops.
         let c = cigar_from_ops(&[(Kind::Match, 90), (Kind::Skip, 5)]);
@@ -662,7 +662,7 @@ mod tests {
     }
 
     #[test]
-    fn trim_3p_with_leading_deletion_strips_D_when_from_left() {
+    fn trim_3p_with_leading_deletion_strips_d_when_from_left() {
         // C3 regression guard: 5D90M, trim 5 from left.
         // The 5 read-positions of M (from the front of the M block) are
         // removed PLUS the now-leading 5D is stripped (Perl reverse-strand
@@ -691,8 +691,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(non_snake_case)]
-    fn trim_3p_middle_D_is_NOT_stripped() {
+    fn trim_3p_middle_d_is_not_stripped() {
         // Reviewer A R2 negative-regression guard: 90M5D5M, trim 5 from right.
         // The 5M at the trailing end clips. The 5D in the MIDDLE must NOT be
         // stripped — only adjacent-to-trimmed-boundary D/N ops are stripped
@@ -749,8 +748,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(non_snake_case)]
-    fn reference_start_after_3p_trim_with_leading_D() {
+    fn reference_start_after_3p_trim_with_leading_d() {
         // C3 regression guard for OB composite shift.
         // 5D90M, start=100, n=5 from left:
         //   - 5 M clipped (read positions)

--- a/rust/bismark-io/src/cigar.rs
+++ b/rust/bismark-io/src/cigar.rs
@@ -293,6 +293,13 @@ impl CigarExt for Cigar {
     }
 
     fn reference_end_after_3p_trim(&self, start: usize, n_read_positions: u32) -> usize {
+        // Short-circuit on the default-cell path (n=0) to skip the
+        // primitive's `Cigar::from(ops.to_vec())` allocation. Mirrors
+        // the sibling `reference_start_after_3p_trim`'s n=0 guard.
+        // Convergent code-review finding (#880).
+        if n_read_positions == 0 {
+            return self.reference_end(start);
+        }
         self.trim_3p_read_positions(n_read_positions, false)
             .reference_end(start)
     }

--- a/rust/bismark-io/src/cigar.rs
+++ b/rust/bismark-io/src/cigar.rs
@@ -7,6 +7,7 @@
 //! `pos.saturating_sub(1)` off-by-one that affected the prior-art Rust
 //! port (97-position drift in the 10M PE audit).
 
+use noodles_sam::alignment::record::cigar::Op;
 use noodles_sam::alignment::record::cigar::op::Kind;
 use noodles_sam::alignment::record_buf::Cigar;
 
@@ -49,6 +50,67 @@ pub trait CigarExt {
     /// - `D`, `N`: no item (those ops consume reference only, not read).
     /// - `H`, `P`: skipped (consume neither read nor reference).
     fn aligned_positions(&self) -> AlignedPositions<'_>;
+
+    /// Return a new `Cigar` with `n_read_positions` of read-consuming ops
+    /// trimmed from one end. Reference-only ops (`D`, `N`) and zero-cost
+    /// ops (`H`, `P`) ADJACENT TO THE TRIMMED BOUNDARY are absorbed for
+    /// free during the same sweep — mirrors Perl
+    /// `bismark_methylation_extractor:1760-1764` `while ($op eq 'D' or eq 'N')`
+    /// loops that fire inside each pop/shift iteration. D/N ops that sit
+    /// "between" read-consuming ops in the middle of the CIGAR are
+    /// preserved.
+    ///
+    /// - `from_left == false`: trim from the CIGAR's RIGHT side. Mirrors
+    ///   Perl `pop @comp_cigar` for forward-strand R1 under `--ignore_3prime`.
+    /// - `from_left == true`: trim from the CIGAR's LEFT side. Mirrors Perl
+    ///   `shift @comp_cigar` for reverse-strand R1 under `--ignore_3prime`.
+    ///
+    /// Read-consuming ops: `M`, `I`, `S`, `=`, `X`. Reference-consuming ops:
+    /// `M`, `D`, `N`, `=`, `X`. `H` and `P` consume neither and are ignored.
+    ///
+    /// **D/N ops in the middle of the CIGAR are NEVER stripped** — only ops
+    /// that become adjacent to the trimmed boundary after the read-consuming
+    /// trim completes. See test `trim_3p_middle_D_is_NOT_stripped`.
+    ///
+    /// Edge cases:
+    /// - `n_read_positions == 0` returns the CIGAR unchanged (no-op fast-path).
+    /// - `n_read_positions >= read_span()` returns an empty `Cigar`.
+    ///
+    /// Added for #879 (Phase H sub-gate 1 PE: `drop_overlap` must mirror
+    /// Perl's `$end_read_1` recompute after `--ignore_3prime` CIGAR
+    /// adjustment at Perl L1726-1782 + L2400-2425).
+    fn trim_3p_read_positions(
+        &self,
+        n_read_positions: u32,
+        from_left: bool,
+    ) -> noodles_sam::alignment::record_buf::Cigar;
+
+    /// 1-based inclusive last reference position covered by the alignment
+    /// AFTER trimming `n_read_positions` from the read's 3' end via the
+    /// CIGAR's RIGHT side. Use for forward-strand R1 under `--ignore_3prime`.
+    ///
+    /// Equivalent to `self.trim_3p_read_positions(n, false).reference_end(start)`.
+    /// Returns `start` when the trimmed CIGAR has zero reference span
+    /// (matching the existing `reference_end` empty-CIGAR convention).
+    ///
+    /// Added for #879.
+    fn reference_end_after_3p_trim(&self, start: usize, n_read_positions: u32) -> usize;
+
+    /// 1-based reference position where the alignment begins AFTER trimming
+    /// `n_read_positions` from the read's 3' end via the CIGAR's LEFT side.
+    /// Use for reverse-strand R1 under `--ignore_3prime`.
+    ///
+    /// Computed as `start + (original_ref_span - trimmed_ref_span)`. This is
+    /// algebraically equivalent to Perl `bismark_methylation_extractor:1803`'s
+    /// composite shift `$start += $ignore_3prime + $D_count + $N_count - $I_count`
+    /// (both reduce to "ref positions in the trimmed-off prefix").
+    ///
+    /// Returns `start` unchanged when `n_read_positions == 0` OR when the
+    /// trimmed prefix consumes no reference (e.g., trim into a soft-clip
+    /// prefix).
+    ///
+    /// Added for #879.
+    fn reference_start_after_3p_trim(&self, start: usize, n_read_positions: u32) -> usize;
 }
 
 /// One aligned position from [`CigarExt::aligned_positions`].
@@ -188,6 +250,158 @@ impl CigarExt for Cigar {
 
     fn aligned_positions(&self) -> AlignedPositions<'_> {
         AlignedPositions::new(self)
+    }
+
+    fn trim_3p_read_positions(&self, n_read_positions: u32, from_left: bool) -> Cigar {
+        // No-op fast-path. Returning a clone keeps callers from depending
+        // on identity semantics; the allocation cost is irrelevant since
+        // this branch is hit on every default-cell record.
+        if n_read_positions == 0 {
+            return Cigar::from(self.as_ref().to_vec());
+        }
+
+        // Walk ops in trim-direction, accumulating dropped read-positions
+        // until we've consumed `n_read_positions`. Then strip any adjacent
+        // D/N ops at the trimmed boundary (Perl L1760-1764).
+        let ops: Vec<Op> = self.as_ref().to_vec();
+        let n = n_read_positions as usize;
+
+        // `kept_indices_range` is the [start, end) into the original ops
+        // vec that survives the trim. The trimmed boundary is at either
+        // end depending on `from_left`.
+        let (kept_start, kept_end, boundary_remaining) = if from_left {
+            walk_trim_from_left(&ops, n)
+        } else {
+            walk_trim_from_right(&ops, n)
+        };
+
+        // Build the trimmed vec. If the boundary op was partially
+        // consumed, emit it with reduced length.
+        let mut trimmed: Vec<Op> = Vec::with_capacity(kept_end.saturating_sub(kept_start) + 1);
+        if from_left {
+            if let Some((kind, len)) = boundary_remaining {
+                trimmed.push(Op::new(kind, len));
+            }
+            trimmed.extend_from_slice(&ops[kept_start..kept_end]);
+        } else {
+            trimmed.extend_from_slice(&ops[kept_start..kept_end]);
+            if let Some((kind, len)) = boundary_remaining {
+                trimmed.push(Op::new(kind, len));
+            }
+        }
+        Cigar::from(trimmed)
+    }
+
+    fn reference_end_after_3p_trim(&self, start: usize, n_read_positions: u32) -> usize {
+        self.trim_3p_read_positions(n_read_positions, false)
+            .reference_end(start)
+    }
+
+    fn reference_start_after_3p_trim(&self, start: usize, n_read_positions: u32) -> usize {
+        if n_read_positions == 0 {
+            return start;
+        }
+        let original_ref_span = self.reference_span();
+        let trimmed = self.trim_3p_read_positions(n_read_positions, true);
+        let trimmed_ref_span = trimmed.reference_span();
+        start + (original_ref_span - trimmed_ref_span)
+    }
+}
+
+/// Walk the ops vec backward (right-side trim) consuming `n` read
+/// positions. D/N ops adjacent to the trimmed boundary are absorbed for
+/// free during this single sweep — they get walked past without
+/// decrementing the read-position counter, mirroring Perl L1760-1764's
+/// `while ($op eq 'D' or eq 'N')` inner loops INSIDE the same pop
+/// iteration. D/N ops in the middle of the CIGAR (not adjacent to the
+/// trimmed boundary) are NEVER consumed by this loop because Phase 1's
+/// "drop entries past the read-consuming op" stops as soon as it lands
+/// on (and consumes) a read-consuming op.
+///
+/// Returns `(kept_start, kept_end, boundary_remaining)` where
+/// `boundary_remaining = Some((kind, partial_len))` if a single op at
+/// the boundary was partially consumed and needs to be re-emitted with
+/// reduced length.
+fn walk_trim_from_right(ops: &[Op], n: usize) -> (usize, usize, Option<(Kind, usize)>) {
+    let mut remaining = n;
+    let mut kept_end = ops.len();
+    let mut boundary_remaining: Option<(Kind, usize)> = None;
+
+    while remaining > 0 && kept_end > 0 {
+        let op = &ops[kept_end - 1];
+        let op_read_consumes = read_consumes(op.kind());
+        if op_read_consumes == 0 {
+            // D/N/H/P — these don't consume read positions. In Perl's
+            // expanded comp_cigar these would be popped INSIDE the same
+            // iteration's `while ($op eq 'D' or eq 'N')` loop without
+            // decrementing the iteration counter. Equivalent: walk past
+            // them for free here.
+            //
+            // This branch fires ONLY when D/N/H/P sit adjacent to the
+            // trimmed end (we walk past them looking for a read-consuming
+            // op). Once we land on a read-consuming op and finish
+            // consuming `remaining`, the loop exits — D/N ops further
+            // in (the middle of the CIGAR) are NEVER touched.
+            kept_end -= 1;
+            continue;
+        }
+        let op_len = op.len();
+        if op_len <= remaining {
+            // Whole op consumed.
+            remaining -= op_len;
+            kept_end -= 1;
+        } else {
+            // Partial op: emit the surviving prefix.
+            let surviving_len = op_len - remaining;
+            remaining = 0;
+            boundary_remaining = Some((op.kind(), surviving_len));
+            kept_end -= 1;
+        }
+    }
+
+    (0, kept_end, boundary_remaining)
+}
+
+/// Mirror of [`walk_trim_from_right`] for the left-side trim (forward
+/// walk from start). Same D/N-absorption semantics: D/N at the leading
+/// boundary get walked past for free; D/N in the middle are preserved.
+fn walk_trim_from_left(ops: &[Op], n: usize) -> (usize, usize, Option<(Kind, usize)>) {
+    let mut remaining = n;
+    let mut kept_start = 0;
+    let mut boundary_remaining: Option<(Kind, usize)> = None;
+
+    while remaining > 0 && kept_start < ops.len() {
+        let op = &ops[kept_start];
+        let op_read_consumes = read_consumes(op.kind());
+        if op_read_consumes == 0 {
+            kept_start += 1;
+            continue;
+        }
+        let op_len = op.len();
+        if op_len <= remaining {
+            remaining -= op_len;
+            kept_start += 1;
+        } else {
+            let surviving_len = op_len - remaining;
+            remaining = 0;
+            boundary_remaining = Some((op.kind(), surviving_len));
+            kept_start += 1;
+        }
+    }
+
+    (kept_start, ops.len(), boundary_remaining)
+}
+
+/// 1 if the op consumes a read base per call, 0 otherwise. M/I/S/=/X
+/// consume; D/N/H/P don't.
+fn read_consumes(kind: Kind) -> usize {
+    match kind {
+        Kind::Match
+        | Kind::Insertion
+        | Kind::SoftClip
+        | Kind::SequenceMatch
+        | Kind::SequenceMismatch => 1,
+        _ => 0,
     }
 }
 
@@ -383,7 +597,11 @@ mod tests {
     // Helper: round-trip a Cigar through a Vec<(Kind, usize)> shape so test
     // assertions stay readable.
     fn ops_of(cigar: &Cigar) -> Vec<(Kind, usize)> {
-        cigar.as_ref().iter().map(|op| (op.kind(), op.len())).collect()
+        cigar
+            .as_ref()
+            .iter()
+            .map(|op| (op.kind(), op.len()))
+            .collect()
     }
 
     #[test]
@@ -466,6 +684,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(non_snake_case)]
     fn trim_3p_middle_D_is_NOT_stripped() {
         // Reviewer A R2 negative-regression guard: 90M5D5M, trim 5 from right.
         // The 5M at the trailing end clips. The 5D in the MIDDLE must NOT be
@@ -473,7 +692,10 @@ mod tests {
         // per Perl L1760-1764. Result: 90M5D.
         let c = cigar_from_ops(&[(Kind::Match, 90), (Kind::Deletion, 5), (Kind::Match, 5)]);
         let trimmed = c.trim_3p_read_positions(5, false);
-        assert_eq!(ops_of(&trimmed), vec![(Kind::Match, 90), (Kind::Deletion, 5)]);
+        assert_eq!(
+            ops_of(&trimmed),
+            vec![(Kind::Match, 90), (Kind::Deletion, 5)]
+        );
     }
 
     #[test]
@@ -492,11 +714,7 @@ mod tests {
     fn reference_end_after_3p_trim_zero_is_existing_reference_end() {
         // With n=0, the helper returns the same value as the existing
         // reference_end. Regression guard for default-cell behavior.
-        let c = cigar_from_ops(&[
-            (Kind::Match, 50),
-            (Kind::Deletion, 5),
-            (Kind::Match, 50),
-        ]);
+        let c = cigar_from_ops(&[(Kind::Match, 50), (Kind::Deletion, 5), (Kind::Match, 50)]);
         assert_eq!(c.reference_end_after_3p_trim(100, 0), c.reference_end(100));
     }
 
@@ -524,6 +742,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(non_snake_case)]
     fn reference_start_after_3p_trim_with_leading_D() {
         // C3 regression guard for OB composite shift.
         // 5D90M, start=100, n=5 from left:


### PR DESCRIPTION
## Summary

Closes #879. Fixes a data-correctness bug where `drop_overlap` used R1's un-clipped CIGAR end as the overlap boundary, dropping R2 calls that Perl would keep (and vice versa for reverse-strand pairs) when `--ignore_3prime` was set. The bug surfaced in the Phase H PE matrix on the post-#876 merged HEAD `45b4c61` (cell `r1r2_3p`, FAIL 8/8 with ~0.54% methylation-call deficit). Isolation smokes confirmed the bug is specific to R1's 3'-clip (`--ignore_3prime`); R2's 3'-clip (`--ignore_3prime_r2`) was already correct via the `extract_calls` filter.

## What changed

**bismark-io** (`1.0.0-beta.7` → `1.0.0-beta.8`):
- `CigarExt::trim_3p_read_positions(n_read_positions, from_left) -> Cigar` — primitive that returns a new CIGAR with N read-consuming positions trimmed from one end, absorbing adjacent D/N for free (mirrors Perl L1760-1764)
- `CigarExt::reference_end_after_3p_trim(start, n) -> usize` — thin helper for forward-strand R1
- `CigarExt::reference_start_after_3p_trim(start, n) -> usize` — thin helper for reverse-strand R1 (uses `start + (original_ref_span − trimmed_ref_span)`, algebraically equivalent to Perl L1803's `+ ignore_3prime + D + N − I` composite shift)

**bismark-extractor**:
- `drop_overlap` signature: `(r2_calls, pair)` → `(r2_calls, pair, ignore_3p_r1: u32)`
- Implementation switches to the new helpers; un-clipped path preserved via the helpers' fast-path when `ignore_3p_r1 == 0`
- 2 call sites updated: `pipeline.rs:354`, `parallel.rs:711`
- Cargo.toml: bismark-io dep bumped to `=1.0.0-beta.8`

**bismark-dedup**:
- Cargo.toml: bismark-io dep bumped to `=1.0.0-beta.8` (workspace consistency — no functional change)

## Why this design

Both dual plan-reviewer rounds independently recommended the CIGAR-trim primitive approach over two strand-specific helpers, because (a) it mirrors Perl's "rewrite the CIGAR then use existing end-calc" pattern at L1807-1828, (b) encapsulates D/N/I handling in one place, (c) avoids directional/positional naming confusion. Plan-reviewer round 1 also caught 3 Critical correctness gaps in the initial design (trailing D/N strip missing; full-clip return-value inconsistent with existing convention; OB composite shift unaddressed) which the rev 1 design absorbed.

## Plan + dual-reviewer audit trail

Full plan + 4 review reports persisted at `plans/05262026_bismark-extractor/`:
- `BUG_879_FIXES_PLAN.md` (rev 1.1 — incl. round-2 test additions)
- `PLAN_REVIEW_879_{A,B}.md` (round 1 — caught the 3 Critical gaps)
- `PLAN_REVIEW_879_{REV1_A,REV1_B}.md` (round 2 — verified rev 1 absorption + raised 2 Important refinements which were folded into rev 1.1)

## Test plan

- [x] **Tests-first commits** (TDD): 17 unit tests in bismark-io + 4 integration tests in bismark-extractor land BEFORE the source change and fail to compile (4 errors, exactly the new tests). Verified.
- [x] **bismark-io fix commit**: 178/178 lib tests pass (was 161; +17 new).
- [x] **bismark-extractor fix commit**: full workspace test suite passes — 0 failures across all 23 test targets. 4 new #879 integration tests pass; 12 existing 2-arg `drop_overlap` tests updated to pass `0` and still PASS.
- [x] `cargo fmt --check` clean.
- [x] `cargo build --release -p bismark-extractor` clean.
- [ ] **Colossal `iso_r1_3p` smoke** on a fresh `--out` dir (expect PASS, was FAIL 8/8 in #879). Post-merge.
- [ ] **Colossal full Phase H PE matrix** on a fresh `--out` dir (expect 10/10 PASS, was 7 PASS + 2 FAIL `r1r2_3p` + 1 truncated `overlap@N=4` in #879's pre-fix run). Post-merge.

## Out of scope for this PR

- Code-reviewer + plan-manager dual audits — happen between PR open and merge per CLAUDE.md global rule.
- `parallel.rs` synthetic worker tests for the dual-dispatch class — tracked at #878 (separate follow-up).
- N=4 perf collapse — #876 Finding #4, separate `perf(extractor):` follow-up.
- Perl edge_clip hang — #876 Finding #3, Perl-side issue.

## Notable findings during implementation

- **The CIGAR-trim primitive's D/N absorption MUST be a single sweep, not a separate "phase 2"**. An early draft had a separate trailing-D/N-strip phase that over-stripped middle-CIGAR D ops. Caught by the `trim_3p_middle_D_is_NOT_stripped` test (`90M5D5M` trim 5 must yield `90M5D`, NOT `85M`). The single-sweep design walks past D/N adjacent to the trim end for "free" without decrementing the read-position counter; once a read-consuming op is satisfied the loop exits, leaving deeper D/N's intact. This is what makes the rev 1 design Perl-faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)