### PR TITLE
docs(extractor): plan artifacts for #884 R2 + #878

### DIFF
--- a/plans/05262026_bismark-extractor/PERF_R2_CODE_REVIEW_reviewer-A.md
+++ b/plans/05262026_bismark-extractor/PERF_R2_CODE_REVIEW_reviewer-A.md
@@ -1,0 +1,205 @@
+# PERF R2 Code Review — Reviewer A
+
+**Scope:** R2 of Bismark extractor perf work (#884) — swap the `--gzip` split-file
+writers from `flate2::write::GzEncoder` to gzp's parallel-gzip
+`gzp::par::compress::ParCompress<gzp::deflate::Gzip>` (the "gzp-in-collector" /
+ALT-1 design).
+
+**Diff reviewed:** `git -C /Users/fkrueger/Github/Bismark-extractor diff 8a2a147 -- rust/`
+(5 files: `output.rs`, `lib.rs`, `Cargo.toml`, `Cargo.lock`, `tests/parallel_phase_f.rs`).
+
+**Verification performed:**
+- Read gzp 0.11.3 source: `par/compress.rs`, `deflate.rs`, `lib.rs`, `Cargo.toml`.
+- Read the full `output.rs`, `state.rs` finalize sequence, `parallel.rs` collector
+  ownership, `output_mode.rs` file-count, and the test file + helpers.
+- Ran `cargo test -p bismark-extractor --test parallel_phase_f` → **17 passed, 0 failed**
+  (incl. the new multibatch test; sweep output confirms empty `.gz` members are
+  deleted under gzip).
+- Ran `cargo clippy --all-targets -- -D warnings` → **clean**.
+
+---
+
+## Summary / Verdict
+
+**APPROVE.** The change is correct, well-scoped, and the central claims hold up
+against the gzp source. Every byte-identity-critical path (plain `.txt`, collector
+ordering, version header, empty-sweep accounting, M-bias / splitting-report) is
+genuinely untouched — the diff only swaps the `gzip == true` arm of
+`open_writer`. The single-member-gzip claim is verified directly in gzp's source
+(one `header()` + Sync/Finish DEFLATE blocks + one `footer()` per stream), and
+gzp's own `test_simple`/`test_simple_drop` decode `Gzip` output with a plain
+single-member `GzDecoder`, exactly matching this code's decode path. `deflate_rust`
+correctly avoids `any_zlib`, so `needs_dict()==false` (no cross-block dictionary,
+no cmake/C). No `MultiGzDecoder` migration is needed.
+
+The only findings are non-blocking: a thread-oversubscription concern at high
+`--parallel` whose magnitude is understated by the code comment (Medium), the
+inherited panic-on-drop-footer-error behavior (Low, documented + accepted), one
+stale doc comment (Low), and two test-coverage gaps (Low). None block merge.
+
+All claims 1–6 from the brief were checked and **verified**; details inline below.
+
+---
+
+## Claims verification (per the brief)
+
+1. **Single-member gzip — VERIFIED.** `ParCompress::run` (`par/compress.rs:218`)
+   writes `format.header()` exactly once before the chunk loop, and
+   `format.footer(&running_check)` exactly once after (`:226-227`).
+   `Gzip::encode` (`deflate.rs:96-100`) uses `FlushCompress::Sync` for non-last
+   chunks and `FlushCompress::Finish` for the last — i.e. sync-flushed DEFLATE
+   blocks within a single member. `Gzip::footer` (`deflate.rs:136-142`) emits
+   `CRC32` + `ISIZE` once. gzp's own `test_simple`/`test_simple_drop`/`test_regression`
+   (`deflate.rs:716-780, 917-960`) decode `Gzip` output with plain
+   `GzDecoder` — authoritative confirmation. The test fixture's 8199 records
+   cross multiple internal blocks and still decode with single-member
+   `GzDecoder`. Claim holds.
+
+2. **Panic-on-drop — VERIFIED, accepted.** gzp `Drop` (`par/compress.rs:310-315`)
+   calls `self.finish().unwrap()` when the handle/channels are still live. A
+   footer-flush I/O error at drop → panic, vs flate2 `GzEncoder::Drop`'s silent
+   swallow. Mid-stream errors still surface as `io::Error` via `Write::write`
+   (`:341-370`). See Low-1 — acceptable for a CLI tool; hardening deferred.
+
+3. **`GZIP_COMPRESS_THREADS = 4`, decoupled from `--parallel` — correct rationale,
+   understated cost.** Decoupling is the right call (the common `--parallel 1
+   --gzip` path would otherwise stay single-threaded). But see Medium-1: in
+   Default mode 12 files are eagerly opened and held open for the whole run, each
+   spawning 4 compressor + 1 writer threads → ~60 gzip threads concurrently,
+   independent of `--parallel`. The doc comment ("a fixed pool of 4") describes
+   per-file, not aggregate, behavior.
+
+4. **`flate2` → `[dev-dependencies]` — VERIFIED.** No functional `src/` use of
+   flate2 remains (`grep` shows only doc/comment mentions; both `use flate2::*`
+   imports removed). gzp pulls flate2 transitively with `rust_backend`. Workspace
+   pin `=1.1.9` satisfies gzp's `>=1.0.25` requirement; the lock has a single
+   flate2 (1.1.9). Tests decode via `flate2::read::GzDecoder` (dev-dep). Correct.
+
+5. **Byte-identity preservation — VERIFIED.** The diff touches only the
+   `gzip == true` branch of `open_writer` (`output.rs:419-431`). Plain `.txt`
+   path, `write_call` body + `batch_seq` ordering (single-collector writer,
+   `parallel.rs:1056`), version-header write (`output.rs:126-128`),
+   `records_written` accounting, M-bias.txt, and splitting-report writing are
+   unchanged. Raw `.gz` bytes change (different framing + no dictionary);
+   decompressed content is identical, as the passing tests assert.
+
+6. **The new test — VERIFIED, with gaps.** `parallel_gzip_multibatch_…` (8199 >
+   2×4096) genuinely guards single-member framing (single-member `GzDecoder`
+   decode of a multi-block stream — a multi-member regression would truncate and
+   fail `== plain`) and N-independence (n1 vs n4 decompressed-byte identity). The
+   sweep log in the run confirms it also exercises empty-key `.gz` deletion
+   (e.g. `CpG_CTOT_large.txt.gz was empty -> deleted`). Gaps: SE-only, no PE; no
+   explicit small-multibatch fixture beyond this one. See Low-3.
+
+---
+
+## Issues by area
+
+### Logic
+- **No correctness defects found.** The single-writer-per-file invariant
+  (collector owns the only `OutputFileMap`) means each `.gz` file is produced by
+  exactly one `ParCompress` → exactly one gzip member. Empty-sweep semantics are
+  unchanged: `records_written` counts call rows (not bytes), so a header-only
+  gzip member is still classified empty and unlinked — verified live in the test
+  output.
+
+### Efficiency
+- **Medium-1 (below): thread oversubscription** is the one efficiency concern.
+- Minor: `OutputFileMap::flush_all` → `BufWriter::flush` → `ParCompress::flush` →
+  `flush_last(false)` always enqueues at least one chunk even when the internal
+  buffer is empty, producing an extra empty Sync DEFLATE block per flush. Harmless
+  (valid DEFLATE, footer CRC unaffected) and flush_all is called once per run.
+  Not worth changing.
+
+### Errors
+- **Low-1 (below): panic-on-drop-footer-error**, and the related observation that
+  `cleanup_all` (error path) drops gzp writers whose `Drop` may panic via
+  `finish().unwrap()` if the underlying disk error that triggered cleanup also
+  fails the footer flush — a panic there would mask the original error. Low
+  severity (error path only, CLI process about to exit). gzp also `.unwrap()`s
+  `core_affinity::get_core_ids()` inside its writer thread (`par/compress.rs:181`);
+  inherited, returns Some on Linux/macOS, not fixable here.
+
+### Structure
+- **Low-2 (below): stale doc comment** at `output.rs:366` still says "the inner
+  GzEncoder, if any" inside `cleanup_all` — it's now a gzp `ParCompress`. Every
+  other doc/comment in the file was updated; this one was missed.
+- The `.expect("GZIP_COMPRESS_THREADS is nonzero")` on the builder's
+  `num_threads()` result (`output.rs:426`) is appropriate — it can only fire if
+  the const is set to 0, a compile-time-visible programmer error. Good.
+- Cargo.toml comments are thorough and accurate (deflate_rust rationale, flate2
+  pin reconciliation, dev-dep move). gzp pulls a second `thiserror 1.0.69` into
+  the lock (transitive); acceptable, no action needed.
+
+---
+
+## Findings (priority-ranked)
+
+### Medium-1 — Thread oversubscription at high `--parallel`; comment understates aggregate thread count
+`output.rs:384-395` frames `GZIP_COMPRESS_THREADS = 4` as "a fixed pool of 4". In
+reality, `OutputFileMap::new` eagerly opens **one `ParCompress` per split file**
+and holds them all open for the entire run (until `finalize_with_empty_sweep`).
+In Default mode that's 12 files; each `ParCompress::from_writer` spawns
+`num_threads (4)` compressor threads **plus 1 writer thread** (`par/compress.rs:104-121,
+182-215`). So `--gzip` Default mode runs **~60 gzip threads** (12 × 5)
+concurrently, on top of the pipeline's N workers + producer + collector —
+**independent of `--parallel`**. At `--parallel 8` on a typical 8–16-core box this
+is meaningful oversubscription.
+
+Mitigating facts: the gzp compressor threads block on `rx.recv()` and only one
+file is actively receiving heavy traffic at a time in practice, so they are not
+all CPU-hot simultaneously; per-writer buffered memory is bounded (~1 MiB:
+`num_threads*2 = 8`-slot channels × 128 KiB `BUFSIZE`), ~12 MiB total. The spike's
+~4.1x win was measured, so the net effect is positive. **No correctness impact.**
+
+Recommendation (non-blocking): update the `GZIP_COMPRESS_THREADS` doc to state the
+aggregate (e.g. "Default mode opens 12 files, so ~48 compressor + 12 writer
+threads run concurrently; bounded because most block on empty input channels").
+Optionally consider lowering to 2–3, or revisiting once the colossal multi-file
+`--gzip` smoke measures real CPU contention. Defer the value change to a measured
+follow-up; just fix the comment now.
+
+### Low-1 — Panic-on-drop footer error not propagated as Result (documented, accepted)
+gzp `Drop` calls `finish().unwrap()` (`par/compress.rs:312`). A footer-flush I/O
+error at drop becomes a panic, unlike flate2's silent swallow. The code documents
+this honestly (`output.rs:410-413`). Hardening (explicit `finish()` to propagate
+`Result`) would require de-type-erasing `Box<dyn Write + Send>` — not worth it now.
+For a CLI tool, panicking with a non-zero exit on a disk-full-at-footer condition
+is arguably *better* than flate2 silently producing a truncated `.gz`.
+**Recommendation:** keep as-is; track as a documented follow-up only if a
+graceful-error contract is later required. Note in passing: `cleanup_all` (error
+path, `output.rs:354-381`) can hit this panic-on-drop and mask the original error
+— acceptable since the process is already terminating on error.
+
+### Low-2 — Stale "GzEncoder" doc comment in `cleanup_all`
+`output.rs:366`: `// Explicitly close the writer (and the inner GzEncoder, if any)`
+— should read "gzp `ParCompress`". Cosmetic; every other reference was updated.
+**Recommendation:** one-line comment fix.
+
+### Low-3 — Test coverage gaps: no PE+gzip, mid-write-failure smoke still skipped
+The gzip integration tests are SE-only (no `extract_pe_parallel` + `--gzip`).
+Risk is low because `open_writer` and the single-collector writer are
+SE/PE-agnostic — PE differs only in record routing, which the existing PE
+byte-identity tests already cover (plain). The
+`smoke_gzip_cleanup_on_write_failure_removes_gz_files` smoke remains intentionally
+skipped (portability; `/dev/full` is Linux-only, per
+`output_modes_phase_e_smoke.rs:17-24`), so the panic-on-drop / cleanup-under-error
+path has no automated coverage. **Recommendation (optional):** add one PE+gzip
+multibatch decode test mirroring the new SE one; consider a Linux-gated
+`/dev/full` write-failure test in a follow-up. Non-blocking.
+
+---
+
+## Fixes I would apply
+None applied (review-only, per skill instructions). The only change I'd recommend
+applying before merge is the trivial Low-2 doc fix; Medium-1's comment update and
+the test additions can ride along or follow up.
+
+## Bottom line
+Approve for merge. The gzp-in-collector design is correctly implemented and
+byte-identity-safe; the single-member and decode claims are verified against gzp
+source and pass the new regression test. The dual plan-review's MultiGzDecoder /
+multi-member Criticals were written against the superseded worker-side-members
+design and **do not apply** to this gzp-in-collector implementation (single writer
+per file ⇒ single member). Address Medium-1's comment and Low-2 at your
+convenience; Low-1 and Low-3 are documented/optional follow-ups.

--- a/plans/05262026_bismark-extractor/PERF_R2_CODE_REVIEW_reviewer-B.md
+++ b/plans/05262026_bismark-extractor/PERF_R2_CODE_REVIEW_reviewer-B.md
@@ -1,0 +1,214 @@
+# PERF R2 Code Review — Reviewer B
+
+**Scope:** R2 of Bismark extractor perf work (#884) — swap the `--gzip` split-file
+writers from single-threaded `flate2::write::GzEncoder` to gzp's parallel-gzip
+`gzp::par::compress::ParCompress<gzp::deflate::Gzip>` ("gzp-in-collector" / ALT-1).
+
+**Diff reviewed:** `git -C /Users/fkrueger/Github/Bismark-extractor diff 8a2a147 -- rust/`
+Files: `rust/bismark-extractor/src/output.rs`, `src/lib.rs`, `Cargo.toml`,
+`rust/Cargo.lock`, `tests/parallel_phase_f.rs`.
+
+**Independent verification performed:**
+- Read gzp 0.11.3 source: `par/compress.rs`, `deflate.rs`.
+- Read surrounding `output.rs`, `state.rs`, `output_mode.rs`, `parallel.rs`,
+  and the test helpers in `parallel_phase_f.rs`.
+- Re-ran `cargo test -p bismark-extractor --test parallel_phase_f` (17 passed),
+  `cargo clippy --all-targets -- -D warnings` (clean), and `cargo tree -i flate2`
+  / `-e features -i gzp`.
+
+---
+
+## Summary
+
+**Verdict: APPROVE.** The change is correct, the byte-identity-of-decompressed-content
+contract holds, the dependency wiring is clean, and the new regression test
+genuinely guards single-member framing + N-independence. All six claims I was
+asked to scrutinize hold up against the gzp source. There are **no Critical or
+High issues**. The findings below are Medium/Low — the only one worth a decision
+before merge is the eager thread-spawn footprint (Medium), which is a resource
+tradeoff, not a correctness bug.
+
+This is materially lower-risk than the SUPERSEDED worker-side-members design the
+plan reviewers flagged: their multi-member "Criticals" do **not** apply to gzp,
+because gzp emits one stream-wide member (verified below), not one member per
+worker/batch.
+
+---
+
+## Claim-by-claim verification
+
+### 1. Single-member gzip — CONFIRMED (was the load-bearing Critical risk)
+`ParCompress::run` (`par/compress.rs:217-228`) writes `format.header()` **once**
+before the receive loop, streams each compressed chunk in order, then writes
+`format.footer()` **once** with a single stream-wide `running_check` (CRC32 +
+ISIZE). `Gzip::header` (`deflate.rs:112-133`) is the standard 10-byte gzip header;
+`Gzip::footer` (`deflate.rs:135-142`) is CRC32 + ISIZE. Internal chunks use
+`FlushCompress::Sync` for non-last and `Finish` for the last block
+(`deflate.rs:96-100`) — sync-flushed DEFLATE blocks inside **one** member. gzp's
+own `test_simple` (`deflate.rs:716`) and `test_simple_drop` (`:750`) decode
+`ParCompress<Gzip>` output with a plain single-member `GzDecoder`. The diff's
+claim is accurate. The existing `GzDecoder`-based tests do **not** silently
+truncate.
+
+### 2. Panic-on-drop — CONFIRMED, acceptable as-is (Low, documented)
+`Drop for ParCompress` (`par/compress.rs:310-315`) calls `self.finish().unwrap()`.
+`finish()` → `flush_last(true)` → joins the writer thread, which is where the
+footer is written (`run()` `:226-228`); any footer-flush I/O error becomes a
+panic. flate2's `GzEncoder::Drop` swallows the equivalent error silently.
+This is acceptable: the only realistic footer-flush failure is ENOSPC at the very
+end of writing an output file, and a panic (loud, with a non-zero exit) is a
+*safer* failure mode than flate2's silent swallow (which could leave a
+truncated-but-uncomplained `.gz`). It is correctly documented at
+`output.rs:410-412`. See L1 below for the one residual nuance (panic mid-sweep).
+
+### 3. `GZIP_COMPRESS_THREADS = 4` decoupled from `--parallel` — sound rationale, but see M1
+The reasoning at `output.rs:384-395` is correct: the default run is `--parallel 1`
+and single-threaded gzip is the dominant serial wall, so tying the pool to
+`--parallel` would leave the common path single-threaded. A fixed pool captures
+the win on every `--gzip` path. **However**, the resource footprint at high
+`--parallel` is underweighted — see M1.
+
+### 4. `flate2` → dev-deps — CONFIRMED clean
+- No non-test `src/` code references `flate2` (grep shows only doc-comment
+  mentions). The `use flate2::...` imports were removed from `output.rs`.
+- `cargo tree -i flate2` resolves to a **single** `flate2 v1.1.9`, shared by
+  gzp, noodles-bgzf, and noodles-cram. The `=1.1.9` pin in `[dev-dependencies]`
+  matches and does not create a second version. No duplicate-crate bloat.
+- Note (not a defect): `flate2` is still a **runtime** transitive dependency via
+  gzp's `deflate_rust` feature (`cargo tree -e features -i gzp` shows
+  `deflate_rust → flate2`). So flate2 still compiles into the binary; moving it
+  to dev-deps only changes the *direct* dependency edge, not whether flate2 is
+  linked. The Cargo.toml comment is accurate ("the src `--gzip` writer is now
+  gzp, not flate2"), but a reader could misread it as "flate2 no longer linked."
+  Minor (L2).
+- `default-features = false` + `deflate_rust` correctly avoids the
+  `libdeflate`/`zlib` C backends (no cmake). `needs_dict()` returns
+  `cfg!(feature = "any_zlib")` (`deflate.rs:80`), which is **false** here, so the
+  cross-block dictionary is skipped — confirming the diff's claim that compressed
+  bytes differ from flate2 but decompressed content is identical.
+
+### 5. Byte-identity — CONFIRMED
+Only the gzip writer **construction** changed (`open_writer` `output.rs:417-433`).
+Verified unchanged: plain `.txt` branch (`Box::new(file)`), `write_call` row
+formatting (`output.rs:208-223`, the Phase-B-locked 5-col format), the
+`SPLIT_FILE_HEADER` write (`output.rs:127`), `records_written` bump-after-success
+(`output.rs:229`), the empty-sweep gating on `records_written == 0`
+(`output.rs:316`), and collector `batch_seq` ordering (`parallel.rs`). The
+`flush_all`→`drop` sequencing is correct: gzp `Write::flush` calls
+`flush_last(false)` (sync block, **no footer**, `par/compress.rs:379-381`); the
+footer is written once at `drop`/`finish`. So one header + one footer per file.
+Decompressed content is byte-identical to the plain peer and N-independent.
+
+### 6. New test quality — GOOD, with minor gaps (L3)
+`parallel_gzip_multibatch_decompresses_identical_across_n_and_to_plain`
+(`parallel_phase_f.rs:813`) uses 8199 records = 2×`BATCH_SIZE`(4096)+7, so the
+stream spans multiple internal sync-flushed blocks — exactly the case that would
+expose a multi-member regression. `decompress_gz` (`:346-350`) uses a
+single-member `GzDecoder` + `read_to_end`: on a hypothetical multi-member stream
+that reads only member 0 and stops (no error), producing truncated output that
+fails `assert_eq!(decoded, plain)`. So the guard is real. It also asserts
+cross-N (`n1` vs `n4`) decompressed-byte identity. This is a meaningful addition
+over the existing single-batch `parallel_gzip_n4_...` test. Gaps noted in L3.
+
+---
+
+## Issues by area
+
+### Logic
+- None. The framing, ordering, flush/drop sequencing, and empty-sweep
+  interaction are all correct.
+
+### Efficiency
+- **M1 (Medium) — eager thread-spawn footprint scales with file count × 4, not with `--parallel`.**
+  `from_writer` (`par/compress.rs:104-131`) spawns **1 writer thread immediately**,
+  and `run()` (`:182`) spawns `num_threads` (=4) **compressor threads**. So each
+  gzipped writer = **5 OS threads**, spawned **eagerly at `OutputFileMap::new`
+  time** (`output.rs:125`), before any data is written. In **Default mode (the
+  common case)** there are **12 split files** (`output_mode.rs:97-110`), i.e.
+  **~60 threads** spun up on every `--gzip` run regardless of `--parallel`.
+  - This includes strands that receive **zero records** (e.g. CTOT/CTOB in a
+    directional library): those 5 threads spin up, sit blocked on `recv()`, and
+    are torn down at the empty-sweep `drop`. Confirmed live in my test run — the
+    log shows 8 of 12 files `was empty -> deleted` while their gzp pools had
+    nonetheless been allocated.
+  - The threads are idle-blocked (not busy-spinning), so steady-state CPU is fine.
+    The cost is thread-creation/teardown overhead and ~60 thread stacks (default
+    8 MiB virtual reservation each on Linux → ~480 MiB *virtual*, far less RSS).
+    For a long-running extraction this is negligible; the concern is purely the
+    "60 threads for 12 files, most receiving little/no data" smell, which gets
+    worse if MergeNonCpG (8 files) or future modes add files.
+  - **Recommendation:** This is acceptable for v1 (correctness is fine and the
+    perf win is real), but consider one of: (a) lower `GZIP_COMPRESS_THREADS` to
+    2–3 (the spike's 4.1x came from 4 threads against *one* serialized wall; with
+    12 concurrent files the per-file pool oversubscribes the box anyway); or
+    (b) add a one-line note in the `GZIP_COMPRESS_THREADS` doc acknowledging that
+    the **total** gzip thread count is `4 × open_file_count`, not 4. The current
+    doc frames "4 threads" as the whole story, which understates the footprint
+    at 12 files. **Do not block merge on this** — flag for the author's decision.
+
+### Errors
+- **L1 (Low) — a panic during the `finalize_with_empty_sweep` drop loop aborts remaining files.**
+  `finalize_with_empty_sweep` (`output.rs:283-343`) iterates entries and
+  `drop(writer)` each (`:304`). If one writer's footer-flush panics (gzp
+  `.unwrap()`), the loop unwinds and the remaining entries' files are neither
+  swept nor logged. With flate2 this couldn't happen (silent swallow). In
+  practice a footer-flush panic means the FS is already failing (ENOSPC), so a
+  hard abort is defensible and arguably better than limping on. The other
+  writers' gzp threads would still be joined via *their* `Drop` during unwind
+  (each `OutputFileEntry` owns its writer; unwinding drops the not-yet-iterated
+  `entries` Vec). No thread leak. **No action required**; documenting that "a
+  footer panic aborts the sweep" alongside the existing `output.rs:410-412`
+  caveat would be a nice-to-have.
+
+### Structure
+- **L2 (Low) — Cargo.toml dev-dep comment could be misread.** The comment at
+  `Cargo.toml` (dev-deps `flate2`) says "the src `--gzip` writer is now gzp, not
+  flate2," which is true, but flate2 is **still linked transitively** via gzp's
+  `deflate_rust`. A future reader auditing "can we drop flate2?" might wrongly
+  conclude it's test-only. One clause ("flate2 remains a runtime transitive dep
+  via gzp's deflate_rust backend; this entry only adds the direct test edge")
+  would prevent that. Cosmetic.
+
+- **L3 (Low) — test coverage gaps in the new test.**
+  - **PE not covered.** The new test is SE-only. This is *low* risk because
+    `extract_pe`/`extract_pe_parallel` route through the identical
+    `OutputFileMap`/`open_writer` — the gzip writer construction is mode-agnostic,
+    so there's no SE-vs-PE divergence in the gzip path. Existing PE gzip coverage
+    exists elsewhere in `parallel_phase_f.rs` (e.g. `extract_pe_parallel` at
+    `:442`). Acceptable.
+  - **Empty `.gz` sweep (CTOT/CTOB) is exercised but not asserted.** With a
+    directional fixture, CTOT/CTOB files are eager-opened (header + gzp pool),
+    written 0 records, and unlinked by the sweep (confirmed in the run log). The
+    test's `for entry in read_dir` only sees *surviving* files, so it never
+    asserts anything about the empty-then-deleted gz files (correct — they're
+    gone). There is no test that an empty-but-kept `.gz` (header-only, no records)
+    decodes to the header line, but that path doesn't occur in practice (sweep
+    removes `records_written==0`), so this is a non-gap. No action.
+
+---
+
+## Fixes I would apply
+None required for correctness. If the author wants to act on the optional items:
+1. (M1) Reduce `GZIP_COMPRESS_THREADS` to 2–3 **or** extend its doc to note the
+   `4 × file_count` total. Decision, not a defect.
+2. (L2) One clarifying clause in the Cargo.toml dev-dep comment about flate2
+   remaining a runtime transitive dep.
+
+(I did not edit source, per instructions.)
+
+---
+
+## Recommendations with priority
+
+| Priority | Item | Ref |
+|----------|------|-----|
+| Critical | none | — |
+| High | none | — |
+| Medium | M1: gzip pool = `4 × open_file_count` threads (≈60 in Default mode), spawned eagerly incl. zero-record strands; consider lowering const to 2–3 or documenting the true total | `output.rs:384-395`, `output.rs:125`, `par/compress.rs:104-131,182`, `output_mode.rs:97-110` |
+| Low | L1: footer-flush panic in the sweep `drop` loop aborts remaining files (FS-failure-only; defensible) | `output.rs:304`, `par/compress.rs:310-315` |
+| Low | L2: Cargo.toml dev-dep comment understates that flate2 is still a runtime transitive dep via gzp `deflate_rust` | `Cargo.toml` dev-deps |
+| Low | L3: new test is SE-only (mode-agnostic writer → low risk); empty-gz sweep exercised but not asserted (non-gap) | `parallel_phase_f.rs:813` |
+
+**Build/test status (re-verified locally):** `parallel_phase_f` 17/17 pass;
+`clippy --all-targets -D warnings` clean; `cargo tree` confirms single flate2
+v1.1.9 and `deflate_rust` feature active.

