### PR TITLE
test(extractor): CI coverage for MethCall.read_pos rebase — OB strand + parallel M-bias dispatch (#878)

### DIFF
--- a/plans/05262026_bismark-extractor/BUG_876_FIXES_PLAN.md
+++ b/plans/05262026_bismark-extractor/BUG_876_FIXES_PLAN.md
@@ -177,6 +177,18 @@ The `edge_clip` cell remains incomplete (Perl-side hang per #876 Finding #3 — 
 9. **`parallel_pe_worker_m_bias_uses_r2_ignore_for_r2`** (in `parallel.rs` test module, NEW): construct `process_pe` with `ignore_r1 = 3, ignore_r2 = 7` → assert R1 calls land in `mbias[0]` slot 1+ and R2 calls land in `mbias[1]` slot 1+, NOT swapped. Reviewer A §1 final note: prevents future "passed wrong ignore field to wrong identity" bugs.
 10. **`se_driver_vs_parallel_driver_m_bias_equality`** (in `parallel.rs` test module or top-level integration test, NEW per Reviewer A I2 / Reviewer B C1): dispatch identical synthetic input through `pipeline::extract_se` (single-threaded) and `parallel::process_se` (parallel worker) with `--ignore 5` → assert M-bias accumulators are byte-equal. **This is the structural regression guard for the dual-driver/dual-dispatch trap class** ([[feedback-dual-driver-back-port]] extended scope).
 
+> **✅ Tests #8–#10 LANDED via #878 (2026-05-29).** The three deferred
+> parallel-worker regression guards shipped as:
+> - #8 → `parallel_se_worker_m_bias_rebased` (`parallel.rs`)
+> - #9 → `parallel_pe_worker_m_bias_uses_r2_ignore_for_r2` (`parallel.rs`)
+> - #10 → `se_driver_vs_parallel_driver_m_bias_equality` (`tests/parallel_phase_f.rs`),
+>   using **`--ignore 2`** NOT the `--ignore 5` sketched above — the 5-bp fixtures
+>   trip the `lo>=hi` early-out (`call.rs:166`) → vacuous empty-output pass (caught
+>   in the #878 dual plan-review, C1).
+> #878 also added an OB/`-`-strand kernel guard (`extract_calls_ob_strand_rebases_read_pos_after_ignore_5p`, `call.rs`),
+> closing the OT-only gap Reviewer B flagged. All three FAIL on reverting the
+> `call.rs:204` rebase (revert-smoke verified). Detail: `TESTS_878_PLAN.md`.
+
 ### Integration check on colossal (manual, not added to in-repo CI)
 
 11. Re-run `scripts/phase_h_se_matrix.sh /weka/.../10M_SE/...bam --out ~/phase_h_se_release_fix876/` on a **fresh** `--out` dir (do NOT clobber `~/phase_h_se_release/` evidence per RELEASE_CHECKLIST escalation §1). Expect: exit 0 (PASS) or exit 3 (perf-miss-only). All 8 non-edge_clip cells should now PASS byte-identity.

--- a/rust/bismark-extractor/src/call.rs
+++ b/rust/bismark-extractor/src/call.rs
@@ -237,10 +237,16 @@ mod tests {
     use noodles_sam::alignment::record_buf::data::field::Value;
     use noodles_sam::alignment::record_buf::{Cigar, RecordBuf, Sequence};
 
-    /// Build a minimal `+`-strand `BismarkRecord` with the given XM string,
-    /// `{n_soft}S{n_match}M` CIGAR, and `XG:Z:CT` (forward strand).
+    /// Build a minimal `BismarkRecord` with the given XM string,
+    /// `{n_soft}S{n_match}M` CIGAR, `XR:Z:CT`, and the caller-chosen `XG`
+    /// strand tag (`b"CT"` → OT/`+`, `b"GA"` → OB/`-`).
     /// Quality scores are filled with `30u8` matching seq length.
-    fn synth_se_record(xm: &[u8], n_soft: usize, n_match: usize) -> BismarkRecord {
+    fn synth_se_record_strand(
+        xm: &[u8],
+        n_soft: usize,
+        n_match: usize,
+        xg: &[u8],
+    ) -> BismarkRecord {
         assert_eq!(
             xm.len(),
             n_soft + n_match,
@@ -272,11 +278,16 @@ mod tests {
             Tag::from(*b"XR"),
             Value::String(BString::from(b"CT".to_vec())),
         );
-        record.data_mut().insert(
-            Tag::from(*b"XG"),
-            Value::String(BString::from(b"CT".to_vec())),
-        );
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
         BismarkRecord::from_noodles_record(record).expect("synth BismarkRecord")
+    }
+
+    /// OT/`+`-strand convenience wrapper (`XG:Z:CT`) — preserves the original
+    /// `synth_se_record` API used by the existing `+`-strand tests.
+    fn synth_se_record(xm: &[u8], n_soft: usize, n_match: usize) -> BismarkRecord {
+        synth_se_record_strand(xm, n_soft, n_match, b"CT")
     }
 
     #[test]
@@ -303,6 +314,56 @@ mod tests {
             calls.len(),
             4,
             "must emit exactly 4 calls after 2-base ignore"
+        );
+    }
+
+    /// #878 Test 1 — OB/`-`-strand rebase + OT≡OB orientation invariance.
+    ///
+    /// The existing #876 rebase guards are OT-only. For OB records
+    /// `iter_aligned` reverses (`read_pos_5p = seq_len-1-BAM_index`,
+    /// `record.rs:236`), so to make an OB fixture yield the SAME 5'-oriented
+    /// calls as an OT fixture `XM_OT`, the OB XM must be `reverse(XM_OT)`.
+    /// With `ignore_5p=2` the surviving calls rebase to read_pos `[0,1,2]`;
+    /// reverting the fix (`call.rs:204` → `aligned.read_pos_5p`) makes both OT
+    /// and OB produce `[2,3,4]`, so the `== [0,1,2]` assertion fails — the
+    /// bidirectional regression-guard property. This guards the OB code path
+    /// (a future refactor moving the `saturating_sub` onto the BAM-coord
+    /// `read_pos` would silently break OB while passing OT-only tests).
+    #[test]
+    fn extract_calls_ob_strand_rebases_read_pos_after_ignore_5p() {
+        // OT "..Zxh." → 5'-order calls: Z@2 (CpG,meth), x@3 (CHG,unmeth), h@4 (CHH,unmeth).
+        let ot = synth_se_record_strand(b"..Zxh.", 0, 6, b"CT");
+        // OB reverse("..Zxh.") = ".hxZ.." → identical 5'-oriented calls.
+        let ob = synth_se_record_strand(b".hxZ..", 0, 6, b"GA");
+
+        let ot_calls = extract_calls(&ot, /*ignore_5p=*/ 2, 0, false).expect("OT extract");
+        let ob_calls = extract_calls(&ob, /*ignore_5p=*/ 2, 0, false).expect("OB extract");
+
+        let ot_pos: Vec<u32> = ot_calls.iter().map(|c| c.read_pos).collect();
+        let ob_pos: Vec<u32> = ob_calls.iter().map(|c| c.read_pos).collect();
+
+        // Rebased to 0-based-after-clip (NOT the absolute 2,3,4).
+        assert_eq!(
+            ob_pos,
+            vec![0, 1, 2],
+            "OB read_pos must rebase after ignore_5p=2 (not stay absolute 2,3,4)"
+        );
+        // Orientation invariance: OT and OB (reversed XM) yield identical positions.
+        assert_eq!(
+            ot_pos, ob_pos,
+            "OT and OB with reversed XM must agree on rebased read_pos"
+        );
+        // Context + methylation also match in 5'-order.
+        let ob_ctx: Vec<(CytosineContext, bool)> =
+            ob_calls.iter().map(|c| (c.context, c.methylated)).collect();
+        assert_eq!(
+            ob_ctx,
+            vec![
+                (CytosineContext::CpG, true),
+                (CytosineContext::CHG, false),
+                (CytosineContext::CHH, false),
+            ],
+            "OB calls must be CpG-meth, CHG-unmeth, CHH-unmeth in 5'-order"
         );
     }
 

--- a/rust/bismark-extractor/src/parallel.rs
+++ b/rust/bismark-extractor/src/parallel.rs
@@ -1141,6 +1141,185 @@ mod tests {
         }
     }
 
+    // ─────────────────────────────────────────────────────────────────────
+    // #878 Tests 2–3: parallel worker M-bias accumulator slots are rebased.
+    // Guards parallel.rs:711 (SE → mbias[0]), :815 (PE R1 → mbias[0]),
+    // :838 (PE R2 → mbias[1], using ignore_r2). pos_1based = read_pos + 1, so
+    // a rebased first call lands at slot 1; reverting call.rs:204 shifts it to
+    // slot ignore+1. These call the private process_se/process_pe directly.
+    // ─────────────────────────────────────────────────────────────────────
+    use bstr::BString;
+    use noodles_core::Position;
+    use noodles_sam::alignment::record::Flags;
+    use noodles_sam::alignment::record::cigar::Op;
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    use noodles_sam::alignment::record::data::field::Tag;
+    use noodles_sam::alignment::record_buf::data::field::Value;
+    use noodles_sam::alignment::record_buf::{Cigar, RecordBuf, Sequence};
+
+    /// Minimal single-`M` `BismarkRecord` (mirrors `tests/parallel_phase_f.rs::synth_record`).
+    fn synth_rec(
+        qname: &[u8],
+        xr: &[u8],
+        xg: &[u8],
+        xm: &[u8],
+        start: usize,
+        flags: u16,
+    ) -> BismarkRecord {
+        let mut record = RecordBuf::default();
+        *record.flags_mut() = Flags::from(flags);
+        *record.sequence_mut() = Sequence::from(vec![b'A'; xm.len()]);
+        *record.alignment_start_mut() = Some(Position::try_from(start).unwrap());
+        *record.reference_sequence_id_mut() = Some(0);
+        *record.cigar_mut() = Cigar::from(vec![Op::new(Kind::Match, xm.len())]);
+        *record.name_mut() = Some(BString::from(qname.to_vec()));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XR"), Value::String(BString::from(xr.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XM"), Value::String(BString::from(xm.to_vec())));
+        BismarkRecord::from_noodles_record(record).expect("synth BismarkRecord")
+    }
+
+    /// Build a `ResolvedConfig` from CLI args (idiom from `parallel.rs:1173/1263`).
+    /// Needs a real `.bam` path arg for the parser; `process_*` never reads it.
+    fn config_with(extra: &[&str]) -> ResolvedConfig {
+        use crate::cli::Cli;
+        use clap::Parser;
+        let tmp = tempfile::Builder::new().suffix(".bam").tempfile().unwrap();
+        std::fs::write(tmp.path(), b"x").unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let mut args = vec!["bismark-methylation-extractor-rs"];
+        args.extend(extra.iter().copied());
+        args.push(&path);
+        let cfg = Cli::try_parse_from(&args).unwrap().validate().unwrap();
+        drop(tmp);
+        cfg
+    }
+
+    /// Sum of all (meth+unmeth) counts across the 3 contexts of one table.
+    fn mbias_total(t: &MbiasTable) -> u64 {
+        t.cpg
+            .iter()
+            .chain(&t.chg)
+            .chain(&t.chh)
+            .map(|p| p.meth + p.unmeth)
+            .sum()
+    }
+
+    /// #878 Test 2 — SE worker M-bias slots are rebased (`parallel.rs:711`).
+    #[test]
+    fn parallel_se_worker_m_bias_rebased() {
+        // OT 6bp: '.'@0,1,2 ; Z(CpG,meth)@3 ; x(CHG,unmeth)@4 ; h(CHH,unmeth)@5.
+        let rec = synth_rec(b"r", b"CT", b"CT", b"...Zxh", 100, 0);
+        let config = config_with(&["--single-end", "--ignore", "3", "--mbias_only"]);
+        let chr_table: Arc<[String]> = Arc::from(vec!["chr1".to_string()].into_boxed_slice());
+        let mut mbias = [MbiasTable::default(), MbiasTable::default()];
+        let mut report = SplittingReport::default();
+        process_se(
+            &rec,
+            0,
+            &chr_table,
+            &config,
+            true,
+            true,
+            &mut mbias,
+            &mut report,
+        )
+        .expect("process_se");
+
+        // Rebased: read_pos 0,1,2 → 1-based slots 1,2,3 (reverted would be 4,5,6).
+        assert_eq!(mbias[0].cpg[1].meth, 1, "CpG meth at rebased slot 1");
+        assert_eq!(mbias[0].chg[2].unmeth, 1, "CHG unmeth at rebased slot 2");
+        assert_eq!(mbias[0].chh[3].unmeth, 1, "CHH unmeth at rebased slot 3");
+        // The absolute (reverted) slots must be empty.
+        assert_eq!(
+            mbias[0].cpg.get(4).map_or(0, |p| p.meth + p.unmeth),
+            0,
+            "no CpG at absolute slot 4"
+        );
+        assert_eq!(
+            mbias[0].chg.get(5).map_or(0, |p| p.meth + p.unmeth),
+            0,
+            "no CHG at absolute slot 5"
+        );
+        assert_eq!(
+            mbias[0].chh.get(6).map_or(0, |p| p.meth + p.unmeth),
+            0,
+            "no CHH at absolute slot 6"
+        );
+        // SE → nothing in the R2 table.
+        assert_eq!(mbias_total(&mbias[1]), 0, "SE leaves mbias[1] empty");
+    }
+
+    /// #878 Test 3 — PE worker uses `--ignore_r2` for R2 + the R2 table
+    /// (`parallel.rs:838`); `--ignore` for R1 (`:815`). R2 of an OT pair is
+    /// CTOT (`-`-strand, reversed: read_pos_5p = seq_len-1-BAM), so its call
+    /// is placed at BAM index `seq_len-1-ignore_r2`. R1/R2 are non-overlapping
+    /// so `drop_overlap` keeps R2.
+    #[test]
+    fn parallel_pe_worker_m_bias_uses_r2_ignore_for_r2() {
+        // R1: OT (CT,CT) '+'-strand, 6bp, CpG 'Z'@BAM3 → read_pos_5p=3;
+        //     --ignore 3 → rebased 0 → mbias[0].cpg slot 1.
+        let r1 = synth_rec(b"pair", b"CT", b"CT", b"...Z..", 100, 0x41);
+        // R2: CTOT (GA,CT) '-'-strand reversed, 9bp, CpG 'Z'@BAM1 →
+        //     read_pos_5p = 9-1-1 = 7; --ignore_r2 7 → rebased 0 → mbias[1].cpg slot 1.
+        //     start=200 (non-overlapping with R1@100) so drop_overlap keeps it.
+        let r2 = synth_rec(b"pair", b"GA", b"CT", b".Z.......", 200, 0x81);
+        let pair = BismarkPair::from_mates(r1, r2).expect("valid OT pair");
+
+        let config = config_with(&["-p", "--ignore", "3", "--ignore_r2", "7", "--mbias_only"]);
+        let chr_table: Arc<[String]> = Arc::from(vec!["chr1".to_string()].into_boxed_slice());
+        let mut mbias = [MbiasTable::default(), MbiasTable::default()];
+        let mut report = SplittingReport::default();
+        process_pe(
+            &pair,
+            0,
+            &chr_table,
+            &config,
+            true,
+            true,
+            &mut mbias,
+            &mut report,
+        )
+        .expect("process_pe");
+
+        // R1 → mbias[0] slot 1 (rebased by --ignore 3); R2 → mbias[1] slot 1 (by --ignore_r2 7).
+        assert_eq!(
+            mbias[0].cpg[1].meth, 1,
+            "R1 CpG meth at mbias[0] rebased slot 1"
+        );
+        assert_eq!(
+            mbias[1].cpg[1].meth, 1,
+            "R2 CpG meth at mbias[1] rebased slot 1"
+        );
+        // Absolute (reverted) slots empty; no cross-table leakage.
+        assert_eq!(
+            mbias[0].cpg.get(4).map_or(0, |p| p.meth + p.unmeth),
+            0,
+            "R1 not at absolute slot 4"
+        );
+        assert_eq!(
+            mbias[1].cpg.get(8).map_or(0, |p| p.meth + p.unmeth),
+            0,
+            "R2 not at absolute slot 8"
+        );
+        assert_eq!(
+            mbias_total(&mbias[0]),
+            1,
+            "mbias[0] holds exactly R1's call"
+        );
+        assert_eq!(
+            mbias_total(&mbias[1]),
+            1,
+            "mbias[1] holds exactly R2's call"
+        );
+    }
+
     /// Plan rev 1 §7.1 + Reviewer A & B both flagged: prove that a
     /// producer panic does NOT deadlock workers. With channel-disconnect-
     /// as-EOS, when the producer's thread closure panics, its `tx_input`

--- a/rust/bismark-extractor/tests/parallel_phase_f.rs
+++ b/rust/bismark-extractor/tests/parallel_phase_f.rs
@@ -424,6 +424,79 @@ fn legacy_vs_parallel_n4_se_default_byte_identical() {
     assert_dirs_byte_identical(&legacy_dir, &parallel_dir, "legacy", "parallel-n4");
 }
 
+/// #878 Test 4 — single-threaded `extract_se` vs parallel `extract_se_parallel`
+/// produce identical output (incl. `M-bias.txt`) under a NON-ZERO `--ignore`.
+///
+/// Structural guard for the dual-driver back-port trap: a rebase that landed in
+/// one driver but not the other would diverge here. Existing `legacy_vs_parallel_*`
+/// tests run `--ignore 0`, which never exercises the rebase.
+///
+/// NOTE (dual-review I-4): this guards driver **divergence**, NOT revert — both
+/// drivers share the rebase, so it stays green on a revert (Tests 1–3 cover
+/// absolute correctness). `--ignore 2` (< the 5-bp fixture reads) is mandatory:
+/// `--ignore 5` would trip the `lo>=hi` early-out (`call.rs:166`) → empty output
+/// → vacuously identical (dual-review C1). The non-emptiness assertion locks that out.
+#[test]
+fn se_driver_vs_parallel_driver_m_bias_equality() {
+    let workdir = tempfile::tempdir().unwrap();
+    let bam_path = workdir.path().join("se.bam");
+    write_se_directional_bam(&bam_path);
+    let bam_s = bam_path.to_str().unwrap();
+
+    let single_dir = workdir.path().join("single");
+    let parallel_dir = workdir.path().join("parallel_n4");
+    extract_se(
+        &bam_path,
+        &resolved_config(&[
+            "--single-end",
+            "--ignore",
+            "2",
+            "--output_dir",
+            single_dir.to_str().unwrap(),
+            bam_s,
+        ]),
+    )
+    .unwrap();
+    extract_se_parallel(
+        &bam_path,
+        &resolved_config(&[
+            "--single-end",
+            "--ignore",
+            "2",
+            "--parallel",
+            "4",
+            "--output_dir",
+            parallel_dir.to_str().unwrap(),
+            bam_s,
+        ]),
+    )
+    .unwrap();
+
+    // Non-emptiness guard (dual-review C1): --ignore must leave surviving calls,
+    // else both dirs are empty and the equality below is vacuous.
+    let mut call_lines = 0usize;
+    for entry in fs::read_dir(&single_dir).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if (name.starts_with("CpG_") || name.starts_with("CHG_") || name.starts_with("CHH_"))
+            && name.ends_with(".txt")
+        {
+            for line in fs::read_to_string(entry.path()).unwrap().lines() {
+                if !line.is_empty() && !line.starts_with("Bismark") {
+                    call_lines += 1;
+                }
+            }
+        }
+    }
+    assert!(
+        call_lines > 0,
+        "--ignore 2 must leave surviving methylation calls (guards the C1 vacuous-pass no-op)"
+    );
+
+    // M-bias.txt + all split/report files identical across the two drivers.
+    assert_dirs_byte_identical(&single_dir, &parallel_dir, "single", "parallel-n4");
+}
+
 #[test]
 fn legacy_vs_parallel_n4_pe_default_byte_identical() {
     let workdir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
Closes the CI coverage gap from #876 / PR #877 (sub-issue of #798). The #876 **Bug B** fix rebases `MethCall.read_pos` at construction (`call.rs:204`: `aligned.read_pos_5p.saturating_sub(ignore_5p)`), but in-repo CI only exercised the OT/`+`-strand `extract_calls` path and **none** of the 3 `parallel.rs` worker M-bias accumulator sites — those were covered only by the manual colossal Phase H walk, not CI. This adds **4 regression-guard tests** (tests-only, no source logic change) so a future refactor that breaks the rebase is caught in CI.

## Tests added
| Test | File | Guards |
|---|---|---|
| `extract_calls_ob_strand_rebases_read_pos_after_ignore_5p` | `call.rs` | OB/`-`-strand rebase + OT≡OB orientation invariance |
| `parallel_se_worker_m_bias_rebased` | `parallel.rs` | SE worker → `mbias[0]` slot 1 (`--ignore 3`) |
| `parallel_pe_worker_m_bias_uses_r2_ignore_for_r2` | `parallel.rs` | R1→`mbias[0]`, R2→`mbias[1]`, `--ignore_r2` applied to R2 |
| `se_driver_vs_parallel_driver_m_bias_equality` | `tests/parallel_phase_f.rs` | single-threaded vs parallel driver M-bias equality (dual-driver trap) |

- `synth_se_record` refactored to a strand-parameterized helper (non-breaking; OT wrapper preserved).
- Fixture orientation (independently re-derived by both reviewers): OB XM = byte-reverse of the OT fixture (`iter_aligned` remaps OB `read_pos_5p = seq_len-1-BAM`); R2 of an OT pair is CTOT (`-`/reversed), so its call sits at BAM index `seq_len-1-ignore_r2`.

## Verification
- Full suite: lib **105** (+3), `parallel_phase_f` **18** (+1); `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check` clean.
- **Revert-smoke (acceptance gate #878):** reverting `call.rs:204` → `aligned.read_pos_5p` makes Tests 1–3 **FAIL**; Test 4 stays **green** by design (it guards driver *divergence*, not revert — Tests 1–3 cover absolute correctness).
- `se_driver_…` uses `--ignore 2` (NOT `--ignore 5`: the 5-bp fixtures would trip the `lo>=hi` early-out → vacuous empty-output pass; caught in dual plan-review C1) + a non-emptiness assertion.
- **Dual independent code-review: APPROVE** (no Critical/High/Medium). **plan-manager: COMPLETE** (0 gaps).

## Scope
Tests only — `call.rs:204` and all other source logic unchanged (every `call.rs`/`parallel.rs` hunk is inside `#[cfg(test)]`). Marks `BUG_876_FIXES_PLAN` tests #8/#9/#10 as landed.

Part of #798. Closes #878.
