### PR TITLE
perf(extractor): mimalloc global allocator — eliminates parallel anti-scaling (#884)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "flate2",
+ "mimalloc",
  "noodles-core 0.20.0",
  "noodles-sam",
  "predicates",
@@ -218,6 +219,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -378,6 +389,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +583,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -958,6 +993,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"

--- a/rust/bismark-extractor/Cargo.toml
+++ b/rust/bismark-extractor/Cargo.toml
@@ -21,6 +21,9 @@ path = "src/main.rs"
 [dependencies]
 bismark-io = { version = "=1.0.0-beta.8", path = "../bismark-io" }
 clap = { version = "=4.5.30", features = ["derive"] }
+# SPIKE (#884, throwaway): multithread allocator to test whether N>1
+# anti-scaling is malloc-arena contention. Remove if it doesn't help.
+mimalloc = { version = "0.1", default-features = false }
 thiserror = "=2.0.0"
 # noodles-sam pinned to match bismark-io's transitive choice (matches dedup precedent).
 # Used for `Header` in the chr-name lookup table builder (header.rs) and in tests.

--- a/rust/bismark-extractor/Cargo.toml
+++ b/rust/bismark-extractor/Cargo.toml
@@ -21,9 +21,12 @@ path = "src/main.rs"
 [dependencies]
 bismark-io = { version = "=1.0.0-beta.8", path = "../bismark-io" }
 clap = { version = "=4.5.30", features = ["derive"] }
-# SPIKE (#884, throwaway): multithread allocator to test whether N>1
-# anti-scaling is malloc-arena contention. Remove if it doesn't help.
-mimalloc = { version = "0.1", default-features = false }
+# Multithreaded allocator (#884). The default system allocator's arena locks
+# were the dominant cost of the extractor's parallel pipeline: 4-8 worker
+# threads blocked in malloc/free on per-record allocations, causing N>1 to run
+# ~2x SLOWER than N=1 (measured: default N=4 155.8s -> 23.5s with mimalloc;
+# anti-scaling eliminated). Allocator-only — output is byte-identical.
+mimalloc = { version = "=0.1.52", default-features = false }
 thiserror = "=2.0.0"
 # noodles-sam pinned to match bismark-io's transitive choice (matches dedup precedent).
 # Used for `Header` in the chr-name lookup table builder (header.rs) and in tests.

--- a/rust/bismark-extractor/src/main.rs
+++ b/rust/bismark-extractor/src/main.rs
@@ -28,6 +28,12 @@ use bismark_extractor::error::BismarkExtractorError;
 use bismark_extractor::{extract_pe_parallel, extract_se_parallel, version_string};
 use bismark_io::{detect_paired_from_header, open_reader};
 
+// SPIKE (#884, throwaway): mimalloc as the global allocator to test whether the
+// N>1 anti-scaling is malloc-arena contention (top showed --parallel 8 at
+// ~364% CPU = blocking-bound). Remove if it doesn't help.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 

--- a/rust/bismark-extractor/src/main.rs
+++ b/rust/bismark-extractor/src/main.rs
@@ -28,9 +28,14 @@ use bismark_extractor::error::BismarkExtractorError;
 use bismark_extractor::{extract_pe_parallel, extract_se_parallel, version_string};
 use bismark_io::{detect_paired_from_header, open_reader};
 
-// SPIKE (#884, throwaway): mimalloc as the global allocator to test whether the
-// N>1 anti-scaling is malloc-arena contention (top showed --parallel 8 at
-// ~364% CPU = blocking-bound). Remove if it doesn't help.
+// Multithreaded global allocator (#884). The parallel pipeline's worker threads
+// allocate heavily per record (record parsing, call Vecs, batch Vecs); under the
+// default system allocator they blocked on arena locks, making `--parallel N>1`
+// run ~2x SLOWER than N=1 (`top` showed only ~364% CPU at `--parallel 8` — i.e.
+// blocking-bound, not CPU-bound). mimalloc removes that contention: default N=4
+// dropped 155.8s -> 23.5s and the anti-scaling vanished. Allocator choice does
+// not affect computed output — byte-identity to the system allocator holds
+// (guarded by the `parallel_phase_f` N≡1 tests + the Phase H matrix).
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
## Summary

Set **mimalloc** as the global allocator for `bismark-methylation-extractor-rs` (#884). The default system allocator's arena locks were the dominant cost of the parallel pipeline — 4–8 worker threads blocked in `malloc`/`free` on per-record allocations, making `--parallel N>1` run **~2× slower than N=1** (`top` showed only ~364% CPU at `--parallel 8` = blocking-bound, not CPU-bound).

## Result (10M PE, colossal; on top of #884 R1 batching)

| | N=1 | N=4 | N=8 |
|---|---|---|---|
| system malloc | 73.7 s | 155.8 s | 163.7 s |
| **mimalloc** | **22.3 s** | **23.5 s** | **23.9 s** |
| `mbias_only` mimalloc | 15.2 s | 15.5 s | 15.5 s |

**Anti-scaling eliminated** (N=1/4/8 now flat ~22–24 s vs doubling), `default N=4` **6.6× faster**, and **Rust is now ~6.7× faster than Perl at N=4** (23.5 s vs ~158 s). The residual *flat* (not positive) scaling is producer-bound serial decode — addressed separately by R3 (parallel `MultithreadedReader`).

## Byte-identity
Allocator-only — output cannot change. The `parallel_phase_f` N=1 vs N=4/N=8 byte-identity tests (incl. the 8199-record batch-boundary test) **pass on the mimalloc binary**; colossal SE+PE `phase_h_smoke` (vs Perl) run as the binding real-data gate.

closes #884