--- a/plans/05262026_bismark-extractor/PERF_R2_COVERAGE.md
+++ b/plans/05262026_bismark-extractor/PERF_R2_COVERAGE.md
@@ -1,0 +1,70 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs. the plan's implementation spec — the "## R2 FINAL approach — gzp-in-collector (ALT-1)" section)
+**Plan:** `plans/05262026_bismark-extractor/PERF_R2_WORKER_OUTPUT_PLAN.md`
+**Date:** 2026-05-29
+**Verdict:** COMPLETE
+
+> Scope note: This audit deliberately covers ONLY the "R2 FINAL approach —
+> gzp-in-collector (ALT-1)" section ("What was implemented" + "Single-member
+> framing" + "Verification status"). The "## Design (rescoped) — SUPERSEDED"
+> and "## Implementation outline" (worker-side-members) sections were explicitly
+> NOT shipped and are out of scope per the verification request.
+>
+> Code state: worktree `/Users/fkrueger/Github/Bismark-extractor`, branch
+> `spike-gzp` @ `65e5ff1`; net R2 diff = `git diff 8a2a147 -- rust/`.
+
+## Summary
+
+- Total items: 7
+- DONE: 7
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED: 0
+- Known-pending (non-code): 1 (Colossal `--gzip` SE/PE `phase_h_smoke` — recorded, not a gap)
+
+## Coverage ledger
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `output.rs::open_writer` swaps flate2 `GzEncoder` → `gzp::par::compress::ParCompress<Gzip>` (`deflate_rust`); writer stays single `Box<dyn Write + Send>`; collector/ordering/empty-sweep/header/plain-`.txt` paths unchanged | "What was implemented" #1 | DONE | `open_writer` (output.rs:407-431) now boxes `ParCompressBuilder::<gzp::deflate::Gzip>::new().num_threads(...).from_writer(file)`. `BoxedWriter = BufWriter<Box<dyn Write + Send>>` unchanged. Plain branch (`else { Box::new(file) }`) intact. Functional diff in output.rs is exactly the import drop + const + this swap; everything else is doc-comment-only — `write_call`, `write_routed_call`, empty-sweep, version header, `batch_seq` ordering untouched. `parallel.rs` has ZERO lines in the R2 diff. |
+| 2 | `GZIP_COMPRESS_THREADS = 4` named const, decoupled from `--parallel` | "What was implemented" #2 | DONE | `const GZIP_COMPRESS_THREADS: usize = 4;` (output.rs:391) with doc explaining decoupling from `--parallel`; passed to `.num_threads(GZIP_COMPRESS_THREADS)`. No reference to `--parallel`/worker count in its value. |
+| 3 | Cargo: `gzp = "=0.11.3"` (default-features off, `deflate_rust`); `flate2` → `[dev-dependencies]`; dead `flate2::write::GzEncoder`/`Compression` imports dropped | "What was implemented" #3 | DONE | `gzp = { version = "=0.11.3", default-features = false, features = ["deflate_rust"] }` under `[dependencies]` (line 37). `flate2 = "=1.1.9"` moved under `[dev-dependencies]` (line 66). Both `use flate2::Compression;` and `use flate2::write::GzEncoder;` removed from output.rs imports. |
+| 4 | New test `parallel_gzip_multibatch_decompresses_identical_across_n_and_to_plain` (8199 records > 2×BATCH_SIZE) in `tests/parallel_phase_f.rs` | "What was implemented" #4 | DONE | Added at parallel_phase_f.rs:816. Uses `write_se_large_bam(&bam_path, 8199)` (> 2×4096). Asserts: gz decode == plain peer; cross-N (1 vs 4) decompressed-byte identity; plus non-gz file/report equivalence. |
+| 5 | Single-member framing: existing `GzDecoder` tests retained, NOT migrated to `MultiGzDecoder` | "Single-member framing" | DONE | `use flate2::read::GzDecoder;` (test line 30) retained; `decompress_gz` (line 346) uses single-member `GzDecoder`. Pre-existing `parallel_gzip_n4_decompresses_identical_to_legacy_plain` (line 741) retained, still single-member. `MultiGzDecoder` appears nowhere in code — only in one output.rs doc comment (line 408) stating it is NOT needed. |
+| 6 | Single-member framing: no worker-side `WorkerOutput`/`records_written` changes | "Single-member framing" | DONE | `parallel.rs` is entirely absent from the R2 diff stat. The collector path, `WorkerOutput` payload, and `records_written` accounting are untouched (confirms C6a/C4 N/A claim). |
+| 7 | Local verification (`cargo fmt --check`, `clippy -D warnings`, `cargo test -p bismark-extractor` 102+ tests) all PASS | "Verification status" | DONE | `cargo test -p bismark-extractor` rerun 2026-05-29: integration crate 102 passed; both gzip tests (`..._n4...`, `..._multibatch...`) pass; all binaries 0 failed (320 tests total across binaries). |
+
+## Gaps (detail)
+
+None. All 7 ledger items are DONE as specified.
+
+## Known-pending (non-code, recorded — NOT a gap)
+
+### Colossal `--gzip` SE/PE `phase_h_smoke` (real-data byte-identity)
+
+The plan's "Verification status" subsection explicitly lists this as **PENDING**.
+This is a real-data validation step on the colossal cluster, not a code
+deliverable. Per the verification request it is recorded here as a known-pending
+verification item, not a code gap. It does not affect the COMPLETE verdict for
+the R2 code scope.
+
+## Test verification (Mode B)
+
+| Test name | File | Status |
+|-----------|------|--------|
+| parallel_gzip_multibatch_decompresses_identical_across_n_and_to_plain | tests/parallel_phase_f.rs | PASS |
+| parallel_gzip_n4_decompresses_identical_to_legacy_plain (retained) | tests/parallel_phase_f.rs | PASS |
+| parallel_se_byte_identical_across_batch_boundary (pre-existing, plain) | tests/parallel_phase_f.rs | PASS |
+| Full `bismark-extractor` suite (integration crate 102 + all binaries) | rust/bismark-extractor | PASS (0 failed) |
+| Colossal `--gzip` SE/PE phase_h_smoke | (real-data, colossal) | PENDING (non-code; per plan) |
+
+## Verdict
+
+**COMPLETE.** Every item in the plan's "R2 FINAL approach — gzp-in-collector
+(ALT-1)" implementation spec ("What was implemented" #1–#4 + the two
+"Single-member framing" consequences) is present in the code exactly as
+specified, and the full local test suite passes. No code gaps. The only
+outstanding item is the colossal `--gzip` SE/PE `phase_h_smoke` real-data
+byte-identity run, which the plan itself marks PENDING and is a deployment-time
+verification, not a code deliverable.

--- a/plans/05262026_bismark-extractor/PERF_R2_PLAN_REVIEW_A.md
+++ b/plans/05262026_bismark-extractor/PERF_R2_PLAN_REVIEW_A.md
@@ -1,0 +1,321 @@
+# Plan Review A — R2: worker-side gzip output (#884)
+
+**Plan:** `PERF_R2_WORKER_OUTPUT_PLAN.md` (rescoped to the `--gzip` path only)
+**Reviewer:** A (fresh context, code-grounded)
+**Date:** 2026-05-29
+
+Verdict: **Sound core idea, well-scoped by the Phase-0 spike, but the plan has
+two concrete Critical gaps that will cause silent or test-visible breakage if
+not addressed: (1) the version-header placement under multi-member gzip is
+unspecified, and (2) three in-repo tests + the test helper decode with
+single-member `GzDecoder`, which truncates multi-member output.** The downstream
+Perl consumption is *safe* (it reads via `gunzip -c`, which is multi-member-
+correct) — but that safety must be asserted, not assumed.
+
+---
+
+## 1. Logic review
+
+### 1.1 Multi-member gzip correctness — holds, with one unaddressed detail (header)
+
+The core claim is correct: a `flate2::write::GzEncoder` finalized per batch emits
+a complete gzip member (header + DEFLATE + CRC32/ISIZE footer) when it is
+`finish()`ed or dropped, and the byte-concatenation of independently-finalized
+members is a valid RFC-1952 multi-member gzip stream. The collector's job reduces
+to `write_all(member_bytes)` per key in `batch_seq` order — a raw append, no
+re-compression. This is the same construction `bgzip`/BGZF uses. **Confirmed
+sound.**
+
+However the plan does **not** specify where the per-file **version header line**
+goes. Today `OutputFileMap::new` (output.rs:126-128) writes `SPLIT_FILE_HEADER`
+(`"Bismark methylation extractor version v0.25.1\n"`) into each writer at
+eager-open — i.e. it becomes the leading bytes of gzip member 0 (or plain bytes
+for `.txt`). Under R2 the worker compresses per-key *call* buffers into members;
+the collector appends them. The plan's design section never says:
+
+- Does the collector still open the file and write the header (as an
+  uncompressed prelude or as its own gzip member 0) before appending worker
+  members? If the collector writes the raw header bytes of `SPLIT_FILE_HEADER`
+  directly into a `.gz` file followed by worker-produced gzip members, the file
+  is **not** a valid gzip stream (raw text prefix + gzip members → `gunzip`
+  errors / `flate2` errors on the leading non-magic bytes).
+- Or does the collector emit a tiny header-only gzip member first, then the
+  workers' members? That works but must be stated.
+
+This is **load-bearing for byte/content-identity** and for the empty-sweep (a
+"header-only" file is what the sweep deletes — see §1.2). It must be pinned in
+the plan with the exact mechanism. **Action item C1.**
+
+Relatedly: the plan says `write_call` becomes "format-then-append" and keeps the
+single-threaded path working. But the single-threaded `.txt` path is explicitly
+out of scope (rescope), and `--gzip` single-threaded (N=1) still flows through
+the parallel pipeline (`extract_se_parallel` is used for all N≥1 — see
+parallel.rs:186-200, `run_pipeline` with `n_workers = parallel.max(1)`). So
+there is **no** surviving "legacy single-threaded gzip writer" — every `--gzip`
+run is the worker/collector path. The plan should drop the implication that a
+`write_call`-based single-threaded gzip path remains as a tested fallback; it
+does not (the only `OutputFileMap::write_call` gzip caller left would be the
+direct unit tests in output_modes_phase_e.rs, see §4).
+
+### 1.2 Empty-sweep interaction — needs the header decision resolved first
+
+`finalize_with_empty_sweep` (output.rs:283-342) classifies a file as empty iff
+`records_written == 0`, then `drop(writer)` to seal the gzip trailer and
+`remove_file`. The doc invariant (output.rs:71-75) is explicit: *"`records_written`
+is bumped iff a call row is written ... Any future writer that adds non-call
+non-header bytes ... MUST also bump this counter."*
+
+Under R2 the collector no longer calls `write_call` (which is where the counter
+bumps today, output.rs:229), so **the plan must define how `records_written` /
+the "did any batch write bytes" signal is maintained collector-side**. The plan
+says "a file is 'empty' if no batch wrote bytes to it" — good intent, but:
+
+- A `.gz` file that received the header member but **zero call members** must
+  still be classified empty and deleted (matches Perl's `was empty -> deleted`
+  and today's behaviour where a header-only file is swept). If the collector
+  writes a header member unconditionally at open, then "no bytes written" can't
+  mean "file size 0" — it must track "any *call* member appended". The counter
+  semantics must be ported, not just the file. **Action item C1 (same root).**
+- Empty member edge: if a worker emits a batch where a given key got zero calls,
+  it should emit **no member** for that key (not an empty-DEFLATE member). An
+  empty gzip member is technically valid but wasteful and risks an off-by-one in
+  the "did anything write" accounting. The plan should state workers omit
+  zero-length keys from `per_key_bytes`. **Action item I1.**
+
+### 1.3 Ordering — correct as designed, matches the existing invariant
+
+The plan requires per-key member concatenation in `batch_seq` order. parallel.rs
+already reorders via `BTreeMap<u64, …>` draining `next_emit_seq` in order
+(parallel.rs:999-1033), and the module's byte-identity invariant §1 (parallel.rs:36-41)
+documents `(batch_seq, within_idx)` as isomorphic to the legacy `input_idx`. R2
+keeps the same reorder buffer; it only changes the per-batch payload from
+`Vec<WorkerOutputItem>` to per-key byte buffers. As long as the collector appends
+each key's member while draining in `next_emit_seq` order, ordering is preserved.
+**Confirmed.** The one subtlety: a batch produces ≤12 members (one per key);
+the collector must append all of a batch's members before advancing
+`next_emit_seq`, which the existing drain loop structure already enforces.
+
+### 1.4 Downstream consumption (the flagged highest-risk interaction) — SAFE, but assert it
+
+Traced end-to-end:
+
+- `state.rs::finalize` → `run_phase_g_chain` is fed `finalization.kept`
+  (the kept `.gz` split-file absolute paths) (state.rs:181-191).
+- `subprocess.rs::build_bismark2bedgraph_argv` appends those kept paths verbatim
+  as the positional tail (subprocess.rs:322-324).
+- Perl `bismark2bedGraph` reads each positional infile. **Every** read path of a
+  `.gz` infile uses the *system* `gunzip -c`:
+  - `:168` `open (READ,"gunzip -c $infile |")` (the `--remove_spaces` pre-pass)
+  - `:202` `open (IN,"gunzip -c $infile |")` (main read)
+  - `:434` / `:446` `open $ifh, "gunzip -c $in | sort … |"` (the sort path)
+
+  GNU/BSD `gunzip -c` (and `zcat`) **fully concatenate-decompress all members**
+  of a multi-member gzip stream — this is RFC-1952 standard and is exactly what
+  BGZF relies on. So multi-member input does **not** break `bismark2bedGraph`.
+  **The Phase G chain is safe under R2.** Note: Perl never uses
+  `IO::Uncompress::Gunzip` here (which would need `MultiStream => 1`), so the
+  known Perl single-member gotcha does **not** apply.
+
+  Caveat to verify on colossal: the header skipping. Perl strips the header via
+  `next if ($line =~ /^Bismark/)` (`:454`) on the *decompressed line stream*, and
+  the `--remove_spaces` path reads exactly one header line with `$_ = <READ>`
+  (`:182`). Both operate on the post-`gunzip` concatenated text, so as long as
+  the multi-member stream decompresses to `header\n` + call-lines (header only
+  once, at the front), Perl behaves identically. This is precisely why the header
+  placement (C1) matters: if R2 accidentally emits the header **per member**
+  (one per batch), the decompressed text gets N header lines interspersed —
+  `:454` filters lines starting `Bismark` so the *main* path is robust, but the
+  `--remove_spaces` path (`:182`) consumes exactly one line as the header and
+  would mis-handle the rest. **Action item C2: add a downstream multi-member
+  test** (and confirm header-once).
+
+### 1.5 `--gzip` is the only place a new `MultiGzDecoder` matters
+
+Because the rescope leaves `.txt` untouched and raw-byte-identical, and the
+collector still writes M-bias.txt / splitting_report.txt itself (strict-byte,
+unchanged), the *only* behavioural change is the `.gz` data files becoming
+multi-member. Good, tight blast radius.
+
+---
+
+## 2. Assumptions
+
+| # | Assumption (stated or implied) | Validity |
+|---|--------------------------------|----------|
+| A1 | Concatenated per-batch gzip members = valid multi-member gzip | **True** (RFC-1952). |
+| A2 | Downstream `bismark2bedGraph` handles multi-member `.gz` | **True** — confirmed it uses system `gunzip -c` at all 4 read sites. Must be *tested*, not just assumed (C2). |
+| A3 | "The smoke already accepts sorted-equivalence for `.gz`" | **True** — `phase_h_smoke.sh:271-282` does `zcat \| sort \| md5sum` for `*.gz`; no raw-`.gz` cmp. |
+| A4 | No in-repo test asserts raw `.gz` byte-identity | **Partly false / dangerous.** `parallel_phase_f.rs:741` and two phase_e tests assert **exact decoded-content equality** (not sorted) using **single-member `GzDecoder`**. These break under multi-member output. See C3. |
+| A5 | A single-threaded `write_call` gzip path survives as a tested fallback | **False** — all N≥1 `--gzip` runs go through `run_pipeline`. The only remaining `write_call`-gzip callers are the phase_e *unit* tests. |
+| A6 | The version header handling carries over unchanged | **Unstated / unresolved** — the biggest logic gap (C1). |
+| A7 | Memory of per-batch per-key buffers × workers is boundable | Plausible; needs a number. BATCH_SIZE=4096 records × ≤12 keys × compressed bytes × (n_workers × channel-depth `n*4`). Compression shrinks it; should be fine but state the bound (I2). |
+
+---
+
+## 3. Efficiency analysis
+
+- **Expected win is real and large.** The spike measured ~52 s flat single-thread
+  `GzEncoder` cost; moving it per-worker parallelizes the dominant term. The
+  ~52 s/N projection (N=4 → ~13 s compression, `.gz` total ~30 s) is the right
+  order of magnitude. The collector's residual work becomes memcpy + `write_all`
+  of already-compressed bytes (small relative to compression).
+- **Channel payload size.** Switching from `Vec<RoutedCall>` (which carries
+  `Arc<[u8]>` qname clones + small structs) to per-key **compressed** byte
+  buffers is generally *smaller* on the wire (gzip shrinks ~3-5×), and removes the
+  collector's per-call `write_call` formatting/routing. Net efficiency positive.
+  The plan's note to "reuse buffers if profiling shows alloc churn" is the right
+  posture — don't pre-optimize.
+- **Compression-level consistency.** Workers must use the **same**
+  `Compression::default()` as today's `open_writer` (output.rs:393) so the
+  *content* is identical and (incidentally) compression ratio/CPU matches the
+  spike. Not a correctness issue for sorted-equivalence, but state it (I3).
+- **One real efficiency caveat:** per-batch members add gzip header/footer
+  overhead (~18 bytes/member) and reset the DEFLATE dictionary every 4096
+  records, slightly reducing compression ratio vs one big member. Negligible at
+  these sizes, but it means `.gz` file *sizes* will differ from N=1-single-member
+  — which is fine because the contract is decoded-sorted-equivalence, not size.
+  Worth a one-line note so no one "fixes" a size delta later.
+
+---
+
+## 4. Validation sufficiency — INSUFFICIENT as written; needs additions
+
+The plan's verification list (spike gate, `cargo test`, clippy/fmt, Phase H
+matrix, perf re-measure) is necessary but has gaps:
+
+1. **(Critical) Existing tests will break and the plan doesn't flag them.**
+   - `tests/parallel_phase_f.rs:741 parallel_gzip_n4_decompresses_identical_to_legacy_plain`
+     runs the **real** `--gzip --parallel 4` pipeline and decodes with
+     `decompress_gz` → `flate2::read::GzDecoder` (line 349), which reads **only
+     the first member**. Under R2 (4 workers, multi-batch) this truncates to the
+     first batch's calls and the `assert_eq!(decoded, plain)` fails.
+   - The helper `decompress_gz` (line 346-351) must switch to
+     `flate2::read::MultiGzDecoder`.
+   - `tests/output_modes_phase_e.rs:345` and
+     `tests/output_modes_phase_e_smoke.rs:183` also use `GzDecoder`, but those
+     drive `OutputFileMap` directly (single member) so they *may* still pass —
+     however they should be migrated to `MultiGzDecoder` defensively, or the plan
+     must explicitly state they remain single-member.
+   - **This is the single most important addition: the plan must enumerate these
+     three call sites and prescribe the `MultiGzDecoder` switch.** (C3)
+
+2. **(Critical) No downstream multi-member test.** The plan explicitly puts the
+   Phase G chain "out of scope," but R2 *changes the bytes that Phase G consumes*.
+   Add at least one test (or a Phase-H cell) that runs `--gzip --parallel 4
+   --bedGraph` end-to-end through the real `bismark2bedGraph` and asserts the
+   resulting `.bedGraph.gz` / `.bismark.cov.gz` is sorted-equivalent to the N=1
+   (or Perl) result. Without it, the highest-risk interaction is unverified by
+   automation. (C2)
+
+3. **(Important) `.gz` N=1 ≡ N=4 sorted-equivalence test.** The plan says "add a
+   `--gzip` N=1≡N=4 sorted-equivalence test if not present." It is **not**
+   present — the only N-cross gzip test is the N=4-vs-legacy-plain one (which
+   itself needs the MultiGzDecoder fix). Add an explicit `--gzip` N=1 vs N=4 test
+   that decodes both with `MultiGzDecoder`, sorts, and compares. (I4)
+
+4. **(Important) Header-once assertion.** Add an assertion that the decoded
+   multi-member `.gz` contains the version header **exactly once at the front**
+   (guards the C1 header-placement decision and the `bismark2bedGraph:182`
+   `--remove_spaces` path). (I5)
+
+5. **(Important) Empty-`.gz` sweep test.** Add/confirm a test that a key which
+   receives zero calls under `--gzip --parallel N` is swept (deleted), and that
+   a key receiving only the header (no call members) is also swept — matching the
+   `records_written == 0` Perl behaviour. (I6)
+
+6. **(Optional) Many-small-batches stress.** Force `BATCH_SIZE` small (or use an
+   input >> BATCH_SIZE) so the `.gz` file has many members, then decode+sort.
+   The 8199-record boundary test referenced in the plan should be extended to the
+   `--gzip` path. (O1)
+
+---
+
+## 5. Alternatives worth noting
+
+- **A1 — Keep compression in the collector but on a dedicated compressor thread
+  pool (one thread per output key, ≤12).** Each key's writer is single-owner, so
+  12 compressor threads could each own a `GzEncoder` and the collector just fans
+  pre-formatted (uncompressed) bytes to them. This avoids multi-member output
+  entirely (each file stays single-member → no test/header/downstream churn) and
+  still parallelizes compression up to 12×. Trade-off: 12 is a hard parallelism
+  cap (vs N workers), and it adds a second fan-out stage. Given the spike shows
+  ~52 s dominated by compression and typical N≤8, a 12-way single-member design
+  could match R2's win **with zero byte-contract change** (raw-`.gz` identity
+  preserved, no MultiGzDecoder migration, no downstream risk). **Worth a
+  paragraph of consideration before committing to multi-member** — it may be the
+  lower-risk path to the same speedup. (Flag for user.)
+
+- **A2 — Worker formats (uncompressed) per-key buffers; collector compresses.**
+  Parallelizes only formatting, not compression — the spike says formatting/raw
+  write is ~6 s and compression is ~52 s, so this recovers little. Reject
+  (consistent with the plan).
+
+- **A3 — `pigz`-style: single member, parallel DEFLATE blocks with a shared
+  dictionary.** Highest fidelity (true single-member, best ratio) but far more
+  complex; not justified. Reject.
+
+---
+
+## 6. Action items
+
+### Critical
+- **C1 — Specify version-header placement under multi-member gzip.** Define
+  exactly how `SPLIT_FILE_HEADER` is emitted (e.g. collector writes a header-only
+  gzip member 0 at open, or the first worker member carries it) and how the
+  empty-sweep's `records_written`/"any-call-bytes" signal is maintained now that
+  the collector no longer calls `write_call`. A raw-text header prefix in front
+  of gzip members would produce an invalid `.gz`. (output.rs:126-128, :229,
+  :283-342)
+- **C2 — Add a downstream multi-member Phase G test.** Run `--gzip --parallel 4
+  --bedGraph` (and `--cytosine_report` if cheap) end-to-end through the real Perl
+  `bismark2bedGraph`; assert `.bedGraph.gz`/`.bismark.cov.gz` sorted-equivalent to
+  N=1/Perl. The chain is `out of scope` for *implementation* but its *input bytes
+  change*, so it is in scope for *validation*. (subprocess.rs:322-324; Perl
+  bismark2bedGraph:168/202/434/446)
+- **C3 — Enumerate and fix the single-member `GzDecoder` test sites.** The plan
+  must call out `tests/parallel_phase_f.rs:346-351` (`decompress_gz`), and the
+  `GzDecoder` uses at `tests/output_modes_phase_e.rs:345` and
+  `tests/output_modes_phase_e_smoke.rs:183`, and prescribe migrating the
+  pipeline-level decode (at minimum `decompress_gz`) to
+  `flate2::read::MultiGzDecoder`. Without this, the existing gzip byte-identity
+  test fails (truncated to member 0) the moment R2 lands.
+
+### Important
+- **I1 — Workers omit zero-length keys** from `per_key_bytes` (no empty gzip
+  members); state this so the empty-sweep accounting stays correct.
+- **I2 — State the in-flight memory bound** (≈ n_workers × channel-depth ×
+  per-batch compressed bytes across ≤12 keys) and confirm it's acceptable.
+- **I3 — Pin `Compression::default()`** in the worker to match today's
+  `open_writer` so content/CPU match the spike.
+- **I4 — Add explicit `--gzip` N=1 ≡ N=4 sorted-equivalence test** (decode both
+  with `MultiGzDecoder`). The plan says "if not present" — it is not present.
+- **I5 — Assert header appears exactly once** at the front of the decoded
+  multi-member stream (guards C1 + the Perl `--remove_spaces` `:182` path).
+- **I6 — Empty-`.gz` sweep test** under `--gzip --parallel N` (zero-call key and
+  header-only key both deleted).
+
+### Optional
+- **O1 — Many-members stress test:** extend the 8199-record boundary test to
+  `--gzip` so the `.gz` file has many members; decode+sort+compare.
+- **O2 — Evaluate the 12-way single-member compressor-thread alternative (A1)**
+  before committing to multi-member; it may deliver the same speedup with zero
+  byte-contract change and no downstream/test churn. (Flag for user decision.)
+- **O3 — One-line note** that `.gz` *file sizes* will differ from N=1 single-
+  member (per-member overhead + dictionary resets) and that this is expected
+  under the decoded-sorted-equivalence contract — so no one "fixes" it later.
+
+---
+
+## Summary
+
+The R2 rescope to gzip-only is well-justified by the spike, and the multi-member
+construction is fundamentally correct. The **highest-risk interaction (Phase G
+downstream) is actually safe** because Perl `bismark2bedGraph` reads every `.gz`
+infile via system `gunzip -c`, which is multi-member-correct — but the plan must
+*test* this, not assume it. Two Critical gaps need closing before implementation:
+(C1) the version-header placement / empty-sweep accounting under multi-member is
+unspecified and could yield invalid `.gz` files, and (C3) three in-repo tests
+decode with single-member `GzDecoder` (notably the real-pipeline
+`parallel_gzip_n4_*` test) and will break/truncate under multi-member output —
+the plan does not mention them. Recommend resolving C1-C3 and adding the
+multi-member downstream + N=1≡N=4 gzip tests before the byte-identity rewrite.

