### PR TITLE
perf(extractor): parallel --gzip via gzp ParCompress in the collector (#884 R2)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
  "rustc-hash",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -123,12 +123,13 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "flate2",
+ "gzp",
  "mimalloc",
  "noodles-core 0.20.0",
  "noodles-sam",
  "predicates",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.0",
  "which",
 ]
 
@@ -147,7 +148,7 @@ dependencies = [
  "proptest",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -199,6 +200,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -288,6 +295,17 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -415,10 +433,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "getrandom"
@@ -433,6 +507,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gzp"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c65d1899521a11810501b50b898464d133e1afc96703cff57726964cfa7baf"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "core_affinity",
+ "flate2",
+ "flume",
+ "num_cpus",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +532,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hybrid-array"
@@ -468,6 +563,18 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lexical-core"
@@ -560,6 +667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "lzma-rust2"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +717,15 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -749,10 +874,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "ppv-lite86"
@@ -868,7 +1035,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -942,6 +1109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +1125,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -1007,10 +1186,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "strsim"
@@ -1049,11 +1243,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15291287e9bff1bc6f9ff3409ed9af665bec7a5fc8ac079ea96be07bca0e2668"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.0",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1101,12 +1315,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1120,6 +1385,28 @@ dependencies = [
  "rustix 1.1.4",
  "winsafe",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/rust/bismark-extractor/Cargo.toml
+++ b/rust/bismark-extractor/Cargo.toml
@@ -27,15 +27,18 @@ clap = { version = "=4.5.30", features = ["derive"] }
 # ~2x SLOWER than N=1 (measured: default N=4 155.8s -> 23.5s with mimalloc;
 # anti-scaling eliminated). Allocator-only — output is byte-identical.
 mimalloc = { version = "=0.1.52", default-features = false }
+# Parallel gzip for the `--gzip` split-file writers (#884 R2). gzp's
+# `ParCompress<Gzip>` fans compression across its own thread pool (decoupled
+# from `--parallel`; see output.rs::GZIP_COMPRESS_THREADS), capturing the
+# single-threaded ~52 s gzip wall measured in the Phase-0 spike (.gz 75 s ->
+# ~18 s, ~4.1x). Emits a SINGLE-member gzip (one header + sync-flushed DEFLATE
+# blocks + one stream-wide CRC footer), so plain `GzDecoder` reads it.
+# deflate_rust = pure-Rust backend (no cmake/C; matches TG-OE's gzp config).
+gzp = { version = "=0.11.3", default-features = false, features = ["deflate_rust"] }
 thiserror = "=2.0.0"
 # noodles-sam pinned to match bismark-io's transitive choice (matches dedup precedent).
 # Used for `Header` in the chr-name lookup table builder (header.rs) and in tests.
 noodles-sam = "=0.85.0"
-# Phase E: --gzip writer wrapping. Pinned to =1.1.9 to match the workspace's
-# existing transitive flate2 (pulled by noodles_bgzf) — verified via
-# `cargo tree -p bismark-extractor | grep flate2`. The Phase E plan's
-# preliminary "=1.0.34" guess was outdated; rev 1 verification step caught it.
-flate2 = "=1.1.9"
 # Phase F: bounded MPMC channels for producer→worker (N×32) and
 # worker→collector (N×8). Pin verified via cargo tree.
 crossbeam-channel = "=0.5.15"
@@ -55,3 +58,11 @@ tempfile = "=3.10.1"
 # Used by tests for synthetic record + header construction.
 bstr = "=1.10.0"
 noodles-core = "=0.20.0"
+# flate2 is still compiled into the binary at RUNTIME — it is gzp's
+# `deflate_rust` backend and noodles_bgzf's encoder (both transitive). This
+# explicit entry only became a *dev*-dependency in #884 R2: src no longer names
+# flate2 (the `--gzip` writer is now gzp), but tests still decode the `.gz`
+# split files via `flate2::read::GzDecoder` to assert decompressed-content
+# byte-identity. Pinned to =1.1.9 to match the single transitive flate2 in the
+# lock (pulled by gzp + noodles_bgzf) — verified via `cargo tree -i flate2`.
+flate2 = "=1.1.9"

--- a/rust/bismark-extractor/src/lib.rs
+++ b/rust/bismark-extractor/src/lib.rs
@@ -17,9 +17,10 @@
 //!   - `Yacht` (1 file `any_C_context_*` with 8-col rows; SE-only),
 //!   - `MbiasOnly` (0 split files; M-bias.txt + splitting-report only).
 //!
-//! `--gzip` wraps every per-mode split file in a `flate2::write::GzEncoder`
-//! and appends `.gz` to filenames. `--mbias_only` silently skips
-//! `InvalidXmByte` errors (per Perl `:2972/3054`).
+//! `--gzip` wraps every per-mode split file in a parallel-gzip
+//! `gzp::par::compress::ParCompress` writer (#884 R2) and appends `.gz` to
+//! filenames. `--mbias_only` silently skips `InvalidXmByte` errors (per Perl
+//! `:2972/3054`).
 //!
 //! SE + PE both run end-to-end, with SE-vs-PE auto-detect via
 //! `@PG ID:Bismark` header probe. M-bias.txt + `_splitting_report.txt`

--- a/rust/bismark-extractor/src/output.rs
+++ b/rust/bismark-extractor/src/output.rs
@@ -3,8 +3,8 @@
 //! Phase B opened 12 strand×context files eagerly at [`OutputFileMap::new`]
 //! time. Phase E generalises this to all 5 non-`MbiasOnly` modes: the
 //! `(key, filename)` list comes from [`crate::output_mode::mode_keys`], and
-//! each file may be wrapped in a `flate2::write::GzEncoder` when
-//! `--gzip` is set. `MbiasOnly` skips eager-open entirely (the map is
+//! each file may be wrapped in a parallel-gzip `gzp::par::compress::ParCompress`
+//! writer when `--gzip` is set. `MbiasOnly` skips eager-open entirely (the map is
 //! empty; `route_call` short-circuits before any `write_call` ever runs).
 //!
 //! The map's value type changed from Phase B's `BufWriter<File>` to
@@ -19,8 +19,6 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use bismark_io::BismarkStrand;
-use flate2::Compression;
-use flate2::write::GzEncoder;
 
 use crate::call::MethCall;
 use crate::cli::{OutputMode, ResolvedConfig};
@@ -37,8 +35,9 @@ pub const BISMARK_VERSION: &str = "v0.25.1";
 /// 5159, 5182, 5205, 5228, 5429, 5452, 5475, 5498, etc.
 pub const SPLIT_FILE_HEADER: &str = "Bismark methylation extractor version v0.25.1\n";
 
-/// Per-call type-erased boxed writer (plain `File` or `GzEncoder<File>`)
-/// wrapped in an 8-KiB `BufWriter`. Phase F may revisit static-dispatch
+/// Per-call type-erased boxed writer (plain `File` or a gzp
+/// `ParCompress<Gzip>` over `File`) wrapped in an 8-KiB `BufWriter`.
+/// Phase F may revisit static-dispatch
 /// once profiling under multicore is available (Phase E plan §9.2 #2).
 type BoxedWriter = BufWriter<Box<dyn Write + Send>>;
 
@@ -106,8 +105,9 @@ impl OutputFileMap {
     /// unless($mbias_only)` skip-eager-open). `flush_all` and `cleanup_all`
     /// remain valid no-ops on the empty map.
     ///
-    /// When `gzip == true` every writer is wrapped in a `flate2::write::GzEncoder`;
-    /// filenames already carry the `.gz` suffix per [`mode_keys`].
+    /// When `gzip == true` every writer is wrapped in a gzp parallel-gzip
+    /// `ParCompress<Gzip>`; filenames already carry the `.gz` suffix per
+    /// [`mode_keys`].
     pub fn new(
         output_dir: &Path,
         input_basename: &str,
@@ -235,10 +235,10 @@ impl OutputFileMap {
     /// are on disk before the run terminates. On the empty `MbiasOnly`
     /// map this is a no-op.
     ///
-    /// For gzipped writers, `BufWriter::flush` propagates to the inner
-    /// `GzEncoder` which writes its trailing gzip footer when the writer
+    /// For gzipped writers, `BufWriter::flush` propagates to the inner gzp
+    /// `ParCompress`, which writes its trailing gzip footer when the writer
     /// drops (which happens at `cleanup_all` time, or at struct-drop time
-    /// for the normal exit path).
+    /// for the normal exit path) — NOT on flush.
     pub fn flush_all(&mut self) -> Result<(), std::io::Error> {
         for entry in self.files.values_mut() {
             entry.writer.flush()?;
@@ -249,8 +249,8 @@ impl OutputFileMap {
     /// Sweep empty per-strand output files at flush time, matching Perl's
     /// end-of-run `was empty -> deleted` behaviour (closes #865).
     ///
-    /// For each entry: drop the writer (closes the `File` + flushes the
-    /// `GzEncoder` trailer if applicable — `flush_all` does NOT write
+    /// For each entry: drop the writer (closes the `File` + flushes the gzp
+    /// `ParCompress` gzip trailer if applicable — `flush_all` does NOT write
     /// the gzip trailer, only `drop` does); if `records_written == 0`,
     /// unlink the file and emit `{filename} was empty ->\tdeleted` to
     /// **STDERR** via `eprintln!`. Otherwise emit `{filename} contains
@@ -298,7 +298,8 @@ impl OutputFileMap {
         {
             // Explicit drop closes the writer AND flushes the gzip trailer
             // for gzipped writers (which `flush_all` doesn't — gzip trailer
-            // emission is tied to GzEncoder's Drop impl, not its flush).
+            // emission is tied to gzp ParCompress's Drop impl, which calls
+            // finish() to write the footer, not to its flush).
             // For kept files this is the seal-the-trailer point.
             drop(writer);
             // Phase G (rev 1 C4): canonicalize BEFORE potential removal so
@@ -362,8 +363,8 @@ impl OutputFileMap {
             },
         ) in entries
         {
-            // Explicitly close the writer (and the inner GzEncoder, if any)
-            // BEFORE calling `remove_file`. A named `let` binding (even
+            // Explicitly close the writer (and the inner gzp `ParCompress`,
+            // if any) BEFORE calling `remove_file`. A named `let` binding (even
             // underscore-prefixed) lives to the end of the loop iteration,
             // so without this explicit drop the file would still be open
             // when `remove_file` runs — benign on Unix but fails on Windows
@@ -380,16 +381,62 @@ impl OutputFileMap {
     }
 }
 
-/// Factory: open the per-key writer, dispatching to plain `File` or
-/// gzipped `GzEncoder<File>` based on `gzip`.
+/// Number of threads gzp uses for parallel `--gzip` compression.
+///
+/// **Decoupled from `--parallel` by design (#884 R2).** gzp's `ParCompress`
+/// runs its own compression thread pool, independent of the extractor's
+/// worker count. The default run is `--parallel 1`, yet single-threaded gzip
+/// is the dominant serial wall (Phase-0 spike: `.gz` 75 s, of which ~52 s is
+/// compression). A fixed pool of 4 captures that wall on *every* `--gzip`
+/// path — including the common `--parallel 1` default — reproducing the
+/// spike's measured ~4.1x (`.gz` 75 s -> ~18 s) regardless of `--parallel`.
+/// Tying it to `--parallel` instead would leave the default path
+/// single-threaded (~75 s), defeating R2's purpose.
+///
+/// **Aggregate thread footprint (dual code-review, Medium):** gzp spawns its
+/// pool *eagerly* at `from_writer` (writer-open), not lazily, and each gzipped
+/// file holds `1 writer + GZIP_COMPRESS_THREADS compressor` threads for the
+/// whole run. So the real total is `(GZIP_COMPRESS_THREADS + 1) × open_files`
+/// — e.g. Default mode opens 12 split files ⇒ ~60 gzip threads, independent of
+/// `--parallel` (including zero-record CTOT/CTOB strands later swept). No
+/// correctness/CPU impact (idle threads block on empty channels), but it is a
+/// thread-count, not a "pool of 4". Lowering the value (e.g. 2–3) or
+/// lazy-opening writers is a measured follow-up — 4 reproduces the validated
+/// spike, so it stays for R2.
+const GZIP_COMPRESS_THREADS: usize = 4;
+
+/// Factory: open the per-key writer, dispatching to plain `File` or a
+/// parallel-gzip `gzp::par::compress::ParCompress<Gzip>` writer based on `gzip`.
 ///
 /// Returns the writer already wrapped in an 8-KiB `BufWriter` (matching
 /// Phase B's capacity). `Box<dyn Write + Send>` is the inner type to
 /// keep the `OutputFileMap::write_call` body branch-free w.r.t. plain-vs-gz.
+///
+/// **gzip output framing (#884 R2):** gzp's `Gzip` format emits a *single*
+/// gzip member — one header, sync-flushed DEFLATE blocks, one stream-wide
+/// CRC32+ISIZE footer (gzp `par/compress.rs` writes `header()`/`footer()`
+/// once per stream). A plain single-member `GzDecoder` reads it correctly; no
+/// `MultiGzDecoder` is needed. The footer is written when the writer is
+/// **dropped** (gzp's `Drop` calls `finish()`), matching the flate2
+/// `GzEncoder` drop-finalization the empty-sweep relies on. Caveats: a
+/// footer-flush I/O error surfaces as a *panic* on drop (gzp `.unwrap()`s),
+/// unlike flate2's silent swallow — mid-stream write errors still propagate
+/// as `io::Error`. The `deflate_rust` backend (pure Rust, no cmake) skips the
+/// cross-block dictionary, so the *compressed* bytes differ from flate2's,
+/// but the *decompressed* content is byte-identical (no test hashes raw
+/// `.gz`; the colossal smoke compares `zcat | sort | md5`).
 fn open_writer(path: &Path, gzip: bool) -> Result<BoxedWriter, std::io::Error> {
     let file = File::create(path)?;
     let inner: Box<dyn Write + Send> = if gzip {
-        Box::new(GzEncoder::new(file, Compression::default()))
+        // #884 R2: parallelize the single-threaded gzip compression wall via
+        // gzp's ParCompress pool (deflate_rust backend). num_threads is a
+        // fixed constant decoupled from --parallel — see GZIP_COMPRESS_THREADS.
+        Box::new(
+            gzp::par::compress::ParCompressBuilder::<gzp::deflate::Gzip>::new()
+                .num_threads(GZIP_COMPRESS_THREADS)
+                .expect("GZIP_COMPRESS_THREADS is nonzero")
+                .from_writer(file),
+        )
     } else {
         Box::new(file)
     };

--- a/rust/bismark-extractor/tests/parallel_phase_f.rs
+++ b/rust/bismark-extractor/tests/parallel_phase_f.rs
@@ -798,6 +798,103 @@ fn parallel_gzip_n4_decompresses_identical_to_legacy_plain() {
     }
 }
 
+/// #884 R2 regression guard: gzp's `ParCompress<Gzip>` must keep emitting a
+/// **single-member** gzip even when the input spans multiple `BATCH_SIZE`
+/// (4096) batches, and the decompressed content must be byte-identical across
+/// `--parallel` 1 vs 4 and to the plain (non-gzip) peer.
+///
+/// 8199 records = two full batches + a 7-record partial, so gzp stitches
+/// several internal sync-flushed DEFLATE blocks into one gzip stream.
+/// `decompress_gz` uses a single-member `GzDecoder`: if a future gzp change
+/// (or a switch to its `Mgzip`/`Bgzf` formats) emitted multi-member output,
+/// the decode would truncate at member 0 and the `== plain` assertion would
+/// fail. Decompressed *byte* identity (not merely sorted-equivalence) holds
+/// because the collector concatenates per-batch output strictly in
+/// `batch_seq` order, so the stream matches N=1's exactly (dual plan-review
+/// C2). Complements the small-fixture single-batch test above.
+#[test]
+fn parallel_gzip_multibatch_decompresses_identical_across_n_and_to_plain() {
+    with_timeout(
+        "parallel_gzip_multibatch_decompresses_identical_across_n_and_to_plain",
+        || {
+            let workdir = tempfile::tempdir().unwrap();
+            let bam_path = workdir.path().join("large.bam");
+            write_se_large_bam(&bam_path, 8199); // > 2 * BATCH_SIZE (4096)
+            let bam_s = bam_path.to_str().unwrap().to_string();
+
+            // Reference: plain (non-gzip) single-threaded output.
+            let plain_dir = workdir.path().join("plain");
+            extract_se(
+                &bam_path,
+                &resolved_config(&[
+                    "--single-end",
+                    "--output_dir",
+                    plain_dir.to_str().unwrap(),
+                    &bam_s,
+                ]),
+            )
+            .unwrap();
+
+            // Gzipped at N=1 and N=4.
+            let mut gz_dirs = Vec::new();
+            for n in [1u32, 4] {
+                let dir = workdir.path().join(format!("gz_n{n}"));
+                extract_se_parallel(
+                    &bam_path,
+                    &resolved_config(&[
+                        "--single-end",
+                        "--gzip",
+                        "--parallel",
+                        &n.to_string(),
+                        "--output_dir",
+                        dir.to_str().unwrap(),
+                        &bam_s,
+                    ]),
+                )
+                .unwrap();
+                gz_dirs.push((n, dir));
+            }
+            let gz_n1_dir = gz_dirs[0].1.clone();
+
+            for (n, dir) in &gz_dirs {
+                for entry in fs::read_dir(dir).unwrap() {
+                    let entry = entry.unwrap();
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    if let Some(stem) = name.strip_suffix(".gz") {
+                        // Single-member decode of a multi-block stream → full
+                        // plain content. Truncation here = a multi-member regression.
+                        let decoded = decompress_gz(&entry.path());
+                        let plain = fs::read(plain_dir.join(stem)).unwrap();
+                        assert_eq!(
+                            decoded, plain,
+                            "gz {name} at n{n} decompressed differs from plain peer \
+                             (truncation here would mean gzp regressed to multi-member)"
+                        );
+                        // Cross-N decompressed-byte identity.
+                        let decoded_n1 = decompress_gz(&gz_n1_dir.join(&name));
+                        assert_eq!(
+                            decoded, decoded_n1,
+                            "gz {name} decompressed differs between n1 and n{n}"
+                        );
+                    } else if name.ends_with("_splitting_report.txt") {
+                        assert_eq!(
+                            normalize_report(&fs::read(entry.path()).unwrap()),
+                            normalize_report(&fs::read(plain_dir.join(&name)).unwrap()),
+                            "non-gz splitting report {name} at n{n} differs"
+                        );
+                    } else {
+                        assert_eq!(
+                            fs::read(entry.path()).unwrap(),
+                            fs::read(plain_dir.join(&name)).unwrap(),
+                            "non-gz file {name} at n{n} differs from plain"
+                        );
+                    }
+                }
+            }
+        },
+    );
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // 4. ERROR PROPAGATION at N=4
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
R2 of #884: parallelize `--gzip` split-file compression by swapping the single-threaded `flate2::write::GzEncoder` writers for **gzp's `ParCompress<Gzip>`** (parallel gzip, `deflate_rust` pure-Rust backend, no cmake).

The Phase-0 spike decomposed the `--gzip` cost (10M PE): extract/decode floor ~16.7s, `.txt` write ~6s, and a **~52s single-threaded gzip compression wall**. gzp parallelizes that wall on its own pool. Chosen over the invasive worker-side-members design in the R2 plan: **both independent plan reviewers recommended gzp-in-collector (ALT-1)** and a throwaway spike confirmed it (`.gz` 75s → 18s).

## What changed
- **`output.rs::open_writer`**: the `--gzip` arm now builds `gzp::par::compress::ParCompress<gzp::deflate::Gzip>`. New `GZIP_COMPRESS_THREADS = 4` const, **decoupled from `--parallel`** so the common `--parallel 1 --gzip` default still gets the win (tying it to `--parallel` would leave the default single-threaded ~75s).
- **Single-member gzip**: gzp's `Gzip` format emits one header + sync-flushed DEFLATE blocks + one stream-wide CRC/ISIZE footer (verified in gzp source + a multibatch test). Existing single-member `GzDecoder` tests stay valid — **no `MultiGzDecoder` migration**. Decompressed content is byte-identical; only raw `.gz` framing differs. Collector ordering, version header, empty-sweep, and the plain `.txt` path are untouched.
- **`Cargo.toml`**: add `gzp = "=0.11.3"` (`deflate_rust`); move `flate2` to `[dev-dependencies]` (now test-only — tests decode `.gz` via `GzDecoder`).
- **Test**: `parallel_gzip_multibatch_decompresses_identical_across_n_and_to_plain` (8199 records > 2×BATCH_SIZE) guards single-member framing + N=1≡N=4 + identity-to-plain.

## Performance (colossal, 10M, `--parallel 4`)
| mode | Perl | Rust | Speedup |
|---|---|---|---|
| SE `--gzip` | 72s | 8s | 9.0× |
| PE `--gzip` | 167s | 19s | 8.7× |

(≥4× SPEC §9.7 target cleared.)

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p bismark-extractor` (102+ tests) ✅
- **Colossal `--gzip` SE+PE `phase_h_smoke` byte-identity: PASS** — 6 `.gz` sorted-equivalent vs Perl (SPEC §8.3 `.gz` contract); M-bias.txt + splitting_report.txt strictly byte-identical ✅
- **Dual independent code-review: APPROVE** (no Critical/High). Documented non-blocking follow-ups: gzp's eager thread-pool footprint (`(threads+1)×open_files` ≈ 60 in Default mode), panic-on-drop footer-error (ENOSPC-only), SE-only test.

## Notes
- `.gz` raw bytes differ from the old flate2 output (different framing + `deflate_rust` skips the cross-block dictionary), but no test hashes raw `.gz` and the smoke compares `zcat|sort|md5`.
- The gzip footer is written on Drop (gzp's `Drop`→`finish()`), matching the prior flate2 lifetime the empty-sweep relies on.

Part of #884 (R2).
