### PR TITLE
perf(extractor): parallel BGZF decode via ThreadedBamReader (#884 R3)

### DIFF
--- a/rust/bismark-extractor/src/parallel.rs
+++ b/rust/bismark-extractor/src/parallel.rs
@@ -70,7 +70,10 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use bismark_io::{BismarkPair, BismarkRecord, BismarkStrand, open_reader};
+use bismark_io::{
+    AlignmentKind, BismarkIoError, BismarkPair, BismarkRecord, BismarkStrand, ThreadedBamReader,
+    open_reader,
+};
 use crossbeam_channel::{Receiver, RecvError, Sender, bounded};
 
 use crate::call::{CytosineContext, MethCall, extract_calls};
@@ -207,7 +210,25 @@ fn run_pipeline(
 
     // Open the reader on the main thread to get the header (for chr_table)
     // before we hand the reader off to the producer thread.
-    let reader = open_reader(input, /*cram_ref=*/ None)?;
+    //
+    // #884 R3: for BAM at N≥2, decode BGZF blocks in parallel via
+    // ThreadedBamReader. Once mimalloc removed the allocator contention, the
+    // single producer's serial BGZF decode became the throughput cap (workers
+    // starve → flat scaling). Parallel decode feeds them faster. SAM/CRAM and
+    // N=1 keep the single-threaded reader (MultithreadedReader has fixed
+    // per-call overhead — 0.69× at worker_count=1 in the spike).
+    // `ThreadedBamReader::from_path` enforces the SAME coordinate-sort rejection
+    // as `open_reader` (bismark BAMs are read-ordered; coord-sorted breaks the
+    // PE adjacent-pairing assumption), so behaviour is unchanged.
+    let is_bam = matches!(AlignmentKind::from_path(input)?, AlignmentKind::Bam);
+    let reader = if n_workers >= 2 && is_bam {
+        ProducerReader::Threaded(ThreadedBamReader::from_path(
+            input,
+            std::num::NonZeroUsize::new(n_workers).expect("n_workers >= 2 in this branch"),
+        )?)
+    } else {
+        ProducerReader::Any(open_reader(input, /*cram_ref=*/ None)?)
+    };
     let chr_table: Arc<[String]> = Arc::from(build_chr_name_table(reader.header())?);
 
     // Console diagnostics (#882) — emit once on the main thread while we still
@@ -361,8 +382,34 @@ fn run_pipeline(
 /// already buffered in the partial batch still ship (today they are emitted
 /// before the producer short-circuits; dropping them would break byte-identity
 /// on error inputs). The producer still `return`s after the first error.
+/// Producer-side reader (#884 R3): either the single-threaded [`AnyReader`]
+/// (SAM/CRAM, or BAM at `--parallel 1`) or the parallel-BGZF
+/// [`ThreadedBamReader`] (BAM at N≥2). Both expose `header()` + `records()`
+/// yielding the same `Result<BismarkRecord, _>`; this enum lets `producer_loop`
+/// own and drive either without changing its body.
+enum ProducerReader {
+    Any(bismark_io::AnyReader<std::io::BufReader<std::fs::File>, std::fs::File>),
+    Threaded(ThreadedBamReader),
+}
+
+impl ProducerReader {
+    fn header(&self) -> &noodles_sam::Header {
+        match self {
+            ProducerReader::Any(r) => r.header(),
+            ProducerReader::Threaded(r) => r.header(),
+        }
+    }
+
+    fn records(&mut self) -> Box<dyn Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_> {
+        match self {
+            ProducerReader::Any(r) => Box::new(r.records()),
+            ProducerReader::Threaded(r) => Box::new(r.records()),
+        }
+    }
+}
+
 fn producer_loop(
-    mut reader: bismark_io::AnyReader<std::io::BufReader<std::fs::File>, std::fs::File>,
+    mut reader: ProducerReader,
     is_paired: bool,
     tx_input: Sender<InputBatch>,
     logger: crate::logging::Logger,


### PR DESCRIPTION
## Summary

#884 R3: wire `bismark-io`'s existing `ThreadedBamReader` (noodles `MultithreadedReader`) into the extractor's producer for **parallel BGZF decode** on BAM inputs at `--parallel N≥2`.

**Stacked on #886 (mimalloc).** Once mimalloc eliminated the allocator-contention anti-scaling, the pipeline became *producer-bound*: the single producer's serial BGZF decode fed workers too slowly, so N=1/4/8 ran **flat ~22 s** (no positive scaling). R3 decodes BGZF blocks in parallel (spike measured ~6.7× decode at 8 threads) to feed workers faster.

## Scope / safety
- BAM + N≥2 → `ThreadedBamReader`; SAM/CRAM and N=1 keep the single-threaded reader (the threaded reader has fixed overhead — 0.69× at worker_count=1 in the spike).
- `ThreadedBamReader::from_path` enforces the **same coordinate-sort rejection** as `open_reader`; record order is preserved (MultithreadedReader returns in order).
- **Byte-identical**: the `parallel_phase_f` N=4 tests (incl. the 8199-record boundary test) now exercise the threaded path and pass; colossal SE+PE smoke is the binding gate.

## Verification
- In-repo: byte-identity tests pass on the threaded binary; `clippy -D warnings` + `fmt` clean.
- **Pending (colossal):** SE/PE byte-identity smoke + perf re-measure — does N=4 now scale *below* N=1 (positive scaling), and how far past Perl?

refs #884