--- a/plans/05262026_bismark-extractor/PERF_R2_PLAN_REVIEW_B.md
+++ b/plans/05262026_bismark-extractor/PERF_R2_PLAN_REVIEW_B.md
@@ -1,0 +1,404 @@
+# PERF R2 Plan Review — Reviewer B (#884 worker-side gzip)
+
+Plan: `PERF_R2_WORKER_OUTPUT_PLAN.md` (rescoped to the `--gzip` path only).
+Reviewed against: `rust/bismark-extractor/src/{output.rs,parallel.rs,state.rs,output_mode.rs}`,
+`bismark-extractor/Cargo.toml`, `Cargo.lock`, and the two `.gz` test sites
+(`tests/parallel_phase_f.rs`, `tests/output_modes_phase_e_smoke.rs`).
+
+The Phase-0 spike is sound and the rescope (gzip-only, leave `.txt` alone) is
+the right call: the data (`.gz` flat at ~75 s, ~52 s of which is single-threaded
+`GzEncoder`) is decisive and `.txt`'s ~6 s isn't worth the byte-identity churn.
+My concerns below are about the *mechanics* of the gzip-only rewrite, where I
+think the plan under-specifies real risks that block byte-identity or erode the
+win.
+
+---
+
+## 1. Logic review
+
+### C1 — The existing `.gz` tests use single-member `GzDecoder` and will SILENTLY pass on truncated output (CRITICAL)
+This is the biggest gap. The plan's whole correctness story for `.gz` is
+"concatenated per-batch members = valid multi-member gzip; smoke `zcat|sort|md5`
+accepts it." But **the repo's actual `.gz` validators do not use `zcat` and do
+not handle multi-member streams**:
+
+- `tests/parallel_phase_f.rs:346` `decompress_gz` → `flate2::read::GzDecoder`
+- `tests/output_modes_phase_e_smoke.rs:180` `read_gz` → `flate2::read::GzDecoder`
+
+`flate2::read::GzDecoder` decodes **only the first gzip member** and stops at its
+trailer, silently ignoring every subsequent member. With R2's multi-member
+output, a file containing batches [0,1,2,…] would decode to **only batch 0's
+content**, and the assertion `decoded == plain_peer` would **fail** — but for the
+wrong reason (truncation), and worse, a *single-batch* test input (< 4096
+records ⇒ exactly one member) would **pass while proving nothing** about the
+multi-member path. The plan says "confirm no test asserts raw `.gz` identity"
+but the real risk is the inverse: the tests assert *decompressed* identity using
+a decoder that can't see past member 1.
+
+**Required before implementation:** swap both helpers to
+`flate2::read::MultiGzDecoder` (also `read` module, drop-in), AND add a test
+whose input spans **≥ 2 batches under `--gzip`** so the multi-member path is
+actually exercised (the 8199-record boundary input already used elsewhere is a
+natural fit: 8199 > 2×4096). Without this, R2 could ship truncated `.gz` files
+and the suite would stay green. The plan's verification step 2 ("add a `--gzip`
+N=1≡N=4 sorted-equivalence test if not present") must be upgraded to "swap to
+MultiGzDecoder + multi-batch input" — sorted-equivalence is not even needed here
+because content order IS preserved (see C2).
+
+### C2 — "sorted-equivalent, not raw-identical" framing is wrong for this design (IMPORTANT, also de-risks C1)
+The plan repeatedly hedges that R2 changes `.gz` from "raw-identical" to
+"sorted-content-equivalent" (lines 99-102, 121-122). But the design concatenates
+per-key chunks **strictly in `batch_seq` order**, and within a batch in `Vec`
+order — exactly the `(batch_seq, within_idx)` total order the collector already
+uses (parallel.rs:996-1033). So the **decompressed byte stream is identical to
+N=1's**, not merely sorted-equivalent. The only thing that differs from a
+single-stream `.gz` is the *container framing* (N members vs 1), which is
+transparent to any spec-compliant gzip reader. This matters because:
+- The test should assert **exact decompressed-byte identity** (via
+  MultiGzDecoder), which is stronger and catches ordering bugs that a
+  `sort`-based check would mask.
+- The "sorted-equivalence" language invites a weaker test than the design
+  actually supports, and would hide a real ordering regression.
+
+Recommend the plan drop the sorted-equivalence framing for the R2 path and
+commit to **decompressed byte-identity** as the gate.
+
+### C3 — Single-source-of-truth for line formatting: the plan acknowledges drift risk but the current code makes the extraction non-trivial (IMPORTANT)
+`OutputFileMap::write_call` (output.rs:170-231) does two things the plan wants to
+split: (a) `route_to_key(mode, context, strand)` and (b) format the 5-col line
+**or** dispatch to `write_yacht_row`. The plan's `format_call_line(...)` must
+reproduce *both* the 5-col branch and the full yacht 8-col branch
+(`write_yacht_row`, output_mode.rs:191) byte-for-byte, including the strand-
+conditional col6/col7 already carried on `RoutedCall`. The plan's proposed
+signature `format_call_line(mode, qname, chr, call, strand, yacht6, yacht7)` is
+adequate, but note `write_yacht_row` is generic over `W: Write` and writes
+incrementally; refactoring it to append into a `Vec<u8>` is fine (Vec: Write),
+but the plan should explicitly state that `write_call` becomes
+`format_call_line` + `append_bytes` so the **single-threaded path is exercised
+by the same formatter** (the plan says this — good; just flag that yacht is in
+scope of the move, not only the 5-col branch).
+
+### C4 — Header line + empty-sweep interaction (IMPORTANT)
+Today the version header (`SPLIT_FILE_HEADER`, output.rs:38/127) is written at
+`OutputFileMap::new` time, and `records_written` starts at 0; the empty-sweep
+(output.rs:283) unlinks a file iff `records_written == 0` even though it has the
+header. Under R2:
+- The header is still written by the collector at open time (good — keep it
+  collector-side, NOT in worker chunks, or every batch member would re-emit it).
+- **Under `--gzip`, the header is currently part of the same `GzEncoder`
+  stream.** If R2 makes the collector write the header as its own gzip member
+  (or raw bytes before the first worker member), the resulting file is
+  header-member + data-members. That decodes fine with MultiGzDecoder, but the
+  plan must specify *who* compresses the header and that it counts as member 0.
+  Easiest: collector writes a header gzip member at open; `append_bytes` then
+  appends worker members. The plan's "append_bytes(key, &[u8])" must take
+  **already-compressed** bytes for `.gz` (a full member) — make that explicit.
+- `records_written == 0` detection: the plan says "a file is empty if no batch
+  wrote bytes to it." But a CTOT/CTOB file in a directional run will have the
+  header member and zero data members. The sweep must key off *data* records,
+  not "bytes written" (the header is bytes). The plan's wording "no batch wrote
+  bytes" is therefore wrong — it must track a **per-key record/data counter**
+  threaded back from workers (e.g. each `WorkerOutput::Batch` carries per-key
+  record counts, or the collector infers "had ≥1 data member"). This is a
+  concrete invariant the current `records_written` bump (output.rs:229) enforces
+  per-call; R2 must reconstruct it at batch granularity or the empty-sweep will
+  **keep files Perl deletes** (Phase H file-set-match gate, FinalizationReport
+  feeds bismark2bedGraph argv — state.rs:144-191). This is under-specified and
+  is a byte-identity / file-set risk.
+
+---
+
+## 2. Assumptions
+
+- **A1 (validated): flate2 backend is `zlib-rs` + `miniz_oxide`** (Cargo.lock:
+  flate2 1.1.9 deps `crc32fast`, `miniz_oxide`, `zlib-rs`). Per-worker
+  `GzEncoder::new(Vec::new(), level)` is already available — no new dep needed.
+  Good; the plan implicitly assumes flate2 stays the encoder and that holds.
+- **A2 (flagged): "N members concatenated = valid multi-member gzip" is true per
+  RFC 1952**, BUT only readers using `MultiGzDecoder`/`zcat -d`/`gunzip` honor it.
+  `bismark2bedGraph` (Phase G subprocess) reads these `.gz` files downstream —
+  the plan must confirm **the downstream consumer reads multi-member gzip**.
+  Perl's own `--multicore` produces multi-member `.gz` (forked gzip streams), so
+  the Perl toolchain already tolerates it (this is actually evidence FOR the
+  approach), but the plan should state this explicitly rather than leave it
+  implied. If any Rust-side reader (future bismark-bedgraph, epic #797) uses
+  single-member `GzDecoder`, it breaks.
+- **A3 (flagged): per-batch member count.** 188M calls / (4096 records/batch ×
+  ~avg calls/record). At ~10–20 calls/record and 4096 records that's a chunk of
+  raw bytes ~ 4096×15calls×~30 bytes/line ≈ **~1.8 MB raw per key per batch** for
+  busy keys, but most of the 12 keys are near-empty per batch. Member count per
+  file = number of batches that routed ≥1 call to that key ≈ up to
+  188M/4096 ≈ **~46,000 batches** → up to ~46k members in the busiest file. See
+  E1 for the compression-ratio consequence.
+
+---
+
+## 3. Efficiency analysis
+
+### E1 — Compression-ratio regression from dictionary reset per member (IMPORTANT — quantify before shipping)
+This is the risk Reviewer A is most likely to underweight. Each gzip member
+starts a **fresh deflate dictionary** (32 KB sliding window resets to empty) and
+carries its own ~18-byte header+trailer (10-byte header, 8-byte CRC+ISIZE). The
+concern is not the ~18 bytes/member overhead (~46k members × 18 B ≈ 0.8 MB —
+trivial against a multi-GB corpus). The real concern is **lost cross-member
+back-references**: Bismark methylation lines are *highly* repetitive (same chr
+string, same qnames clustered, `+`/`-`/XM bytes from a tiny alphabet), so a
+single long stream lets deflate reference matches hundreds of KB back. Per-batch
+members cap match distance at the batch boundary.
+
+**Quantification needed (cheap, do it in the spike tail):** compress one busy
+file two ways — (a) one stream, (b) split into 4096-record members and
+concatenate — and compare sizes. If a busy key's batch chunk is ~1.8 MB raw,
+the 32 KB window is already small relative to the chunk, so *intra-chunk*
+matching is mostly preserved and the ratio loss is likely **single-digit %**.
+But near-empty keys (CTOT/CTOB, or CHH-rare) get tiny members where the
+header/trailer overhead and cold dictionary dominate — those files could grow
+noticeably in *relative* terms (though they're small absolutely). Net: I expect
+a few-% total size increase, acceptable, **but the plan must measure and record
+it**, because "we made `.gz` 8% bigger" is a real user-visible regression that
+should be a conscious tradeoff, not a surprise. Add to verification: "total
+`.gz` byte size N=4 vs N=1 baseline, accept if < ~10% larger."
+
+**Mitigation if ratio loss is unacceptable:** coalesce — workers emit *raw*
+formatted bytes per key (not compressed), collector compresses each key's
+concatenated stream with a **single** `GzEncoder`. But that puts compression
+back on the collector (the thing we're trying to parallelize) → defeats R2. The
+honest tradeoff is exactly the one in §5 (gzp): parallelize the *single stream*
+instead of fragmenting it.
+
+### E2 — Granularity: per-worker-per-batch-per-key encoder is the right call, with a caveat (matches plan)
+The plan's "compress each key's batch buffer into a member" means up to
+12 short-lived `GzEncoder<Vec<u8>>` per batch per worker. Creating/destroying a
+`GzEncoder` per (batch,key) is cheap relative to the compression itself, and it
+keeps the ordered-concat-by-batch model intact (which is what preserves
+byte-identity). The **alternative** — per-worker-per-key *streaming* encoders
+that span batches — breaks the ordered-concat model entirely: a worker only sees
+a non-contiguous subset of batches for a key, so its single stream can't be
+slotted into the global `batch_seq` order. So per-batch is **forced** by the
+reorder design, not just a choice. The plan is right; just document that
+streaming-across-batches is incompatible with the collector's `batch_seq`
+reorder (parallel.rs:1006-1033), so it's not a live alternative.
+
+The caveat: 12 encoders/batch where most keys are empty — **skip empty keys**
+(don't emit a zero-record member; emit nothing for that key this batch). The
+plan's `HashMap<OutputKey, Vec<u8>>` (sparse) naturally does this; a "fixed array
+indexed by key" (the plan's other suggestion) risks emitting empty members.
+Prefer the sparse map, and have the collector treat "key absent from this
+batch's per_key_bytes" as "append nothing."
+
+### E3 — Collector write() floor after R2 (the Phase-0 question, finished)
+Phase 0 measured `.gz` ≈ 75 s = 16.7 floor + ~6 `.txt`-equivalent + ~52
+compression. After R2 the ~52 s parallelizes to ~52/N. The collector still does:
+(a) memcpy worker bytes, (b) `write_all` compressed bytes to 12 files. The
+*compressed* corpus is ~5–8× smaller than the 5 GB `.txt` (so ~0.7–1 GB of
+writes), and the ~6 s `.txt`-write figure was for the **full 5 GB**; writing
+~1 GB of already-compressed bytes is ~**1–1.5 s**. So the post-R2 `.gz` floor ≈
+16.7 (decode) + ~1.5 (compressed write) + ~52/N (compression) + format. At N=4:
+≈ 16.7 + 1.5 + 13 + (~4 format) ≈ **~35 s**; at N=8 ≈ **~28 s**. The plan's "~30 s"
+target is plausible at N≥4–8 but the **16.7 s decode floor is now ~half the
+wall** and does NOT parallelize beyond what R3's ThreadedBamReader already gave.
+So R2 gets `.gz` from 75→~30 s (2.5×) — real and worth it — but the plan should
+state that decode (16.7 s) becomes the next dominant term, capping further
+gains. Don't promise linear scaling past N=4.
+
+### E4 — Channel payload size grows (memory) (note)
+`WorkerOutput::Batch` changes from `Vec<RoutedCall>` (pointers/Arc-shared
+qnames, ~tens of bytes/call) to per-key **compressed** byte buffers (~1.8 MB
+raw → ~0.3 MB compressed per busy key per batch). With channel capacity
+`n_workers*4` (parallel.rs:255) and N=8, that's 8*4=32 in-flight batches ×
+~0.5 MB ≈ **~16 MB** — fine, *smaller* than shipping raw RoutedCalls would be.
+But note the plan says "mind the size … reuse buffers if profiling shows alloc
+churn": with compression, the *raw* per-key buffer (1.8 MB) is the churn source,
+allocated+freed per batch per worker. A per-worker reusable scratch buffer
+(cleared, not freed) per key is the obvious fix; the plan flags it — good.
+
+---
+
+## 4. Validation sufficiency
+
+Gaps beyond C1/C2 (the decoder swap is the #1 validation hole):
+
+- **V1 — multi-batch `.gz` input is mandatory.** Current `.gz` tests likely use
+  small inputs (single member). A test with input > 2×BATCH_SIZE under `--gzip`
+  comparing MultiGzDecoder output to the plain peer is the load-bearing new test.
+  (Ties to C1.)
+- **V2 — empty-sweep under `--gzip` with a never-written key.** Add/confirm a
+  test that a directional run still **deletes** the CTOT/CTOB `.gz` files (only a
+  header member, zero data members). This guards C4. The smoke already checks
+  file-set match (`output_modes_phase_e_smoke.rs:513`) for plain; add the gzip
+  variant with a key that receives zero data across all batches.
+- **V3 — gzip level interaction (see §below).** If R2 changes the compression
+  level, byte-output changes but decompressed content is identical → tests that
+  assert decompressed identity still pass. Confirm **no test hashes the raw
+  `.gz` bytes** (I found none — both helpers decompress first), so a level change
+  is test-safe. State this in the plan.
+- **V4 — Phase H gate is decompressed-content, not raw `.gz` bytes.** Confirm the
+  colossal Phase H harness compares `zcat | …` and not `md5 file.gz`. If it
+  hashes raw `.gz`, multi-member framing (and any level change) breaks it. The
+  plan asserts the smoke accepts it but does not name the Phase H comparison
+  method — pin this down (it's the binding gate, verification step 4).
+
+### gzip level (Reviewer-B focus item)
+The plan does NOT mention changing the level; `open_writer` uses
+`Compression::default()` (level 6, output.rs:393). TG-OE dropped to level 1 for
+−23% wall. **Recommendation:** keep level 6 for R2's first cut (parallelism
+already buys the big win; don't conflate two variables). Level is a *separate*,
+trivially-revertible knob: lowering it changes raw `.gz` bytes but not
+decompressed content, so it's byte-identity-safe given V3. If post-R2 the ~52/N
+compression term is still the bottleneck at the target N, drop to level 1 as a
+follow-up and re-measure size (E1 ratio concern compounds with low level on
+small members). Do not bundle it into R2 — it muddies the byte-identity
+attribution and the size regression measurement.
+
+---
+
+## 5. Alternatives
+
+### ALT-1 — `gzp::ParCompress` in the collector (single-writer, no worker rewrite) (STRONGLY worth comparing)
+This is the simpler win the plan should explicitly weigh and reject-with-reasons.
+`gzp` (parallel gzip) keeps the **single-stream** model: the collector writes
+formatted bytes into a `gzp::ParCompress<Gzip>` writer per file, which fans
+compression of *blocks of one logical stream* across its own thread pool and
+emits a **single coherent multi-block gzip** (BGZF-style or standard). Tradeoffs
+vs the plan's worker-side members:
+
+| Axis | Plan (worker members) | gzp in collector |
+|---|---|---|
+| Compression ratio | fragmented per 4096-rec member (E1 risk) | near single-stream (blocks are large, tuned) |
+| Code change | invasive: WorkerOutput payload, format move, append_bytes, empty-sweep rework (C4) | localized: wrap the 12 collector writers |
+| Byte-identity surface | new (multi-member, per-key counts) | smaller (still single logical stream) |
+| Parallelism source | the N extractor workers (shared with decode/format) | gzp's own pool (extra threads, separate from N) |
+| New dep | none (flate2 already in) | adds `gzp` (+ its deflate backend) |
+| `.txt` path | untouched | untouched |
+| Decode/format still serial? | format moves to workers (bonus) | format stays collector-serial (~the 6 s) |
+
+**My read:** the plan's approach has one genuine advantage gzp lacks — it also
+moves **formatting** off the collector (the original R3 finding: ~8 s of
+format+route+write was collector-serial). gzp only parallelizes *compression*,
+leaving format/route on the collector. Since the spike attributes ~52 s to
+compression and only ~6 s to format+write, **gzp captures the dominant 52 s with
+far less code churn and better compression ratio**, at the cost of leaving ~6 s
+of format on the collector and adding a dep + its own threads (which contend
+with the N workers for cores). Given byte-identity is the expensive part of this
+project, **the plan should at minimum run a half-day `gzp`-in-collector spike and
+compare wall + `.gz` size + diff-size against the worker-member approach before
+committing to the invasive rewrite.** This is the same "measure before invasive
+rewrite" discipline the plan applied in Phase 0 — apply it to the *mechanism*
+choice too, not just the go/no-go.
+
+### ALT-2 — Bigger batches for the gzip path only
+If E1 shows meaningful ratio loss, raise BATCH_SIZE on the `.gz` path (e.g.
+32768) so each member is larger → fewer dictionary resets, better ratio, fewer
+members. BATCH_SIZE is documented as a pure throughput knob with no correctness
+impact (parallel.rs:92-101), so this is safe. Tradeoff: larger in-flight memory
+and coarser reorder granularity (more latency before a batch can be emitted).
+Worth keeping as a tuning lever; the plan should note BATCH_SIZE may want to
+differ for gzip.
+
+---
+
+## 6. Interaction with R1's batched WorkerOutput (the explicit focus item)
+
+Changing `WorkerOutput::Batch { batch_seq, results: Vec<WorkerOutputItem> }`
+(parallel.rs:146-160) to carry per-key compressed bytes is **more invasive than
+the plan implies** and touches R1's hard-won invariants:
+
+- **C6a — Err handling must survive (CRITICAL to preserve).** Today
+  `WorkerOutputItem::Ok { routed_calls }` and `::Err { error }` live **per
+  within-batch slot**, and the collector's deterministic Err selection
+  (`update_best_err`, parallel.rs:1070) depends on `(batch_seq, within_idx)`.
+  If the batch payload becomes "per-key compressed bytes," the **per-item Err
+  slots are erased** — you can't fold formatting+compression of Ok items into a
+  per-key blob *and* keep per-item Err positions. The plan's design must keep a
+  **parallel `results: Vec<WorkerOutputItem>` (or at least the Err list with
+  their within_idx)** alongside `per_key_bytes`, OR move Err selection to the
+  worker. Simplest: `WorkerOutput::Batch { batch_seq, per_key_bytes:
+  HashMap<OutputKey, Vec<u8>>, errors: Vec<(usize, BismarkExtractorError)> }`
+  where `errors` carries the within-idx of each failed item. The plan does NOT
+  mention preserving Err-slot information at all — this is a real omission that
+  would regress R1's byte-identical stderr on error inputs (guarded by
+  `worker_preserves_order_and_keeps_err_slots_in_partial_batch`,
+  parallel.rs:1302, which would then fail or need rewriting).
+
+- **C6b — FinalDelta unchanged (good).** M-bias + SplittingReport still
+  accumulate per-worker and merge at EOS (parallel.rs:1035-1047). R2 doesn't
+  touch this; counters are computed in `process_se`/`process_pe` regardless of
+  whether calls are shipped as RoutedCalls or compressed bytes. Confirm the
+  worker still runs `increment_counters` + `mbias.accumulate` **before**
+  formatting/compressing (it does today, lines 754-776) — keep that order.
+
+- **C6c — mbias_only fast path (good, but verify).** Under `--mbias_only`,
+  workers emit no RoutedCalls today (parallel.rs:748,762). Under R2 they must
+  emit no per_key_bytes (empty map) — the plan says so (line 124). The collector
+  must then do nothing per batch, only merge FinalDeltas. Confirm the empty-map
+  batch still advances `next_emit_seq` so the reorder doesn't stall (it must:
+  even an all-empty batch occupies a `batch_seq`).
+
+- **C6d — collector reorder loop (parallel.rs:1006-1033) gets simpler, good.**
+  The `for routed in &routed_calls { write_routed_call(...) }` inner loop is
+  replaced by `for (key, bytes) in per_key_bytes { state.fhs.append_bytes(key,
+  bytes) }`. This is strictly less work on the collector (no per-call route/
+  format) — the intended win. `write_routed_call` (parallel.rs:1086) and the
+  per-call `write_call` routing in the collector are dropped; `write_call` stays
+  only for the single-threaded `extract_se`/`extract_pe` path. Confirm those
+  legacy paths still exist and still use `write_call` (they're the byte-identity
+  reference) — the plan keeps them (outline step 1) — good.
+
+---
+
+## Action items
+
+### Critical
+1. **C1/V1 — Swap `.gz` test decoders to `MultiGzDecoder` and add a ≥2-batch
+   `--gzip` input test.** Current `decompress_gz`/`read_gz` use single-member
+   `GzDecoder` (parallel_phase_f.rs:346, output_modes_phase_e_smoke.rs:180) and
+   will silently validate only batch 0 — truncated multi-member output would
+   pass on small inputs and fail-for-wrong-reason on large ones. This is the #1
+   pre-implementation fix; without it the suite cannot detect a broken R2.
+2. **C6a — Preserve per-item Err slots in the new `WorkerOutput::Batch`.** Folding
+   Ok items into per-key compressed blobs erases the within-idx that
+   `update_best_err` + the order/slot test depend on. Add an explicit
+   `errors: Vec<(within_idx, error)>` (or equivalent) to the batch payload, or
+   the R1 byte-identical-stderr-on-error invariant regresses.
+3. **C4 — Re-specify the empty-sweep "data vs bytes" counter.** The header is
+   bytes; the sweep deletes iff **zero data records** (output.rs:229/315). "No
+   batch wrote bytes" is wrong — thread a per-key **record count** back from
+   workers so directional CTOT/CTOB `.gz` files are still deleted (Phase H
+   file-set + bismark2bedGraph argv gate). Specify who writes the header member.
+
+### Important
+4. **ALT-1 — Spike `gzp::ParCompress` in the collector before the invasive
+   rewrite.** It captures the dominant ~52 s compression with localized code, no
+   Err/empty-sweep rework, and better compression ratio (single logical stream);
+   it leaves only ~6 s format on the collector. Compare wall + `.gz` size + diff-
+   size vs worker-members. Apply the Phase-0 "measure before rewrite" discipline
+   to the mechanism choice.
+5. **E1 — Measure `.gz` size regression** from per-member dictionary resets
+   (one-stream vs concatenated-4096-rec-members on a busy file). Add an accept
+   threshold (e.g. < ~10% larger) to verification. Consider per-gzip-path
+   BATCH_SIZE bump (ALT-2) if ratio loss is material.
+6. **C2 — Commit to decompressed byte-identity (not "sorted-equivalent") for the
+   R2 `.gz` path.** The design preserves order, so the stronger assertion holds
+   and catches ordering bugs the sorted check would mask.
+7. **C3 — State that `format_call_line` must cover BOTH the 5-col and the yacht
+   8-col branches**, with `write_call` re-expressed as format+append so the
+   single-threaded path exercises the same formatter (drift guard).
+8. **V4/A2 — Pin down the downstream/Phase-H reader.** Confirm `bismark2bedGraph`
+   and the colossal Phase H harness consume **multi-member** gzip
+   (`zcat`/`gunzip`/MultiGzDecoder), not single-member, and compare decompressed
+   content (not raw `.gz` md5). Perl's `--multicore` already emits multi-member
+   `.gz`, so the toolchain likely tolerates it — but state it.
+
+### Optional
+9. **Defer the gzip level change.** Keep `Compression::default()` (level 6) for
+   R2; treat level as a separate, byte-identity-safe follow-up knob (no test
+   hashes raw `.gz` bytes — both helpers decompress). Don't bundle it.
+10. **E2 — Use the sparse `HashMap<OutputKey, Vec<u8>>` (not a fixed array)** so
+    empty keys emit no member; have the collector treat "key absent this batch"
+    as "append nothing." Avoids zero-record members.
+11. **E4 — Reuse a per-worker scratch raw buffer per key** (clear, don't free) to
+    avoid per-batch alloc churn of the ~1.8 MB raw buffers.
+12. **E3 — Don't promise linear scaling past N≈4** in the success criterion: the
+    16.7 s decode floor becomes ~half the post-R2 `.gz` wall (~30 s), capping
+    gains. Record the result against the 22.3/23.5/23.9 mimalloc baseline as
+    planned, but frame the `.gz` target as ~30 s at N=4–8, not "N=4 < N=1" alone.

--- a/plans/05262026_bismark-extractor/PERF_R2_WORKER_OUTPUT_PLAN.md
+++ b/plans/05262026_bismark-extractor/PERF_R2_WORKER_OUTPUT_PLAN.md
@@ -1,0 +1,205 @@
+# Plan — R2: worker-side output (#884)
+
+## Context
+
+After mimalloc (merged) eliminated the allocator anti-scaling and R1 (merged)
+batched the channels, the extractor's `default` run is **flat ~22 s across
+N=1/4/8** — producer/collector-bound, no positive scaling. R3 (parallel decode,
+closed #887) showed the residual `default` serial cost is **not** decode but the
+**single-threaded collector writes** (~8 s = `default` 22 s − `mbias_only` 14 s):
+the collector calls `write_routed_call` → `OutputFileMap::write_call` for every
+one of ~188M calls, formatting each line + routing by context×strand to one of
+12 `BoxedWriter`s, all on one thread.
+
+**R2** moves the per-call **formatting (and `--gzip` compression)** into the
+workers; the collector only **concatenates pre-formatted byte chunks** per output
+file in batch order. Goal: give `default` positive N>1 scaling by parallelizing
+the formatting/compression that currently serializes in the collector.
+
+## The open question R2 MUST answer first (Phase 0)
+
+The ~8 s collector cost is `format + route + write()`. R2 parallelizes
+`format`/compress but the **raw `write()` to 12 files stays collector-serial**.
+**If the ~8 s is dominated by formatting/gzip → R2 wins; if by disk write() →
+R2 is marginal (another R3).** We do not yet know the split. **Phase 0 measures
+it before the invasive rewrite** (R3 taught us: measure, don't assume).
+
+## Phase 0 — de-risk spike (throwaway, before any byte-identity rewrite)
+
+Cheapest decisive probes on colossal (10M PE, shipped R1+mimalloc build), **no
+code change** — just run modes × N=1/4/8 and decompose by subtraction:
+- **0a. Measure THREE output modes** (Felix): `mbias_only` (no writes),
+  `default` (`.txt`), and `default --gzip` (`.gz`) at N=1/4/8.
+  - `(.txt − mbias_only)` ≈ format + raw 5 GB `write()` (the `.txt` floor).
+  - `(.gz − .txt)` ≈ gzip-compression cost (single-threaded `GzEncoder` in the
+    collector today — likely the biggest serial wall; TG-OE: ~60% of runtime).
+  - Whether `.gz` *anti-scales* or is flat at N>1 shows how much R2's worker-side
+    compression would recover.
+- **0b. Formatting-vs-raw-write split for `.txt`** (only if `.txt` is the focus):
+  a throwaway variant that formats but `write()`s to a `Sink`/`/dev/null`.
+  `default_to_devnull − mbias_only` = formatting (parallelizable);
+  `default − default_to_devnull` = raw write() (serial).
+- **0c. (if favourable)** worker-formats/compresses prototype at N=1/4/8 to
+  confirm `default N=4 < N=1` (and `.gz N=4 < N=1`).
+- **Gate / likely outcomes:** R2 is clearly worth it for **`.gz`** if its
+  compression is a large serial/flat cost (expected). For **`.txt`**, proceed
+  only if 0b shows formatting ≫ raw-write; if raw `write()` dominates `.txt`,
+  scope R2 to the gzip path (or accept the `.txt` floor — already 6.7× past
+  Perl). Append `## Spike Results` here.
+
+## Spike Results (Phase 0 — 2026-05-29) — RESCOPES R2 TO THE GZIP PATH
+
+Shipped R1+mimalloc baseline, 10M PE, colossal:
+| mode | N=1 | N=4 | N=8 |
+|---|---|---|---|
+| mbias_only | 16.7 | 16.7 | 17.1 |
+| `.txt` | 22.9 | 25.0 | 26.4 |
+| **`.gz`** | **75.2** | **77.5** | **78.2** |
+
+Decomposition: extract/decode floor ~16.7 s; `.txt` write ≈ **~6 s** (format +
+raw 5 GB write); **`.gz` compression ≈ ~52 s** (single-threaded collector
+`GzEncoder`, dead **flat** across N).
+
+**Verdict:**
+- **R2 is worth it for `--gzip` ONLY** — the ~52 s serial compression wall is
+  huge and fully parallelizable (per-worker `GzEncoder`). Expected: ~52 s/N at
+  N≥4 ⇒ `.gz` N=4 ≈ 75 s → ~30 s.
+- **`.txt` path: do NOT pursue** — only ~6 s, mostly serial raw `write()` R2
+  can't help. Phase-0b (/dev/null probe) unnecessary; the `.txt` floor stays.
+- **Urgency:** Perl's `--multicore` forks parallelize *its* gzip, so on the
+  common `--gzip` path we are likely at parity/slower than Perl today; R2 is
+  what keeps us ahead there.
+
+**RESCOPE:** R2 = **worker-side gzip compression only** (per-worker `GzEncoder`
+per batch → collector concatenates ordered multi-member gzip members per file).
+The plain-`.txt` write path stays collector-side (cheap). This narrows the
+byte-identity surface to `.gz` (sorted-content-equivalent, already accepted) and
+leaves the raw-`.txt` path — and its raw-byte-identity — entirely untouched.
+
+## R2 FINAL approach — gzp-in-collector (ALT-1), SUPERSEDES the worker-side-members design below
+
+The dual plan-review (`PERF_R2_PLAN_REVIEW_{A,B}.md`) independently recommended
+**ALT-1: `gzp::ParCompress` in the collector** over the invasive worker-side-
+members design described in `## Design` / `## Implementation outline` below. A
+throwaway spike (`spike-gzp` @ `65e5ff1`) confirmed it. **The worker-side-members
+design below was NOT implemented; it is retained for context only.**
+
+### Spike result (gzp-in-collector)
+10M PE, colossal, R1+mimalloc baseline:
+
+| mode | before | after | speedup |
+|---|---|---|---|
+| `.gz` (default `--parallel 1`) | ~75 s | **~18 s** | **~4.1x** |
+
+Valid gzip (`gunzip -t` OK), works at all N. gzp parallelizes compression on its
+own pool, independent of `--parallel`.
+
+### What was implemented (R2 PR, base `rust/iron-chancellor`)
+1. **`output.rs::open_writer`** — `--gzip` writers swapped from a single-threaded
+   `flate2::write::GzEncoder` to `gzp::par::compress::ParCompress<gzp::deflate::Gzip>`
+   (`deflate_rust` pure-Rust backend, no cmake). ~10-line change; the writer stays
+   a single `Box<dyn Write + Send>`, so the collector's per-key write path,
+   ordering (`batch_seq`), empty-sweep, version header, and the plain `.txt` path
+   are all UNCHANGED.
+2. **`GZIP_COMPRESS_THREADS = 4`** (named const) — decoupled from `--parallel` by
+   design, so the common `--parallel 1 --gzip` default still gets the ~4.1x win
+   (tying it to `--parallel` would leave the default single-threaded ~75 s).
+3. **Cargo**: add `gzp = "=0.11.3"` (default-features off, `deflate_rust`); move
+   `flate2` to `[dev-dependencies]` (now test-only — tests decode `.gz` via
+   `GzDecoder`); drop the dead `flate2::write::GzEncoder`/`Compression` imports.
+4. **Test**: add `parallel_gzip_multibatch_decompresses_identical_across_n_and_to_plain`
+   (8199 records > 2×BATCH_SIZE) — guards single-member framing + N=1≡N=4
+   decompressed-byte identity + identity-to-plain.
+
+### Single-member framing — the dual-review Criticals are MOOT for this design
+gzp's `Gzip` format emits a **single** gzip member (one header + sync-flushed
+DEFLATE blocks + one stream-wide CRC32/ISIZE footer — gzp `par/compress.rs:218`
+writes the header once, `:226-227` the footer once). Proven by source AND
+empirically (the multibatch test decodes with single-member `GzDecoder` and
+matches the plain peer). Therefore:
+- **No `MultiGzDecoder` migration** (dual-review C1/C3) — those applied to the
+  worker-side *multi-member* design, not gzp. Existing `GzDecoder` tests stay valid.
+- **No multi-member downstream risk** (dual-review C2) — single-member `.gz` is
+  what Perl already consumes.
+- **Err-slot / empty-sweep rework** (Reviewer B C6a/C4) — N/A: the collector path,
+  `WorkerOutput` payload, and `records_written` accounting are untouched.
+- Behavioural nuance carried forward: the gzip footer is written on **Drop**
+  (gzp's `Drop`→`finish()`), like flate2's `GzEncoder`. Caveat: a footer-flush
+  I/O error *panics* on drop (gzp `.unwrap()`s) vs flate2's silent swallow;
+  mid-stream write errors still surface as `io::Error`. Flagged for code-review.
+- `.gz` raw bytes differ from the old flate2 output (framing + no cross-block
+  dict on `deflate_rust`), but decompressed content is byte-identical; no test
+  hashes raw `.gz`, and the colossal smoke compares `zcat | sort | md5`.
+
+### Verification status
+- Local: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
+  `cargo test -p bismark-extractor` (102+ tests) — all PASS (2026-05-29).
+- Colossal `--gzip` SE/PE `phase_h_smoke` (real-data byte-identity) — **PASS**
+  (10M, `--parallel 4`): SE Perl 72s → Rust 8s (9.0×), PE Perl 167s → Rust 19s
+  (8.7×); 6 `.gz` sorted-equivalent vs Perl + M-bias/splitting_report byte-identical.
+- Dual code-review: **APPROVE** (no Critical/High). Shipped as PR #888 (clean
+  single commit `b17dd6e`, base `rust/iron-chancellor`).
+
+---
+
+## Design (rescoped: gzip path only) — SUPERSEDED (worker-side-members; not shipped)
+
+- Worker, per batch: instead of emitting `Vec<RoutedCall>`, format each call's
+  line into a **per-`OutputKey` byte buffer** (`HashMap<OutputKey, Vec<u8>>` or a
+  fixed array indexed by key); under `--gzip`, compress each key's batch buffer
+  into a gzip **member** (`flate2 GzEncoder` per worker). Emit
+  `WorkerOutput::Batch{batch_seq, per_key_bytes}`.
+- Collector, per batch in `batch_seq` order: for each key, **append the bytes**
+  to that key's file (raw `write_all`, no per-record formatting/routing). The
+  format/route/compress work is now parallel; the collector does memcpy+write.
+- `OutputFileMap` gains a raw `append_bytes(key, &[u8])` path; the line-formatting
+  logic in `write_call` moves to a worker-callable function (shared, so SE/PE/
+  yacht/mode dispatch stays one source of truth — guard against drift).
+- M-bias + splitting_report stay collector-side (tiny; already correct).
+- The empty-sweep "kept/deleted" logic still runs at finalize (a file is "empty"
+  if no batch wrote bytes to it).
+
+## Byte-identity
+- Plain `.txt`: final file = concatenation of per-batch per-key chunks in
+  `batch_seq` order = exactly N=1's record order → **raw byte-identical**.
+- `.gz`: per-batch gzip members concatenated = valid multi-member gzip; decode-
+  sorted-equivalent (smoke `zcat|sort|md5`) — allowed for data files. (Note:
+  this changes `.gz` from raw-identical to sorted-equivalent vs N=1; the smoke
+  already accepts that for `.gz`, but confirm no test asserts raw `.gz` identity.)
+- M-bias.txt + splitting_report.txt: unchanged (collector-written, strict-byte).
+
+## Implementation outline (parallel.rs + output.rs)
+1. Extract the per-call line-formatting from `OutputFileMap::write_call` into a
+   pure `format_call_line(mode, qname, chr, call, strand, yacht6, yacht7) ->
+   bytes` (+ the key-routing) usable by workers; `write_call` becomes
+   format-then-append (keeps the single-threaded path working/ tested).
+2. Worker: per batch, format calls into per-key buffers (gzip-compress per key
+   if `--gzip`); emit `WorkerOutput::Batch{batch_seq, per_key_bytes}` (replace
+   `Vec<RoutedCall>`).
+3. Collector: `OutputFileMap::append_bytes(key, bytes)` per key per batch in
+   `batch_seq` order. Drop `write_routed_call`/per-call routing in the collector.
+4. Channel payload changes from `Vec<RoutedCall>` to per-key byte buffers — mind
+   the size (a batch's formatted bytes); reuse buffers if profiling shows alloc churn.
+
+## Edge cases / risks
+- **Byte-identity is the gate** (Phase H matrix). The ordering proof holds only
+  if per-key chunks are concatenated strictly in batch_seq order.
+- `--gzip` multi-member vs raw-identical: confirm tests + the smoke's `.gz`
+  sorted-equivalence accept it.
+- Memory: per-batch per-key buffers in flight × workers; bound it.
+- `--mbias_only`: no split files → workers emit no bytes (fast path unchanged).
+- Mode dispatch (comprehensive/merge/yacht): the moved formatter must reproduce
+  the exact per-mode line + key routing — single source of truth, no drift.
+
+## Verification
+1. Phase 0 spike gate (above) — proceed only if favourable.
+2. `cargo test` byte-identity suite (incl. the 8199-record boundary test) — must
+   pass; add a `--gzip` N=1≡N=4 sorted-equivalence test if not present.
+3. clippy `-D warnings` + fmt.
+4. Phase H matrix on colossal (SE+PE, N=1&N=4) — binding byte-identity gate.
+5. Perf re-measure: `default N=4 < N=1` (positive scaling) — the R2 success
+   criterion; record vs the 22.3/23.5/23.9 mimalloc baseline.
+
+## Out of scope
+- Further allocator tuning; SAM/CRAM-specific paths; the `--bedGraph`/cytosine
+  subprocess chain (Phase G, separate).

--- a/plans/05262026_bismark-extractor/TESTS_878_CODE_REVIEW_reviewer-A.md
+++ b/plans/05262026_bismark-extractor/TESTS_878_CODE_REVIEW_reviewer-A.md
@@ -1,0 +1,98 @@
+# Code Review — #878 regression-guard tests (Reviewer A)
+
+**Verdict: APPROVE.** All 4 tests are correct, the fixtures match what `extract_calls`/`process_*` actually produce, the regression guards genuinely fire on revert (verified by running the smoke), and there are no source logic changes. No Critical/High findings. A few Low/Medium polish notes only.
+
+**Scope reviewed:** uncommitted diff in worktree `/Users/fkrueger/Github/Bismark-extractor` across 3 files (`call.rs`, `parallel.rs`, `tests/parallel_phase_f.rs`), verified against the actual semantics of `call.rs:extract_calls`, `bismark-io record.rs:iter_aligned`, `bismark-io strand.rs:from_xr_xg`, `bismark-io pair.rs:from_mates`, `parallel.rs:process_se/process_pe`, `mbias.rs:accumulate`, `overlap.rs:drop_overlap`, and `cli.rs:validate`.
+
+---
+
+## Verification performed
+
+### Build / test (sandbox-disabled)
+- `cargo test -p bismark-extractor`: **lib 105 + parallel_phase_f 18**, all green (matches plan). Total 17 "test result: ok" lines, 0 FAILED.
+- `cargo clippy --all-targets -- -D warnings`: **clean** (no warnings).
+- `cargo fmt --check` (from `rust/`): **clean** (exit 0).
+
+### Revert-smoke (the #878 acceptance gate) — RAN IT MYSELF
+Temporarily set `call.rs:204` → `read_pos: aligned.read_pos_5p` (drop the rebase):
+- `extract_calls_ob_strand_rebases_read_pos_after_ignore_5p` — **FAILED** ✓
+- `parallel_se_worker_m_bias_rebased` — **FAILED** ✓
+- `parallel_pe_worker_m_bias_uses_r2_ignore_for_r2` — **FAILED** ✓
+- (pre-existing `extract_calls_rebases_read_pos_after_ignore_5p` OT guard — also FAILED, expected) ✓
+- `se_driver_vs_parallel_driver_m_bias_equality` (Test 4) — **stayed GREEN** ✓ (confirms it is a *divergence* guard, not a revert guard, exactly per A-I4).
+
+Restored `call.rs:204`. Re-ran: all green.
+
+### R2-ignore mis-wire smoke — RAN IT MYSELF
+Temporarily set the R2 accumulate site (`parallel.rs:838`) `mbias[1]` → `mbias[0]`:
+- `parallel_pe_worker_m_bias_uses_r2_ignore_for_r2` — **FAILED** ✓ (the `mbias[1].cpg[1].meth == 1` assert + `mbias_total(&mbias[1]) == 1` catch the wrong-table write).
+Restored.
+
+> Note: the source files were touched by an auto-format/save hook between my temporary edits; I re-verified `git diff` ends with **zero source-logic lines** added or removed (`read_pos: aligned…` and `mbias[N].accumulate` appear in neither `+` nor `-`). Final `git status` shows only the 3 intended files; diff stat `+320/-7`, test-only.
+
+---
+
+## Fixture correctness (the #1 risk) — all verified
+
+### Test 1 (OB byte-reversal)
+- `from_xr_xg` (`strand.rs:65-68`): `(CT,CT)→OT` forward, `(CT,GA)→OB` reverse. ✓
+- `iter_aligned` (`record.rs:299-307`): for `-`-strand, remaps `read_pos_5p = seq_len-1-BAM`, then `reverse()`s order. **XM byte is taken as-is** (`xm[ap.read_pos]`, `record.rs:290`) — NOT complemented. The fixtures rely on this, and it holds. ✓
+- OT `"..Zxh."` (forward): surviving BAM 2,3,4 → `Z`(CpG,T)@2, `x`(CHG,F)@3, `h`(CHH,F)@4; `ignore_5p=2` rebases to `[0,1,2]`. ✓
+- OB `".hxZ.."` (= `reverse("..Zxh.")`): `Z`@BAM3→`read_pos_5p=5-3=2`, `x`@BAM2→3, `h`@BAM1→4; after reverse, emitted in 5'-order as `Z,x,h` at `read_pos_5p [2,3,4]`; rebase→`[0,1,2]`. ✓ The asserted contexts `(CpG,true),(CHG,false),(CHH,false)` match. The fixture is **correct**, not plausible-but-wrong.
+
+### Test 2 (SE)
+`"...Zxh"` OT, `--ignore 3`: surviving read_pos_5p 3,4,5 (`Z`,`x`,`h`) → rebased 0,1,2 → 1-based slots 1,2,3. Asserts `cpg[1].meth=1, chg[2].unmeth=1, chh[3].unmeth=1`; absolute (reverted) slots `cpg[4]/chg[5]/chh[6]` checked zero via `.get(n).map_or(0,…)`. Includes non-CpG (CHG+CHH) — exercises `accumulate` context routing. `mbias[1]` asserted empty (SE). ✓ The `.get(n)` checks are correct: under the fix the Vec grows only to index 3, so `.get(4..6)`→`None`→0; under revert it grows to 6 and `.get(4)`→`Some{meth:1}`→fails. Bidirectional. ✓
+
+### Test 3 (PE R2-is-CTOT reversed)
+- `from_mates` (`pair.rs:40-78`): requires R1 identity (flag 0x40) + R2 identity (flag 0x80); fixtures use `0x41`/`0x81`. Pair strand from R1 = OT. R2 `(GA,CT)` = CTOT (reverse). ✓ (mirrors the in-tree `from_mates_ot_pair` test exactly.)
+- R1 `"...Z.."` OT start=100, `--ignore 3` (`ignore_5p_r1`): `Z`@read_pos_5p 3 → rebase 0 → `mbias[0].cpg[1].meth=1`. ✓
+- R2 `".Z......."` CTOT start=200, 9M, `--ignore_r2 7` (`ignore_5p_r2`): `Z`@BAM1 → `read_pos_5p = 9-1-1 = 7` → ref_pos = 200+1 = **201**; rebase by 7 → 0 → `mbias[1].cpg[1].meth=1`. ✓ The R2-ignore (`config.ignore_5p_r2`, used at `process_pe` `:791`) and the R2 table index (`mbias[1]`, `:838`) are both exercised.
+- Overlap: pair is forward (`is_forward_pair_strand(OT)=true`); `drop_overlap` keeps R2 calls with `ref_pos > r1_ref_end`. r1_ref_end = 100+6-1 = 105; R2 call ref_pos = 201 > 105 → kept. ✓ Non-overlapping placement is correct; R2 survives without `--include_overlap`.
+- Cross-table leak guards: `mbias[0].cpg.get(4)`==0, `mbias[1].cpg.get(8)`==0, and `mbias_total` per table == 1. ✓ Each fixture has exactly one call so totals are exact.
+
+### Test 4 (divergence guard + non-empty)
+- `write_se_directional_bam` emits **5-bp** reads (`b"ACGTC"`). `--ignore 5` → `lo=5 >= hi=5` → empty (the C1 trap). `--ignore 2` → lo=2<hi=5; surviving calls = r_OT_2(2) + r_OT_3(1) + r_OB_1(1) + r_OB_2(1) = **5** (r_OT_1 `"Zz..."` contributes 0). Non-empty. ✓
+- Non-emptiness scan: split files are plain text by default (gzip only under `--gzip`, not passed); header = `"Bismark methylation extractor version v0.25.1\n"` (`output.rs:36`), so `!line.starts_with("Bismark")` correctly excludes only the header; prefixes `CpG_/CHG_/CHH_` match the default-mode split file names. The `call_lines > 0` assertion is non-vacuous and prevents the C1 silent-degradation. ✓
+- Correctly documented as guarding driver divergence, not revert. ✓
+
+---
+
+## Issues by area
+
+### Logic
+None.
+
+### Efficiency
+None (test-only; fixtures are tiny).
+
+### Errors
+None. `config_with`'s tempfile lifetime is **sound**: `validate()` only checks `path.exists()` (`cli.rs:431-436`), never opens the file; the tmp is alive through the parse+validate call and dropped afterward; `cfg` retains only the `PathBuf`, which `process_*` never reads. (Verified.)
+
+### Structure / style
+- **Low — helper duplication.** `parallel.rs::synth_rec` (6 args) duplicates most of `tests/parallel_phase_f.rs::synth_record` (7 args, adds `seq`). They live in different test scopes (unit vs integration crate) so can't share without a `tests/common/mod.rs` — which the integration file already flags as a deferred TODO (`parallel_phase_f.rs:44-46`). The unit-side `synth_rec` could not reuse the integration helper regardless. Acceptable; matches existing pattern. No action required.
+- **Low — `synth_se_record` refactor is correctly non-breaking.** `synth_se_record(xm,n_soft,n_match)` now wraps `synth_se_record_strand(…, b"CT")`; the existing OT test (`extract_calls_rebases_read_pos_after_ignore_5p`) is unchanged in behavior (XG:Z:CT) and still passes. Doc-comment on the new `_strand` fn accurately describes `b"CT"→OT`, `b"GA"→OB`. ✓
+- **Low — doc-comment line refs.** The Test 2/3 block comment cites `parallel.rs:711 / :815 / :838` for the accumulate sites; these match the current source (`:711` SE, `:815` PE-R1, `:838` PE-R2). Test 1's doc cites `record.rs:236` for the OB reversal — the formula is documented at `record.rs:236` and implemented at `:305`; close enough, accurate in spirit. No fix needed.
+
+---
+
+## Recommendations (priority-ranked)
+
+- **Critical:** none.
+- **High:** none.
+- **Medium:** none.
+- **Low (optional, non-blocking):**
+  1. If a future PR adds `tests/common/mod.rs`, fold `synth_rec`/`synth_record`/`synth_se_record_strand` into one parameterized builder (already a tracked deferral).
+  2. Consider asserting `mbias_total(&mbias[0]) == 3` in Test 2 (currently asserts the 3 specific slots + that 3 absolute slots are zero, which is equivalent but the explicit total would mirror Test 3's style). Cosmetic.
+
+---
+
+## Acceptance summary
+- 4 tests added, all passing. ✓
+- Tests 1–3 fail on `call.rs:204` revert (verified by running). ✓
+- Test 4 stays green on revert, fails only on driver divergence (by design). ✓
+- R2-ignore mis-wire caught by Test 3 (verified). ✓
+- Non-emptiness guard prevents the C1 vacuous-pass. ✓
+- Zero source `*.rs` logic changes (only the non-breaking `synth_se_record` test-helper refactor). ✓
+- clippy `-D warnings` + fmt clean. ✓
+
+**Report path:** `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/TESTS_878_CODE_REVIEW_reviewer-A.md`

--- a/plans/05262026_bismark-extractor/TESTS_878_CODE_REVIEW_reviewer-B.md
+++ b/plans/05262026_bismark-extractor/TESTS_878_CODE_REVIEW_reviewer-B.md
@@ -1,0 +1,216 @@
+# Code Review (Reviewer B) — #878 regression-guard tests for `MethCall.read_pos` rebase
+
+**Target:** uncommitted diff in worktree `/Users/fkrueger/Github/Bismark-extractor` (base detached at `2bfe722`).
+**Files:** `src/call.rs`, `src/parallel.rs`, `tests/parallel_phase_f.rs` (3 files, +320/-7).
+**Scope claim:** 4 regression-guard tests, **no source `*.rs` logic changes**.
+**Plan:** `plans/05262026_bismark-extractor/TESTS_878_PLAN.md`.
+
+---
+
+## Verdict
+
+**APPROVE.** The implementation matches the plan, the fixtures are correctly oriented
+(independently re-derived from `bismark-io` source, not trusted from comments), and all four
+guards are **real** — I confirmed them empirically with the revert-smoke and two extra
+mis-wire smokes. No correctness, efficiency, or structural defects of any priority above Low.
+The scope claim (tests-only, no source logic change) is verified: the base commit already
+carries the `call.rs:204` fix, and applying the diff to a clean checkout leaves line 204
+untouched.
+
+No issues were fixed in source (the brief forbids source edits, and none were warranted).
+
+---
+
+## How this review was conducted (important — shared-worktree hazard)
+
+The live worktree `Bismark-extractor` was being **concurrently mutated** during my review — a
+sibling process (almost certainly Reviewer A running the same revert-smoke) repeatedly toggled
+`call.rs:204` between the fix (`aligned.read_pos_5p.saturating_sub(ignore_5p)`) and the revert
+(`aligned.read_pos_5p`). My first `cargo test` in the live tree showed Test 3 FAILING with
+`mbias[0].cpg[1].meth == 2` because the fix had been transiently reverted out from under me;
+the `Edit` tool also threw "File has been modified since read." This is a **process-isolation
+problem in the review harness, not a code defect** — but it means any test run against the live
+worktree is unreliable while a second reviewer is active.
+
+To get a trustworthy result I:
+1. Captured the *intended* test-only patch from a moment when the live tree had the fix in place
+   (verified the captured patch contains **no** `read_pos: aligned` revert line).
+2. Created an isolated detached worktree at `2bfe722` and applied the patch there.
+3. Ran all builds/tests/smokes in that isolated tree, immune to the concurrent toggling.
+4. Cleaned up the isolated worktree and confirmed the live tree settled back to the clean
+   intended state (fix present, only the 3 test files modified, no stray diagnostic).
+
+All "PASS/FAIL" results below are from the **isolated** worktree.
+
+---
+
+## Independent verification results
+
+### Build / test / lint (isolated worktree, fix in place)
+- `cargo test -p bismark-extractor`: **all green**. lib **105** (plan claims +3 → 102→105 ✓);
+  `parallel_phase_f` **18** (+1 ✓); every other suite green.
+- The 4 new tests pass: `extract_calls_ob_strand_rebases_read_pos_after_ignore_5p`,
+  `parallel_se_worker_m_bias_rebased`, `parallel_pe_worker_m_bias_uses_r2_ignore_for_r2`,
+  `se_driver_vs_parallel_driver_m_bias_equality`.
+- `cargo clippy -p bismark-extractor --all-targets -- -D warnings`: **clean**.
+
+### Revert-smoke (the key acceptance gate, #878)
+Reverted `call.rs:204` → `aligned.read_pos_5p` in the isolated tree:
+- Test 1 (`extract_calls_ob_strand_...`): **FAILS** (panics at `call.rs:346`). ✓
+- Test 2 (`parallel_se_worker_m_bias_rebased`): **FAILS** (panics at `parallel.rs:1236`). ✓
+- Test 3 (`parallel_pe_worker_m_bias_uses_r2_ignore_for_r2`): **FAILS** (`parallel.rs:1292`). ✓
+- Test 4 (`se_driver_vs_parallel_driver_m_bias_equality`): **stays GREEN**. ✓ — exactly the
+  documented divergence-guard behaviour (plan A-I4); both drivers share the rebase, so a revert
+  does not diverge them.
+
+### Extra mis-wire smokes (beyond the plan's revert-smoke — to prove Test 3's claims)
+With the fix in place, I injected two independent regressions:
+- **R2 ignore mis-wire** (`parallel.rs:791` `ignore_5p_r2` → `ignore_5p_r1`): Test 3 **FAILS**
+  (`mbias[1].cpg[1].meth` 0 ≠ 1). Confirms the test really guards "R2 uses `--ignore_r2`".
+- **R2 cross-table mis-wire** (`parallel.rs:838` `mbias[1]` → `mbias[0]`): Test 3 **FAILS**
+  (`mbias[0].cpg[1].meth` 2 ≠ 1; the `mbias_total` assertions also catch it). Confirms the
+  `mbias[1]` index guard is bidirectional.
+
+These two extra smokes give high confidence that Test 3 is not a vacuous pass.
+
+---
+
+## Fixture-orientation re-derivation (the dual-review trap — done from source, not comments)
+
+### Strand classification (`bismark-io/src/strand.rs:65-68`)
+OT = `CT/CT` (forward), OB = `CT/GA` (reverse), CTOT = `GA/CT` (reverse), CTOB = `GA/GA`.
+
+### OB reversal kernel (`bismark-io/src/record.rs:299-307`)
+For non-forward records: `read_pos_5p = seq_len - 1 - BAM_index`, then the call list is
+`reverse()`d (emitted ascending in `read_pos_5p`). Confirmed verbatim in source.
+
+### Test 1 (OB)
+- OT `"..Zxh."` (forward): Z@2 (CpG-meth), x@3 (CHG-unmeth), h@4 (CHH-unmeth). `ignore_5p=2`
+  keeps read_pos_5p ≥ 2 → survive at 2,3,4 → rebased **[0,1,2]**.
+- OB `".hxZ.."` = `reverse("..Zxh.")`. BAM bytes h@1, x@2, Z@3 → read_pos_5p `5-1-BAM` =
+  h→4, x→3, Z→2; after reverse the 5'-order is Z@2, x@3, h@4 → survive → rebased **[0,1,2]**.
+- Asserted `ob_pos == [0,1,2]`, `ot_pos == ob_pos`, and contexts `[CpG-true, CHG-false,
+  CHH-false]` — **all match my re-derivation**. The fixture is genuinely the byte-reverse and
+  asserts the right thing (not merely passing). ✓
+
+### Test 3 (PE R2 = CTOT)
+- `BismarkPair::from_mates` (`pair.rs:40`) requires R1 flag with `ReadIdentity::R1` and R2 with
+  `R2`; Test 3 uses `0x41`/`0x81` (matches the existing `make_pair_records` fixture). An OT pair
+  has R2 = CTOT (`pair.rs:142` `from_mates_ot_pair`). ✓
+- R1 `"...Z.."` OT: Z@BAM3 → read_pos_5p 3; `--ignore 3` → rebased **0** → `mbias[0].cpg[1]`.
+- R2 `".Z......."` CTOT (9 bp, reverse): Z@BAM1 → read_pos_5p `9-1-1 = 7`; `--ignore_r2 7` →
+  rebased **0** → `mbias[1].cpg[1]`. ✓ (single `Z`, so exactly one call.)
+- Overlap: R1 ref span 100–105; R2's Z at ref 201; `drop_overlap` keeps `c.ref_pos >
+  r1_ref_end` (OT branch, `overlap.rs:113`) → 201 > 105 → R2 survives. Non-overlapping by
+  design. ✓
+- The deviation note #2 in the plan ("R2 of an OT pair is CTOT; Z at BAM `seq_len-1-ignore_r2`
+  = 9-1-7 = 1") is accurate.
+
+---
+
+## Are the guards real, non-vacuous? (brief item 2)
+
+- **Tests 1–3 fail on revert** — confirmed empirically (above). Each is bidirectional:
+  asserts the rebased slot is nonzero AND the absolute (reverted) slot is zero.
+- **Test 2 absolute-slot assertions are safe AND meaningful.** `MbiasTable.{cpg,chg,chh}` are
+  **lazily-grown `Vec`s** (`mbias.rs:51-63`, resize to `idx+1` only on write). The test uses
+  `.get(4)/.get(5)/.get(6).map_or(0, …)` — when the fix is in place those vecs never grow that
+  far, so `.get()` returns `None` → 0 (no panic). On revert they grow to len ≥ 5 and `.get(4)`
+  returns `Some` with the count → the `== 0` assertion fails. Using `.get()` (not `[idx]`) is the
+  *correct* choice given lazy growth. ✓
+- **Test 4 non-emptiness is non-vacuous.** I re-derived `write_se_directional_bam` under
+  `--ignore 2` over its 5-bp reads: r_OT_1 `Zz...` → 0 (both dropped), r_OT_2 `..X.x` → 2,
+  r_OT_3 `H.h..` → 1, r_OB_1 `Z....` (OB) → 1, r_OB_2 `..h..` (OB) → 1. **5 surviving calls**,
+  matching the plan's iteration log. The assertion scans CpG_/CHG_/CHH_ split files, skips empty
+  and `Bismark`-header lines, and requires `call_lines > 0` — sound and genuinely exercised
+  (`lo=2 < hi=5`, so the `lo >= hi` early-out at `call.rs:166` is *not* hit). ✓
+
+---
+
+## Helper soundness (brief item 3)
+
+- **`config_with` (parallel.rs):** writes a temp `.bam`, runs `Cli::try_parse_from(...).validate()`,
+  then `drop(tmp)`. `validate()` checks input-file existence **during the call**
+  (`cli.rs:432-436`, `path.exists()` loop); the resulting `ResolvedConfig.files` owns the
+  `PathBuf`, and `process_se`/`process_pe` **never read the file** (verified — they only read
+  `config` fields). So dropping the tempfile after `validate()` is **not** a use-after-free:
+  `validate()` does not need the file to persist past its own return. ✓
+- **`synth_rec` flags/tags:** sets `flags`, single-`M` CIGAR of `xm.len()`, `seq = vec![b'A';
+  xm.len()]`, refid 0, and XR/XG/XM tags. `from_noodles_record` enforces XM-len == seq-len
+  (`record.rs:125`) — satisfied. PE flags `0x41`/`0x81` satisfy `from_mates`. ✓
+- **`mbias_total`:** correctly sums `meth+unmeth` across all three context vecs; the per-table
+  `== 1` assertions in Test 3 add a strong "exactly one call, no leakage" guard. ✓
+- **`synth_se_record_strand` refactor (call.rs):** the original 3-arg `synth_se_record` is
+  preserved as a `b"CT"` (OT) wrapper. All three pre-existing OT callers
+  (`call.rs:303, 375, 400`) still compile and assert the same values — confirmed: the OT
+  template test still passes with `[0,1,2,3]`/4-calls. Non-breaking refactor. ✓
+
+---
+
+## Edge / coverage (brief item 4)
+
+- **CHG/CHH exercised, not only CpG:** Test 1 asserts CpG+CHG+CHH; Test 2 asserts a CpG-meth,
+  a CHG-unmeth, AND a CHH-unmeth at three different rebased slots — so the context routing in
+  `MbiasTable::accumulate` is genuinely exercised. ✓ Test 3 is CpG-only, but that is appropriate
+  (its purpose is R1/R2 table + ignore dispatch, and Test 2 already covers multi-context routing).
+- **Methylated/unmethylated mix:** Test 2 covers both (`meth` for CpG, `unmeth` for CHG/CHH). ✓
+- No missing assertion that would let a real regression slip — see the two extra mis-wire smokes.
+
+---
+
+## Efficiency / structure (brief item 5)
+
+- **Duplication** between `parallel.rs::synth_rec` and integration `synth_record`: acceptable.
+  The unit test lives in the lib crate and cannot reach the integration-test helper; the only
+  difference (`synth_rec` derives `seq` from XM length vs `synth_record` taking explicit `seq`)
+  is benign. Low.
+- **Import-block placement:** the new `use` block (`parallel.rs:1151-1158`) sits mid-module
+  rather than grouped with `use super::*;` at the top of the `tests` mod (`:1071`). Compiles
+  cleanly and clippy is silent (so the imports are needed, not redundant), but conventionally
+  these would live at the top of the module. Purely cosmetic. Low.
+- Naming is clear and self-documenting; doc-comments accurately state the guarded line numbers
+  and the revert/divergence semantics.
+
+---
+
+## Issues (prioritised)
+
+**Critical / High / Medium:** none.
+
+**Low:**
+1. *(Process, not code)* **Shared-worktree race during review.** Concurrent revert-smoke runs by
+   two reviewers in the same worktree corrupt each other's test state (I observed `call.rs:204`
+   toggling mid-run, producing a spurious Test 3 failure, and an `Edit`-conflict error). This is
+   a harness/process-isolation gap, not a defect in the #878 code. Recommendation: future
+   dual-review of mutating smokes should use **separate worktrees per reviewer**. I worked around
+   it via an isolated worktree; the live tree is confirmed back to clean intended state.
+2. **`BUG_876_FIXES_PLAN.md §6` not yet updated.** The plan's implementation-outline step 4
+   ("mark §6 deferrals #8/#9/#10 as landed") is **not done** in this diff. However,
+   `TESTS_878_PLAN.md:255` explicitly defers this to PR time ("Remaining: update
+   `BUG_876_FIXES_PLAN.md §6` ... at PR time"), and it is a doc-only task outside the
+   tests-only code scope. Flagging for tracking, not blocking.
+3. *(Cosmetic)* Mid-module import block placement (see Structure above).
+
+---
+
+## Recommendations
+
+- **Ship it.** The tests are correct, the fixtures are independently verified, and the guards
+  are demonstrably real (revert-smoke + two mis-wire smokes all behave as designed).
+- Before/at PR: complete the `BUG_876_FIXES_PLAN.md §6` doc-update (Low #2).
+- Process: adopt per-reviewer worktrees for any review that runs mutating smokes (Low #1).
+- Optional polish: move the `parallel.rs` tests-mod `use` block to the top of the module (Low #3).
+
+---
+
+## Key `file:line` references
+- Fix under guard: `rust/bismark-extractor/src/call.rs:204`.
+- M-bias accumulators guarded: `src/parallel.rs:710-711` (SE), `:814-815` (PE R1),
+  `:837-838` (PE R2 → `mbias[1]`, `ignore_5p_r2` via `:791`).
+- New tests: `src/call.rs:330` (Test 1), `src/parallel.rs:1232` (Test 2), `:1282` (Test 3),
+  `tests/parallel_phase_f.rs:438` (Test 4).
+- New helpers: `synth_se_record_strand` (`call.rs:243`), `synth_rec`/`config_with`/`mbias_total`
+  (`parallel.rs:1160/1192/1208`).
+- Orientation sources independently checked: `bismark-io/src/strand.rs:65-68`,
+  `bismark-io/src/record.rs:299-307`, `bismark-io/src/pair.rs:40-78/142`,
+  `src/overlap.rs:99-113`, `src/mbias.rs:51-63`, `src/cli.rs:432-436/484-500`.

--- a/plans/05262026_bismark-extractor/TESTS_878_COVERAGE.md
+++ b/plans/05262026_bismark-extractor/TESTS_878_COVERAGE.md
@@ -1,0 +1,55 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs the plan's "What was implemented" / 4 tests + acceptance)
+**Plan(s):** `plans/05262026_bismark-extractor/TESTS_878_PLAN.md`
+**Code:** worktree `/Users/fkrueger/Github/Bismark-extractor` (uncommitted, detached @ `2bfe722`)
+**Date:** 2026-05-29
+**Verdict:** COMPLETE
+
+## Summary
+
+- Total items: 9 (4 tests + 5 acceptance/deviation/process items)
+- DONE: 6
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED (documented = acceptable): 3
+- Known-pending PR-time item (not a code gap): 1 (`BUG_876_FIXES_PLAN.md §6`)
+
+## Coverage ledger
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | Test 1 `extract_calls_ob_strand_rebases_read_pos_after_ignore_5p` + non-breaking `synth_se_record` → `synth_se_record_strand(xm,n_soft,n_match,xg)` refactor; OB rebase + OT≡OB | Plan §"Behavior" Test 1; impl-notes | DONE | Present in `call.rs` `mod tests`. OT `"..Zxh."` vs OB `".hxZ.."` (= reverse), `ignore_5p=2`, asserts `read_pos == [0,1,2]` for both + OT≡OB + context/meth `[(CpG,true),(CHG,false),(CHH,false)]`. `synth_se_record` retained as `b"CT"` wrapper (non-breaking). |
+| 2 | Test 2 `parallel_se_worker_m_bias_rebased` — SE worker → `mbias[0]` slot 1 under `--ignore 3` | Plan §"Behavior" Test 2 | DONE | Present in `parallel.rs` `mod tests`. Calls private `process_se` via `super::*`. XM `"...Zxh"`, asserts CpG/CHG/CHH at rebased slots 1/2/3, absolute slots 4/5/6 zero, `mbias[1]` empty. Includes non-CpG (CHG+CHH) routing. Helpers `synth_rec`/`config_with`/`mbias_total` added. |
+| 3 | Test 3 `parallel_pe_worker_m_bias_uses_r2_ignore_for_r2` — R1→`mbias[0]`, R2→`mbias[1]` under `--ignore 3 --ignore_r2 7` | Plan §"Behavior" Test 3 | DONE | Present in `parallel.rs` `mod tests`. Calls private `process_pe`. R1 `"...Z.."` @start 100, R2 `".Z......."` @start 200 (non-overlapping → `drop_overlap` keeps R2). Asserts `mbias[0].cpg[1].meth==1`, `mbias[1].cpg[1].meth==1`, absolute slots 4/8 zero, each table total==1. |
+| 4 | Test 4 `se_driver_vs_parallel_driver_m_bias_equality` — single vs parallel driver M-bias equality + non-emptiness assertion | Plan §"Behavior" Test 4 | DONE | Present in `tests/parallel_phase_f.rs`. Uses `--ignore 2` (per C1, NOT the rev-0 `--ignore 5`), counts non-header CpG/CHG/CHH lines (`call_lines > 0`), then `assert_dirs_byte_identical(single, parallel-n4)`. Doc-comment states it guards divergence not revert. |
+| 5 | Acceptance (a): all 4 tests pass | Plan §Validation 1 | DONE | All 4 named tests PASS. Full suite green: lib **105**, `parallel_phase_f` **18** (matches expected). |
+| 6 | Acceptance (b): Tests 1–3 FAIL on reverting `call.rs:204`; Test 4 stays green | Plan §Validation 2 | DONE | Revert-smoke executed (Edit-tool revert; sandbox blocked `perl -i`/`cp` to /tmp): Tests 1,2,3 FAILED (+ pre-existing #876 OT guards `extract_calls_rebases_read_pos_after_ignore_5p`, `extract_calls_rebase_combined_with_soft_clip`). Test 4 stayed GREEN. Fix restored (md5 matches pre-revert backup). |
+| 7 | Acceptance (c): NO source `*.rs` logic changes (only test-helper refactor) | Plan §Validation; impl-notes | DONE | `git diff` touches 3 files; all `call.rs`/`parallel.rs` hunks lie inside `#[cfg(test)] mod tests` (call.rs hunks @237+, mod tests @223; parallel.rs hunk @1141, mod tests @1070). `call.rs:204` rebase fix (`saturating_sub`) intact. |
+| 8 | Documented DEVIATED: `process_se`/`process_pe` arg order is `(record/pair, chr_id, chr_table, config, …)` not `(…, config, chr_id, chr_table)` as rev-1 sketched | impl-notes Deviation 1 | DEVIATED (documented) | Tests call the actual signature; deviation documented. Acceptable. |
+| 9 | Documented DEVIATED: R2 of OT pair is CTOT (`-`-strand reversed); R2 `Z` placed at BAM idx `seq_len-1-ignore_r2` (9-1-7=1). Plus `--mbias_only` adopted for Tests 2–3 | impl-notes Deviations 2 & 3 | DEVIATED (documented) | Empirically confirmed; pins exact placement vs rev-1's "control R2 orientation". `--mbias_only` adopted as the optional isolation path. Acceptable. |
+
+## Known-pending PR-time item (per plan, NOT a code gap)
+
+- **`BUG_876_FIXES_PLAN.md §6` update** (#8/#9/#10 deferrals → mark landed). Plan impl-notes explicitly list this as "Remaining: update `BUG_876_FIXES_PLAN.md §6` … at PR time." Verified: §6 of `BUG_876_FIXES_PLAN.md` currently lists out-of-scope items with no #8/#9/#10 "landed" markers — confirming the update has not yet been applied. Per the plan this is a PR-time documentation task, not a coverage gap in the #878 test work.
+
+## Gaps (detail)
+
+None. All 4 tests exist, do what the plan specifies, pass green, and produce the required revert-smoke behavior. The three DEVIATED items are documented in the plan's "Deviations" section (process arg order, R2=CTOT-reversed placement, `--mbias_only` adoption) and are acceptable.
+
+## Test verification (Mode B)
+
+| Test name | File | Status (green run) | Status on `call.rs:204` revert |
+|-----------|------|--------------------|--------------------------------|
+| `extract_calls_ob_strand_rebases_read_pos_after_ignore_5p` | `rust/bismark-extractor/src/call.rs` (tests mod) | PASS | FAILED (as required) |
+| `parallel_se_worker_m_bias_rebased` | `rust/bismark-extractor/src/parallel.rs` (tests mod) | PASS | FAILED (as required) |
+| `parallel_pe_worker_m_bias_uses_r2_ignore_for_r2` | `rust/bismark-extractor/src/parallel.rs` (tests mod) | PASS | FAILED (as required) |
+| `se_driver_vs_parallel_driver_m_bias_equality` | `rust/bismark-extractor/tests/parallel_phase_f.rs` | PASS | PASS (divergence guard, stays green by design — A-I4) |
+
+Suite-level: `cargo test -p bismark-extractor` → lib `105 passed`, `parallel_phase_f 18 passed`, all other binaries green (0 failures). Matches the expected counts (lib 105, parallel_phase_f 18).
+
+Revert-smoke note: the sandbox blocked in-place writes to the source file via `perl -i`/`cp` (Operation not permitted; a stale cached read briefly masked this). The revert was applied with the Edit tool, tests run, then restored — final `call.rs` md5 is byte-identical to the pre-revert backup, and the git diff afterward contains only test-module hunks.
+
+## Verdict
+
+**COMPLETE.** All 4 regression-guard tests are present, behave as specified, pass on the green run, and satisfy the #878 acceptance: Tests 1–3 fail on reverting the `call.rs:204` rebase, Test 4 stays green as the divergence guard, and there are no source `*.rs` logic changes (only the non-breaking `synth_se_record` → `synth_se_record_strand` test-helper refactor). The three deviations are documented (process arg order; R2=CTOT-reversed; `--mbias_only` adopted) = acceptable. The `BUG_876_FIXES_PLAN.md §6` update is a known-pending PR-time documentation item per the plan, not a code gap.

--- a/plans/05262026_bismark-extractor/TESTS_878_PLAN.md
+++ b/plans/05262026_bismark-extractor/TESTS_878_PLAN.md
@@ -1,0 +1,255 @@
+# Plan — #878: close CI coverage gap for `MethCall.read_pos` rebase (tests only)
+
+**Epic:** `#798` (extractor release). Follow-up to #876 / PR #877.
+**Issue:** #878. **Scope:** add 4 regression-guard tests; **no source `*.rs` changes.**
+
+## Revision history
+- **rev 1 (2026-05-29):** Folded dual plan-review (`TESTS_878_PLAN_REVIEW_reviewer-{A,B}.md`).
+  Both APPROVE WITH CHANGES; both independently found the same Critical.
+  - **C1 (both, Critical):** Test 4's `--ignore 5` was a silent no-op (5-bp fixtures →
+    `lo>=hi` early-out → empty outputs → trivially byte-identical even on revert). → use
+    **`--ignore 2`** + a **non-emptiness assertion**. Added the **fixture-length > ignore**
+    invariant (B-I3) everywhere ignore is set.
+  - **I (both):** Test 1 OB fixture = **byte-reverse** of OT (intended-5'-first call at the
+    **last BAM index**); Test 3 must **control PE overlap** (non-overlapping ref positions).
+  - **A-I1:** `process_se/pe` need 3 more args (`chr_id`, `chr_table`, `report`).
+  - **A-I4:** Test 4 guards driver **divergence**, not revert — acceptance reconciled.
+  - **Assumption 2 RESOLVED:** `ResolvedConfig` via `Cli::try_parse_from([...]).validate()`
+    (precedent `parallel.rs:1173/1263`); the "construct directly" fallback is dropped.
+  - Adopted: `mbias_only=true` + exact-count + non-CpG-context assertions for Tests 2–3.
+
+## Goal
+Lock the #876 **Bug B** fix (`MethCall.read_pos` rebased at construction) into in-repo
+CI so a future refactor can't silently regress it. The fix is at `call.rs:204`:
+
+```rust
+read_pos: aligned.read_pos_5p.saturating_sub(ignore_5p)   // rebased ("0-based-after-clip")
+// pre-fix was: aligned.read_pos_5p                         // absolute
+```
+
+CI currently exercises only the **OT/`+`-strand** path of `extract_calls` and **none**
+of the 3 `parallel.rs` worker M-bias accumulator sites. Colossal Phase H (SE matrix +
+PE smoke) verifies these on real data, but colossal is the manual release-walk gate, not
+CI. This plan adds 4 tests covering (1) the OB/`-`-strand kernel path and (2) the parallel
+worker M-bias dispatch, each engineered to **fail if the fix is reverted**.
+
+## Context (code under test + existing patterns)
+
+**Fix + its consumers** (all read `MethCall.read_pos`; M-bias uses `pos_1based = read_pos + 1`):
+- Source of the rebase: `call.rs:204` (`extract_calls`).
+- Single-threaded consumer: `route.rs:95`.
+- Parallel worker consumers: `parallel.rs:711` (SE → `mbias[0]`), `:815` (PE R1 → `mbias[0]`),
+  `:838` (PE R2 → `mbias[1]`). All compute `pos_1based = call.read_pos.saturating_add(1)`.
+
+**Drivers / visibility (decides test placement):**
+- `extract_calls(record, ignore_5p, ignore_3p, mbias_only_silence) -> Result<Vec<MethCall>>`
+  — `pub`, `call.rs:152`. Has a `#[cfg(test)] mod tests` (`call.rs:222`) with helper
+  `synth_se_record(xm, n_soft, n_match)` (hardcodes `XR:Z:CT` + **`XG:Z:CT`** = OT) and the
+  OT template test `extract_calls_rebases_read_pos_after_ignore_5p` (`:283`).
+- `process_se` / `process_pe` — **private** (`parallel.rs:659` / `:742`); take
+  `&mut [MbiasTable; 2]`. Reachable only from `parallel.rs`'s own `#[cfg(test)] mod tests`
+  (`:1069`). → Tests 2–3 are **unit tests inside parallel.rs**.
+- `extract_se` / `extract_pe` — `pub`, single-threaded (`pipeline.rs:73` / `:220`).
+- `extract_se_parallel` / `extract_pe_parallel` — `pub` (`parallel.rs:183` / `:192`).
+  → Test 4 is an **integration test** in `tests/parallel_phase_f.rs`.
+
+**M-bias table:** `MbiasTable::accumulate(context, position_1based, methylated)` is **1-based**
+(`mbias.rs:51`; slot 0 unused). Counters at `mbias.cpg[slot]` / `.chg[slot]` / `.chh[slot]`
+(`MbiasPos { meth, unmeth }`). So "first surviving call lands at **slot 1**" ⟺ rebase applied;
+"lands at slot `ignore+1`" ⟺ rebase reverted.
+
+**OB orientation (Test 1's subtlety):** for `-`-strand records (`XR:Z:CT` + `XG:Z:GA`),
+`iter_aligned` walks the read from the **sequenced 5' end**, so `read_pos_5p` is counted in
+sequenced order while `record.xm()` stays BAM-stored (`call.rs:131-134` invariant). Existing
+OB orientation fixtures/tests to mirror: `tests/se_phase_b.rs:107, 299-317`.
+
+**Integration fixtures to reuse** (`tests/parallel_phase_f.rs`): `synth_record(...)` (`:57`),
+`write_se_directional_bam` (`:86`, already mixes OT+OB), `write_pe_directional_bam` (`:156`),
+`resolved_config(args)` (`:244`, parses CLI → `ResolvedConfig`), `assert_dirs_byte_identical`
+(`:290`, compares **all** output files incl. `M-bias.txt`). Template: `legacy_vs_parallel_n4_se_default_byte_identical` (`:392`).
+
+## Behavior — the 4 tests
+
+### Test 1 — OB/`-`-strand rebase (unit, `call.rs` tests mod)
+Parameterize the record builder by XG (or add `synth_se_record_ob`). Build an OB record
+(`XR:Z:CT`, `XG:Z:GA`) whose XM yields known calls; run `extract_calls(rec, ignore_5p=N>0, 0, false)`.
+- **OB byte-reversal — MUST author the fixture correctly (dual-review I, the likeliest
+  silent-error site).** `iter_aligned` walks OB records from the sequenced 5' end:
+  `read_pos_5p = seq_len - 1 - BAM_index` (`bismark-io record.rs:299-307`). XM bytes are
+  authored in **BAM order** but the assertions read **sequenced-5' order** — so the call you
+  intend to be "5'-first" must sit at the **LAST BAM index** of the XM string. Concretely:
+  to make OB assert the *same* `read_pos` sequence as an OT fixture `XM_OT`, the OB fixture's
+  XM must be **`reverse(XM_OT)`**. Mirror the existing pattern at `se_phase_b.rs:315-334`.
+- **Assert:** `read_pos` values are rebased (first surviving 5'-call → `0`), computed in
+  sequenced-5' order.
+- **Parametric OT≡OB:** OT with `XM_OT` and OB with `reverse(XM_OT)` yield **identical
+  `read_pos` sequences** under the same `ignore_5p`. Orientation-invariance guard.
+- **Fixture length > ignore_5p** (see invariant below) so ≥1 call survives.
+- **Regression-guard property:** with the fix reverted, OB `read_pos` becomes absolute
+  (`>= ignore_5p`) → assertion fails. (Bidirectional: also assert the count is correct.)
+
+### Test 2 — `parallel_se_worker_m_bias_rebased` (unit, `parallel.rs` tests mod)
+Construct a synthetic SE `BismarkRecord` with **XM length > 3** (so `--ignore 3` leaves ≥1
+call; e.g. a 6-byte XM placing a CpG **and** a non-CpG call at sequenced positions ≥3), an
+empty `let mut mbias = [MbiasTable::default(), MbiasTable::default()]`, and a `ResolvedConfig`
+built via `Cli::try_parse_from(["…","--ignore","3","--mbias_only", <throwaway.bam>]).validate()`
+(precedent `parallel.rs:1173/1263`; `--mbias_only` isolates accumulation from RoutedCall
+emission). Call `process_se(&record, &config, chr_id=0, &chr_table, /*mbias_only_silence=*/true,
+/*mbias_only=*/true, &mut mbias, &mut report)` (full signature below).
+- **Assert (exact counts):** the surviving call lands at `mbias[0].<ctx>[1]` with the **exact**
+  `{meth|unmeth}` count == 1 (slot **1**, rebased), and `mbias[0].<ctx>[ignore+1=4]` is **zero**.
+  Include a **non-CpG (CHG or CHH)** call so the context routing in `accumulate` is exercised.
+- **Regression-guard:** revert → count moves to slot 4 → assertion fails (bidirectional:
+  slot 1 nonzero AND slot 4 zero).
+
+### Test 3 — `parallel_pe_worker_m_bias_uses_r2_ignore_for_r2` (unit, `parallel.rs` tests mod)
+Synthetic PE pair via the public `BismarkPair::from_mates(r1, r2)` constructor; `ResolvedConfig`
+with `--ignore 3 --ignore_r2 7 --mbias_only` (CLI-parse idiom). Call `process_pe(&pair, &config,
+chr_id=0, &chr_table, true, true, &mut mbias, &mut report)`.
+- **Fixture-length invariant:** R1 XM length **> 3** and R2 XM length **> 7** (e.g. R1 6-byte,
+  R2 ≥9-byte) so each mate leaves ≥1 surviving call after its own ignore.
+- **Control PE overlap (dual-review I):** PE default is `no_overlap=true` → `process_pe`
+  (`parallel.rs:795`) runs `drop_overlap` on R2. Place R1 and R2 at **non-overlapping reference
+  positions** (distinct `alignment_start` + non-overlapping spans) — OR pass `--include_overlap`
+  — so R2's call survives to `mbias[1]`. (Non-overlapping positions preferred: keeps the test
+  about ignore-rebasing, not overlap policy.)
+- **Assert:** R1's surviving call → **`mbias[0]`** slot 1 (rebased by 3); R2's surviving call →
+  **`mbias[1]`** slot 1 (rebased by 7), exact count == 1. Cross-check the wrong table/slot is
+  zero — guards the R2-ignore value (`:838` uses `ignore_r2`) AND the `mbias[1]` index.
+- **Regression-guard:** revert rebase, or apply R1's ignore to R2, or write R2 into `mbias[0]`
+  → assertion fails.
+
+### Test 4 — `se_driver_vs_parallel_driver_m_bias_equality` (integration, `parallel_phase_f.rs`)
+Run `extract_se` (single-threaded, `pipeline.rs`) and `extract_se_parallel` (parallel) on the
+same `write_se_directional_bam` input with `resolved_config([... "--ignore", "2", ...])` into two
+dirs; `assert_dirs_byte_identical` (compares `M-bias.txt` among all outputs).
+- **⚠️ `--ignore` MUST be < read length (dual-review C1 — Critical).** `write_se_directional_bam`
+  emits **5-bp** reads; `--ignore 5` trips the `lo >= hi` early-out (`call.rs:166`) → every
+  record yields 0 calls → empty split files + header-only `M-bias.txt` → `assert_dirs_byte_identical`
+  passes **trivially, even on a full revert** (tests nothing). Use **`--ignore 2`** (lo=2 < hi=5
+  → ~3 surviving positions per record) **AND add a non-emptiness assertion** (≥1 data row in
+  `M-bias.txt`, or a non-header line in a split file) so the cell can never silently degrade to
+  the no-op.
+- **Purpose:** the **dual-driver-trap structural guard** (`[[feedback_dual_driver_back_port]]`)
+  — catches a fix landing in one driver but not the other under a non-zero `--ignore`.
+- **Acceptance nuance (dual-review A-I4):** Test 4 guards **driver divergence**, NOT revert —
+  both drivers share the rebase, so it stays green on a revert. The issue's "each test fails on
+  revert" applies to **Tests 1–3**; Test 4 is the divergence guard (Tests 2–3 cover absolute
+  correctness of the parallel path). State this in the test doc-comment.
+- **Distinct from existing `legacy_vs_parallel_*` tests:** those run default (`--ignore 0`),
+  which doesn't exercise the rebase. This adds the non-zero-`--ignore` cell.
+
+## Implementation outline
+1. **call.rs (Test 1):** generalize `synth_se_record` to take an `xg: &[u8]` arg (or add
+   `synth_se_record_ob`); add `extract_calls_ob_strand_rebases_read_pos` + the parametric
+   OT≡OB assertion. Reason the OB XM in sequenced-5' order per `call.rs:131-134` /
+   `se_phase_b.rs:304-317`.
+2. **parallel.rs tests mod (`:1069`) (Tests 2–3):** add the two unit tests calling `process_se` /
+   `process_pe` and asserting `mbias[idx].<ctx>[slot]`.
+   - **Full signatures (dual-review A-I1 — confirm at impl):**
+     `process_se(record: &BismarkRecord, config: &ResolvedConfig, chr_id: u32,
+     chr_table: &Arc<[String]>, mbias_only_silence: bool, mbias_only: bool,
+     mbias: &mut [MbiasTable; 2], report: &mut SplittingReport) -> …`; `process_pe` takes a
+     `&BismarkPair` instead of `&BismarkRecord`. Construct: `report = SplittingReport::default()`,
+     `chr_table: Arc<[String]> = Arc::from(vec!["chr1".to_string()])`, `chr_id = 0`.
+   - **Config:** `Cli::try_parse_from(["bin","--ignore","3", …, <throwaway.bam path>])
+     .unwrap().validate().unwrap()` — the idiom already used at `parallel.rs:1173/1263`
+     (needs a throwaway `.bam` path arg to satisfy the parser; a `tempfile` path is fine since
+     `process_*` never reads the file, only `config`).
+   - **PE pair:** `BismarkPair::from_mates(r1, r2)` (public constructor).
+3. **tests/parallel_phase_f.rs (Test 4):** add `se_driver_vs_parallel_driver_m_bias_equality`
+   mirroring `legacy_vs_parallel_n4_se_default_byte_identical` (`:392`) but with `--ignore 5`.
+4. **Docs:** mark `BUG_876_FIXES_PLAN.md` §6 deferrals (#8/#9/#10) as landed; close #878's
+   acceptance checklist.
+
+## Assumptions
+- **[CONFIRMED by dual review]** `process_se` / `process_pe` are callable from `parallel.rs`'s
+  `#[cfg(test)] mod tests` via `super::*`; full signatures captured in Implementation outline §2.
+- **[CONFIRMED by dual review — Assumption 2 resolved]** `ResolvedConfig` is constructible with
+  `--ignore` / `--ignore_r2` via `Cli::try_parse_from([...]).validate()` (precedent
+  `parallel.rs:1173/1263`); all `ResolvedConfig` fields are `pub` if direct construction is ever
+  preferred. The earlier "construct directly as fallback" hedge is dropped — the CLI-parse idiom
+  is the path. (Only caveat: the parser needs a throwaway `.bam` path arg.)
+- **Fixture-length > ignore invariant [dual-review C1/I3]:** every test's fixture read length
+  MUST exceed its `--ignore` (and R2 length > `--ignore_r2`), else `extract_calls` early-returns
+  empty at `call.rs:166` (`lo >= hi`) and the test silently asserts over nothing.
+- XM byte→context mapping: `Z/z`=CpG, `X/x`=CHG, `H/h`=CHH (upper=meth). Pick fixture XM so
+  the surviving call's context is unambiguous for the slot assertion.
+- **OB `iter_aligned` reversal [CONFIRMED]:** `read_pos_5p = seq_len-1-BAM_index`
+  (`bismark-io record.rs:299-307`); OB fixture XM = byte-reverse of the OT fixture (Test 1).
+
+## Validation (acceptance = Tests 1–3 fail when the fix is reverted; Test 4 = divergence guard)
+1. **Green run:** `cargo test -p bismark-extractor` — all 4 new tests pass (+ existing 102+).
+2. **Revert-smoke (the key acceptance gate, #878):** temporarily change `call.rs:204` to
+   `read_pos: aligned.read_pos_5p,` → `cargo test` → confirm **Tests 1, 2, 3 FAIL** (slots
+   shift to absolute). **Test 4 stays green by design** (both drivers share the rebase — it
+   guards divergence, not revert; this is why Tests 2–3 assert *absolute* slots). Restore.
+3. **Non-emptiness self-check (guards the C1 no-op class):** confirm Test 4's `M-bias.txt`
+   actually has ≥1 data row (the test asserts this); a green Test 4 over empty output is the
+   failure mode the dual review caught. Equivalently: each test's fixture length > its ignore.
+4. **R2-ignore mis-wire smoke:** temporarily swap `mbias[1]`→`mbias[0]` or `ignore_r2`→`ignore`
+   at `parallel.rs:838` → confirm **Test 3 FAILS**. Restore.
+5. `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check` clean.
+
+## Questions or ambiguities
+- **(Open, non-critical)** Tests 2–3 placement: unit-in-`parallel.rs` (recommended — asserts
+  in-memory slots directly via the private fns) vs integration via `extract_*_parallel` + parse
+  `M-bias.txt`. Recommend unit; fall back to integration only if `ResolvedConfig`/`process_*`
+  proves unergonomic from the test module.
+- **(Open)** Whether to extend `synth_se_record` in place vs add an OB variant — cosmetic.
+- No **Critical** ambiguities: the issue specifies test names, inputs, and acceptance.
+
+## Self-Review
+- **Logic:** the `pos_1based = read_pos+1` mapping makes "slot 1 vs slot ignore+1" the precise
+  discriminator; each test names the absolute (reverted) slot it checks is zero, so the guard is
+  bidirectional. ✓
+- **Edge cases:** Test 1 covers OB orientation (the gap Reviewer B flagged); Test 3 covers the
+  R1≠R2 ignore + `mbias[0]`≠`mbias[1]` index (two independent failure modes); Test 4 covers
+  cross-driver divergence. CHG/CHH (not just CpG) should appear in ≥1 fixture so the context
+  routing in `accumulate` is exercised, not only CpG. ✓ (added to outline step 1/2)
+- **Integration:** no source changes → zero risk to byte-identity; tests reuse established
+  fixtures/assert helpers. ✓
+- **Remaining risk:** `ResolvedConfig` construction ergonomics in `parallel.rs` unit tests
+  (Assumption 2) — the only thing that could push Tests 2–3 to the integration-style fallback.
+  Flagged, non-blocking.
+
+---
+
+## Implementation notes (2026-05-29 — DONE, all 4 tests landed)
+
+**What was built (tests only, zero source `*.rs` logic changes):**
+- **Test 1** (`call.rs` tests): refactored `synth_se_record` → `synth_se_record_strand(xm,
+  n_soft, n_match, xg)` (non-breaking; `synth_se_record` is now a `b"CT"` wrapper) + added
+  `extract_calls_ob_strand_rebases_read_pos_after_ignore_5p`. OT `"..Zxh."` vs OB
+  `".hxZ.."` (= `reverse`), `ignore_5p=2`, both assert rebased `read_pos [0,1,2]` + OT≡OB.
+- **Tests 2–3** (`parallel.rs` tests mod): added `synth_rec`, `config_with`, `mbias_total`
+  helpers + `parallel_se_worker_m_bias_rebased` (`--ignore 3`, SE → `mbias[0]` slot 1) and
+  `parallel_pe_worker_m_bias_uses_r2_ignore_for_r2` (`--ignore 3 --ignore_r2 7`, R1→`mbias[0]`
+  slot 1, R2→`mbias[1]` slot 1). Called the private `process_se`/`process_pe` via `super::*`.
+- **Test 4** (`tests/parallel_phase_f.rs`): `se_driver_vs_parallel_driver_m_bias_equality`
+  (`--ignore 2`, `extract_se` vs `extract_se_parallel`, non-emptiness guard + `assert_dirs`).
+
+**Deviations from the plan (documented per code-impl skill):**
+1. **`process_se`/`process_pe` arg order** is `(record/pair, chr_id, chr_table, config,
+   mbias_only_silence, mbias_only, mbias, report)` — `chr_id`/`chr_table` come *before*
+   `config`, not after as the rev-1 outline sketched. Corrected in the tests.
+2. **R2 of an OT pair is CTOT (`-`-strand, reversed)** — confirmed empirically. R2 fixture
+   places its `Z` at BAM index `seq_len-1-ignore_r2` (9-1-7=1) so `read_pos_5p=7` rebases to 0.
+   The rev-1 plan flagged "control R2 orientation"; this pins the exact placement.
+3. Used `--mbias_only` for Tests 2–3 to isolate accumulation (adopted optional).
+
+**Iteration log:** Test 1 — passed first run (OB byte-reversal correct). Tests 2–3 — passed
+first run (PE R2-reversed placement correct). Test 4 — passed first run; `--ignore 2` yields 5
+surviving calls across the 5-bp fixtures (r_OT_1 `"Zz..."` drops, the other 4 contribute),
+non-empty. One `cargo fmt` pass reflowed dense `assert_eq!`/builder lines (no logic change).
+
+**Verification (all PASS):**
+- Full suite: lib **105** (+3), `parallel_phase_f` **18** (+1); all other suites green.
+- **Revert-smoke** (temporarily set `call.rs:204` → `aligned.read_pos_5p`): Tests 1, 2, 3
+  FAIL (+ existing #876 OT guards); **Test 4 stays GREEN** (divergence guard, not revert —
+  confirms A-I4). Fix restored; re-verified green.
+- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
+
+**Acceptance (#878):** ✅ 4 tests added + passing; ✅ each of Tests 1–3 fails on revert;
+✅ no source `*.rs` logic changes (only the non-breaking `synth_se_record` test-helper
+refactor). Remaining: update `BUG_876_FIXES_PLAN.md §6` (#8/#9/#10 → landed) at PR time.

--- a/plans/05262026_bismark-extractor/TESTS_878_PLAN_REVIEW_reviewer-A.md
+++ b/plans/05262026_bismark-extractor/TESTS_878_PLAN_REVIEW_reviewer-A.md
@@ -1,0 +1,128 @@
+# Plan Review — TESTS_878_PLAN.md (Reviewer A)
+
+**Plan:** `/Users/fkrueger/Github/Bismark/plans/05262026_bismark-extractor/TESTS_878_PLAN.md`
+**Issue:** #878 — add 4 regression-guard tests (no source changes) locking the #876 Bug B `MethCall.read_pos` rebase into CI.
+**Code reviewed at:** worktree `/Users/fkrueger/Github/Bismark-extractor`, HEAD `2bfe722` (newer than the plan's drafting tip — line refs still hold, see below).
+**Verdict:** **APPROVE WITH CHANGES.** The plan is well-grounded and feasible; all line refs and the central design (slot-1 vs slot-`ignore+1` discriminator) are confirmed against real code. **One Critical defect**: Test 4's `--ignore 5` produces *zero* surviving calls on the existing 5-base fixture, so it exercises nothing and is vacuously byte-identical. Two Important clarifications. Otherwise sound.
+
+---
+
+## 1. Logic review
+
+### Line-ref verification (all confirmed against `2bfe722`)
+| Plan claim | Actual | Status |
+|---|---|---|
+| rebase at `call.rs:204` | `call.rs:204` `read_pos: aligned.read_pos_5p.saturating_sub(ignore_5p)` | ✅ |
+| `extract_calls` at `:152` | `:152` | ✅ |
+| call.rs test mod `:222`, helper `synth_se_record`, OT test `:283` | `:222`, `:243`, `:283` | ✅ |
+| OB invariant doc `:131-134` | `:131-134` | ✅ |
+| `process_se` `:659` / `process_pe` `:742` (private) | `:659` / `:742`, both `fn` (no `pub`) | ✅ |
+| M-bias sites `:711` SE / `:815` PE-R1 / `:838` PE-R2 | exact | ✅ |
+| `mbias.rs:51` 1-based `accumulate`, slot 0 unused | `:51`, `debug_assert!(>=1)`, `pub cpg/chg/chh: Vec<MbiasPos>`, `pub meth/unmeth` | ✅ |
+| single-threaded consumer `route.rs:95` | `:95` `pos_1based = call.read_pos.saturating_add(1)` | ✅ |
+| `parallel.rs` test mod `:1069` | `:1069` | ✅ |
+| `tests/parallel_phase_f.rs` helpers `synth_record:57`, `write_se_directional_bam:86`, `write_pe_directional_bam:156`, `resolved_config:244`, `assert_dirs_byte_identical:290`, template `legacy_vs_parallel_n4_se_default_byte_identical:392` | all exact | ✅ |
+| `se_phase_b.rs` OB fixtures `:107`, OB tests `:299-317` | `ob_record` `:108`, `extract_calls_minus_strand_orients_*` `:297-334` | ✅ (plan says `:107`; actual `:108`, off-by-one, cosmetic) |
+
+The consumer comment inside `call.rs:193-194` references the **old** parallel.rs lines `625/729/752`; the plan correctly uses the **current** `711/815/838`. No action — that stale in-source comment is out of scope for a tests-only PR.
+
+### The core discriminator is correct
+`accumulate` is strictly 1-based (`mbias.rs:51-71`); workers compute `pos_1based = call.read_pos + 1` (`parallel.rs:710/814/837`). With the fix, the first surviving call has `read_pos == 0` → slot **1**; reverted, `read_pos == ignore_5p` → slot **`ignore+1`**. The plan's "slot 1 vs slot ignore+1, assert both" design is the right bidirectional guard and matches BUG_876 §6 decision T1. ✅
+
+### Test 1 (OB orientation) — verified correct, this was the flagged risk
+I independently grounded the OB reasoning against `bismark-io/src/record.rs:263-311` (`iter_aligned`):
+- Forward (OT/CTOB): `read_pos_5p == BAM read_pos`.
+- `-`-strand (OB/CTOT): `read_pos_5p = seq_len - 1 - BAM_read_pos`, then the `Vec` is **reversed** (`:299-307`), so the first emitted item is `read_pos_5p == 0` at the sequenced 5' end.
+- `seq_len = xm.len()` includes soft-clip; soft-clip read positions are counted (only `ref_offset?` filters them from emission), so the OB formula uses the full length.
+
+Cross-checked against the existing fixture `extract_calls_minus_strand_orients_both_calls` (`se_phase_b.rs:315-334`): `ob_record(b"Zh...", ...)`, 5M, seq_len 5 → BAM pos 0 (`Z`) emits last at `read_pos_5p = 4`; BAM pos 1 (`h`) emits at `read_pos_5p = 3`. The test asserts exactly that. The plan's instruction to "reason in sequenced-5' order, mirror se_phase_b.rs:304-317" is therefore **correct**, and the OT≡OB invariance claim holds: a fixture whose XM, *written in sequenced-5' order*, is identical on both strands will produce identical `read_pos` sequences. **No correctness problem in Test 1's design** — but see Important I-2 (the fixture must be authored in BAM-stored order, which is reversed from the order the assertions read).
+
+### Tests 2–3 (parallel worker) — feasible, but the plan's signature sketch is incomplete
+The plan sketches `process_se(&record, &config, …, false, false, &mut mbias, …)`. The **real** signature (`parallel.rs:659-668`) is:
+```
+fn process_se(record: &BismarkRecord, chr_id: u32, chr_table: &Arc<[String]>,
+              config: &ResolvedConfig, mbias_only_silence: bool, mbias_only: bool,
+              mbias: &mut [MbiasTable; 2], report: &mut SplittingReport) -> Result<Vec<RoutedCall>, _>
+```
+`process_pe` (`:742`) is the same shape with `pair: &BismarkPair` instead of `record`. The plan's "…" hides three **required** args: `chr_id: u32`, `chr_table: &Arc<[String]>`, `report: &mut SplittingReport`. All are trivially constructible in a unit test:
+- `chr_id = 0`, `chr_table = Arc::from(vec!["chr1".to_string()].into_boxed_slice())` (already done at `parallel.rs:1177`).
+- `report = SplittingReport::default()` (`state.rs` uses `SplittingReport::default()`; confirmed it derives Default).
+
+This is **non-blocking** — the plan's Assumption 1 already says "if their signatures need other args … construct minimal ones." Recommend the plan name `chr_id`/`chr_table`/`report` explicitly so the implementer doesn't have to rediscover them (Important I-1).
+
+### Test 3 — wrong-table/wrong-slot cross-checks are sound
+R1 → `mbias[0]` (`:815`), R2 → `mbias[1]` (`:838`), with `config.ignore_5p_r2` driving R2's `extract_calls` (`:791`). Asserting "R2 lands in `mbias[1]` slot 1, and `mbias[0]` is unchanged by R2; rebased by 7 not 3" guards all three failure modes (rebase revert, R1-ignore-applied-to-R2, wrong-table-index). ✅ One caveat: PE default has `no_overlap = true` (`cli.rs:484`), so `drop_overlap` runs on R2 calls (`parallel.rs:795-799`). The fixture must place R1 and R2 calls at **non-overlapping ref positions** or pass `--include_overlap`, else R2 calls may be silently dropped and the R2 assertion sees nothing. Flag this (Important I-3).
+
+---
+
+## 2. Assumptions audit
+
+| Plan assumption | Verdict |
+|---|---|
+| A1: `process_se`/`process_pe` callable from `parallel.rs` test mod via `super::*` | ✅ Confirmed — they are module-private `fn`s; the test mod is `mod tests { use super::*; }` (`:1071`). Existing tests already call module-private items (`worker_loop`, `update_best_err`). |
+| A2 (flagged main risk): `ResolvedConfig` with `--ignore`/`--ignore_r2` constructible in unit test | ✅ **Strongly confirmed** — the parallel.rs test mod *already* builds configs via `Cli::try_parse_from([...]).validate()` (`:1173-1174`, `:1263-1273`). All `ResolvedConfig` fields are `pub` (`cli.rs:271-300`: `ignore_5p_r1:279`, `ignore_5p_r2:283`, `mbias_off:300`). The plan's "fallback to direct construction" is **unnecessary** — the CLI-parse path is the established idiom. Remove the fallback hedge or downgrade it to a footnote. |
+| CLI flag mapping `--ignore→ignore_5p_r1`, `--ignore_r2→ignore_5p_r2` | ✅ `cli.rs:498-501`; flags are `--ignore`/`--ignore_r2`/`--ignore_3prime`/`--ignore_3prime_r2` (`:56-69`). |
+| XM byte→context mapping `Z/z`=CpG, `X/x`=CHG, `H/h`=CHH | ✅ `call.rs:94-99`. |
+| OB `iter_aligned` reverses | ✅ `record.rs:299-307`. |
+| dev-deps (`noodles-sam`, `noodles-core`, `bstr`) available for synthetic records in tests | ✅ `Cargo.toml [dev-dependencies]`. |
+
+**Unstated assumption the plan should make explicit:** Tests 2–3 with `mbias_only=false` will execute the `RoutedCall` emission path, which calls `compute_yacht_columns` (`route.rs:38`). That's safe only because default `output_mode != Yacht` returns `(0,0)` early (`route.rs:43-45`). If the implementer ever passes `--yacht` it would need `alignment_start` set. Cleaner: pass `mbias_only=true` so the worker skips `RoutedCall` emission entirely (`parallel.rs:715-718/819-821`) and the test isolates M-bias accumulation. Recommend the plan say `mbias_only=true` for Tests 2–3 (Optional O-1).
+
+---
+
+## 3. Efficiency
+
+- 4 tests, no source changes, reuse of established fixtures/helpers — appropriately minimal. ✅
+- Tests 2–3 as in-memory unit tests (no fixture file, no reader/collector spin-up) are the fastest option and assert the slot directly. Good call vs the integration fallback.
+- Test 4 reuses `write_se_directional_bam` + `assert_dirs_byte_identical` — cheap.
+
+No efficiency concerns.
+
+---
+
+## 4. Validation sufficiency
+
+**Confirmed strong:**
+- `assert_dirs_byte_identical` (`parallel_phase_f.rs:290-324`) compares **all** files including `M-bias.txt` strictly (only `*_splitting_report.txt` is path-normalized). ✅ Plan's claim holds.
+- No existing `legacy_vs_parallel_*` test uses nonzero `--ignore` (grep confirmed; the only test `--ignore` use is `sanity.rs:50`, unrelated). So **Test 4 is not redundant** — it is the sole nonzero-ignore cross-driver cell. ✅
+- Revert-smoke gate (Validation §2) correctly predicts Tests 1–3 FAIL and Test 4 MAY pass on revert (both drivers share the bug). The plan is honest that Test 4 is a *structural cross-driver* guard, not a revert-fail guard. ✅
+- CHG/CHH coverage called out in Self-Review (not just CpG) — good; `MbiasTable` has separate `cpg/chg/chh` vecs so context routing must be exercised.
+
+**Gaps:**
+- **Critical C-1 (below)** breaks Test 4's validation entirely under `--ignore 5`.
+- The issue/BUG_876 acceptance says "each test fails on revert." Test 4 *by design* does not fail on revert. This is defensible (it's a different guard class) but the plan should state this divergence from the literal acceptance text explicitly so the verifier doesn't flag Test 4 as failing acceptance. (Important I-4.)
+- Not covered, and arguably should be acknowledged as out-of-scope: `--mbias_off` (skips accumulation — `parallel.rs:709/813/836`), `ignore_3prime` interaction with the rebase (3' trim does not change `read_pos`, only the `hi` bound — so no rebase interaction, safe to omit but worth a one-line note), soft-clip + OB combined (existing `extract_calls_rebase_combined_with_soft_clip` covers OT+softclip; an OB+softclip case is the only genuinely untested rebase permutation, but it lives in bismark-io's `iter_aligned` cigar tests, not here). I'd accept omitting these for a 4-test guard, but the plan should say so.
+
+---
+
+## 5. Critical / Important / Optional findings
+
+### Critical
+- **C-1 — Test 4's `--ignore 5` exercises nothing on the 5-base fixture; it is vacuously byte-identical and guards nothing.**
+  `write_se_directional_bam` (and `write_pe_directional_bam`) emit **only 5-base reads** (`b"ACGTC"`, XM length 5, all `5M`). In `extract_calls` (`call.rs:161-168`): `lo = ignore_5p = 5`, `hi = xm_len - ignore_3p = 5`, so `lo >= hi` → **early return `Ok(Vec::new())`** for *every* record. M-bias.txt has zero data rows in both runs → byte-identical with OR without the fix → the rebase path is never touched.
+  I enumerated surviving calls per ignore value across all 5 SE records: `--ignore 5` → **0 surviving calls** for every record (and `--ignore 4` → only `r_OT_2`/`r_OB_1` survive at one position each).
+  **Fix:** use `--ignore 1` (max surviving calls: r_OT_1→slot1, r_OT_2→slots2,4, r_OT_3→slot2, r_OB_1→slot4, r_OB_2→slot2) or `--ignore 2` (r_OT_2→slots1,3, r_OT_3→slot1, r_OB_1→slot3, r_OB_2→slot1 — note r_OT_1's two calls at pos 0,1 are *both* trimmed). `--ignore 1` keeps the most non-trivial data and the widest slot spread; recommend `--ignore 1` (or `2`). **Do not use `--ignore 5`.**
+  *Root cause note:* the `--ignore 5` value was inherited verbatim from BUG_876_FIXES_PLAN §6 test #10, which itself never reconciled the value against the fixture length — a latent error now propagated. Worth a line in the plan's deviation log.
+
+### Important
+- **I-1 — Name the three hidden `process_se`/`process_pe` params.** The plan's signature sketch omits `chr_id: u32`, `chr_table: &Arc<[String]>`, `report: &mut SplittingReport` (all required; see §1). Add: `chr_id=0`, `chr_table = Arc::from(vec!["chr1".to_string()].into_boxed_slice())`, `report = SplittingReport::default()`. (`parallel.rs:659-668/742-751`, `state.rs`.)
+- **I-2 — Test 1 fixture must be authored in BAM-stored order, asserted in 5'-order.** The OB `read_pos` the assertions read is `seq_len-1-BAM_pos` after reversal. The plan says "reason in sequenced-5' order" (correct for assertions) but the implementer writes the XM bytes in **BAM order**. Spell out: "place the intended-5'-first call at the *last* BAM XM index." Mirror `se_phase_b.rs:315-334` exactly. A plausible-but-wrong fixture here is the single most likely silent error.
+- **I-3 — Test 3 PE fixture must avoid the overlap drop.** PE default `no_overlap=true` (`cli.rs:484`) runs `drop_overlap` on R2 (`parallel.rs:795-799`). Place R1 and R2 at non-overlapping reference positions (as `write_pe_directional_bam` does — R1@100, R2@110 etc.) or pass `--include_overlap`, else the R2 `mbias[1]` assertion may see zero calls for the wrong reason.
+- **I-4 — State Test 4's divergence from literal acceptance.** Issue acceptance is "each test fails on revert"; Test 4 does not (by design, both drivers share the bug). The plan acknowledges this in Validation §2 but should also note it where the verifier checks acceptance, so Test 4 isn't logged as failing the acceptance criterion.
+
+### Optional
+- **O-1 — Pass `mbias_only=true` for Tests 2–3** to skip `RoutedCall`/`compute_yacht_columns` emission and isolate M-bias accumulation (counters still increment under `mbias_only`; `parallel.rs:707-712` runs before the `mbias_only` `continue`). Simpler, no need to set `alignment_start` for yacht.
+- **O-2 — Drop the "construct `ResolvedConfig` directly" fallback** in Assumption 2. The CLI-parse path is already the established idiom in the same test module (`:1173`, `:1263`); the fallback is dead weight.
+- **O-3 — Add one sentence** noting `ignore_3prime`/`--mbias_off`/OB+soft-clip are deliberately out of scope (3' trim doesn't touch `read_pos`; `mbias_off` short-circuits accumulation; OB+soft-clip is covered by bismark-io cigar tests), so the verifier doesn't flag them as gaps.
+- **O-4 — Fix the cosmetic `:107`→`:108` ref** for `ob_record` (minor).
+
+---
+
+## 6. Alternatives considered
+- **Test 4 as a unit-level `process_se` vs `extract_se`-state equality test** (as BUG_876 §6 test #10 originally envisioned with custom synthetic records) would let the implementer pick a read length and ignore value that *guarantees* surviving calls, sidestepping C-1's fixture-length trap. But the plan's integration form is fine once the ignore value is fixed; no need to change the form.
+- The plan could fold Test 4 into a parameterized variant of `legacy_vs_parallel_n4_se_default_byte_identical` (same body, `--ignore 1`), reducing duplication. Cosmetic.
+
+---
+
+## 7. Bottom line
+Design is correct and feasible; every load-bearing line ref and the slot-discriminator mechanism check out against real code, and Assumption 2 (the flagged risk) is solidly satisfied by an existing idiom. **Must-fix before implementation: C-1 (change Test 4 `--ignore 5` → `1` or `2`).** Address I-1..I-4 to de-risk implementation. Then this is a clean, low-risk tests-only PR.

--- a/plans/05262026_bismark-extractor/TESTS_878_PLAN_REVIEW_reviewer-B.md
+++ b/plans/05262026_bismark-extractor/TESTS_878_PLAN_REVIEW_reviewer-B.md
@@ -1,0 +1,101 @@
+# Plan Review — TESTS_878_PLAN.md (Reviewer B)
+
+**Plan:** `plans/05262026_bismark-extractor/TESTS_878_PLAN.md`
+**Scope:** 4 regression-guard tests, no source `*.rs` changes, locking #876 Bug B (`call.rs:204` `read_pos` rebase) into CI.
+**Verdict:** **APPROVE WITH CHANGES.** The overall strategy is sound and the placement decisions (unit-in-`call.rs`, unit-in-`parallel.rs`, integration) are all viable against the real code. But **Test 4 as written is a silent-pass no-op** (Critical), and **Test 1's OT≡OB equivalence omits the load-bearing byte-reversal detail** that is exactly where a plausible-but-wrong test would slip through (Important). All claims about callability/constructibility check out.
+
+All line refs below verified against the worktree `/Users/fkrueger/Github/Bismark-extractor`.
+
+---
+
+## 1. Logic review
+
+### Test 1 — OB/`-`-strand rebase (unit, `call.rs`)
+The orientation model is confirmed real, not an artifact. `bismark-io/src/record.rs:299-307`: for `-`-strand (OB/CTOT) records, `iter_aligned` remaps `read_pos_5p = seq_len - 1 - BAM_read_pos` **and** reverses the call vector, so the first emitted item sits at `read_pos_5p == 0` and corresponds to the **last** BAM byte. The ignore filter at `call.rs:179` operates on this already-5'-oriented `read_pos_5p`, so with `ignore_5p=N` the first surviving OB call has `read_pos_5p == N`, rebased by `:204` to `0`. On revert it becomes `N` (absolute) → assertion fails. **The OB guard is genuinely bidirectional and works identically to OT.** ✓
+
+The existing OB tests `extract_calls_minus_strand_orients_5prime` (`se_phase_b.rs:297-313`) and `extract_calls_minus_strand_orients_both_calls` (`:315-334`) already prove orientation at `--ignore 0`, but **neither stacks a non-zero `--ignore` onto OB** — so the rebase-on-OB cell is a genuine gap. Test 1 is not redundant. ✓
+
+**However — the OT≡OB equivalence claim is under-specified and is the trap the brief warned about.** "the same logical XM (oriented identically in sequenced order) yields identical `read_pos` sequences on OT and OB" is *true*, but to realize it the OB record's **BAM-stored XM must be the byte-reverse of the OT record's BAM-stored XM** (because `iter_aligned` reverses OB back to sequenced order). The plan never states this. Concretely: OT BAM XM `zXhZxH` ⟺ OB BAM XM `HxZhXz`. An implementer who naively passes the *same* BAM XM string to both an OT and OB builder will get **reversed `read_pos` sequences**, and either (a) the assertion fails for the wrong reason, or (b) — worse — if they pick a palindromic/symmetric fixture, the test passes while asserting nonsense. This must be spelled out in the plan, not deferred to "reason it at impl time."
+
+### Test 2 — `parallel_se_worker_m_bias_rebased` (unit, `parallel.rs`)
+`process_se` (`parallel.rs:659`) signature is `(record, chr_id, chr_table, config, mbias_only_silence, mbias_only, mbias, report)`. All args constructible in-module (see §2). The slot logic is correct: `process_se:710` computes `pos_1based = call.read_pos.saturating_add(1)`, and with the rebase a call surviving `--ignore 3` lands at `read_pos==0` → slot 1; on revert it lands at `read_pos==3` → slot 4. Asserting `mbias[0].<ctx>[1]` nonzero **and** `mbias[0].<ctx>[4]` zero is a bidirectional guard. ✓ One caveat: the fixture must have a read **longer than the ignore region** so the early-out at `call.rs:166` (`lo >= hi`) does not fire and zero the whole record — see Critical C1 for why this matters most acutely in Test 4.
+
+### Test 3 — `parallel_pe_worker_m_bias_uses_r2_ignore_for_r2` (unit, `parallel.rs`)
+`process_pe` (`parallel.rs:742`) is reachable; `BismarkPair::from_mates(r1, r2)` (`bismark-io/src/pair.rs`) is the public pair constructor, usable in-module. The two failure modes are independent and both guarded: (1) R2-ignore value — `process_pe:789-794` calls `extract_calls(pair.r2(), config.ignore_5p_r2, …)`; (2) table index — `:838` writes `mbias[1]`. Asserting R1→`mbias[0]`[slot rebased-by-3] and R2→`mbias[1]`[slot rebased-by-7], with the cross cells zero, catches all of: rebase revert, R1-ignore-applied-to-R2, and `mbias[0]`-instead-of-`mbias[1]`. ✓
+
+**Not redundant** with existing coverage: `route_call_r2_goes_to_mbias_index_1` (`se_phase_b.rs:901-930`) only exercises the **single-threaded** `route.rs` path with a hand-built `MethCall{read_pos:5}` (no ignore rebase). `extract_pe_per_mate_ignore_r2_only_skips_r2_positions` (`pe_phase_c.rs:1142`) verifies the R2-ignore *filter* via split-file output, not the M-bias *slot*. Test 3 is the **only** test touching parallel `process_pe`'s M-bias accumulation with distinct R1/R2 ignore — keep it. ✓
+
+**Subtlety to flag for the implementer:** for a PE pair, R1 must be `+`-strand and R2 `-`-strand (or vice versa) for both to yield non-empty calls; the rebase for R2 happens in `read_pos_5p` (already 5'-oriented). Pick the fixture so R2's *surviving* call after `--ignore_r2 7` is unambiguous, and ensure R2 reads are >7 bp. Also: with `--no_overlap` default ON, `process_pe:795` calls `drop_overlap` — the plan's `process_pe(…)` call must use a config where R1/R2 don't overlap (distinct ref positions), or pass `--include_overlap`, else R2 calls may be silently dropped and the test asserts on an empty table. The plan does not mention this.
+
+### Test 4 — `se_driver_vs_parallel_driver_m_bias_equality` (integration) — **BROKEN AS SPECIFIED**
+The plan says: run `extract_se` vs `extract_se_parallel` on `write_se_directional_bam` with `--ignore 5`. **This is a silent-pass no-op.** `write_se_directional_bam` (`parallel_phase_f.rs:86-117`) writes **5-base reads** (`b"Zz..."`, `b"..X.x"`, `b"H.h.."`, `b"Z...."`, `b"..h.."`). In `extract_calls` (`call.rs:161-168`): with `ignore_5p=5`, `xm_len=5`, `ignore_3p=0` → `lo=5`, `hi=5`, `lo >= hi` → **returns empty `Vec` for every record**. Result: empty split files + header-only `M-bias.txt` (`max_position()==0`, `mbias.rs:114`) in BOTH dirs → `assert_dirs_byte_identical` trivially passes while exercising **zero** rebase logic. It would also pass with the fix fully reverted. The plan's own §Validation point 2 even concedes "Test 4 may still pass" on revert — but the real problem is it passes on revert **because it tests nothing**, not because "both drivers share the bug."
+
+Fix: either (a) use `--ignore 2` (well under 5 bp, leaves surviving calls), or (b) introduce a longer fixture (≥8 bp reads) and use `--ignore 5`. Given the goal is "exercise the rebase under non-zero ignore," `--ignore 2` on the existing fixture is the minimal correct change. After fixing, also confirm the M-bias.txt actually contains non-zero data rows (otherwise it still proves nothing) — consider asserting `M-bias.txt` is non-trivial, or better, that the two dirs match **and** at least one split file is non-empty.
+
+---
+
+## 2. Assumptions
+
+- **Assumption 1 (process_se/process_pe callable via `super::*`): VALID.** Both are private fns in `parallel.rs`; the existing `#[cfg(test)] mod tests` (`:1069`) already imports `super::*` and calls `worker_loop`, `update_best_err`, builds `InputBatch`/`WorkerInputItem`. `BismarkRecord`, `BismarkPair`, `MbiasTable`, `extract_calls`, `CytosineContext`, `SplittingReport` are all in module scope via the top-of-file `use` (`:73-82`). The test mod will need to add noodles imports for record-building (not currently present in the mod) — trivial, mirror `call.rs:233-238`.
+
+- **Assumption 2 (ResolvedConfig constructible with `--ignore`/`--ignore_r2`): VALID — stronger than the plan claims.** The existing parallel.rs tests (`:1156`, `:1255`) already build a `ResolvedConfig` via `Cli::try_parse_from(args).unwrap().validate().unwrap()`, and `cli.rs:498-500` maps `--ignore`→`ignore_5p_r1`, `--ignore_r2`→`ignore_5p_r2`, `--ignore_3prime`→`ignore_3p_r1`. So the recommended unit placement is **definitely viable** — the plan's "main remaining risk" is over-stated; this should be downgraded from a flagged risk to "confirmed." One gotcha the plan omits: `Cli::validate()` checks input-file existence (`validate_rejects_input_file_not_found`), so the test must write a throwaway `.bam` tmpfile first — exactly as `:1164` and `:1260` already do.
+
+- **Assumption (XM byte→context): VALID** per `classify_xm_byte` (`call.rs:88-109`).
+
+- **Unstated assumption — fixture read length vs ignore:** The plan never states that fixtures must be longer than the ignore value. This omission is what makes Test 4 a no-op and is a latent trap for Tests 2/3 too.
+
+- **Unstated assumption — PE overlap (`--no_overlap` default):** see Test 3 note above. `process_pe:795` applies `drop_overlap` unless `--include_overlap`.
+
+---
+
+## 3. Efficiency
+
+No concerns. Four small tests, no source changes, reuse established fixtures/helpers. Test 4 is an extra full driver round-trip on a 5-record BAM — negligible. The unit tests (2/3) avoid disk I/O for the hot path (only the throwaway tmpfile for `validate()`), which is the right call over an integration variant.
+
+---
+
+## 4. Validation sufficiency
+
+- **"Revert `call.rs:204` → tests fail" gate:** Sufficient for Tests 1/2/3 (all assert the absolute slot is zero, not just driver-equality). **Insufficient for Test 4** as written (it tests nothing). The plan's §Validation step 2 correctly predicts Tests 1-3 fail and Test 4 may pass, but mis-attributes Test 4's pass to "shared bug" rather than "empty fixture."
+- **R2-specific mis-wire smoke (§Validation step 3):** Good — temporarily swapping `mbias[1]`→`mbias[0]` or R2-ignore→R1-ignore at `:838` and confirming Test 3 fails is the right adversarial check. Keep it.
+- **Silent-pass risks identified:**
+  1. Test 4 empty fixture (Critical C1).
+  2. Test 1 reversed/palindromic OB fixture asserting nonsense (Important I1).
+  3. Tests 2/3 where the surviving call's slot coincides between rebased and absolute — avoided as long as `ignore >= 1` and the asserted "absolute" slot (`ignore+1`) differs from slot 1, which it does for `ignore=3`/`7`. ✓ But add: assert the call **count** (e.g. `mbias[0].cpg[1].meth == 1`), not just non-zero, to catch a double-count or wrong-context routing.
+  4. Context coverage: the plan's self-review commits to exercising ≥1 non-CpG context. Worth making this a hard assertion in Test 2 (e.g. a CHG call), since `accumulate` routes by context (`mbias.rs:56-60`) and a CpG-only fixture wouldn't catch a context-routing regression.
+
+---
+
+## 5. Alternatives
+
+- **Table-driven OT/OB for Test 1:** A single parametric helper `assert_rebase_for_xg(xg: &[u8], bam_xm: &[u8], ignore, expected_read_pos: &[u32])` driven over `(CT-OT, sequenced_xm)` and `(GA-OB, reverse(sequenced_xm))` rows would make the byte-reversal explicit in code and structurally prevent the I1 trap. Recommended over two ad-hoc tests. The plan's "generalize `synth_se_record` to take `xg`" is a good first step but doesn't force the reversal.
+- **Test 4 granularity:** Comparing whole dirs is acceptable (it's the established pattern and catches split-file divergence too), but the plan should add an explicit non-emptiness assertion so a future fixture/flag change can't silently re-empty it. Alternatively target `M-bias.txt` specifically with a "contains a non-zero data row" check — strictly stronger for this test's stated purpose.
+- **Consider folding Test 4's value into a cross-N cell:** `parallel_se_byte_identical_across_n_1_2_4_8` (`:467`) could gain an `--ignore 2` variant, but the legacy-vs-parallel driver comparison (the dual-driver trap) is distinct and worth its own test. Keep Test 4, fix the ignore value.
+
+---
+
+## Action items
+
+### Critical
+- **C1 — Test 4 is a silent-pass no-op.** `write_se_directional_bam` uses 5-bp reads; `--ignore 5` triggers the `lo >= hi` early-out (`call.rs:166`) for every record → both dirs empty → trivially identical, passes even on full revert. Change to `--ignore 2` (or add an ≥8-bp fixture), and add a non-emptiness assertion (M-bias.txt has a non-zero data row, or a split file is non-empty). (`parallel_phase_f.rs:86-117`, `call.rs:161-168`)
+
+### Important
+- **I1 — Spell out the OB BAM-XM byte-reversal in Test 1.** The OT≡OB equivalence requires the OB record's BAM-stored XM to be the byte-reverse of the OT's (because `iter_aligned` reverses OB; `bismark-io/src/record.rs:305-307`). Without this stated, an implementer can pass the same string to both and assert reversed positions, or pick a symmetric fixture that passes while asserting nonsense. State the concrete fixture pair (e.g. OT `zXhZxH` ⟺ OB `HxZhXz`) and the expected `read_pos` sequence for each. Prefer a table-driven helper that forces the reversal.
+- **I2 — Test 3 must control PE overlap.** `process_pe:795` applies `drop_overlap` unless `--include_overlap`. Use non-overlapping R1/R2 ref positions or pass `--include_overlap` so R2's call isn't silently dropped before it reaches `mbias[1]`. (`parallel.rs:795`)
+- **I3 — State the fixture-length invariant.** Add an assumption: "all fixtures use reads longer than the largest ignore value." This is the root cause of C1 and a latent trap for Tests 2/3.
+
+### Optional
+- **O1 — Assert exact counts and a non-CpG context** in Tests 2/3 (`mbias[0].chg[1].meth == 1`, not just non-zero) to catch double-count / context-misroute regressions. (`mbias.rs:56-60`)
+- **O2 — Downgrade Assumption 2's risk framing.** ResolvedConfig-via-CLI-parse in `parallel.rs` tests is already proven (`parallel.rs:1156, 1255`); the plan's "only thing that could push to integration fallback" is not a real risk. Note the throwaway-`.bam` requirement for `validate()`.
+- **O3 — Table-driven OT/OB helper** (see Alternatives) to make Test 1 robust by construction.
+
+---
+
+## Summary table
+
+| Test | Placement viable? | Bidirectional guard? | Redundant? | Issue |
+|------|-------------------|----------------------|------------|-------|
+| 1 OB rebase | ✓ unit call.rs | ✓ (once reversal correct) | No | **I1** reversal under-specified |
+| 2 SE worker | ✓ unit parallel.rs | ✓ | No | I3 fixture length; O1 exact count/context |
+| 3 PE worker | ✓ unit parallel.rs | ✓ | No | **I2** overlap; I3 fixture length |
+| 4 driver equality | ✓ integration | ✗ as written | No (distinct cell) | **C1 no-op fixture/ignore** |


### PR DESCRIPTION
Tracks the planning/review/coverage paper trail for the two merged PRs #888 (#884 R2 — parallel `--gzip` via gzp) and #894 (#878 — read_pos rebase CI coverage), matching the existing #876 plan-doc convention in `plans/05262026_bismark-extractor/`. **Docs only — no code.** 12 files: PERF_R2_* (plan + dual plan-review + dual code-review + coverage) and TESTS_878_* (same set).