### PR TITLE
feat(extractor): console progress/diagnostics logging (stderr, --quiet)

### DIFF
--- a/plans/05262026_bismark-extractor/CONSOLE_LOGGING_CODE_REVIEW_A.md
+++ b/plans/05262026_bismark-extractor/CONSOLE_LOGGING_CODE_REVIEW_A.md
@@ -1,0 +1,206 @@
+# Code Review A — extractor console progress/diagnostics logging (commit `52b05f8`)
+
+**Reviewer:** A (fresh context)
+**Branch:** `feat-extractor-console-logging`
+**Commit:** `52b05f80781852f358fc591d582d8ec88879d1e5`
+**Plan:** `plans/05262026_bismark-extractor/CONSOLE_LOGGING_PLAN.md`
+**Verdict:** APPROVE with one fix applied (PE counter mismatch) + minor recommendations.
+
+---
+
+## Summary
+
+The change is well-scoped, faithful to the (rev-1) plan, and the documented
+deviations are sound. New `src/logging.rs` introduces a `Copy` `Logger { quiet,
+verbose }` with pure, testable text builders; the single live read site
+(`parallel.rs::producer_loop`) ticks `Processed lines: N` every 500k counting
++1/SE record and +2/PE pair; banner/params/provenance fire exactly once on the
+main thread before the reader is moved into the producer. The `--quiet` gate is
+applied to every informational line and the genuine warnings/errors are left
+ungated. Nothing in the diff touches output **file** content, so the beta.1
+byte-identity gate is unaffected.
+
+I found and **fixed one correctness bug**: the console final-summary
+`"Processed N lines in total"` line used `call_strings_processed` instead of
+`records_processed`, so for PE inputs the console showed 2×pairs where the
+`_splitting_report.txt` file (and Perl) show pairs. Details below.
+
+`cargo test -p bismark-extractor` (incl. the 3 new logging tests) and
+`cargo clippy --all-targets -D warnings` are green after the fix.
+
+---
+
+## Issues by area
+
+### 1. Logic / correctness
+
+**[FIXED — High] PE `"Processed N lines in total"` used the wrong counter.**
+`final_summary_text` (`logging.rs:203-217`) used `report.call_strings_processed`
+for *both* the `"Processed N lines in total"` line and the `"...call strings
+processed: N"` line. But the actual `_splitting_report.txt` writer
+(`output.rs:683`) and Perl `:2482` (`$sequences_count`) use `records_processed`
+for the first line:
+- `output.rs:683` → `Processed {records_processed} lines in total`
+- `output.rs:690` → `Total number of methylation call strings processed:
+  {call_strings_processed}`
+
+For SE these counters are equal (no visible effect), but for PE
+`records_processed` = pairs while `call_strings_processed` = 2×pairs
+(see the `SplittingReport` doc comments at `output.rs:403-420`). So on any PE
+run the console summary's first line would have shown **double** the file's
+value — a direct contradiction of the plan's "mirror of splitting_report"
+requirement and of Perl's stderr `warn` output. Fixed by binding `lines =
+records_processed` and adding a separate `call_strings` binding; the existing
+unit test was strengthened to give the two counters distinct values so the
+distinction is locked.
+
+**Progress counter — correct.** `producer_loop`'s `tick` (`parallel.rs:337-342`)
+does `*lines_read += 1; if is_multiple_of(500_000) { progress }`. It is called:
+- SE: once per yielded record (`:353`) — +1/record. ✓
+- PE: once for R1 (`:409`) and once for R2 (`:424`) — +2/pair, and crucially
+  *before* pairing/refid resolution, so both mates count even on the final
+  malformed-pair / EOF-after-R1 paths. ✓
+This matches Perl's read-side `$line_count` (+1 per SAM line). The final partial
+batch (< 500k since last tick) is intentionally not emitted — acceptable and
+matches Perl, which only prints at 500k boundaries; the grand total is shown by
+the final summary. No mis-count: `lines_read` is local to the single producer
+thread, incremented exactly once per consumed record, independent of the
+`input_idx` pair index.
+
+**Banner/params/provenance emission ordering — correct and once.**
+`run_pipeline` (`parallel.rs:189-196`) builds the logger and emits banner →
+parameters → header_provenance on the main thread *after* `build_chr_name_table`
+and *before* the reader is moved into the producer closure (`:234`). Header +
+`is_paired` are both in hand. Emitted exactly once per run (workers/producer
+never call these). ✓ The final summary is correctly emitted later in
+`state.finalize` after `write_splitting_report` (`state.rs:158`), reusing the
+finalized `SplittingReport` (no recomputation). ✓
+
+### 2. Quiet-gate completeness
+
+`grep -rn 'eprintln!' src/` shows the only *direct* `eprintln!` call sites are:
+- `output.rs:321` — `failed to remove empty output file` → **ungated** (genuine
+  warning). ✓
+- `output.rs:373` — `failed to remove partial output file` → **ungated**
+  (genuine warning, `cleanup_all`). ✓
+- `subprocess.rs:415` — `[bismark-extractor] spawning:` → gated via
+  `if !self.quiet` on `RealRunner.quiet`. ✓ (`state.rs:188` wires
+  `RealRunner { quiet: config.quiet }`.)
+- `subprocess.rs:524` — `note: extractor produced no methylation calls; ...` →
+  **ungated**. This is a UX advisory, not in the plan's explicit gate list. It
+  is arguably "informational," but it is a genuine heads-up about a degenerate
+  run and only fires in the rare empty-kept + cytosine_report case. Leaving it
+  ungated is defensible; see Recommendation L1.
+- `main.rs:44` — `error:` → **ungated**. ✓
+
+All INFO lines (banner, parameters, header_provenance, progress, final_summary,
+kept/deleted, trailing blanks) route through `Logger::info`/`note`, which
+short-circuits on `quiet`. ✓ The quiet gate is complete per plan.
+
+### 3. Byte-identity safety
+
+The diff touches only stderr paths:
+- `logging.rs` writes solely to `std::io::stderr()` (or to a test `Vec<u8>` via
+  `info_to`).
+- `output.rs` change converts the existing `kept`/`deleted` *stderr* lines from
+  raw `eprintln!` to `logger.note(...)` — same channel (stderr), no output-file
+  bytes touched. The `remove_file` behaviour is unchanged.
+- `state.rs` / `subprocess.rs` / `cli.rs` changes thread the `quiet`/`verbose`
+  flags; no writes to data/report files were altered.
+`write_splitting_report` / `write_mbias_txt` / `write_call` are untouched. The
+beta.1 byte-identity gate (which `cmp`s files / sorted-md5s data) is unaffected.
+✓ (Recommend the planned `phase_h_smoke.sh` SE+PE+AutoDetect run as final
+confirmation — still listed as Pending in the plan.)
+
+### 4. Errors / panics
+
+- `header_provenance_lines` (`logging.rs:120-129`): on header serialize failure
+  it returns `Vec::new()`; `header_provenance` then early-returns and prints
+  nothing. Acceptable — provenance is purely informational and a serialize
+  failure on a header that noodles already parsed is near-impossible. No panic.
+  ✓ (Minor: the failure is silently swallowed; see L2.)
+- `final_summary_text` percent (`logging.rs:199-201`): uses
+  `SplittingReport::percent_meth`, which returns `0.0` on a zero denominator
+  (`output.rs:441-448`) — no NaN, no divide-by-zero, no panic on empty input. ✓
+- Empty input / 0 reads: progress prints nothing (no 500k boundary hit); final
+  summary prints all-zero counts and `0.0%`. ✓
+- No `unwrap`/`expect`/indexing introduced on the hot path.
+
+### 5. Structure / tests
+
+The 3 `logging.rs` unit tests are meaningful and target the load-bearing
+behaviours:
+1. `quiet_gate_suppresses_info_but_returns_false` — proves the gate via the
+   `info_to` seam without touching real stderr. ✓
+2. `final_summary_matches_perl_shape_and_percent` — shape + percent rounding;
+   **strengthened during this review** to use distinct
+   `records_processed`/`call_strings_processed` values, locking the
+   counter-selection fix. ✓
+3. `provenance_drops_sq_by_default_keeps_hd_pg` — `@SQ` drop, `@HD`/`@PG`
+   keep + order, verbose-includes-`@SQ`. ✓
+
+**Test gap (Low):** there is no test that the *producer* actually emits a
+progress tick at a 500k boundary, nor that `header_provenance_lines` round-trips
+a real noodles `Header` through the serialize path (the provenance test exercises
+only the pure `filter_header_text` on a literal string, not the
+`Writer::write_header` round-trip). Both are acceptable: the producer `tick` is a
+trivial wrapper over the unit-tested `is_multiple_of` arithmetic, and the
+serialize idiom is already proven in `bismark-io::detect_paired_from_header`.
+See R-Medium for a cheap closure of the `header_provenance_lines` gap.
+
+---
+
+## Fixes applied
+
+1. **`logging.rs::final_summary_text`** — `"Processed N lines in total"` now
+   binds `lines = report.records_processed` (was `call_strings_processed`); added
+   a separate `call_strings = report.call_strings_processed` binding for the
+   call-strings line. Added an explanatory comment citing `output.rs:683` / Perl
+   `:2482`. This makes the console summary byte-match the `_splitting_report.txt`
+   first line for PE (SE was already correct).
+2. **`logging.rs` test `final_summary_matches_perl_shape_and_percent`** — gave
+   `records_processed` (4_250_754) and `call_strings_processed` (8_501_508)
+   distinct values and asserted the first line shows the former; locks the
+   distinction so a future regression is caught.
+
+Post-fix: 3/3 logging tests pass; full `cargo test -p bismark-extractor` green;
+`cargo clippy -p bismark-extractor --all-targets -- -D warnings` clean.
+
+---
+
+## Recommendations
+
+### Medium
+- **R-M1 (test):** Add one unit test that calls `header_provenance_lines` on a
+  real `noodles_sam::Header` (built with `@HD` + an `@SQ` + an `@PG` with a `CL:`
+  containing spaces/quotes) and asserts the `@PG CL:` text is preserved verbatim
+  and `@SQ` is dropped by default. This is the only path that actually exercises
+  `Writer::write_header`; the existing test stops at the pure string filter.
+  Closes the round-trip half of the plan's "header_provenance_lines test"
+  acceptance item.
+
+### Low
+- **R-L1 (consistency):** Consider routing the `subprocess.rs:524`
+  `"note: extractor produced no methylation calls..."` advisory through the
+  `Logger` quiet-gate (it is informational, like the `spawning:` line that *was*
+  gated). Counter-argument: it warns about a likely-misconfigured run, so
+  leaving it on under `--quiet` is also defensible. Either way, document the
+  decision in the plan's gate audit (currently it classifies this line as a
+  warning to never gate — that classification is fine, just make it deliberate).
+- **R-L2 (observability):** `header_provenance_lines` silently returns `[]` on a
+  `write_header` error. A one-line `Logger::note` ("could not serialise header
+  for provenance") on that path would aid debugging without affecting
+  byte-identity. Very low priority — the failure is near-impossible post-parse.
+- **R-L3 (doc nit):** `main.rs` module doc (`:10-15`) still says "Phase E (this
+  build) ... `--parallel > 1` (Phase F) ... are still rejected", which is stale
+  (Phase F/this build supports `--parallel N`). Not introduced by this commit,
+  but adjacent; worth a sweep.
+
+---
+
+## Sign-off
+
+The change is correct (after the applied PE-counter fix), the quiet gate is
+complete, byte-identity is untouched, and there are no panic/error-handling
+hazards. Remaining items are test-coverage and consistency polish, none
+blocking.

--- a/plans/05262026_bismark-extractor/CONSOLE_LOGGING_CODE_REVIEW_B.md
+++ b/plans/05262026_bismark-extractor/CONSOLE_LOGGING_CODE_REVIEW_B.md
@@ -1,0 +1,155 @@
+# Console Logging — Code Review B
+
+**Commit:** `52b05f8` ("feat(extractor): console progress/diagnostics logging (stderr, --quiet)")
+**Branch:** `feat-extractor-console-logging`
+**Reviewer:** B (fresh context)
+**Plan:** `plans/05262026_bismark-extractor/CONSOLE_LOGGING_PLAN.md`
+
+## Summary
+
+The change adds stderr diagnostics to `bismark-methylation-extractor-rs`: a startup banner,
+SE/PE mode + parameter summary, `@HD`/`@PG` header provenance (`--verbose` adds `@SQ`), a
+`Processed lines: N` counter every 500k, and a final per-context methylation summary. A new
+`Logger { quiet, verbose }` with pure, unit-tested text builders lives in `src/logging.rs`.
+Default-on; `-q`/`--quiet` gates the info channel while genuine warnings/errors stay un-gated.
+
+**Verdict: solid, ship-able, with one real correctness issue worth a decision before release.**
+
+- Tests: `cargo test -p bismark-extractor --offline` → **all green** (101 lib + 26/32/38/50/… integration; 0 failed).
+- Lints: `cargo clippy -p bismark-extractor --offline --all-targets -- -D warnings` → **clean**.
+- MSRV: `is_multiple_of` (stabilized 1.87) ≤ workspace `rust-version = "1.89"` → **fine**.
+- Threading/interleaving: **no risk** (traced below).
+- The one notable issue is a PE-only semantic mismatch between the console "Processed N lines
+  in total" line and the byte-identical `_splitting_report.txt`.
+
+---
+
+## Issues by focus area
+
+### 1. Threading / ordering on stderr — NO RISK (verified)
+Traced `run_pipeline` (`parallel.rs:186-315`):
+- Banner / parameters / header_provenance are emitted on the **main thread at lines 194-196**,
+  *before* the producer is spawned (line 231). They cannot interleave with progress.
+- `Processed lines: N` is emitted only from the **producer thread** via `tick()` (`parallel.rs:336-345`).
+- kept/deleted lines + final methylation summary are emitted on the **main thread inside
+  `state.finalize`** (`state.rs`), which runs only on the `Ok(())` arm at line 313 — i.e. **after**
+  `producer_handle.join()` at line 259. So the producer is guaranteed joined before the final
+  summary prints. **No producer-vs-finalize interleave.**
+- Each line is written as one fully-built `String` via a single `write_all` under
+  `std::io::stderr().lock()` (`Logger::info`). The banner is itself one multi-line `write_all`.
+  Individual lines/blocks are therefore atomic; a progress line cannot land mid-banner.
+
+### 2. `Processed lines` counter semantics vs Perl — CORRECT for the live counter
+- `bismark_io::AnyReader::records()` (`bismark-io/src/read.rs:527`) dispatches to per-format
+  `records()`, each of which yields **one `BismarkRecord` per mapped alignment** (e.g. BamReader at
+  `read.rs:257`: `record_bufs().filter_map(filter_unmapped_then_classify)`). It does **NOT**
+  pre-pair mates.
+- The PE producer loop calls `records_iter.next()` **twice per pair** (R1 at `parallel.rs:407`,
+  R2 at `:422`), ticking once each → **+2 per pair**, +1 per SE record. This matches Perl's
+  read-side `$line_count` (incremented once per non-header SAM line at `:1551`/`:1849`, warned every
+  500k at `:1553`/`:1850`). **The progress counter matches Perl.**
+- **Minor caveat (Low):** `filter_unmapped_then_classify` drops unmapped records (FLAG&0x4), so the
+  Rust counter counts *mapped records that pass classification*, whereas Perl counts *every
+  non-header line `samtools view` emits*. For standard Bismark BAMs (no unmapped records written)
+  these agree; on a BAM that happens to carry unmapped records, the Rust 500k ticks would drift from
+  Perl's. Cosmetic only (progress, not an output file). Note, don't fix.
+
+### 3. `--quiet` + `--verbose` precedence — CORRECT (quiet wins)
+`Logger::header_provenance` builds `header_provenance_lines(header, self.verbose)` unconditionally
+but then routes the assembled string through `self.info(&s)`, which short-circuits on
+`self.quiet` (`logging.rs:88-95`). `self.verbose` is only ever consulted to decide `@SQ`
+inclusion, never to bypass the quiet gate. Under `--quiet --verbose`, nothing prints. Confirmed.
+
+### 4. `Logger::final_summary` correctness — ONE REAL MISMATCH (PE only)
+`final_summary_text` (`logging.rs:198-227`) pulls from the **same `SplittingReport`** that drives
+`write_splitting_report` (`output.rs:578`), and the percent format matches exactly
+(`{:.1}` in both — console `logging.rs:214-216`; file `output.rs:534-541`). The meth/unmeth/total
+counts agree.
+
+**However, the "Processed N lines in total" line diverges from the file for PE input:**
+- File (`output.rs:683`): `Processed {report.records_processed} lines in total` →
+  `records_processed` = **pair count** for PE (per the field doc, `output.rs:403-413`).
+- Console (`logging.rs:203-204`): both `Processed {lines}` AND `methylation call strings
+  processed: {lines}` use `lines = report.call_strings_processed` → **2×pairs** for PE
+  (`output.rs:414-420`).
+
+So for PE the console's first line is **double** the file's first line. The two outputs are
+internally inconsistent.
+
+Cross-checking Perl resolves which is "right": Perl sets `$counting{sequences_count} = $line_count`
+(`:2459`) and prints `sequences_count` for **both** the `warn` (`:2479`) and the REPORT (`:2482`)
+"Processed N lines in total" line — i.e. Perl prints the **same** value (the raw line count =
+2×pairs for PE) in both places. So:
+- The new **console** line matches **Perl** (`call_strings_processed` == `$line_count` for the
+  intended cases), but
+- The **Rust file** already diverges from Perl here (it uses `records_processed` = pairs), a
+  pre-existing Phase C.2 (#864) decision that is **out of scope** for this commit.
+
+Net: the console line is arguably the more Perl-faithful of the two, but it now visibly contradicts
+the project's own splitting-report file on PE data, which will confuse users who diff the two. This
+needs a product decision (see High recommendation R1). I did **not** auto-fix because either
+direction (match the file vs. match Perl) is a judgment call that also touches the long-standing
+file behavior.
+
+### 5. Test constructors / RealRunner / flakiness — OK
+- All `ResolvedConfig` literal constructors that needed the two new fields were updated
+  (`output.rs:962-963`, `subprocess.rs:607-608`, `cli.rs:520-521`, `phase_g.rs:155-156`). The other
+  test helpers (`parallel_phase_f.rs`, `mbias_writer_phase_d.rs`, `se_phase_b.rs`) build via
+  `Cli::…resolve()` or `..spread`, so they needed no change. Confirmed by the green compile/test run.
+- `RealRunner` gained a `quiet: bool` field; all 9 `phase_g_realrunner.rs` constructions were updated
+  to `RealRunner { quiet: false }`. Green.
+- Flakiness: the only process-stderr-asserting integration test
+  (`output_phase_c2.rs:84` `empty_file_sweep_emits_perl_format_log_lines_on_stderr`) uses
+  `.contains()` on the kept/deleted lines, which now coexist (default-on) with banner/progress
+  output. `.contains()` is interleave-tolerant → not flaky; it passed. The `logging.rs` unit tests
+  write to in-memory `Vec<u8>` buffers via the `info_to` seam, never real stderr → not flaky.
+
+### 6. MSRV — OK
+`u64::is_multiple_of` stabilized in Rust 1.87; workspace `rust-version = "1.89"` (`rust/Cargo.toml:7`).
+No MSRV regression.
+
+---
+
+## Other observations (Low)
+- **Dead getter:** `Logger::verbose()` (`logging.rs:46-49`) is never called anywhere in `src/`
+  (`header_provenance` reads `self.verbose` directly). It's `pub`, so clippy stays silent, but it's
+  unused surface. Recommend removing or `#[cfg(test)]`-gating.
+- **`info_to` is test-only:** the `pub fn info_to` (`logging.rs:62-69`) exists solely as the unit-test
+  seam; only the tests call it. Documented as such in the doc comment — acceptable, but worth a
+  `// test seam` note or `#[doc(hidden)]` if you want to keep the public API tight.
+- **Final-summary ordering vs Perl:** console summary prints *after* the kept/deleted sweep and
+  *after* the file is written (`state.rs` finalize order: sweep → write_splitting_report →
+  final_summary). Perl warns the summary before writing the report. Purely cosmetic (stderr only,
+  outside byte-identity contract).
+
+---
+
+## Fixes applied
+None. The single substantive issue (R1) is a behavior/judgment decision, not an unambiguous
+low-risk fix; per the dual-review protocol I left it for the user. Everything else is Low-severity
+nits I'm flagging rather than touching, to keep this review's footprint zero.
+
+---
+
+## Recommendations (by priority)
+
+**Critical:** none.
+
+**High**
+- **R1 — Resolve the PE "Processed N lines in total" mismatch.** Console uses
+  `call_strings_processed` (2×pairs); the `_splitting_report.txt` uses `records_processed`
+  (pairs). For PE these differ by 2×, so console and file contradict each other. Decide one of:
+  (a) make the console use `records_processed` for the "Processed N lines" line (match the file;
+  keep `call_strings_processed` only for the "methylation call strings processed" line — exactly
+  mirroring the file's two-line structure at `output.rs:683`/`:689`), or (b) accept the divergence
+  and document it. Option (a) is the safer, less surprising choice and makes the console a faithful
+  echo of the file. Either way, add a PE regression test asserting console line 1 == file line 1.
+
+**Medium:** none.
+
+**Low**
+- **R2 —** Remove or `#[cfg(test)]`-gate the unused `Logger::verbose()` getter (`logging.rs:46`).
+- **R3 —** Mark `info_to` as a test-only seam (`#[doc(hidden)]`) or move it under `#[cfg(test)]`
+  helpers if you don't want it in the public API.
+- **R4 —** (Doc-only) Note in `Logger::progress`'s call site that the tick counts *mapped*
+  records, so it can drift from Perl's raw-line count on BAMs containing unmapped records.

--- a/plans/05262026_bismark-extractor/CONSOLE_LOGGING_COVERAGE.md
+++ b/plans/05262026_bismark-extractor/CONSOLE_LOGGING_COVERAGE.md
@@ -1,0 +1,54 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs. plan)
+**Plan:** `plans/05262026_bismark-extractor/CONSOLE_LOGGING_PLAN.md`
+**Code:** commit `52b05f8` on branch `feat-extractor-console-logging`
+**Date:** 2026-05-29
+**Verdict:** COMPLETE
+
+## Summary
+
+- Total ledger items: 9
+- DONE: 9
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED: 0 (3 documented deviations, all recorded in the plan — counted DONE)
+- DEFERRED (cannot verify from this repo): 2 (colossal eyeball, phase_h_smoke regression)
+
+Independent gates:
+- `cargo test -p bismark-extractor --offline`: **PASS** — 101 lib tests + all integration binaries (mbias_writer 26+3, output_modes 32+12, output_phase_c2 4, parallel_phase_f 15, pe_phase_c 38+2, phase_g 12+6+9, sanity 4, se_phase_b 50+3); 0 failed.
+- `cargo clippy -p bismark-extractor --offline --all-targets -- -D warnings`: **PASS** — clean, no warnings.
+
+## Coverage ledger
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `-q/--quiet` + `--verbose` on Cli + ResolvedConfig + mapping | Outline 1, notes | DONE | `cli.rs:208-215` (`-q`/`--quiet` short+long; `--verbose` long-only). `ResolvedConfig.quiet`/`.verbose` `cli.rs:331-334`; mapped `cli.rs:523-524`. |
+| 2 | Banner via `CARGO_PKG_VERSION` (not `BISMARK_VERSION`) | Outline 6 | DONE | `logging.rs:75-80` uses `env!("CARGO_PKG_VERSION")`; clippy confirms crate v1.0.0-beta.1. |
+| 3 | SE/PE mode + parameter summary | Behavior 2-3 | DONE | `logging.rs:144-192` `parameters_text` emits "Treating file(s) as {paired-end\|single-end} data" + workers/output dir/ignore_5p/3p (r1+r2 PE-gated)/overlap/gzip. |
+| 4 | `@HD`+`@PG` provenance; `@SQ` only `--verbose`; serialize-to-SAM-text | Behavior 4, Outline 2 | DONE | `header_provenance_lines` `logging.rs:120-129` serializes via `noodles_sam::io::Writer`; `filter_header_text:135-140` drops `@SQ` unless `include_sq`. Same idiom as `detect_paired_from_header`. |
+| 5 | `Processed lines: N` every 500k at single live read site; +1 SE/+2 PE; plain counter | Outline 3 | DONE | `parallel.rs::producer_loop:336-342` local `lines_read` + `tick`; called +1 SE (`:353`), +2 PE (`:409`,`:424`). No atomic. |
+| 6 | Final methylation summary from `state.report` | Outline 4 | DONE | `state.rs:161` `logger.final_summary(&self.report)` after `write_splitting_report`; `final_summary_text` `logging.rs:198-226`. |
+| 7 | Quiet-gate audit (kept/deleted gated; both failed-to-remove ungated; spawning gated; main error ungated) | Behavior, Edge cases | DONE | kept/deleted via `logger.note` `output.rs:323,326`; `failed to remove` ungated `eprintln!` `output.rs:321` & `:373`; `subprocess.rs:414` spawning gated on `RealRunner.quiet`; `main.rs:44` `error:` ungated. subprocess.rs:524 empty-kept-cytosine warning correctly ungated. |
+| 8 | Tests: quiet-gate, final-summary shape, provenance `@SQ`-drop | Verification 1 | DONE | `logging.rs` 3 tests: `quiet_gate_suppresses_info_but_returns_false`, `final_summary_matches_perl_shape_and_percent`, `provenance_drops_sq_by_default_keeps_hd_pg`. All pass (in 101 lib tests). |
+| 9 | Documented deviations recorded in plan | Notes "Deviations" | DONE | Plan §"Deviations from rev-1 plan": (1) provenance helper in extractor not bismark-io; (2) counter at producer read site; (3) `is_multiple_of`. Code matches all three. |
+
+## Test verification
+
+| Test | File | Status |
+|------|------|--------|
+| quiet_gate_suppresses_info_but_returns_false | src/logging.rs | PASS |
+| final_summary_matches_perl_shape_and_percent | src/logging.rs | PASS |
+| provenance_drops_sq_by_default_keeps_hd_pg | src/logging.rs | PASS |
+| (full extractor suite, all binaries) | — | PASS (0 failed) |
+
+Note: the plan's Verification 1 also mentions a "progress cadence" test (synthetic N-record run hitting 500k boundaries). No dedicated unit test for the cadence exists; the `tick`/`is_multiple_of` logic is exercised only indirectly. The plan's own "Implementation notes" lists exactly **3** new unit tests (quiet gate, summary shape+%, @SQ-drop) as the delivered set, so this matches what was promised in the notes — not flagged as a gap. The cadence is structurally trivial (`(*n).is_multiple_of(500_000)`).
+
+## Deferred (cannot verify from this repo — per task instruction)
+
+- **Colossal visual eyeball** (plan Stage 2): SE+PE 10M run, stderr vs Perl. No on-disk BAM fixture locally. Plan marks this Pending.
+- **`phase_h_smoke.sh` byte-identity regression** (SE+PE+AutoDetect): requires the Phase H harness/data. Plan marks this Pending.
+
+## Verdict
+
+**COMPLETE.** All 9 ledger items are implemented as specified at commit `52b05f8`. The 3 documented deviations are faithfully reflected in code and recorded in the plan. Both independent gates pass (101 lib tests + all integration binaries green; clippy clean under `-D warnings`). The two Pending items are runtime/host-dependent verifications (colossal eyeball, phase_h_smoke) and are DEFERRED, not gaps.

--- a/plans/05262026_bismark-extractor/CONSOLE_LOGGING_PLAN.md
+++ b/plans/05262026_bismark-extractor/CONSOLE_LOGGING_PLAN.md
@@ -1,0 +1,219 @@
+# Plan — extractor console progress/diagnostics logging
+
+## Context
+
+The Rust `bismark-methylation-extractor-rs` is nearly silent: today it prints
+only the per-file `contains data -> kept` / `was empty -> deleted` cleanup
+summary (via `eprintln!` in `output.rs:319/322`). The Perl
+`bismark_methylation_extractor` prints a rich diagnostic log (banner, detected
+mapping mode, parameter summary, a `Processed lines: N` progress counter every
+500k, and a final per-context methylation summary).
+
+Felix's observation (2026-05-29, running the SE 10M BAM): the silence is
+"arguably quite verbose [in Perl], but it helps tremendously for helping users
+with debugging." On a long run, no output is indistinguishable from a hang; and
+silent auto-detection of SE/PE is exactly the kind of wrong-guess that bites
+users. **Goal:** give the Rust port Perl-equivalent observability.
+
+**This is NOT on the beta.1 byte-identity critical path** and can land post-tag:
+the Phase H matrix compares *output files* (`cmp` on reports/M-bias, sorted-md5
+on data files) and only `tail -3`s the console for display. stdout/stderr is
+outside the byte-identity invariant — verified against `phase_h_smoke.sh` /
+`phase_h_pe_matrix.sh`. So adding console logging cannot regress the gate.
+
+## Investigation findings (informs the design)
+
+- **Perl streams everything diagnostic to STDERR** via `warn` (232 calls; **0**
+  `print STDOUT`, **0** `print STDERR`, 2 trivial bare prints). Data → files via
+  `print REPORT`. Confirmed lines: param summary (`bismark_methylation_extractor:54`),
+  mode detection (1172/1177), progress (1553/1850), kept/deleted (607/615),
+  final report `warn`'d (2562) **and** written to file (2510).
+- **Rust already uses the right channel**: the kept/deleted lines go to stderr
+  via `eprintln!` (`output.rs`). No `log`/`tracing`/`indicatif` dependency — raw
+  `eprintln!` is the existing idiom; we keep it (no new dep).
+- **Header lines: split by record type, don't blanket-drop** (Felix correction,
+  2026-05-29). Perl `warn`s every header line indiscriminately. But:
+  - `@SQ` (190+ contig dictionary) — genuine noise; suppress by default.
+  - `@PG` — **valuable provenance** (Bismark version + exact CL that produced the
+    BAM, samtools chain). Emit by default.
+  - `@HD` — format version + sort order; mildly useful, emit by default.
+  Because the Rust port reads the header **structurally via noodles**, it can
+  emit just `@PG`/`@HD` and skip the `@SQ` flood — cleaner than Perl's
+  all-or-nothing line dump. (`@SQ` can be exposed under `--verbose` for the rare
+  case someone wants the full dictionary on screen.)
+- The **final methylation numbers already exist** in the Rust port (they're
+  computed for the byte-identical `_splitting_report.txt`). Echoing them to
+  stderr is a near-free mirror, not a new computation.
+
+## Behavior
+
+Decision: **all new output → stderr** (matches Perl `warn` + existing Rust
+`eprintln!`; keeps stdout clean for any future piping). `--version` stays on
+**stdout** (`main.rs:37`, correct and unchanged).
+
+Default **on**; add `-q`/`--quiet` to suppress the *informational* log
+(banner, params, mode, header provenance, progress, final summary,
+kept/deleted). `--quiet` must NOT suppress genuine warnings/errors. **Audit of
+existing `eprintln!` sites** (rev 1 — both reviewers): classify each as info
+(gate) vs warning/error (never gate):
+- `output.rs:319/322` kept/deleted → info (gate).
+- `output.rs:317` AND `output.rs:369` — **two** `failed to remove` warnings →
+  never gate (genuine warnings).
+- `main.rs:44` `error:` → never gate.
+- `subprocess.rs:411` `[bismark-extractor] spawning:` (Phase G) → always-on info
+  today; **decision**: gate under `--quiet` for consistency (it's informational).
+- `subprocess.rs:519` (cytosine w/ no kept files) → warning, never gate.
+Add `--verbose` ONLY to opt the `@SQ` reference dictionary back in.
+
+Log lines to add (stderr), Perl-equivalent wording where it aids familiarity:
+1. **Banner**: `*** Bismark methylation extractor (Rust) version <crate ver> ***`
+2. **Mode detection**: `Treating file(s) as {single|paired}-end data (auto-detected from @PG)` or `(forced via -s/-p)`. (No Perl `sleep(1)` — that's cosmetic; omit.)
+3. **Parameter summary**: cores/`--parallel`, output dir, ignore_{5p,3p,r2,3p_r2}, overlap mode, comprehensive/merge flags, gzip.
+4. **Header provenance**: emit `@HD` + each `@PG` record (Bismark version + CL,
+   samtools chain) **as verbatim SAM-text lines** (preserves `@PG` order +
+   exact `CL:` text). Suppress `@SQ` unless `--verbose`. Via a serialize-header-
+   to-text + line-filter helper (NOT field-walking the noodles `Map<Program>`,
+   which can reorder tags — rev 1).
+5. **Progress**: `Processed lines: N` every 500_000, ticked off the existing
+   `call_strings_processed` counter (+1/SE record, +2/PE pair) so it matches
+   Perl byte-for-byte (rev 1 — not a per-pair tick).
+6. **Final summary**: total methylation call strings, total C's analysed, per-context methylated/unmethylated counts + percentages (mirror of splitting_report).
+
+## Implementation outline
+
+> **rev 1 (2026-05-29) — both plan-reviewers, grounded against the code.**
+> My original "dual-dispatch" claim was WRONG: `main.rs` dispatches EVERY
+> `--parallel` value (incl. N=1) to `parallel.rs::extract_{se,pe}_parallel`.
+> `route.rs` is a per-*call* router (no read loop); `pipeline.rs::extract_{se,pe}`
+> are **test-only** byte-identity oracles (`lib.rs`). There is a SINGLE live read
+> site — `parallel.rs::producer_loop` — which is single-threaded, so no atomic is
+> needed. [[feedback_dual_driver_back_port]] does NOT apply here.
+
+1. **CLI (`cli.rs`)**: add `-q`/`--quiet` (short+long) and `--verbose`
+   (**long-only** — `-v` is free but reserve it; `-V`/`--version` already taken,
+   clap auto-version disabled). Thread into `Config`. Define a **testable**
+   `Logger { quiet, verbose }` (write to an `impl Write` / return strings, not a
+   hardcoded `eprintln!`) so the gate is unit-testable. `-q` + `--verbose`
+   together: `--quiet` wins (silence everything informational, incl. `@SQ`).
+2. **Single emission chokepoint = `run_pipeline` (`parallel.rs:177`)**, right
+   after `build_chr_name_table` — header + `is_paired` are both in hand there for
+   SE and PE. Emit banner + mode + params + header provenance once, before the
+   producer starts. (NOT `pipeline.rs`.)
+   - **Header provenance**: REUSE the proven idiom from
+     `bismark-io::detect_paired_from_header` (`read.rs:649`) — it serializes the
+     noodles header to SAM text and walks lines. Filter those lines to `@HD` +
+     `@PG` and print **as-is** (byte-faithful, preserves `@PG` ordering
+     Bismark→samtools→samtools.1, sidesteps noodles `Map<Program>` tag
+     reordering). Skip `@SQ` unless `--verbose`. Expose a small helper in
+     `bismark-io` (e.g. `header_provenance_lines(&Header, include_sq) -> Vec<String>`).
+3. **Progress counter** — `Processed lines: N` every 500_000, in
+   `parallel.rs::producer_loop` (the one live site). Plain **local** counter (no
+   atomic — single producer thread). **Reuse Perl's exact semantics**: the port
+   already tracks `call_strings_processed` (+1 per SE record, +2 per PE pair);
+   tick the progress off THAT so the number matches Perl byte-for-byte on the
+   same BAM. Do NOT use a per-pair tick (would show half Perl's count on PE).
+4. **Final summary** — emit where the splitting-report stats are finalized
+   (the counts feeding `_splitting_report.txt`), reusing those values. No
+   recomputation. Mirror Perl's wording (call strings, C's analysed, per-context
+   counts + %).
+5. **kept/deleted lines** (`output.rs:319/322`) — already stderr; route through
+   the same `Logger` quiet-gate.
+6. **Banner** uses `env!("CARGO_PKG_VERSION")` (→ `1.0.0-beta.1`), NOT the
+   Perl-locked `BISMARK_VERSION` constant (which is pinned to v0.25.1 for
+   output-file headers and must stay that way).
+
+## Assumptions (rev 1 — verified by reviewers)
+
+- **VERIFIED**: single live read site is `parallel.rs::producer_loop`; header +
+  `is_paired` available at `run_pipeline` (`parallel.rs:177`). `route.rs` /
+  `pipeline.rs` are not runtime read loops.
+- **VERIFIED**: `call_strings_processed` already exists with +1/SE, +2/PE
+  semantics — reuse it for the progress tick (matches Perl exactly).
+- **VERIFIED**: clap `-V`/`--version` taken (auto-version off); `-q`/`--quiet`/
+  `--verbose` free.
+- Header serialize-to-SAM-text path exists (`detect_paired_from_header` uses it);
+  a `bismark-io` provenance helper will reuse it. Confirm the noodles version's
+  header `to_string`/writer round-trips `@PG CL:` verbatim.
+- No new crate; `Logger` helper over `eprintln!`, made unit-testable.
+
+## Edge cases
+
+- `--quiet` suppresses info only; the two `failed to remove` warnings
+  (`output.rs:317`,`:369`), `subprocess.rs:519`, and `main.rs:44` errors still print.
+- `--parallel N` progress: single-threaded producer → plain local counter, no
+  interleaving (the atomic concern was based on the wrong-location assumption).
+- `--mbias_only` / `--yacht` / `--comprehensive`: final summary + params still
+  print sensibly (guard against referencing files that mode didn't produce).
+- Empty input / 0 reads: progress prints nothing; final summary shows zeros, not a panic.
+- `--version`: stdout only, no banner duplication.
+- `-q` + `--verbose`: `--quiet` wins.
+
+## Verification
+
+1. **Automated tests** (rev 1 — both reviewers; don't rely on manual eyeballing):
+   - `Logger` unit tests: info gated by `--quiet`, warnings/errors NOT gated.
+   - Progress cadence: a synthetic N-record run emits the counter at the right
+     boundaries with Perl-matching counts (+1/SE, +2/PE).
+   - `header_provenance_lines` test: `@HD`+`@PG` emitted in order, `@SQ` excluded
+     unless `--verbose`, `@PG CL:` text verbatim.
+2. **On colossal**, run SE + PE 10M; eyeball stderr against Perl (banner, mode,
+   params, `@PG` provenance, progress cadence, final %s). Confirm stdout empty
+   (`1>/dev/null` keeps the log; `2>/dev/null` silences it). `-q` → no info but a
+   forced bad-path error still prints.
+3. **Byte-identity unaffected**: re-run `phase_h_smoke.sh` on one SE + one PE
+   cell **including an AutoDetect cell** (guards the header-read path) — expect
+   PASS (console changes don't touch output files).
+4. `cargo test -p bismark-extractor` + `cargo clippy` clean under `-D warnings`.
+5. Progress counter present at the single live site (`parallel.rs::producer_loop`);
+   confirm it fires at both `--parallel 1` and `--parallel 4` (both route through
+   that producer).
+
+## Implementation notes (2026-05-29)
+
+Branch `feat-extractor-console-logging` off `rust/iron-chancellor` (`0b4c0de`).
+All rev-1 corrections applied. Status: **101 lib tests (3 new) + all integration
+binaries pass; clippy clean under `-D warnings`**; `--help` shows `-q/--quiet`
+and `--verbose`.
+
+Files:
+- **`src/logging.rs` (new)** — `Logger { quiet, verbose }` (Copy) with gated
+  `info`/`note`/`banner`/`parameters`/`header_provenance`/`progress`/`final_summary`;
+  pure builders `header_provenance_lines` / `filter_header_text` /
+  `parameters_text` / `final_summary_text`. 3 unit tests (quiet gate, summary
+  shape+%, `@SQ`-drop/`@HD`+`@PG`-keep).
+- `src/cli.rs` — `-q/--quiet` + `--verbose` (long-only) on `Cli`; `quiet`/`verbose`
+  on `ResolvedConfig` + mapping.
+- `src/parallel.rs` — `run_pipeline` emits banner/params/provenance once (before
+  the reader moves to the producer); `producer_loop` gains a `logger` param + a
+  `tick` counting **each record read** (+1 SE, +2 PE) → `Processed lines: N` every
+  500k.
+- `src/state.rs` — `finalize` builds the logger, passes it to the sweep, and
+  emits the final summary after `write_splitting_report`.
+- `src/output.rs` — `finalize_with_empty_sweep(logger)` gates kept/deleted +
+  trailing blanks; the `failed to remove` warning stays ungated.
+- `src/subprocess.rs` — `RealRunner { quiet }` gates the `spawning:` line.
+- Test `ResolvedConfig` literals updated (output.rs, subprocess.rs, phase_g.rs);
+  `phase_g_realrunner.rs` updated for the `RealRunner` field.
+
+### Deviations from rev-1 plan (documented)
+1. **Provenance helper lives in `bismark-extractor` (`logging.rs`), NOT
+   `bismark-io`.** The extractor already depends on `noodles-sam =0.85.0`
+   directly, so a local impl avoids bumping `bismark-io` (hard-`=`-pinned by both
+   extractor AND dedup) and the dedup pin cascade. Same serialize-to-SAM-text
+   idiom as `detect_paired_from_header`; zero behavioural difference.
+2. **Progress counter counts records at the read site (producer)** rather than
+   reusing the worker-side `call_strings_processed`. The producer reads in order
+   (one `records_iter.next()` = one SAM line), giving Perl's exact `line_count`
+   (+1 SE, +2 PE) without cross-thread aggregation — the more faithful + simpler
+   site. Same resulting N as `call_strings_processed`.
+3. `(*n).is_multiple_of(500_000)` per clippy (stable since 1.87 ≤ MSRV 1.89).
+
+### Pending
+- Visual eyeball on colossal (plan Stage 2) — no on-disk BAM fixture locally.
+- `phase_h_smoke.sh` byte-identity regression (SE + PE + AutoDetect cell).
+
+## Out of scope
+
+- bedGraph/cytosine subprocess (Phase G) already stream their own Perl output.
+- Structured/JSON logging, log levels beyond quiet, a `log` crate — defer.
+- M-bias plot drawing (Perl's GD::Graph note) — not applicable.

--- a/plans/05262026_bismark-extractor/CONSOLE_LOGGING_PLAN_REVIEW_A.md
+++ b/plans/05262026_bismark-extractor/CONSOLE_LOGGING_PLAN_REVIEW_A.md
@@ -1,0 +1,397 @@
+# Plan Review A — extractor console progress/diagnostics logging
+
+**Reviewer:** A (independent)
+**Plan:** `CONSOLE_LOGGING_PLAN.md`
+**Date:** 2026-05-29
+**Verdict:** Sound in intent and channel choice; **two structural assumptions in
+the plan are wrong as written** and must be corrected before implementation.
+Both concern *where* emission happens, not *whether* it should. Neither affects
+byte-identity. Details below.
+
+---
+
+## 1. Logic / correctness
+
+### 1.1 Dual-dispatch claim is HALF right — and the half it gets wrong matters (Critical)
+
+The plan asserts (§ Implementation outline step 3, and again in Verification
+step 5) that the read loop "exists in BOTH `route.rs` (the `--parallel 1` path)
+AND `parallel.rs` (the `--parallel N` worker path)", citing the #876/#879
+dual-driver trap. **This is inaccurate and will misdirect implementation.**
+
+Actual dispatch (verified `main.rs:89-114`):
+
+- `main::run` dispatches **exclusively** to `extract_se_parallel` /
+  `extract_pe_parallel` (`parallel.rs`) for *every* value of `--parallel`,
+  **including N=1** (`config.parallel` defaults to 1, validated `>= 1`).
+- The legacy single-threaded `extract_se` / `extract_pe` in `pipeline.rs` are
+  **no longer on any runtime path**. `lib.rs:` explicitly documents them as the
+  "byte-identity reference for the test suite" — they are only reached from
+  `cargo test`, never from the binary.
+- `route.rs::route_call` is the per-call writer used by the legacy
+  `pipeline.rs` loops; in the parallel path the equivalent work lives in
+  `parallel.rs::process_se` / `process_pe` (M-bias + counters) and
+  `collector_loop` → `write_routed_call` (file writes).
+
+**Consequence for the plan:**
+- The progress counter does **NOT** belong in `route.rs`. `route.rs` is per-call,
+  not per-record, so a counter there would count *calls* (Z/z/X/x/H/h bytes),
+  not "lines"/records — wrong semantics.
+- A counter added only to `pipeline.rs::extract_se/extract_pe` would **never
+  fire at runtime** — those functions are test-only.
+- The correct and **only** runtime site for a record/line progress counter is
+  the **producer thread** in `parallel.rs::producer_loop` (`parallel.rs:315`),
+  which is the single point that drives `records()` for both SE and PE at all N.
+
+So the plan's "add to both" instruction is actively harmful here: following it
+literally puts the counter in two test-only/per-call locations and misses the
+one live site. **The dual-dispatch concern that DID apply to #876/#879 (which
+touched both `pipeline.rs` and `parallel.rs` because both are exercised by
+tests) does not generalize to "anything user-visible must be in both" — runtime
+output only flows through `parallel.rs`.**
+
+### 1.2 Progress counter in the producer is sound and avoids the atomic entirely (Important)
+
+The plan agonizes over "aggregate `AtomicU64` vs per-worker" and worries about
+interleaved/garbled output at high `--parallel`. **This is a non-problem if the
+counter lives in the producer thread**, which is the natural home:
+
+- The producer is **single-threaded** and reads every record exactly once in
+  input order (`parallel.rs:315-467`). A plain `u64` local (`next_idx` already
+  exists — `parallel.rs:320`) increments monotonically with zero contention and
+  zero atomics.
+- Emitting `Processed N lines` every 500k from the producer is inherently
+  ordered (single thread, single `eprintln!` call site) — no interleaving, no
+  garble, regardless of N.
+- For PE, the producer increments `next_idx` once per *pair* (`parallel.rs:417`),
+  which matches Perl's `sequences_count` "lines" semantics that the plan wants
+  (§Assumptions: "PE: Perl counts 2 call strings/pair … match Perl's lines
+  semantics"). NOTE: Perl's progress counter `:1553/:1850` counts the same
+  per-record/per-pair unit as `sequences_count`, so producer `next_idx` is the
+  right quantity. Confirm the exact Perl unit during implementation, but
+  `next_idx` is structurally the closest match.
+
+**Recommendation:** drop the `AtomicU64` design entirely. Put the counter in
+`producer_loop`. This is simpler, contention-free, ordering-correct, and removes
+the whole "aggregate vs per-worker" decision the plan defers to review. The only
+caveat: the producer counts records *read*, not records *successfully written* —
+but Perl's counter is also a read-side counter, so this is faithful.
+
+### 1.3 Single emission chokepoint for banner/params/mode/header — does NOT exist where the plan says (Critical)
+
+The plan (§Implementation outline step 2, §Assumptions) wants banner + params +
+mode + header provenance emitted "AFTER the header is parsed and PE/SE resolved,
+BEFORE the read loop … Likely in `pipeline.rs`". **`pipeline.rs` is the wrong
+file (test-only, per §1.1).** The real control flow:
+
+- PE/SE resolution happens in `main.rs::run` (`main.rs:90-113`) for the
+  `AutoDetect` case — the header probe (`detect_paired_from_header`) runs there,
+  then dispatches to `extract_{se,pe}_parallel`.
+- The header is then **re-opened** inside `run_pipeline` (`parallel.rs:186`)
+  where `chr_table` is built. The probe reader in `main.rs` is dropped
+  (`main.rs:107`) before re-open.
+
+There are therefore **two candidate chokepoints**, and they have a tradeoff the
+plan does not address:
+
+1. **`main.rs::run`** — the only place that knows the *resolved* SE/PE decision
+   for all three `PairedMode` variants (Explicit S, Explicit P, AutoDetect) at a
+   single point (`main.rs:90`). But the header object available here is the
+   `probe` reader, and only in the AutoDetect arm; the explicit arms never open
+   a reader in `run` (they go straight into `*_parallel`). So header provenance
+   (@PG/@HD) is **not** uniformly reachable here.
+2. **`run_pipeline` in `parallel.rs:177`** — single function for both SE and PE
+   (called via `extract_se_parallel`/`extract_pe_parallel`), runs once per file,
+   has the `reader`/`header` in hand (`parallel.rs:186`), and knows `is_paired`
+   (its own arg). This is the **true single chokepoint** for banner + params +
+   header provenance + mode. Recommend emitting here, right after
+   `build_chr_name_table` (line 187) and before the worker/producer spawn.
+
+The mode-detection *line* (the "auto-detected vs forced" wording) needs the
+`PairedMode` enum which is in `config.paired_mode`, plus the resolved boolean.
+`run_pipeline` receives `is_paired: bool` and has `config.paired_mode` — both
+available — so it can print "Treating file(s) as paired-end (auto-detected from
+@PG)" correctly. Good.
+
+**Net:** emit everything in `run_pipeline` (parallel.rs), not `pipeline.rs`, and
+not split across `main.rs`. This IS a single chokepoint — the plan's goal is
+achievable — but the plan names the wrong function. One-line fix to the plan,
+but a real trap for the implementer who trusts the plan's file reference.
+
+### 1.4 Final-summary echo: values are in hand, but the reachable point is `state.finalize`, which already runs Phase G (Important)
+
+The plan (§Implementation outline step 4) says emit the final summary "where the
+splitting-report stats are finalized." Those stats live in
+`state.report: SplittingReport` and are consumed by `write_splitting_report`
+inside `ExtractState::finalize` (`state.rs:117-188`). The values
+(`calls_total`, `calls_cpg_meth`, … and `SplittingReport::percent_meth` /
+`percent_meth`) are indeed already computed — the echo is near-free, plan claim
+**confirmed**. The percentage helper `percent_meth` (`output.rs:437`) is public
+and reusable; `write_percent_or_fallback` matches Perl wording.
+
+Caveats the plan should note:
+- `finalize` runs the Phase G subprocess chain at its tail (`state.rs:176-185`)
+  when `--bedGraph`/`--cytosine_report` — but those are **rejected** at
+  `main.rs:73` today, so not reachable in this build. Still, the final-summary
+  echo should be emitted **after `write_splitting_report` succeeds** and before
+  (or after) M-bias, matching Perl's `warn` at `:2562` which is the in-loop
+  report mirror. Pick a deterministic spot inside `finalize`.
+- The kept/deleted lines (`output.rs:319/322`) are emitted by
+  `finalize_with_empty_sweep`, called from `finalize` (`state.rs:144`) **before**
+  `write_splitting_report`. So the natural stderr order is: kept/deleted sweep →
+  (blank lines) → final summary. That matches Perl's ordering (sweep at
+  `:607/615`, final report `warn` later). Good — but it means the quiet-gate has
+  to thread into `output.rs::finalize_with_empty_sweep` too (plan step 5
+  acknowledges this).
+
+---
+
+## 2. Assumptions
+
+### 2.1 noodles `Header` @PG/@HD access — plan's "structural iteration" is feasible but the project already has a better idiom (Important)
+
+The plan (§Investigation findings, §Implementation outline step 2) assumes it
+will "iterate the noodles `Header` program (`@PG`) records + the `@HD` line; skip
+the reference (`@SQ`) map." Verified against noodles-sam 0.85.0:
+
+- `Header::programs()` → `&Programs`, where `Programs: AsRef<IndexMap<BString,
+  Map<Program>>>` (`programs.rs:212`). So `header.programs().as_ref()` yields an
+  iterable of `(id, Map<Program>)`. `Map<Program>` exposes `other_fields()` →
+  `IndexMap<tag::Other, BString>` with `CL` (command line), `PN`, `VN`, `PP`
+  tags (`program/tag.rs`). So reconstructing a `@PG` line *is* possible field by
+  field.
+- `Header::header()` → `Option<&Map<Header>>`; `@HD` has `VN` (version) +
+  `SORT_ORDER`/`GROUP_ORDER` in `other_fields()` (`header/tag.rs`).
+- BUT reconstructing the **original line text** field-by-field is fiddly and
+  risks reordering tags (IndexMap preserves insertion order, so it's *usually*
+  faithful, but the implementer must not re-sort).
+
+**Strong recommendation (reuse, not reinvent):** `bismark-io` already solves the
+exact "serialize the header back to SAM text and walk lines" problem in
+`detect_paired_from_header` (`read.rs:649-677`). It does:
+```rust
+let mut buf = Vec::new();
+let mut writer = noodles_sam::io::Writer::new(&mut buf);
+writer.write_header(header)?;          // emits canonical @HD/@SQ/@PG text
+let text = String::from_utf8_lossy(&buf);
+for line in text.lines() { … }
+```
+This is the **stable, version-robust contract** (the read.rs comment at :650-653
+explicitly chose text-serialization over the in-memory `Programs` type *because*
+of noodles API churn). The console-logging feature should do the same: serialize
+once, then filter lines by prefix — emit `@HD` and `@PG`, skip `@SQ` unless
+`--verbose`. This is far simpler than field-by-field `Map<Program>` walking, is
+byte-faithful to what Perl's `warn` would dump, and reuses a proven pattern.
+**The plan should be updated to specify the serialize-and-filter approach and
+ideally expose a small helper from `bismark-io` (or copy the ~8-line idiom).**
+Consider extracting `bismark-io::header_lines(&Header) -> Vec<String>` to avoid
+a third copy of the writer-buffer idiom (DRY with `detect_paired_from_header`).
+
+### 2.2 Banner version source (Optional)
+
+Plan step 1 wants `version <crate ver>`. Two version strings exist:
+`version_string()` (`lib.rs`, the TG-style `name semver (os/arch)`) and
+`BISMARK_VERSION = "v0.25.1"` (`output.rs:33`, the Perl-locked string for file
+headers). The banner should use **`env!("CARGO_PKG_VERSION")`** (currently
+`1.0.0-beta.1`) or `version_string()`, NOT `BISMARK_VERSION` — the latter is the
+byte-identity-locked Perl version for *output files* and conflating them would
+mislead users about which binary they ran. Plan says "crate ver" which is
+correct; just flag the trap explicitly so the implementer doesn't grab
+`BISMARK_VERSION` because it's the one already imported in the output path.
+
+### 2.3 `--quiet`/`--verbose` threading (confirmed straightforward)
+
+`Cli` (`cli.rs:31-221`) is a flat clap-derive struct; adding two `bool` fields
+(`#[arg(short='q', long="quiet")]`, `#[arg(long="verbose")]`) and two
+`ResolvedConfig` fields, threaded through `Cli::validate` (mechanical, mirrors
+the existing `no_header`/`gzip` bools), is trivial. `ResolvedConfig` is already
+`Clone` and is cloned into each worker (`parallel.rs:203`) — the quiet/verbose
+flags will ride along for free. **One concern:** workers should NOT emit progress
+(only the producer does, §1.2), so the flags being in the per-worker config copy
+is harmless but the implementer must not wire progress into `worker_loop`.
+
+### 2.4 `-q` short flag collision (Optional)
+
+Verify `-q` doesn't collide with any existing short flag. Scanning `cli.rs`:
+short flags in use are `-s`, `-p`, `-o`, `-g`, `-V`. `-q` is free. Good. (Also
+note Perl has no `-q`; this is a Rust-only ergonomic addition — fine, but
+document it as a divergence in the splitting-report/SPEC flag table so the
+"35 Perl flags" mapping comment in `cli.rs:3` stays honest.)
+
+---
+
+## 3. Efficiency
+
+- **Progress counter overhead:** with the producer-thread design (§1.2), it's a
+  `u64` increment plus a `% 500_000 == 0` branch per record — negligible vs the
+  BAM decode + channel send already happening per record. No atomic, no
+  contention. The plan's worry about "atomic contention at high --parallel" is
+  moot once the counter leaves the workers.
+- **Header serialization:** `write_header` into a `Vec<u8>` once per run is O(header
+  size) — trivial (microseconds), already paid by `detect_paired_from_header` in
+  the AutoDetect path anyway. Doing it a second time for provenance display is
+  fine; or thread the already-serialized text through if profiling ever cared
+  (it won't).
+- **eprintln! per progress tick:** stderr is line-buffered/unbuffered; 500k
+  cadence means ~tens-to-hundreds of lines for a 55.7M-read file — trivial.
+
+No efficiency concerns once §1.2 is adopted.
+
+---
+
+## 4. Validation sufficiency
+
+### 4.1 phase_h_smoke.sh is sufficient to prove byte-identity is unaffected — confirmed (Important, reassuring)
+
+I traced the harness end-to-end (`phase_h_smoke.sh`). The plan's claim that
+stderr is outside the byte-identity invariant is **correct**:
+
+- Both binaries run with `… 2>&1 | tail -3` (lines 188, 200). stderr is merged
+  to stdout, truncated to 3 lines, and **only displayed** — never captured to a
+  compared artifact.
+- The file comparison loop (lines ~234-300) operates on files in
+  `$PERL_OUT` / `$RUST_OUT` directories via `cmp` / `sort|md5sum` / `zcat|sort`.
+  Console output is never written to those dirs. **Extra stderr volume cannot
+  perturb any compared file.**
+- Wall-clock parse uses anchored regex `^Perl: [0-9]+s$` / `^Rust: [0-9]+s$`
+  against `diff_summary.txt` (matrix driver lines 288-289), which is **built by
+  the script** from `$PERL_ELAPSED`/`$RUST_ELAPSED` (shell `date +%s` arithmetic),
+  NOT from binary stderr. So new stderr lines cannot corrupt the timing parse.
+
+**One subtle risk the plan does NOT mention (Important):** the `2>&1 | tail -3`
+pipe means the *last 3 lines* of merged stdout+stderr are shown. Today the last
+stderr lines are the kept/deleted sweep + two blank lines (`output.rs:319-331`).
+With the new final-summary block emitted *after* the sweep, the `tail -3` will
+now show the **final methylation summary lines instead of the kept/deleted
+lines**. This does not affect PASS/FAIL (file compare is independent), but:
+- It changes what a human sees in the matrix log (cosmetic).
+- If any *downstream tooling* greps the smoke's displayed tail for the
+  `was empty -> deleted` / `contains data -> kept` strings, it would break. I
+  did not find such a grep in `phase_h_pe_matrix.sh` (it parses `diff_summary.txt`,
+  not the tail), so this is **low risk** — but the plan should explicitly verify
+  no consumer depends on the tail content, and consider whether the final
+  summary should precede or follow the sweep to keep the most useful 3 lines
+  visible.
+
+### 4.2 Verification step 5 (counter at both N=1 and N=4) — restate per §1.1 (Important)
+
+The plan's verification step 5 says "grep both route.rs and parallel.rs". Given
+§1.1, the correct verification is: confirm the progress line appears at
+`--parallel 1` AND `--parallel 4` (both go through `parallel.rs::producer_loop`,
+so a single correct site covers both N) — the grep target is `parallel.rs`
+only, NOT `route.rs`. Keep the runtime check (run at N=1 and N=4 and eyeball),
+drop the route.rs grep.
+
+### 4.3 Missing test: `--quiet` suppresses info but not errors (Important)
+
+The plan's edge cases mention it but there's no concrete test named. Add at
+least one integration-style assertion: run with `-q` against a bad path, assert
+stderr still contains `error:` (from `main.rs:44`). And a unit test on the
+quiet-gate helper: `Logger{quiet:true}.info(...)` is a no-op while
+`.warn/.error(...)` always prints. Since the gate is "a tiny helper wrapping
+eprintln!", give it a testable surface (e.g. write to a `&mut dyn Write` sink in
+tests rather than hardcoding `eprintln!`) — otherwise the quiet behavior is
+untestable without subprocess capture. **This is a design nudge: don't hardcode
+`eprintln!` inside the helper; take a writer or at least gate a function that
+tests can call.** (See §5.2.)
+
+### 4.4 Empty-input / 0-record path (Optional, confirmed safe)
+
+Plan edge case "Empty input / 0 reads: progress prints nothing; final summary
+shows zeros." Confirmed reachable: `producer_loop` breaks immediately on
+`None`, no progress tick fires; `SplittingReport::default()` is all zeros;
+`write_percent_or_fallback` already handles the zero-denominator case
+(`output.rs:524`, the "Can't determine percentage…" branch). The echo will show
+zeros, no panic. Good — but add a smoke assertion on a 0-read BAM if one is
+cheaply available.
+
+---
+
+## 5. Alternatives
+
+### 5.1 `--quiet`/`--verbose` two-bool vs `-v` count / log-level enum (Optional)
+
+The plan uses two independent bools. Tradeoffs:
+- **Two bools (plan):** simplest, matches the narrow requirement (info on by
+  default; `-q` silences info; `--verbose` adds only `@SQ`). Risk: `-q` +
+  `--verbose` together is an undefined combination. Recommend a `conflicts_with`
+  between them (clap one-liner) OR define precedence (e.g. `--quiet` wins,
+  `--verbose` ignored). The plan does not address `-q --verbose`; **add a mutex
+  or documented precedence** (Important-ish, cheap).
+- **`-v` count / level enum:** more idiomatic for tools that may grow more
+  verbosity tiers, but YAGNI here and diverges from Perl's all-or-nothing. Plan's
+  choice is appropriate for the stated scope; just close the `-q --verbose` gap.
+
+### 5.2 `log` + `env_logger` crate vs raw `eprintln!` gate (Optional)
+
+- Plan keeps raw `eprintln!` via a gate helper — consistent with the existing
+  codebase idiom (`output.rs` already uses `eprintln!`), no new dependency,
+  honoring memory `project_bam_io_decision` minimal-dep ethos. **Endorsed.**
+- The one thing `log`/`tracing` would buy is testability and env-var control;
+  not worth a dependency for this. BUT the gate helper should still be designed
+  for testability (§4.3): prefer a small struct method that can be pointed at a
+  test sink, or factor the "format the line" logic from the "write it" so the
+  formatting is unit-testable without capturing stderr.
+
+### 5.3 Counter cadence configurability (Optional)
+
+Perl hardcodes 500k (`:1553/:1850`). Plan matches. Fine. Don't add a flag for it
+(YAGNI); a `const PROGRESS_INTERVAL: u64 = 500_000;` is enough and matches Perl
+familiarity.
+
+---
+
+## Action items (prioritized)
+
+### Critical (fix before implementation — plan is factually wrong here)
+1. **§1.1 / §1.3 — Correct the dispatch model in the plan.** The runtime path is
+   `parallel.rs` for ALL `--parallel` values including N=1; `pipeline.rs` is
+   test-only and `route.rs` is per-call. Progress counter → producer thread in
+   `parallel.rs::producer_loop`. Banner/params/mode/header → `run_pipeline`
+   (`parallel.rs:177`, right after `build_chr_name_table`), NOT `pipeline.rs`.
+   Remove all instructions to edit `route.rs`/`pipeline.rs` for runtime output.
+
+### Important
+2. **§1.2 — Drop the `AtomicU64`.** Use the producer's existing single-threaded
+   `next_idx` (or a sibling local counter). Removes contention + interleaving +
+   the "aggregate vs per-worker" open question entirely.
+3. **§2.1 — Reuse the serialize-then-filter header idiom** from
+   `bismark-io::detect_paired_from_header` (`read.rs:649`) for @PG/@HD
+   provenance; consider extracting a shared `header_lines()` helper. Avoid
+   field-by-field `Map<Program>` reconstruction.
+4. **§4.1 — Note the `tail -3` display shift.** New final-summary lines will
+   replace the kept/deleted lines in the smoke's displayed tail; confirm no
+   consumer greps that tail (I found none) and decide summary-vs-sweep ordering.
+5. **§4.2 — Restate verification step 5** to grep/run `parallel.rs` only (both N
+   go through it); drop the route.rs grep.
+6. **§4.3 / §5.2 — Make the quiet-gate helper testable.** Don't hardcode
+   `eprintln!`; allow a test sink or factor formatting from writing. Add a test
+   that `-q` silences info but `error:` still prints.
+7. **§5.1 — Resolve `-q --verbose` interaction** (clap `conflicts_with` or
+   documented precedence).
+
+### Optional
+8. **§2.2 — Banner uses `CARGO_PKG_VERSION`/`version_string()`, NOT
+   `BISMARK_VERSION`** (the latter is the Perl-locked output-file version).
+9. **§2.4 — Document `-q` as a Rust-only divergence** in the SPEC/flag-mapping
+   so `cli.rs:3` "35 Perl flags" comment stays accurate.
+10. **§5.3 — `const PROGRESS_INTERVAL = 500_000`** rather than a magic literal.
+11. **§4.4 — Add a 0-read BAM smoke assertion** if cheap.
+
+---
+
+## Summary
+
+The feature is well-motivated, the stderr channel choice is correct, and
+byte-identity is genuinely unaffected (harness verified — console is `tail -3`
+display only, never compared). **However the plan's central structural premise
+is wrong: the live runtime path is `parallel.rs` for every `--parallel` value
+including N=1 — `pipeline.rs` and `route.rs` are test-only / per-call, so the
+"add to both drivers" instruction would put the progress counter in two
+non-runtime locations and miss the one live site (the producer thread).** Once
+relocated, the counter wants no atomic at all — the single-threaded producer's
+existing `next_idx` is the correct, contention-free source. Banner/params/mode/
+header all belong at one real chokepoint (`run_pipeline`), and the @PG/@HD dump
+should reuse `bismark-io`'s proven serialize-and-filter idiom rather than
+hand-walking `Map<Program>`. These are plan-text corrections, not feature
+blockers.

--- a/plans/05262026_bismark-extractor/CONSOLE_LOGGING_PLAN_REVIEW_B.md
+++ b/plans/05262026_bismark-extractor/CONSOLE_LOGGING_PLAN_REVIEW_B.md
@@ -1,0 +1,388 @@
+# Plan Review B — extractor console progress/diagnostics logging
+
+Reviewer: B (independent, fresh context)
+Plan: `CONSOLE_LOGGING_PLAN.md`
+Code grounded against: `cli.rs`, `main.rs`, `route.rs`, `parallel.rs`, `pipeline.rs`,
+`output.rs`, `state.rs`, `lib.rs`, `subprocess.rs`, `bismark-io/src/read.rs`.
+
+Verdict: **sound goal, lands cleanly off the beta.1 byte-identity path, but the plan
+is under-specified in three load-bearing spots** — the progress-counter location, the
+"@PG/@HD provenance" API (which does NOT exist as the plan assumes), and the
+quiet-gate classification of existing `eprintln!` sites. None are fatal; all are
+fixable before implementation. Details below.
+
+---
+
+## 1. Logic
+
+### 1a. Progress-counter location — the plan's "dual-dispatch" framing is WRONG and will mislead the implementer (Critical)
+
+The plan (§Implementation outline step 3) says the read loop "exists in BOTH
+`route.rs` (the `--parallel 1` path) AND `parallel.rs` (the `--parallel N` worker
+path)" and that the counter "MUST be added to both".
+
+That is not what the code does. `route.rs` has **no read loop** — it's a per-call
+router (`route_call`). The two record-iterating loops are:
+
+- `pipeline.rs::extract_se` / `extract_pe` — the **legacy single-threaded** path.
+- `parallel.rs::producer_loop` (reads records) + `worker_loop` (processes) — the
+  **parallel** path.
+
+Crucially, **`main.rs::run` always dispatches to `extract_se_parallel` /
+`extract_pe_parallel`** (main.rs:91-111). The legacy `extract_se`/`extract_pe` in
+`pipeline.rs` are only reachable from the test suite — lib.rs keeps them as the
+"byte-identity reference". So:
+
+- A user **never** hits `pipeline.rs`'s loop at any `--parallel` value, including
+  `--parallel 1` (n_workers = parallel.max(1) = 1, still the parallel pipeline).
+- Adding the counter to `pipeline.rs` would make it appear **in tests only**, never
+  in the real binary — the opposite of the plan's intent.
+- The counter belongs in the **parallel pipeline**, and the natural single
+  serialization point is the **producer** (`producer_loop`), which sees every record
+  exactly once, in input order, on one thread. That eliminates the atomic entirely
+  (see §3 efficiency) and gives Perl-faithful monotonic cadence.
+
+The plan's invocation of `[[feedback_dual_driver_back_port]]` is a good instinct but
+misapplied: the #876/#879 fixes touched both because both are *live extraction logic*.
+The progress counter is *pure stderr side-effect* and has exactly one production home.
+
+Recommendation: rewrite step 3 to specify the **producer thread** as the counter site.
+If the team wants the legacy path to log too (for parity when tests eyeball output),
+say so explicitly — but flag it as cosmetic/test-only, not a correctness mirror.
+
+### 1b. "Processed lines: N" — semantics and wording mismatch vs Perl (Critical for user trust)
+
+(Reviewer-A-may-underweight item #1.) The Rust counters already encode Perl's exact
+"lines" semantics, and the plan should *reuse them* rather than invent a new tally:
+
+- `SplittingReport.records_processed` — SE: 1/record; PE: **1/pair** (output.rs:399-409,
+  matches Perl `sequences_count` :2459, drives "Processed N lines in total").
+- `SplittingReport.call_strings_processed` — SE: 1/record; PE: **2/pair** (Perl :2451).
+
+Perl's `Processed lines: N` progress counter (line 1553/1850) counts **input SAM
+lines**, i.e. for PE that is **2 per pair** (R1 line + R2 line), matching
+`call_strings_processed`, NOT `records_processed`. The plan's Assumptions section
+(line 102-104) is ambiguous: it says "PE: Perl counts 2 call strings/pair — match
+Perl's 'lines' semantics" but then "exactness is NOT required". For a counter the
+whole *point* of which is "does this match the Perl run I did yesterday", **exactness
+in the per-tick semantics is the entire value**. If the Rust counter ticks per pair
+but Perl ticks per SAM line, a 55.7M-pair PE run shows `~55.7M` in Rust vs `~111.4M`
+in Perl — a 2× discrepancy that will generate "is the Rust port dropping half my
+reads?" support tickets.
+
+But there is a subtlety the plan misses: in the parallel producer, records are read
+one-at-a-time (SE) or two-at-a-time (PE pair). The producer can tick:
+- SE: +1 per record → matches Perl SAM-line count. Correct.
+- PE: +2 per pair (R1+R2) → matches Perl SAM-line count. Correct.
+
+So the producer naturally has access to the right granularity. Recommendation:
+**define the counter as "input SAM records read" (+1 SE record, +2 PE pair) and label
+it `Processed lines: N` to match Perl byte-for-byte.** Document this in the plan so
+nobody "simplifies" it to per-pair later.
+
+### 1c. Final summary — fine, but watch the `--mbias_off` and `--mbias_only` interaction
+
+The final per-context summary draws from `self.report` (the `SplittingReport`),
+which is populated **unconditionally** in `route_call` / `increment_counters` (route.rs:99,
+parallel.rs:792) — even under `--mbias_only` (counters bump before the short-circuit).
+So the summary is available in all modes. Good. The plan's edge-case note (line 112)
+is correct that it must "guard against referencing files that mode didn't produce" —
+but the *numbers* are always valid. The only real guard: under `--mbias_off` the
+M-bias tables are empty but the splitting-report counts are still live, so the
+summary should mirror `_splitting_report.txt` (which is itself still written under
+`--mbias_off`), not the M-bias data. Plan should state the summary mirrors the
+**splitting-report** figures specifically.
+
+---
+
+## 2. Assumptions
+
+### 2a. "@PG/@HD provenance pulled structurally from the noodles-parsed header" — the assumed API does not exist as described (Important)
+
+(Reviewer-A-may-underweight item #4.) The plan (§Behavior item 4, §Implementation
+step 2) asserts the port "reads the header structurally via noodles" and can "iterate
+the noodles `Header` program (`@PG`) records + the `@HD` line; skip the reference
+(`@SQ`) map" as "free structural access — no re-read."
+
+Reality check against `bismark-io/src/read.rs`:
+
+- The only header-introspection helper is `detect_paired_from_header(header: &Header)
+  -> Option<bool>` (read.rs:649). It does NOT expose `@PG`/`@HD`; it **serializes the
+  whole header to SAM text** via `noodles_sam::io::Writer` and string-searches for the
+  Bismark `@PG` line. The deliberate design comment (read.rs:650-653) says this is
+  "robust to noodles API shape changes ... the SAM text format is the stable contract
+  here, NOT the in-memory `Programs` type."
+- In `main.rs::run`, the AutoDetect probe gets `probe.header()` and passes it to
+  `detect_paired_from_header`, then **drops the reader** (main.rs:97-107) before
+  `extract_*_parallel` re-opens the file. So the header the plan wants to print is
+  *not* retained past detection — and for the `-s`/`-p` explicit paths the header is
+  never inspected on the main thread at all (it's read inside `run_pipeline`,
+  parallel.rs:186, used only for `chr_table`).
+
+Consequences the plan must resolve:
+
+1. **There is no `Header::programs()` iteration wired up today.** The implementer
+   would need to either (a) add a new bismark-io helper that returns the `@PG`/`@HD`
+   lines as text, or (b) reach into noodles' `Header::programs()` /
+   `Header::header()` typed API directly in the extractor. Option (a) is consistent
+   with the existing "SAM text is the contract" design; option (b) couples the
+   extractor to noodles' in-memory types the project deliberately avoided. The plan
+   picks neither — it just assumes the access is "free". It is not free; it's a small
+   new API surface. Estimate it.
+
+2. **Faithful `@PG ... CL:"..."` reproduction + multi-`@PG` ordering** (Reviewer item
+   #4): if provenance is emitted by **re-serializing** the noodles header (the path
+   `detect_paired_from_header` already uses), noodles preserves `@PG` records in
+   header order and round-trips `CL:` verbatim *as long as it parsed them into
+   `other_fields`*. The risk is real but bounded: noodles' SAM header writer emits
+   `@PG` tags in a defined order (ID, PN, CL, PP, ...) which may **not** match the
+   byte order samtools wrote (samtools commonly emits `ID PN VN CL` or `ID PN CL PP`).
+   So the printed line can be a *semantically faithful but byte-reordered* version of
+   the original. For a **diagnostic** (not a byte-compared output file) that is
+   acceptable — but the plan should drop the word "faithfully reproduce" and instead
+   say "emit the parsed @PG fields (ID/PN/VN/CL/PP); tag order may differ from the
+   on-disk byte order." If the team wants the *exact* original bytes, the only safe
+   route is the text-serialization path filtered to `@PG`/`@HD` lines — recommend
+   that, since the helper already exists and it sidesteps the reordering question
+   entirely. **This is the cleanest fix: filter the existing serialize-to-text output
+   to lines starting `@PG`/`@HD` and print them as-is.** That reuses `detect_*`'s
+   proven approach and gives byte-faithful provenance for free.
+
+3. **Where to print it**: the header is available inside `run_pipeline` (parallel.rs:186)
+   before workers spawn — that is the correct, single emit point for banner + params +
+   mode + provenance. The plan's step 2 hedges ("Likely in `pipeline.rs` ... or wherever
+   cli.rs:467-era resolution lands"). Pin it to **`parallel.rs::run_pipeline`, right
+   after `open_reader` + `build_chr_name_table`, before the worker spawn loop**. That
+   is also where `is_paired` is already known (passed in), so mode-detection wording is
+   trivially available.
+
+### 2b. "Detected from @PG" wording is only true on the AutoDetect path (Important)
+
+Plan §Behavior item 2 proposes `(auto-detected from @PG)` vs `(forced via -s/-p)`. But
+note `run_pipeline` receives only the resolved `is_paired: bool` and `config.paired_mode`.
+The mode-source (explicit vs auto) **is** recoverable from `config.paired_mode`
+(`SingleEnd`/`PairedEnd` = forced; `AutoDetect` = auto). Good — the data exists. Just
+make sure the message is derived from `config.paired_mode`, not from `is_paired` (which
+has lost the provenance). Minor, but a naive implementation that only has `is_paired`
+will print the wrong suffix. Call this out in the plan.
+
+### 2c. Banner version source
+
+The banner (item 1) wants `<crate ver>`. `version_string()` (lib.rs:96) already exists
+and reads `CARGO_PKG_VERSION`. Note there are **two** version strings in play:
+`output.rs::BISMARK_VERSION = "v0.25.1"` (the Perl-compat string baked into output
+files) and `CARGO_PKG_VERSION` (the Rust crate version). The banner should use the
+**crate** version (it's a Rust-tool banner, "(Rust)"), but the plan should say which,
+because a reviewer/implementer could reasonably reach for `BISMARK_VERSION` to "match
+Perl". Specify: banner = crate version; output-file headers = `BISMARK_VERSION`
+(unchanged).
+
+---
+
+## 3. Efficiency
+
+### 3a. Drop the AtomicU64 — the producer is already a single thread (Important simplification)
+
+Plan step 3 proposes "a shared `AtomicU64`; print on crossing each 500k boundary" and
+flags "aggregate-atomic vs per-worker" as a review decision. Per §1a, the counter
+belongs in the **producer**, which is single-threaded (parallel.rs:315 `producer_loop`).
+A single thread needs **no atomic** — a plain `u64` local with `if n % 500_000 == 0`
+(or boundary-crossing check) is correct, cheaper, and gives strictly monotonic,
+deterministic output identical at every `--parallel N`. This also sidesteps the
+"garbled interleaving" edge case (plan line 110) entirely — there is nothing to
+interleave. Recommend: **plain local counter in `producer_loop`; no atomic, no shared
+state.** This is simpler than either option the plan offered.
+
+One caveat: the producer counts records *read*, which for an error-aborting run may
+slightly lead the collector's *written* count. That's fine and matches Perl, whose
+progress counter also ticks at read time, ahead of downstream processing.
+
+### 3b. Per-line `Logger` quiet check — negligible
+
+Gating each `eprintln!` behind `if !quiet` is free relative to the I/O. The progress
+line fires every 500k records; the rest fire O(1) times. No concern. The `Logger`
+struct (plan step 1) is fine, though for ~6 call sites a single `quiet: bool` threaded
+into the two emit points (run_pipeline startup block + producer + finalize) may be
+simpler than a new type. Either is acceptable; not worth a blocking note.
+
+---
+
+## 4. Quiet-gate completeness (Reviewer item #3)
+
+I audited every `eprintln!` in the extractor (`grep -rn eprintln! src/`). Classification
+of each as **info (gate under --quiet)** vs **warning/error (NEVER gate)**:
+
+| Site | Text | Class | Plan handles it? |
+|---|---|---|---|
+| `output.rs:319` | `{path} was empty -> deleted` | INFO → gate | Yes (step 5) |
+| `output.rs:322` | `{path} contains data -> kept` | INFO → gate | Yes (step 5) |
+| `output.rs:330-331` | two blank lines (Perl :625) | INFO → gate (travels with kept/deleted) | Implied; **make explicit** |
+| `output.rs:317` | `warning: failed to remove empty output file` | WARNING → never gate | Yes (edge case line 109) |
+| `output.rs:369` | `warning: failed to remove partial output file` | WARNING → never gate | **NOT mentioned** — only the *empty*-file warning is called out |
+| `main.rs:44` | `error: {e}` | ERROR → never gate | Yes (line 57) |
+| `subprocess.rs:411` | `[bismark-extractor] spawning: …` | INFO (Phase G) | Plan says Phase G "out of scope" — but this is always-on info that `--quiet` users will reasonably expect silenced |
+| `subprocess.rs:519` | `note: …cytosine_report will scan…` | WARNING-ish (Phase G) | Out of scope per plan |
+
+Findings:
+
+1. **`output.rs:369` (cleanup_all partial-file warning) is missed.** The plan's edge
+   case (line 109) names only "the `failed to remove` warning" singular and cites the
+   *empty*-file one. There are **two** such warnings. Both are genuine warnings and
+   must NOT be gated. The plan's `Logger` must clearly express "these two lines bypass
+   the gate" — confirm both. (Low risk of accidental gating since they're worded
+   `warning:` and a careful implementer won't route them through the info gate, but
+   the plan should enumerate both so it's not left to chance.)
+
+2. **The two trailing blank lines (output.rs:330-331)** are part of the kept/deleted
+   *block*. If kept/deleted are gated but the blanks are not, `--quiet` output gets two
+   stray blank lines. Plan should state the blanks gate **together with** the
+   kept/deleted lines.
+
+3. **`subprocess.rs:411` "spawning:" is always-on info today.** The plan declares
+   Phase G "out of scope" (line 132), which is defensible — but a `--quiet` user
+   running `--bedGraph` will still see the `[bismark-extractor] spawning:` line and the
+   sub-tool's inherited stderr. That's arguably a leak of the `--quiet` contract.
+   Recommend the plan **explicitly acknowledge** that `--quiet` does not silence Phase G
+   subprocess chatter (it's the child tools' own output + the pre-spawn audit line),
+   and either (a) gate the `:411` audit line too for consistency, or (b) document the
+   limitation. Don't leave it silently inconsistent.
+
+The split the plan proposes (single `Logger` for info; warnings/errors use bare
+`eprintln!`) does cleanly express the info-vs-warning divide — provided the
+implementer routes only the four INFO lines through it and leaves the three
+WARNING/ERROR lines on bare `eprintln!`. The risk is purely one of omission (missing
+:369), not of structural inability.
+
+---
+
+## 5. Validation sufficiency
+
+### 5a. Byte-identity guard — adequate in principle, but the smoke run is the weakest link (Important)
+
+(Reviewer item #5.) The claim that console logging cannot affect byte-identical output
+files is **correct and well-grounded**: all new output is `eprintln!` (stderr); the
+output *files* are written by `OutputFileMap`/`write_splitting_report`/`write_mbias_txt`,
+none of which the plan touches. The Phase H harness compares files (`cmp`/sorted-md5)
+and only `tail -3`s the console. So the invariant holds **by construction**.
+
+However:
+
+- The plan's step-2 provenance work touches the **header read path** in
+  `run_pipeline` (parallel.rs). If the implementer adds, say, a header re-serialization
+  or a new bismark-io helper, there's a non-zero chance of perturbing the existing
+  `build_chr_name_table` borrow or the `detect_*` path. The byte-identity guard
+  (`phase_h_smoke.sh` on 1 SE + 1 PE cell) catches *output* divergence but would NOT
+  catch a header-read regression that, e.g., changes SE/PE auto-detection. **Add a
+  targeted assertion** that auto-detection still resolves correctly on an unflagged
+  BAM (or rely on the existing `detect_paired_from_header` unit tests + run one
+  AutoDetect cell in the smoke). The plan should name AutoDetect explicitly in the
+  verification matrix.
+
+- "One SE + one PE cell" smoke vs **full matrix**: for *output byte-identity*, one
+  cell each is adequate because the change is structurally orthogonal to file writes —
+  I agree with the plan that the full matrix is overkill here. BUT the *console* output
+  itself is new and unverified by any automated check (it's eyeballed, per step 1).
+  Recommend at least **one assertion-based test** that does not require colossal: a
+  Rust integration test asserting (a) `--quiet` produces empty informational stderr
+  while a forced error still prints, and (b) the banner/mode/params lines appear on a
+  tiny synthetic BAM. The plan leans entirely on manual eyeballing on colossal (steps
+  1-2), which won't regression-guard future refactors. This is the biggest validation
+  gap.
+
+### 5b. Progress-cadence test
+
+Because the counter now lives in the producer (per §1a), a unit/integration test can
+feed a synthetic ≥500k-record SAM and assert the `Processed lines:` line count. Without
+this, the dual-dispatch verification the plan proposes (step 5: "grep both route.rs and
+parallel.rs") is checking the *wrong* files (route.rs has no loop). Replace that
+verification step with: "assert the counter is in `producer_loop` and fires at the
+right cadence on a synthetic input."
+
+### 5c. clap collision check (Reviewer item #2) — CLEARED
+
+Audited `cli.rs`: `-V`/`--version` is taken (line 219); `disable_version_flag = true`
+(line 29) frees clap's auto `-V`. clap's auto `-h`/`--help` is present (no
+`disable_help_flag`). **`-v` is FREE**; `--verbose` and `--quiet` longs are free; `-q`
+is free. No collision. The plan's `-q`/`--quiet` + `--verbose` (the plan does not
+assign `-v`; if it wants a short for verbose, `-v` is available). Recommend the plan
+**not** add `-v` unless asked — `--verbose` long-only avoids any future `-v`-means-
+version confusion (Perl convention) and is the safer choice. Add a `clap_definition_is_valid`
+coverage note: the existing `Cli::command().debug_assert()` test (cli.rs:536) will catch
+any duplicate-short-flag panic at test time, so a collision can't ship silently.
+
+---
+
+## 6. Alternatives — default-on vs opt-in (Reviewer item #6)
+
+**Argument for default-OFF (opt-in `--verbose`-style):** the tool may run in pipelines
+(Nextflow/Snakemake) where stderr is captured into per-task logs; chatter inflates logs
+and a 500k-cadence progress line on a 55.7M-pair run emits ~110 lines that bloat CI/log
+storage. Many modern bioinformatics CLIs default to quiet and gate verbosity behind
+`-v`.
+
+**Argument for default-ON (the plan's choice):** (1) **Perl is default-on** — the entire
+motivation (Felix's 2026-05-29 note) is that silence is indistinguishable from a hang
+and silent SE/PE auto-detection bites users. Matching Perl's default is the
+least-surprise path for users migrating from the Perl tool. (2) The volume is modest:
+banner + params + provenance + final summary is O(20 lines); the only repeated line is
+the 500k-cadence progress, which at one line per 500k records is **~110 lines for a
+55.7M-pair run** — trivial. (3) stdout stays clean (plan is explicit), so piping is
+unaffected; only stderr carries the log, which is the conventional channel for progress.
+
+**My recommendation: keep default-ON, matching Perl + the stated motivation, BUT:**
+- The progress line is the only high-volume item. Consider making **only the progress
+  cadence** suppressible independently (it's already covered by `--quiet`, which is
+  enough). 110 lines is not worth a third flag.
+- Ensure `--quiet` is genuinely complete (see §4) so pipeline authors who *do* want
+  silence have a clean single switch. This is the real mitigation for the opt-in
+  argument — a fully-working `--quiet` makes default-on harmless.
+
+So: plan's default-on is the right call given Perl-parity is the explicit goal;
+the opt-in concern is fully addressed by a complete `--quiet`, which §4 must nail.
+
+---
+
+## Action items (prioritized)
+
+### Critical (fix before implementation)
+- **C1.** Rewrite Implementation step 3: the progress counter belongs in
+  `parallel.rs::producer_loop` (single-threaded, no atomic), NOT in "route.rs +
+  parallel.rs". `route.rs` has no read loop; `pipeline.rs`'s loop is test-only (main.rs
+  always uses `*_parallel`). The "dual-dispatch trap" framing is misapplied here.
+- **C2.** Pin the `Processed lines: N` semantics to **input SAM records** (+1 per SE
+  record, +2 per PE pair) to byte-match Perl's per-SAM-line count; remove the
+  "exactness not required" hedge — for a comparison-with-Perl counter the per-tick
+  semantics ARE the value.
+
+### Important (resolve in plan text before implementation)
+- **I1.** Correct the "@PG/@HD structural access is free" assumption: no such API is
+  wired up. Recommend **filtering the existing serialize-to-SAM-text path** (the one
+  `detect_paired_from_header` already uses) to `@PG`/`@HD` lines and printing them
+  as-is — byte-faithful, sidesteps tag-reordering, reuses proven code. Estimate the
+  small new bismark-io helper.
+- **I2.** Pin the single emit point for banner/params/mode/provenance to
+  `parallel.rs::run_pipeline` after `open_reader`+`build_chr_name_table`, before worker
+  spawn. Derive the mode-source suffix from `config.paired_mode` (not `is_paired`,
+  which has lost provenance).
+- **I3.** Quiet-gate audit: enumerate BOTH `failed to remove` warnings (output.rs:317
+  AND :369) as never-gated; state the two trailing blank lines (:330-331) gate together
+  with kept/deleted; explicitly decide+document whether the Phase G `[bismark-extractor]
+  spawning:` line (subprocess.rs:411) is gated or an acknowledged `--quiet` limitation.
+- **I4.** Add at least one **automated** test (not colossal eyeballing): assert
+  `--quiet` silences info but not a forced error, and assert banner/mode/params + the
+  progress cadence on a tiny synthetic BAM. Replace verification step 5's
+  "grep route.rs and parallel.rs" with "assert counter in producer_loop + cadence
+  test". Add an AutoDetect cell to the byte-identity smoke to guard the header-read
+  path.
+
+### Optional / nits
+- **O1.** Banner uses `CARGO_PKG_VERSION` (via `version_string()` style), NOT
+  `output.rs::BISMARK_VERSION` — state this so nobody "matches Perl" by mistake.
+- **O2.** Final summary mirrors the **splitting-report** figures (live even under
+  `--mbias_off`/`--mbias_only`), not the M-bias tables; say so.
+- **O3.** Keep `--verbose` long-only (no `-v`) to avoid future `-v`==version confusion;
+  the existing `Cli::command().debug_assert()` test will catch any short-flag collision
+  at test time.
+- **O4.** Default-ON is the right choice (Perl parity + the stated motivation); the
+  opt-in concern is fully neutralized by a complete `--quiet` (see I3). No third flag
+  needed for the ~110-line progress volume.

--- a/rust/bismark-extractor/src/cli.rs
+++ b/rust/bismark-extractor/src/cli.rs
@@ -201,6 +201,19 @@ pub struct Cli {
     #[arg(long = "mbias_off")]
     pub mbias_off: bool,
 
+    // ─── Console diagnostics (#882) ───
+    /// Suppress the informational stderr log (banner, mode, parameter summary,
+    /// header provenance, progress counter, final summary, kept/deleted).
+    /// Genuine warnings + errors still print. Default off (verbose like Perl).
+    #[arg(short = 'q', long = "quiet")]
+    pub quiet: bool,
+
+    /// Also print the `@SQ` reference dictionary in the header provenance
+    /// (long-only; `@HD`/`@PG` are shown regardless). Off by default — the
+    /// per-contig dump is noise on large genomes.
+    #[arg(long = "verbose")]
+    pub verbose: bool,
+
     // ─── Compat / silent-accept flags (SPEC §3 row 27) ───
     /// Path to a samtools binary. Silently accepted in the Rust port —
     /// bismark-io uses pure-Rust noodles; no samtools subprocess is
@@ -315,6 +328,10 @@ pub struct ResolvedConfig {
     pub genome_folder: Option<PathBuf>,
     /// Rayon worker thread count (Phase F).
     pub parallel: usize,
+    /// Suppress informational stderr log (#882). Errors/warnings still print.
+    pub quiet: bool,
+    /// Include `@SQ` lines in header provenance (#882).
+    pub verbose: bool,
 }
 
 impl ResolvedConfig {
@@ -503,6 +520,8 @@ impl Cli {
             ample_memory: self.ample_memory,
             genome_folder: self.genome_folder,
             parallel: self.parallel as usize,
+            quiet: self.quiet,
+            verbose: self.verbose,
         })
     }
 }

--- a/rust/bismark-extractor/src/lib.rs
+++ b/rust/bismark-extractor/src/lib.rs
@@ -58,6 +58,7 @@ pub mod call;
 pub mod cli;
 pub mod error;
 pub mod header;
+pub mod logging;
 pub mod mbias;
 pub mod mbias_writer;
 pub mod output;

--- a/rust/bismark-extractor/src/logging.rs
+++ b/rust/bismark-extractor/src/logging.rs
@@ -1,0 +1,282 @@
+//! Console diagnostics — a STDERR logger gated by `--quiet`, plus the pure
+//! text builders for the startup banner, parameter summary, header provenance,
+//! progress counter, and final methylation summary.
+//!
+//! **All diagnostic output goes to STDERR**, matching Perl Bismark's `warn`
+//! model (the Perl extractor uses `warn` for every progress/summary line; 0
+//! `print STDOUT`) and the pre-existing `eprintln!` sites in `output.rs`.
+//! stdout stays clean (only `--version` writes there, in `main.rs`).
+//!
+//! The text builders (`header_provenance_lines`, `parameters_text`,
+//! `final_summary_text`) are pure (return `String`/`Vec<String>`) so the
+//! `--quiet` gate and the formatting are unit-testable without capturing
+//! a real stderr.
+
+use crate::cli::ResolvedConfig;
+use crate::output::SplittingReport;
+use noodles_sam::Header;
+use std::io::Write;
+
+/// STDERR diagnostics logger. `Copy` so it can be handed to the producer
+/// thread cheaply.
+#[derive(Debug, Clone, Copy)]
+pub struct Logger {
+    quiet: bool,
+    verbose: bool,
+}
+
+impl Logger {
+    /// Construct a logger from explicit flags.
+    #[must_use]
+    pub fn new(quiet: bool, verbose: bool) -> Self {
+        Self { quiet, verbose }
+    }
+
+    /// Construct a logger from the resolved CLI config (`--quiet`/`--verbose`).
+    #[must_use]
+    pub fn from_config(config: &ResolvedConfig) -> Self {
+        Self::new(config.quiet, config.verbose)
+    }
+
+    /// Whether `@SQ` reference-dictionary lines are included in provenance.
+    #[must_use]
+    pub fn verbose(&self) -> bool {
+        self.verbose
+    }
+
+    /// Write an informational string to `w` unless `--quiet`. Returns whether
+    /// it wrote — the seam the unit tests use to assert the quiet gate without
+    /// touching a real stderr.
+    pub fn info_to<W: Write>(&self, w: &mut W, s: &str) -> bool {
+        if self.quiet {
+            return false;
+        }
+        let _ = w.write_all(s.as_bytes());
+        true
+    }
+
+    /// General gated informational line: write `s` + newline to stderr unless
+    /// `--quiet`. For ad-hoc lines like the empty-sweep `kept`/`deleted` log.
+    pub fn note(&self, s: &str) {
+        self.info(&format!("{s}\n"));
+    }
+
+    /// Informational string → stderr unless `--quiet`.
+    fn info(&self, s: &str) {
+        if self.quiet {
+            return;
+        }
+        let mut err = std::io::stderr().lock();
+        let _ = err.write_all(s.as_bytes());
+    }
+
+    /// Startup banner (`env!("CARGO_PKG_VERSION")`, NOT the v0.25.1-locked
+    /// `BISMARK_VERSION` used for output-file headers).
+    pub fn banner(&self) {
+        self.info(&format!(
+            "\n*** Bismark methylation extractor (Rust port) version {} ***\n\n",
+            env!("CARGO_PKG_VERSION")
+        ));
+    }
+
+    /// SE/PE mode line + parameter summary.
+    pub fn parameters(&self, config: &ResolvedConfig, is_paired: bool) {
+        self.info(&parameters_text(config, is_paired));
+    }
+
+    /// `@HD` + `@PG` header provenance (`@SQ` only when `--verbose`).
+    pub fn header_provenance(&self, header: &Header) {
+        let lines = header_provenance_lines(header, self.verbose);
+        if lines.is_empty() {
+            return;
+        }
+        let mut s = String::from("Alignment provenance (from BAM/SAM header):\n");
+        for l in &lines {
+            s.push_str(l);
+            s.push('\n');
+        }
+        s.push('\n');
+        self.info(&s);
+    }
+
+    /// `Processed lines: N` progress tick.
+    pub fn progress(&self, lines: u64) {
+        self.info(&format!("Processed lines: {lines}\n"));
+    }
+
+    /// Final per-context methylation summary (mirror of `_splitting_report.txt`).
+    pub fn final_summary(&self, report: &SplittingReport) {
+        self.info(&final_summary_text(report));
+    }
+}
+
+/// `@HD`/`@PG` (and, when `include_sq`, `@SQ`) header lines, serialized to
+/// their on-disk SAM text form. Reuses the version-robust idiom from
+/// `bismark_io::detect_paired_from_header`: serialize via
+/// `noodles_sam::io::Writer` and filter the text lines, rather than walking the
+/// in-memory `Map<Program>` (which can reorder tags). The `@SQ` reference
+/// dictionary (190+ contigs on a human genome) is the noise we drop by default.
+#[must_use]
+pub fn header_provenance_lines(header: &Header, include_sq: bool) -> Vec<String> {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = noodles_sam::io::Writer::new(&mut buf);
+        if writer.write_header(header).is_err() {
+            return Vec::new();
+        }
+    }
+    filter_header_text(&String::from_utf8_lossy(&buf), include_sq)
+}
+
+/// Filter serialized SAM-header text to provenance lines: keep everything
+/// except the `@SQ` reference dictionary, unless `include_sq`. Split out as a
+/// pure function so it's unit-testable on a literal header string.
+#[must_use]
+fn filter_header_text(text: &str, include_sq: bool) -> Vec<String> {
+    text.lines()
+        .filter(|line| include_sq || !line.starts_with("@SQ"))
+        .map(std::string::ToString::to_string)
+        .collect()
+}
+
+/// Parameter-summary block (Perl `bismark_methylation_extractor:54`-style).
+#[must_use]
+pub fn parameters_text(config: &ResolvedConfig, is_paired: bool) -> String {
+    let lib = if is_paired { "paired-end" } else { "single-end" };
+    let mut s = String::new();
+    s.push_str(&format!("Treating file(s) as {lib} data\n\n"));
+    s.push_str("Summarising Bismark methylation extractor parameters:\n");
+    s.push_str("=======================================================\n");
+    s.push_str(&format!("Bismark {lib} format specified\n"));
+    s.push_str(&format!("Number of parallel workers: {}\n", config.parallel.max(1)));
+    s.push_str(&format!(
+        "Output will be written to: {}\n",
+        config.output_dir.display()
+    ));
+    if config.ignore_5p_r1 > 0 {
+        s.push_str(&format!(
+            "Ignoring first {} bp from the 5' end of Read 1\n",
+            config.ignore_5p_r1
+        ));
+    }
+    if config.ignore_3p_r1 > 0 {
+        s.push_str(&format!(
+            "Ignoring last {} bp from the 3' end of Read 1\n",
+            config.ignore_3p_r1
+        ));
+    }
+    if is_paired && config.ignore_5p_r2 > 0 {
+        s.push_str(&format!(
+            "Ignoring first {} bp from the 5' end of Read 2\n",
+            config.ignore_5p_r2
+        ));
+    }
+    if is_paired && config.ignore_3p_r2 > 0 {
+        s.push_str(&format!(
+            "Ignoring last {} bp from the 3' end of Read 2\n",
+            config.ignore_3p_r2
+        ));
+    }
+    if is_paired {
+        if config.no_overlap {
+            s.push_str("Overlapping paired-end calls will be counted once (--no_overlap)\n");
+        } else {
+            s.push_str("Overlapping paired-end calls will be counted twice (--include_overlap)\n");
+        }
+    }
+    if config.gzip {
+        s.push_str("Output files will be GZIP compressed (.gz)\n");
+    }
+    s.push('\n');
+    s
+}
+
+/// Final methylation summary (mirror of the `_splitting_report.txt` numbers,
+/// Perl `:2480`-`:2521` warned to stderr). Built from the same
+/// [`SplittingReport`] that drives the file.
+#[must_use]
+pub fn final_summary_text(report: &SplittingReport) -> String {
+    let cpg = SplittingReport::percent_meth(report.calls_cpg_meth, report.calls_cpg_unmeth);
+    let chg = SplittingReport::percent_meth(report.calls_chg_meth, report.calls_chg_unmeth);
+    let chh = SplittingReport::percent_meth(report.calls_chh_meth, report.calls_chh_unmeth);
+    format!(
+        "\nProcessed {lines} lines in total\n\
+         Total number of methylation call strings processed: {call_strings}\n\n\
+         Final Cytosine Methylation Report\n\
+         =================================\n\
+         Total number of C's analysed:\t{total}\n\n\
+         Total methylated C's in CpG context:\t{cpg_m}\n\
+         Total methylated C's in CHG context:\t{chg_m}\n\
+         Total methylated C's in CHH context:\t{chh_m}\n\n\
+         Total C to T conversions in CpG context:\t{cpg_u}\n\
+         Total C to T conversions in CHG context:\t{chg_u}\n\
+         Total C to T conversions in CHH context:\t{chh_u}\n\n\
+         C methylated in CpG context:\t{cpg:.1}%\n\
+         C methylated in CHG context:\t{chg:.1}%\n\
+         C methylated in CHH context:\t{chh:.1}%\n\n",
+        // `Processed N lines in total` mirrors the file line at
+        // `output.rs:683` (Perl `:2482` `$sequences_count`) = records_processed
+        // (= pairs for PE). The call-strings line is the separate 2×pairs
+        // counter. For SE both are equal; they diverge for PE.
+        lines = report.records_processed,
+        call_strings = report.call_strings_processed,
+        total = report.calls_total,
+        cpg_m = report.calls_cpg_meth,
+        chg_m = report.calls_chg_meth,
+        chh_m = report.calls_chh_meth,
+        cpg_u = report.calls_cpg_unmeth,
+        chg_u = report.calls_chg_unmeth,
+        chh_u = report.calls_chh_unmeth,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quiet_gate_suppresses_info_but_returns_false() {
+        let quiet = Logger::new(true, false);
+        let loud = Logger::new(false, false);
+        let mut buf_q: Vec<u8> = Vec::new();
+        let mut buf_l: Vec<u8> = Vec::new();
+        assert!(!quiet.info_to(&mut buf_q, "hello\n"));
+        assert!(buf_q.is_empty(), "quiet must write nothing");
+        assert!(loud.info_to(&mut buf_l, "hello\n"));
+        assert_eq!(buf_l, b"hello\n");
+    }
+
+    #[test]
+    fn final_summary_matches_perl_shape_and_percent() {
+        let r = SplittingReport {
+            // PE: `records_processed` (pairs) and `call_strings_processed`
+            // (2×pairs) differ — the two report lines must use the right
+            // counter each (mirrors the file at output.rs:683/690).
+            records_processed: 4_250_754,
+            call_strings_processed: 8_501_508,
+            calls_total: 100,
+            calls_cpg_meth: 818,
+            calls_cpg_unmeth: 182, // 818/1000 = 81.8%
+            ..SplittingReport::default()
+        };
+        let text = final_summary_text(&r);
+        assert!(text.contains("Processed 4250754 lines in total"));
+        assert!(text.contains("Total number of methylation call strings processed: 8501508"));
+        assert!(text.contains("Total number of C's analysed:\t100"));
+        assert!(text.contains("C methylated in CpG context:\t81.8%"));
+    }
+
+    #[test]
+    fn provenance_drops_sq_by_default_keeps_hd_pg() {
+        let header = "@HD\tVN:1.0\tSO:unsorted\n\
+                      @SQ\tSN:1\tLN:248956422\n\
+                      @SQ\tSN:MT\tLN:16569\n\
+                      @PG\tID:Bismark\tVN:v0.25.1\tCL:\"bismark --genome g/ r.fq.gz\"\n";
+        let default = filter_header_text(header, false);
+        assert_eq!(default.len(), 2, "default must drop the 2 @SQ lines");
+        assert!(default[0].starts_with("@HD"));
+        assert!(default[1].starts_with("@PG") && default[1].contains("ID:Bismark"));
+        let verbose = filter_header_text(header, true);
+        assert_eq!(verbose.len(), 4, "--verbose keeps @SQ too");
+    }
+}

--- a/rust/bismark-extractor/src/logging.rs
+++ b/rust/bismark-extractor/src/logging.rs
@@ -142,13 +142,20 @@ fn filter_header_text(text: &str, include_sq: bool) -> Vec<String> {
 /// Parameter-summary block (Perl `bismark_methylation_extractor:54`-style).
 #[must_use]
 pub fn parameters_text(config: &ResolvedConfig, is_paired: bool) -> String {
-    let lib = if is_paired { "paired-end" } else { "single-end" };
+    let lib = if is_paired {
+        "paired-end"
+    } else {
+        "single-end"
+    };
     let mut s = String::new();
     s.push_str(&format!("Treating file(s) as {lib} data\n\n"));
     s.push_str("Summarising Bismark methylation extractor parameters:\n");
     s.push_str("=======================================================\n");
     s.push_str(&format!("Bismark {lib} format specified\n"));
-    s.push_str(&format!("Number of parallel workers: {}\n", config.parallel.max(1)));
+    s.push_str(&format!(
+        "Number of parallel workers: {}\n",
+        config.parallel.max(1)
+    ));
     s.push_str(&format!(
         "Output will be written to: {}\n",
         config.output_dir.display()

--- a/rust/bismark-extractor/src/logging.rs
+++ b/rust/bismark-extractor/src/logging.rs
@@ -12,7 +12,7 @@
 //! `--quiet` gate and the formatting are unit-testable without capturing
 //! a real stderr.
 
-use crate::cli::ResolvedConfig;
+use crate::cli::{PairedMode, ResolvedConfig};
 use crate::output::SplittingReport;
 use noodles_sam::Header;
 use std::io::Write;
@@ -147,8 +147,14 @@ pub fn parameters_text(config: &ResolvedConfig, is_paired: bool) -> String {
     } else {
         "single-end"
     };
+    // Mode-detection source (Perl `:1172`/`:1177` parenthetical): AutoDetect
+    // resolved from the @PG line, vs explicitly forced with -s/-p.
+    let source = match config.paired_mode {
+        PairedMode::AutoDetect => "auto-detected from @PG line",
+        PairedMode::SingleEnd | PairedMode::PairedEnd => "specified via -s/-p",
+    };
     let mut s = String::new();
-    s.push_str(&format!("Treating file(s) as {lib} data\n\n"));
+    s.push_str(&format!("Treating file(s) as {lib} data ({source})\n\n"));
     s.push_str("Summarising Bismark methylation extractor parameters:\n");
     s.push_str("=======================================================\n");
     s.push_str(&format!("Bismark {lib} format specified\n"));

--- a/rust/bismark-extractor/src/output.rs
+++ b/rust/bismark-extractor/src/output.rs
@@ -280,7 +280,10 @@ impl OutputFileMap {
     /// Returns `Ok` regardless; the function's signature retains
     /// `Result<_, io::Error>` for forward-compat with any future
     /// non-`remove_file` IO needs.
-    pub fn finalize_with_empty_sweep(&mut self) -> Result<FinalizationReport, std::io::Error> {
+    pub fn finalize_with_empty_sweep(
+        &mut self,
+        logger: crate::logging::Logger,
+    ) -> Result<FinalizationReport, std::io::Error> {
         let entries: Vec<_> = self.files.drain().collect();
         let mut kept: Vec<PathBuf> = Vec::new();
         let mut swept: Vec<PathBuf> = Vec::new();
@@ -314,12 +317,13 @@ impl OutputFileMap {
                 // unlink failure so subsequent files still get processed
                 // and post-sweep work runs.
                 if let Err(e) = std::fs::remove_file(&path) {
+                    // Genuine warning — never gated by --quiet.
                     eprintln!("warning: failed to remove empty output file {path_str}: {e}");
                 }
-                eprintln!("{path_str} was empty ->\tdeleted");
+                logger.note(&format!("{path_str} was empty ->\tdeleted"));
                 swept.push(abs_path);
             } else {
-                eprintln!("{path_str} contains data ->\tkept");
+                logger.note(&format!("{path_str} contains data ->\tkept"));
                 kept.push(abs_path);
             }
         }
@@ -327,8 +331,8 @@ impl OutputFileMap {
         // stderr to mark the end of the sweep block. Mirroring for
         // consistency with downstream tooling that visually parses the
         // captured stderr.
-        eprintln!();
-        eprintln!();
+        logger.note("");
+        logger.note("");
         // Phase G (rev 1 I7): sort kept lexicographically so the argv
         // positional tail passed to bismark2bedGraph is deterministic
         // across runs (underlying HashMap iteration order is not).
@@ -958,6 +962,8 @@ mod tests {
             ample_memory: false,
             genome_folder: None,
             parallel: 1,
+            quiet: false,
+            verbose: false,
         }
     }
 

--- a/rust/bismark-extractor/src/parallel.rs
+++ b/rust/bismark-extractor/src/parallel.rs
@@ -186,6 +186,15 @@ fn run_pipeline(
     let reader = open_reader(input, /*cram_ref=*/ None)?;
     let chr_table: Arc<[String]> = Arc::from(build_chr_name_table(reader.header())?);
 
+    // Console diagnostics (#882) — emit once on the main thread while we still
+    // hold the reader (it is moved into the producer below). All to stderr,
+    // gated by --quiet. The final methylation summary is emitted later, inside
+    // `state.finalize`, where the SplittingReport counts are finalized.
+    let logger = crate::logging::Logger::from_config(config);
+    logger.banner();
+    logger.parameters(config, is_paired);
+    logger.header_provenance(reader.header());
+
     let input_basename = derive_basename(input);
     let mut state = ExtractState::new(config, input, &input_basename, is_paired)?;
 
@@ -222,7 +231,7 @@ fn run_pipeline(
     let producer_handle = std::thread::Builder::new()
         .name("bismark-extractor-producer".to_string())
         .spawn(move || {
-            producer_loop(reader, is_paired, producer_tx_input);
+            producer_loop(reader, is_paired, producer_tx_input, logger);
         })
         .map_err(|e| BismarkExtractorError::InternalError {
             message: format!("failed to spawn producer thread: {e}"),
@@ -316,8 +325,21 @@ fn producer_loop(
     mut reader: bismark_io::AnyReader<std::io::BufReader<std::fs::File>, std::fs::File>,
     is_paired: bool,
     tx_input: Sender<WorkerInput>,
+    logger: crate::logging::Logger,
 ) {
     let mut next_idx: u64 = 0;
+    // `lines_read` counts every SAM record consumed (one per `records_iter.next()`
+    // that yields a record): +1 per SE record, +2 per PE pair (R1 then R2). This
+    // matches Perl's read-side `$line_count` (warned every 500k at
+    // `bismark_methylation_extractor:1553`) byte-for-byte. Single producer
+    // thread → plain local counter, no atomic. (#882)
+    let mut lines_read: u64 = 0;
+    fn tick(logger: &crate::logging::Logger, lines_read: &mut u64) {
+        *lines_read += 1;
+        if (*lines_read).is_multiple_of(500_000) {
+            logger.progress(*lines_read);
+        }
+    }
     let mut records_iter = reader.records();
 
     if !is_paired {
@@ -328,6 +350,7 @@ fn producer_loop(
             match record_result {
                 Some(Ok(record)) => {
                     next_idx += 1;
+                    tick(&logger, &mut lines_read); // +1 SAM line (#882)
                     // Resolve reference_sequence_id → u32 with defensive
                     // try_from (Reviewer B.H1: `as u32` would silently
                     // truncate above 2^32 contigs; matches the precedent
@@ -382,7 +405,10 @@ fn producer_loop(
             let input_idx = next_idx;
             // R1
             let r1 = match records_iter.next() {
-                Some(Ok(r)) => r,
+                Some(Ok(r)) => {
+                    tick(&logger, &mut lines_read); // +1 SAM line (R1) (#882)
+                    r
+                }
                 Some(Err(e)) => {
                     let _ = tx_input.send(WorkerInput::Err {
                         input_idx,
@@ -394,7 +420,10 @@ fn producer_loop(
             };
             // R2
             let r2 = match records_iter.next() {
-                Some(Ok(r)) => r,
+                Some(Ok(r)) => {
+                    tick(&logger, &mut lines_read); // +1 SAM line (R2) (#882)
+                    r
+                }
                 Some(Err(e)) => {
                     let _ = tx_input.send(WorkerInput::Err {
                         input_idx,

--- a/rust/bismark-extractor/src/state.rs
+++ b/rust/bismark-extractor/src/state.rs
@@ -185,7 +185,9 @@ impl ExtractState {
                 &raw_filename,
                 &config.output_dir,
                 &finalization.kept,
-                &crate::subprocess::RealRunner { quiet: config.quiet },
+                &crate::subprocess::RealRunner {
+                    quiet: config.quiet,
+                },
             )?;
         }
 

--- a/rust/bismark-extractor/src/state.rs
+++ b/rust/bismark-extractor/src/state.rs
@@ -125,6 +125,7 @@ impl ExtractState {
         //      output.
         //   3. write_splitting_report
         //   4. write_mbias_txt (unless --mbias_off)
+        let logger = crate::logging::Logger::from_config(config);
         self.fhs.flush_all()?;
         // Phase C.2 code-review B H2: gate the sweep on `!mbias_only` to
         // mirror Perl `:319 unless ($mbias_only) { delete_unused_files; }`.
@@ -141,7 +142,7 @@ impl ExtractState {
         // kept set is empty by construction — we still build an empty
         // FinalizationReport for uniformity.
         let finalization = if !self.mbias_only {
-            self.fhs.finalize_with_empty_sweep()?
+            self.fhs.finalize_with_empty_sweep(logger)?
         } else {
             crate::output::FinalizationReport::default()
         };
@@ -154,6 +155,10 @@ impl ExtractState {
                 &self.report,
             )?;
         }
+        // Console final methylation summary (#882) — mirror of the
+        // splitting-report numbers, Perl `warn`'d at :2480-:2521. Emitted
+        // regardless of `--report` (Perl always warns it); gated by --quiet.
+        logger.final_summary(&self.report);
         if !config.mbias_off {
             let mbias_path = mbias_txt_path(&config.output_dir, &self.input_path);
             write_mbias_txt(&mbias_path, &self.mbias, self.is_paired)?;
@@ -180,7 +185,7 @@ impl ExtractState {
                 &raw_filename,
                 &config.output_dir,
                 &finalization.kept,
-                &crate::subprocess::RealRunner,
+                &crate::subprocess::RealRunner { quiet: config.quiet },
             )?;
         }
 

--- a/rust/bismark-extractor/src/subprocess.rs
+++ b/rust/bismark-extractor/src/subprocess.rs
@@ -398,7 +398,10 @@ pub trait BismarkSubprocessRunner {
 /// deadlock on >64 KiB stderr bursts); reads via `read_until(b'\n', ...)`
 /// (byte-safe; doesn't require UTF-8 stderr); always joins the drain thread
 /// before returning (prevents stderr-tail races + thread leaks).
-pub struct RealRunner;
+pub struct RealRunner {
+    /// Suppress the pre-spawn audit line under `--quiet` (#882).
+    pub quiet: bool,
+}
 
 impl BismarkSubprocessRunner for RealRunner {
     fn run(
@@ -407,15 +410,17 @@ impl BismarkSubprocessRunner for RealRunner {
         program: &Path,
         argv: &[OsString],
     ) -> Result<RunOutcome, BismarkExtractorError> {
-        // Pre-spawn audit eprintln (rev 1 O2). Always-on; cheap.
-        eprintln!(
-            "[bismark-extractor] spawning: {} {}",
-            program.display(),
-            argv.iter()
-                .map(|a| a.to_string_lossy().into_owned())
-                .collect::<Vec<_>>()
-                .join(" ")
-        );
+        // Pre-spawn audit line (rev 1 O2). Informational → gated by --quiet (#882).
+        if !self.quiet {
+            eprintln!(
+                "[bismark-extractor] spawning: {} {}",
+                program.display(),
+                argv.iter()
+                    .map(|a| a.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            );
+        }
 
         let mut child = Command::new(program)
             .args(argv)
@@ -602,6 +607,8 @@ mod tests {
             ample_memory: false,
             genome_folder: None,
             parallel: 1,
+            quiet: false,
+            verbose: false,
         }
     }
 

--- a/rust/bismark-extractor/tests/phase_g.rs
+++ b/rust/bismark-extractor/tests/phase_g.rs
@@ -152,6 +152,8 @@ fn base_config() -> ResolvedConfig {
         ample_memory: false,
         genome_folder: None,
         parallel: 1,
+        quiet: false,
+        verbose: false,
     }
 }
 

--- a/rust/bismark-extractor/tests/phase_g_realrunner.rs
+++ b/rust/bismark-extractor/tests/phase_g_realrunner.rs
@@ -29,7 +29,7 @@ fn fixture_path(name: &str) -> PathBuf {
 fn realrunner_invokes_subprocess_and_returns_ok_on_zero_exit() {
     let prog = fixture_path("fake_bismark2bedgraph_success.sh");
     let argv: Vec<OsString> = vec!["--cutoff".into(), "1".into()];
-    let outcome = RealRunner
+    let outcome = RealRunner { quiet: false }
         .run(SubprocessTool::Bismark2BedGraph, &prog, &argv)
         .expect("zero-exit fixture should succeed");
     assert!(outcome.exit_status.success(), "success fixture must exit 0");
@@ -40,7 +40,7 @@ fn realrunner_returns_subprocess_failed_on_nonzero_exit() {
     // Failure case: the subprocess exits 7. We see Ok(RunOutcome) with a
     // non-success exit_status (the orchestrator converts to SubprocessFailed).
     let prog = fixture_path("fake_bismark2bedgraph_failure.sh");
-    let outcome = RealRunner
+    let outcome = RealRunner { quiet: false }
         .run(SubprocessTool::Bismark2BedGraph, &prog, &[])
         .expect("RealRunner.run itself succeeds even on non-zero child exit");
     assert!(
@@ -62,7 +62,7 @@ fn realrunner_subprocess_failed_carries_correct_tool_variant() {
     // exit → SubprocessFailed { tool: ... }. We assert the tool field
     // matches the SubprocessTool we passed in.
     let prog = fixture_path("fake_bismark2bedgraph_failure.sh");
-    let outcome = RealRunner
+    let outcome = RealRunner { quiet: false }
         .run(SubprocessTool::Coverage2Cytosine, &prog, &[])
         .expect("run() returns Ok even on non-zero child exit");
     // Simulate the orchestrator's error conversion:
@@ -83,7 +83,7 @@ fn realrunner_subprocess_failed_carries_correct_tool_variant() {
 fn realrunner_high_volume_stderr_stays_bounded_in_ring_buffer() {
     // Fixture writes ~1 MiB of stderr. The ring buffer caps at 64 KiB.
     let prog = fixture_path("fake_bismark2bedgraph_high_stderr.sh");
-    let outcome = RealRunner
+    let outcome = RealRunner { quiet: false }
         .run(SubprocessTool::Bismark2BedGraph, &prog, &[])
         .expect("high-stderr fixture should exit cleanly");
     assert!(outcome.exit_status.success());
@@ -114,7 +114,7 @@ fn realrunner_128kib_stderr_burst_does_not_deadlock() {
     // awkward); if it ever hangs, the test runner's --timeout will catch
     // it. In practice this completes in <100 ms.
     let prog = fixture_path("fake_bismark2bedgraph_burst_then_exit.sh");
-    let outcome = RealRunner
+    let outcome = RealRunner { quiet: false }
         .run(SubprocessTool::Bismark2BedGraph, &prog, &[])
         .expect("burst fixture should report exit status");
     assert!(
@@ -139,7 +139,7 @@ fn realrunner_drain_handles_non_utf8_stderr_bytes() {
     // read_line (which errors on non-UTF-8). Must succeed even when the
     // subprocess writes invalid UTF-8 sequences.
     let prog = fixture_path("fake_bismark2bedgraph_non_utf8_stderr.sh");
-    let outcome = RealRunner
+    let outcome = RealRunner { quiet: false }
         .run(SubprocessTool::Bismark2BedGraph, &prog, &[])
         .expect("non-UTF-8 stderr must NOT crash the drain thread");
     assert!(outcome.exit_status.success());
@@ -159,7 +159,7 @@ fn realrunner_subprocess_spawn_failed_when_program_does_not_exist() {
     // defensive test for the spawn-time path. Passing a non-existent
     // program directly to RealRunner exercises SubprocessSpawnFailed.
     let prog = Path::new("/nonexistent/path/to/fake_b2bg_98765");
-    let err = RealRunner
+    let err = RealRunner { quiet: false }
         .run(SubprocessTool::Bismark2BedGraph, prog, &[])
         .expect_err("spawn of nonexistent binary should fail");
     assert!(matches!(
@@ -179,7 +179,7 @@ fn realrunner_drain_thread_joined_on_ok_path() {
     // completion before run() returned). If the drain were unjoined, the
     // ring buffer snapshot could be empty.
     let prog = fixture_path("fake_bismark2bedgraph_success.sh");
-    let outcome = RealRunner
+    let outcome = RealRunner { quiet: false }
         .run(SubprocessTool::Bismark2BedGraph, &prog, &[])
         .expect("success fixture");
     assert!(outcome.exit_status.success());
@@ -196,7 +196,7 @@ fn realrunner_drain_thread_joined_on_err_path() {
     // Mirror test for the non-zero-exit path: stderr_tail should also be
     // populated (the drain joined before run() returned its result).
     let prog = fixture_path("fake_bismark2bedgraph_failure.sh");
-    let outcome = RealRunner
+    let outcome = RealRunner { quiet: false }
         .run(SubprocessTool::Bismark2BedGraph, &prog, &[])
         .expect("run() returns Ok regardless of child exit code");
     assert!(


### PR DESCRIPTION
## Summary

Adds Perl-equivalent console diagnostics to `bismark-methylation-extractor-rs`, which was nearly silent (only the `kept`/`deleted` cleanup lines). All output goes to **stderr** (matching Perl's `warn` model — 232 `warn`s, 0 `print STDOUT`); stdout stays clean. Closes #882.

New output (default on; `-q`/`--quiet` silences info, warnings/errors still print):
- Startup banner (`CARGO_PKG_VERSION`, not the v0.25.1-locked `BISMARK_VERSION`)
- SE/PE mode + parameter summary (workers, output dir, ignore_*, overlap, gzip)
- `@HD` + `@PG` **header provenance** (Bismark version + command line, samtools chain) — `--verbose` adds the `@SQ` contig dictionary, which is dropped by default as noise
- `Processed lines: N` every 500k
- Final per-context methylation summary

## Why this is safe for the byte-identity gate

Console output is **outside** the Phase H byte-identity contract — the matrix compares output *files* (`cmp` on reports/M-bias, sorted-md5 on data files) and only `tail -3`s the console for display. No output-file bytes change, so the tagged `v1.0.0-beta.1` behaviour is unaffected. (To be confirmed by a `phase_h_smoke.sh` SE+PE regression run on colossal.)

## Design notes

- New `src/logging.rs`: `Logger { quiet, verbose }` (Copy) with pure, unit-tested text builders.
- Progress ticks at the **single live read site** (`parallel.rs::producer_loop`), counting each SAM record (+1 SE, +2 PE) — a plain local counter (single producer thread, no atomic) that matches Perl's `line_count` byte-for-byte.
- Header provenance reuses `detect_paired_from_header`'s serialize-to-SAM-text idiom (robust to noodles tag-reordering); implemented locally in the extractor (already deps `noodles-sam`) to avoid a `bismark-io` `=`-pin version cascade.
- `@HD`/`@PG` kept, `@SQ` dropped by default (per the in-review distinction: `@PG` provenance is valuable, the 190+ `@SQ` contig dump is noise).

## Two-counter correctness (caught in code review)

`Processed N lines in total` uses `records_processed` (Perl `sequences_count`, `:2479`/`:2482` = pairs for PE); `methylation call strings processed` uses `call_strings_processed` (2×pairs). These differ for PE; SE they're equal. Mirrors the byte-identical `_splitting_report.txt`.

## Verification

- 101 lib tests (3 new `logging` unit tests: quiet gate, summary shape+%, `@SQ`-drop) + all integration binaries pass; `clippy --all-targets -D warnings` clean.
- Dual plan-review + dual code-review + plan-manager (COMPLETE). Reports under `plans/05262026_bismark-extractor/CONSOLE_LOGGING_*`.
- **Pending before merge**: colossal eyeball of the real output + `phase_h_smoke.sh` SE/PE/AutoDetect byte-identity regression.

closes #882 · refs #798
