### PR TITLE
perf(extractor): always-on fixed-2-thread parallel BGZF decode for BAM (#884 R3)

### DIFF
--- a/plans/05262026_bismark-extractor/PERF_R3_CODE_REVIEW_reviewer-A.md
+++ b/plans/05262026_bismark-extractor/PERF_R3_CODE_REVIEW_reviewer-A.md
@@ -1,0 +1,112 @@
+# Code Review — #884 R3 (fixed 2-thread parallel-BGZF decode + BAM worker floor)
+
+**Reviewer:** A (independent, fresh context)
+**Target:** worktree `/Users/fkrueger/Github/Bismark-extractor`, branch `perf-r3-fixed2-decode` @ `6f182f8`
+**Diff base:** `b2af4e5..6f182f8` (two commits: `40f3670` always-on threaded decode; `6f182f8` worker floor)
+**Files reviewed:** `rust/bismark-extractor/src/parallel.rs`, `rust/bismark-extractor/tests/parallel_phase_f.rs`, plus `bismark-io` `read.rs` (`ThreadedBamReader`, `AlignmentKind::from_path`, `open_reader`, `AnyReader`), `cli.rs` (`--parallel` validation), and the vendored `noodles-bgzf 0.47.0` `MultithreadedReader`.
+
+---
+
+## Verdict: APPROVE — no blocking findings
+
+The R3 change is correct, byte-identity-preserving, and well-scoped. Build, tests (parallel_phase_f 19/19), clippy `-D warnings`, and `cargo fmt --check` all pass locally on my own runs (not just the main session's report). The single Low-priority item below is a pre-existing micro-redundancy, not introduced by this change.
+
+---
+
+## Summary
+
+R3 makes two coupled changes, both BAM-only:
+1. **Always-on threaded decode** (`40f3670`): BAM now reads via `ThreadedBamReader` with a fixed `DECODE_THREADS = 2`, decoupled from `--parallel`. SAM/CRAM keep `open_reader` (single-threaded). Dispatched through a new `ProducerReader` enum so `run_pipeline`/`producer_loop` bodies are otherwise unchanged.
+2. **BAM worker floor** (`6f182f8`): `n_workers = config.parallel.max(if is_bam { 2 } else { 1 })` so a single extract worker can't bottleneck the 2-thread decode.
+
+Both axes (decode-thread count, extract-worker count) are byte-orthogonal to output, verified below.
+
+---
+
+## Issues by area
+
+### 1. Byte-identity (the central concern) — PASS
+
+**Decode-thread axis (single → threaded-2).** Byte-identity here requires `ThreadedBamReader::records()` to yield records in the *exact* order of the single-threaded `BamReader`. I verified the noodles `MultithreadedReader` (`noodles-bgzf-0.47.0/src/io/multithreaded_reader.rs`, which is the version `bismark-io` resolves to) is **FIFO block-ordered**:
+- `spawn_reader` reads frames *sequentially in file order* and, per frame, pushes a dedicated 1-capacity `buffered_rx` onto `read_tx` **in read order** (`multithreaded_reader.rs:375–391`).
+- `recv_buffer` consumes `read_rx.recv()` then `buffered_rx.recv()` (`:352–360`), so blocks are surfaced in the order they were read, *regardless of which inflater thread finished first*. Each block has its own private `buffered_tx`/`buffered_rx` pair, so out-of-order inflation cannot reorder the output stream.
+- Therefore the decompressed byte stream is identical to single-threaded decode → identical `record_bufs` → identical `BismarkRecord` sequence. Worker-count-invariant by construction.
+
+This is now *directly exercised*: `legacy_vs_parallel_n1_se_default_byte_identical` (`tests/parallel_phase_f.rs:423`) compares legacy `extract_se` (uses `open_reader` → single-threaded `BamReader::from_path`, confirmed at `pipeline.rs:74`) against `extract_se_parallel --parallel 1` — which post-R3 uses `ThreadedBamReader` (2 decode threads) AND `n_workers = max(1,2) = 2`. So this test is no longer "N=1 vs N=1": it is genuinely single-threaded-decode vs threaded-2-decode + 2-worker, byte-for-byte. It passes.
+
+**Extract-worker axis (floor-at-2).** Output is byte-identical across extract-worker counts by the `(batch_seq, within_idx)` collector reorder (`BTreeMap`, module docs `parallel.rs:24–44`). `legacy_vs_parallel_n4_*` already validate 4-worker vs single byte-identity and still pass. The floor changes only how many workers spin up; it cannot move bytes.
+
+Conclusion: floor-at-2 and threaded-2-decode change timing only. No byte-identity risk.
+
+### 2. Floor-at-2 logic — CORRECT
+
+`config.parallel.max(if is_bam { 2 } else { 1 })` (`parallel.rs:233`):
+- BAM, `--parallel 1` → `1.max(2) = 2`. ✓
+- BAM, `--parallel 4` → `4.max(2) = 4` (floor doesn't cap). ✓
+- SAM/CRAM, `--parallel 1` → `1.max(1) = 1`. ✓
+- `--parallel 0` is rejected in CLI validation (`cli.rs:421–424`, `InvalidParallelValue`), so `config.parallel >= 1` always holds here; no `max(0,...)` surprise. ✓
+
+No off-by-one. The downstream channel capacities `bounded(n_workers * 4)` (`parallel.rs:273–274`) stay `>= 1` (n_workers ≥ 2 for BAM, ≥ 1 otherwise), preserving the no-deadlock property.
+
+### 3. `is_bam` reuse / no double-sniff — CORRECT
+
+`is_bam` is computed once via `AlignmentKind::from_path(input)?` (`parallel.rs:224`) and reused for both the worker floor (`:233`) and reader selection (`:246`).
+- BAM branch: `ThreadedBamReader::from_path` re-opens the file but does **not** re-sniff via `AlignmentKind` — it just `File::open` + `MultithreadedReader` + `read_header` (`read.rs:318–328`). So R3 itself adds no extra `AlignmentKind` sniff.
+- SAM/CRAM branch: `open_reader(input, None)` *does* internally re-sniff via `AlignmentKind::from_path` (`read.rs:566`). That is a pre-existing double-sniff (~100–700 µs once, per the BGZF-block-inflate cost noted in `read.rs:93`), **not introduced by R3** — `open_reader` always sniffed. See Low-1.
+- SAM and CRAM both correctly take the `Any` path: `AlignmentKind::from_path` returns `Sam`/`Cram` (never `Bam`) for them (`read.rs:124–138`), so `is_bam == false`. ✓
+
+### 4. Coord-sort rejection — PRESERVED
+
+`ThreadedBamReader::from_path` (not `_without_sort_check`) calls `check_not_coordinate_sorted(&header)` (`read.rs:326`), exactly as `BamReader::from_path` does (`read.rs:237`). So the parallel BAM path retains the same `UnsortedInput` rejection it had under `open_reader`. The PE adjacent-pairing read-order contract is unchanged. ✓ (The comment at `parallel.rs:243–245` correctly states this.)
+
+### 5. The SAM dispatch test — SOUND
+
+`sam_input_matches_bam_through_r3_dispatch` (`tests/parallel_phase_f.rs`):
+- The `se_directional_records()` refactor is behavior-preserving: the 5 records are byte-for-byte the same literals previously inlined in `write_se_directional_bam` (verified field-by-field against the diff). Both `write_se_directional_bam` and the new `write_se_directional_sam` iterate the same `Vec`, so the BAM and SAM containers hold identical records. All existing tests that call `write_se_directional_bam` still pass (19/19).
+- The test runs both inputs at `--parallel 4`: the BAM goes Threaded (2-decode) + 4 workers; the SAM goes `Any` (single-threaded) + 4 workers — so it genuinely contrasts the two reader paths. Identical input records ⇒ identical CpG/CHG/CHH split-file bytes. It asserts `compared > 0` to guard against a vacuous all-empty pass. ✓
+- **Skipping `_splitting_report.txt` is correct and necessary.** That file's *content* embeds the input path/filename (the report header includes the input file), and the basename is `se` for both (`se.bam`/`se.sam`) so the *filename* matches — but the body would differ on the `.bam` vs `.sam` path text. The split-data files (CpG/CHG/CHH) carry no filename, share the `se` basename in both dirs, and are the right byte-identity surface. The `bam_dir.join(&name)` lookup is valid because both dirs use the same `se` basename. ✓
+
+One minor note (not a defect): the test proves "same records → same output across reader paths," which is the dispatch guard it claims. It does *not* independently re-prove threaded-vs-single decode ordering — but that is covered by `legacy_vs_parallel_n1` (see area 1). The two tests together fully cover R3.
+
+### 6. CRAM — UNCHANGED, not newly broken
+
+CRAM resolves `is_bam == false` → `open_reader(input, /*cram_ref=*/ None)`. With `None`, the CRAM arm returns `MissingCramReference` (`read.rs:569–572`) — identical to pre-R3 behavior (the old code also called `open_reader(input, None)`). So CRAM remains end-to-end-unsupported exactly as before; R3 does not touch it. ✓
+
+### 7. Efficiency / structure — CLEAN
+
+- `ProducerReader::records` boxes once per call (`parallel.rs:410–415`) — `producer_loop` calls `records()` once and drives the iterator, so it's a single allocation for the whole run, mirroring `AnyReader::records`' existing boxing (`read.rs:527`). No per-record vtable regression beyond what already existed.
+- `DECODE_THREADS` const-asserts via `NonZeroUsize::new(2).unwrap()` in const context (`parallel.rs:113`) — fine, evaluates at compile time.
+- No dead code: the `ProducerReader::Any` arm is reached by SAM (and would be by CRAM), `Threaded` by BAM. Both `header()` arms used (`:251`, `:260`, and producer).
+- `clippy --all-targets -- -D warnings`: clean. `cargo fmt --check`: clean (my runs).
+- `SamWriter` import in the test is used (`write_se_directional_sam`), no unused-import warning.
+
+---
+
+## Recommendations
+
+### Critical
+None.
+
+### High
+None.
+
+### Medium
+None.
+
+### Low
+
+**Low-1 — pre-existing double-sniff on the SAM/CRAM path (informational, do not block).**
+For SAM/CRAM, R3 computes `is_bam` via `AlignmentKind::from_path` (`parallel.rs:224`), then `open_reader` re-sniffs via `AlignmentKind::from_path` again (`read.rs:566`). This is a redundant magic-byte sniff (one extra `open(2)` + first-byte read; for SAM it's trivial, no BGZF inflate). It is **not introduced by R3** — `open_reader` has always self-sniffed — and the path is rarely hot (SAM/CRAM are not the BGZF perf target). If ever optimized, a `ThreadedBamReader`-style direct `SamReader::from_path` in the else-arm (using the already-known `AlignmentKind`) would remove it, but that's gold-plating and out of scope here. No action recommended for this PR.
+
+**Low-2 — comment-vs-measurement drift (cosmetic).**
+The `DECODE_THREADS` doc comment (`parallel.rs:107–112`) cites `--mbias_only 18.3→13.0 s` while the task summary cites `18.8→12.3 s`, and the floor comment (`:226–232`) gives yet another set (`~18.5 / ~16` → `~17.8 / ~13`). These are illustrative trial numbers, not asserted invariants, so this is purely cosmetic. Consider normalizing to one measured figure to avoid future confusion. Non-blocking.
+
+---
+
+## Verification performed
+- `cargo test -p bismark-extractor --test parallel_phase_f` → **19 passed, 0 failed**.
+- `cargo test ... sam_input_matches_bam_through_r3_dispatch` → **1 passed**.
+- `cargo clippy -p bismark-extractor --all-targets -- -D warnings` → clean.
+- `cargo fmt --check -p bismark-extractor` → clean (exit 0).
+- Read noodles `MultithreadedReader` source to confirm FIFO block ordering (byte-identity root cause).
+- Traced `is_bam` / `open_reader` / `ThreadedBamReader::from_path` / `AlignmentKind::from_path` / `--parallel` validation to confirm dispatch, sort-check parity, and floor arithmetic.

--- a/plans/05262026_bismark-extractor/PERF_R3_CODE_REVIEW_reviewer-B.md
+++ b/plans/05262026_bismark-extractor/PERF_R3_CODE_REVIEW_reviewer-B.md
@@ -1,0 +1,173 @@
+# Code Review — #884 R3: always-on fixed 2-thread parallel BGZF decode + BAM worker floor (Reviewer B)
+
+**Target:** `git -C /Users/fkrueger/Github/Bismark-extractor diff b2af4e5 6f182f8 -- rust/bismark-extractor/`
+(commits `40f3670` always-on threaded decode; `6f182f8` BAM worker floor)
+**Files changed:** `rust/bismark-extractor/src/parallel.rs`, `rust/bismark-extractor/tests/parallel_phase_f.rs`
+**Reviewer:** B (independent, fresh context — conclusions formed from source, not the diff's comments)
+
+## Verdict: APPROVE
+
+The change is correct, well-scoped, and well-documented. I independently re-verified the
+byte-identity linchpin in the noodles 0.47.0 source (the version actually pinned, not the
+plan-cited 0.47.0 by guess — confirmed in `Cargo.lock`). The ordering guarantee holds at any
+worker count. `cargo test -p bismark-extractor` = 19/19 parallel_phase_f + full suite green;
+`cargo test -p bismark-io threaded_bam` green; `cargo clippy --all-targets -D warnings` clean.
+
+No Critical or High issues. A handful of Low/informational notes below — none block merge.
+
+---
+
+## Independent verification of the byte-identity linchpin (concern #1)
+
+`noodles_bgzf::io::MultithreadedReader` (`.../noodles-bgzf-0.47.0/src/io/multithreaded_reader.rs`):
+
+- `spawn_reader` (`:364`) reads BGZF frames **sequentially in file order**. For each frame it
+  creates a one-shot channel `(buffered_tx, buffered_rx)`, dispatches `(buffer, buffered_tx)` to the
+  shared inflater pool (`inflate_tx`), and **immediately** pushes `buffered_rx` onto `read_tx`
+  **in the same frame order** (`:385-386`).
+- The consumer `recv_buffer` (`:352`) pops `read_rx` FIFO (frame order) and **blocks** on that
+  frame's `buffered_rx.recv()`. So even if inflater workers finish out of order, the consumer
+  emits decompressed blocks in strict file order.
+- This ordering is **independent of `worker_count`** — 2, 4, or N all emit identically. The R3
+  floor-at-2 / fixed-2-decode claims rest on this, and it holds.
+
+**Conclusion:** byte-identity across worker counts is real, not assumed. The "decode parallel,
+emit sequential" property is structural in noodles, not incidental.
+
+**Test-strength judgement (the concern raised):**
+- The extractor's `legacy_vs_parallel_n1`/`sam_input_matches_*` fixtures are 5 tiny records →
+  **a single BGZF data block** (verified: `BamWriter` uses noodles' default single-threaded BGZF
+  `Writer`, flushing at ~64 KiB; 5 short records never reach that). With one data block, parallel
+  inflate has nothing to reorder, so these tests are **NOT** a genuine multi-block ordering guard
+  on their own — they guard dispatch + per-record extraction correctness, not inflate ordering.
+- The real ordering guard is `bismark-io::threaded_bam_reader_preserves_record_order`
+  (`tests/integration_fixture_bam.rs:261`), which I confirmed runs over a **4-BGZF-block** fixture
+  (`test_files/tiny_pe_bismark.bam`, 203 records — I parsed the BGZF BSIZE chain: header block +
+  ~2 data blocks + EOF) at **worker_count=4**. Multiple inflaters genuinely process distinct
+  blocks here, and the test asserts FIFO qname order. This is a meaningful guard and it passes.
+- The plan (rev 1, B-I2) already documents exactly this split. So the coverage is honest. See
+  Low-1 for an optional belt-and-suspenders addition.
+
+---
+
+## Issues by area
+
+### Logic / correctness
+- **Worker-floor (concern #2):** `n_workers = config.parallel.max(if is_bam {2} else {1})`
+  (`parallel.rs:233`). `config.parallel` is `>= 1` always (`cli.rs:422` rejects `--parallel 0`;
+  default 1). So BAM always gets `>= 2` workers, SAM/CRAM `>= 1`. Correct. The byte-identity-across-
+  worker-count claim that makes this floor *safe* is the `batch_seq` BTreeMap reorder in the
+  collector (unchanged by this diff) — verified independent of worker count by the existing
+  `legacy_vs_parallel_n1/n4` pair and the new test runs at N=4. Floor changes timing only, not bytes. ✓
+- **Dispatch (concern #3):** `AlignmentKind::from_path` (`read.rs:111`) is a **magic-byte sniff**,
+  not extension-based — it inflates the first BGZF block and checks `BAM\x01` payload magic. So
+  `is_bam` is true **only** for genuine BGZF-wrapped BAM, regardless of extension. This directly
+  defuses the "`.bam` extension on a non-BGZF file" worry: such a file would sniff as SAM/CRAM/error,
+  NOT route to the threaded reader. CRAM (`C`+`RAM` magic) → `Cram` → `Any`/`open_reader` →
+  `CramReader`, unchanged. SAM (`@`) → `Any`. Routing is correct for all three. ✓
+- **stdin:** the extractor takes a path argument (`config.files[0]`), not a stream; `from_path`
+  opens a real file. No stdin path exists, so no mis-classification risk there. ✓
+- **Coord-sort rejection (concern, Validation #4):** `ThreadedBamReader::from_path` (`read.rs:318`)
+  calls the **same** `check_not_coordinate_sorted` (`read.rs:326`) as `BamReader::new`
+  (`read.rs:237`) used by `open_reader`. `from_path` (not `from_path_without_sort_check`) is used
+  at `parallel.rs:247`. Rejection semantics identical → PE adjacent-pairing contract preserved. ✓
+- **Legacy reference is genuinely single-threaded:** `extract_se`/`extract_pe` (`pipeline.rs:74,221`)
+  use `open_reader` → `AnyReader::Bam(BamReader)` (single-threaded noodles BGZF). So the
+  `legacy_vs_parallel_n1` BAM comparison really is single-threaded-decode vs 2-thread-decode through
+  the full extraction pipeline — a true (if single-block) cross-check. ✓
+- **Production routing:** `main.rs:101-125` routes **every** run (incl. `--parallel 1` default and
+  AutoDetect) through `extract_*_parallel` → `run_pipeline`. So the threaded reader + floor are
+  exercised in production at the default, matching the plan's "default benefits" goal. ✓
+
+### Errors / edge cases
+- **Empty BAM:** `parallel_empty_bam_at_n4_produces_header_only_files` passes; the threaded reader
+  + 2 decode threads handle a header-only BAM (sweep of all 12 files works). ✓
+- **`ProducerReader::records()` boxing:** returns `Box<dyn Iterator<...> + '_>` to unify the two
+  reader types. Allocation is once per run (not per record), negligible. The `BismarkIoError` item
+  type matches both arms. Clean. ✓
+- **Truncated/corrupt BAM (informational, Low-2):** noodles' `MultithreadedReader` masks a
+  *raw-frame* read error as clean EOF — `spawn_reader` (`:380`) returns the `io::Error` into the
+  JoinHandle and stops, but `recv_buffer` (`:352`) sees `read_rx` disconnect and returns
+  `Ok(None)` (EOF). The error only surfaces on `finish()`, which `ProducerReader`/`records()` never
+  calls. *Inflate* errors (corrupt block payload) DO propagate mid-stream. The single-threaded
+  `BamReader` surfaces truncated-frame errors directly. So on a truncated tail, the threaded path
+  may silently stop at EOF where single-threaded would error. This is a pre-existing noodles
+  property shared by `bismark-dedup`'s use of `ThreadedBamReader`, NOT introduced here, and does
+  NOT affect byte-identity on well-formed inputs. Flag only; out of scope to fix in this PR.
+
+### Efficiency
+- **Always-on 2 decode threads (concern #5):** spawned eagerly in `from_path` (the header read
+  triggers `MultithreadedReader::resume()`). Confirmed no test-suite regression — `parallel_phase_f`
+  (19 tests, each spawning 2 decode threads on tiny BAMs) finishes in 0.38s; smoke tests in 0.35s.
+  The cost is ~+1 core on real workloads (documented), bounded. Acceptable. ✓
+- **Redundant sniffs (Low-3):** in AutoDetect mode a BAM is opened+sniffed up to 3× (probe
+  `open_reader` in `main.rs:108`, `AlignmentKind::from_path` in `run_pipeline:224`, then
+  `ThreadedBamReader::from_path` re-opens as BGZF). Each is ~µs on warm cache and the pattern
+  predates this PR (the probe was already there). Not worth changing.
+
+### Structure / style
+- `DECODE_THREADS` const (`parallel.rs:113`) with `NonZeroUsize::new(2).unwrap()` compiles as a
+  const (rustc accepts the `unwrap` in const context here — clippy clean). Doc-comment is thorough
+  and cites the oxy measurement + the `GZIP_COMPRESS_THREADS` precedent. Good.
+- `ProducerReader` enum + impl is minimal and idiomatic; both `run_pipeline` and `producer_loop`
+  drive it uniformly with no body changes. Clean abstraction. ✓
+- `se_directional_records()` refactor (concern #4): extracts the 5 records into a shared helper so
+  BAM and SAM fixtures hold byte-identical records. **Behavior-preserving** for the ~15 existing
+  callers of `write_se_directional_bam` — the records, tags, positions, and write order are
+  identical to the old inline version (same literals, same order); only `finish()` placement is
+  unchanged. The full suite (incl. all `se_phase_b` / smoke tests using this fixture) is green. ✓
+
+---
+
+## Recommendations (priority-ranked)
+
+### Critical
+None.
+
+### High
+None.
+
+### Medium
+None.
+
+### Low
+1. **(Optional) Add an extractor fixture spanning >= 2 BGZF data blocks for the dispatch/n1 tests.**
+   The current 5-record BAM is a single block, so `legacy_vs_parallel_n1` and
+   `sam_input_matches_bam_through_r3_dispatch` do not themselves exercise parallel inflate ordering
+   (they rely on `bismark-io`'s 4-block fixture for that). The plan already acknowledges this. If
+   cheap, writing ~2000 synthetic records (the existing `large` multibatch fixture may already
+   cross a block boundary — worth confirming) into a byte-identity test would give the extractor
+   its own multi-block ordering guard. Not required: the bismark-io guard covers the mechanism.
+
+2. **(Informational) Document the truncated-BAM EOF-masking difference.** Noodles' threaded reader
+   treats a truncated raw frame as EOF (vs single-threaded erroring). Pre-existing, shared with
+   dedup, byte-identity-irrelevant on valid input. A one-line note near `DECODE_THREADS` or in the
+   bismark-io `ThreadedBamReader` doc would help future debugging of "threaded run silently
+   produced fewer records on a corrupt file." No code change needed.
+
+3. **(Informational) The SAM dispatch test compares split files only, not the file set.** It
+   asserts every CpG/CHG/CHH `.txt` present in `sam_dir` is byte-equal to BAM and that `compared >
+   0`, but does NOT assert SAM produced the *same set* of files as BAM. Since the SAM path is
+   unchanged `open_reader` code, this is fine; the test's purpose (guard the new `is_bam ?
+   Threaded : Any` else-arm routes SAM away from the threaded reader and yields identical
+   methylation calls) is met. Skipping `splitting_report` is correct — its body legitimately
+   differs (`Input file: se.bam` vs `se.sam`), and `normalize_report` only strips path lines, not
+   the filename embedded in the body, so it could not be reused here.
+
+---
+
+## Validation evidence (run by this reviewer)
+
+- `cargo test --manifest-path rust/Cargo.toml -p bismark-extractor` → all green; `parallel_phase_f`
+  19/19 incl. `legacy_vs_parallel_n1_se_default_byte_identical`,
+  `sam_input_matches_bam_through_r3_dispatch`, `parallel_empty_bam_at_n4_*`.
+- `cargo test --manifest-path rust/Cargo.toml -p bismark-io threaded_bam` → 4/4 incl.
+  `threaded_bam_reader_preserves_record_order` (4-block fixture, worker_count=4).
+- `cargo clippy --manifest-path rust/Cargo.toml -p bismark-extractor --all-targets -- -D warnings`
+  → clean.
+- BGZF block count of `tiny_pe_bismark.bam` verified = 4 (header + ~2 data + EOF) via manual
+  BSIZE-chain parse.
+- noodles-bgzf version verified = `0.47.0` (`Cargo.lock`), and the cited ordering source read
+  directly from `~/.cargo/.../noodles-bgzf-0.47.0/src/io/multithreaded_reader.rs`.
+
+**Report path:** `/Users/fkrueger/Github/Bismark-extractor/plans/05262026_bismark-extractor/PERF_R3_CODE_REVIEW_reviewer-B.md`

--- a/plans/05262026_bismark-extractor/PERF_R3_COVERAGE.md
+++ b/plans/05262026_bismark-extractor/PERF_R3_COVERAGE.md
@@ -1,0 +1,61 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs. plan)
+**Plan(s):** `PERF_R3_DECODE_PLAN.md` (rev 1)
+**Code:** worktree `/Users/fkrueger/Github/Bismark-extractor`, branch `perf-r3-fixed2-decode` @ `6f182f8`
+**Net diff:** `git -C /Users/fkrueger/Github/Bismark-extractor diff b2af4e5 -- rust/` (274 lines; `parallel.rs` +76/-, `parallel_phase_f.rs` +126/-35)
+**Date:** 2026-05-30
+**Verdict:** COMPLETE
+
+## Summary
+
+- Total items: 11 (7 ledger items, several with sub-parts)
+- DONE: 10
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED: 0
+- PENDING (non-gap, by plan): 1 — colossal byte-identity smoke (Validation #6), recorded as in-progress per task instructions
+
+## Coverage ledger
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `DECODE_THREADS: NonZeroUsize = 2` const with rationale doc | Behavior #1 / Impl-outline #2 | DONE | `parallel.rs:114`; full doc-comment (oxy sweet-spot, 3/4 no gain, decoupled from `--parallel`, parallels `GZIP_COMPRESS_THREADS`). `NonZeroUsize::new(2).unwrap()` const-form per rev-1 [A-O3]. |
+| 2 | `ProducerReader` enum {Any, Threaded} + `header()`/`records()` | Behavior #3 / Impl-outline #3 | DONE | `parallel.rs:397-415`. `header() -> &noodles_sam::Header`; `records() -> Box<dyn Iterator<Item = Result<BismarkRecord, BismarkIoError>>>`. |
+| 3 | Reader selection: BAM→`ThreadedBamReader::from_path(input, DECODE_THREADS)` always (no n_workers gate); SAM/CRAM→`open_reader`; `is_bam` via `AlignmentKind::from_path` | Behavior #2 / Impl-outline #4 | DONE | `is_bam` at `:224` (`AlignmentKind::from_path`); selection at `:246-250`, unconditional for BAM. |
+| 4 | `producer_loop` takes `ProducerReader`; module doc updated | Behavior #4 / Impl-outline #6,#7 | DONE | `producer_loop` param `mut reader: ProducerReader` at `:430-431`; module doc updated `:11-12` (notes BAM threaded-decode path). Header call sites `:251` (chr_table) + `:260` (provenance log) unchanged via `ProducerReader::header()`. |
+| 5 | Floor-at-2 fallback (`config.parallel.max(if is_bam {2} else {1})`) — pre-authorized per Validation #7 | Validation #7 (pre-authorized) | DONE (as planned) | `n_workers` at `:251` (`config.parallel.max(if is_bam { 2 } else { 1 })`). Comment documents the `--parallel 1` BAM measure-miss (~18.5 s) and notes byte-identity preserved across worker counts. Matches the plan's pre-authorized fallback — NOT an unplanned deviation. |
+| 6a | Test `sam_input_matches_bam_through_r3_dispatch` (SAM dispatch else-arm) | Validation #3 | DONE | `parallel_phase_f.rs`; compares CpG/CHG/CHH split files BAM (threaded) vs SAM (Any). PASS. |
+| 6b | `se_directional_records` shared fixture | rev-1 [B-I4] support | DONE | `parallel_phase_f.rs`; 5 SE-directional records shared by BAM + SAM writers. |
+| 6c | `bismark-io::threaded_bam_reader_preserves_record_order` (ordering guard) | Validation #2 / rev-1 [B-I2] | DONE | `bismark-io/tests/integration_fixture_bam.rs:261`; 203-record real Perl BAM, `worker_count=4`, asserts qname order == single-threaded. PASS. |
+| 7a | Coord-sort rejection via `from_path` (not `from_path_without_sort_check`) | Behavior #5 / Validation #4 | DONE | `ThreadedBamReader::from_path` (`read.rs:318`) calls `check_not_coordinate_sorted` (`read.rs:326`); shared `check_not_coordinate_sorted` unit-tested at `read.rs:899`. Code uses `from_path` (`parallel.rs:247`). |
+| 7b | In-repo byte-identity suite green (parallel_phase_f N=1/N=4) + clippy/fmt | Validation #1, #5 | DONE | `parallel_phase_f` = 19 passed; `lib` = 105 passed; all extractor binaries green (see test table). clippy/fmt per main-session report. |
+| 7c | Colossal byte-identity smoke SE+PE plain AND --gzip | Validation #6 | PENDING (not a gap) | Recorded as in-progress per task instructions; binding gate runs off-repo. |
+
+## Test verification
+
+| Test name | File | Status |
+|-----------|------|--------|
+| `parallel_phase_f` (whole binary, incl. N=1/N=4 byte-identity + 8199-record multibatch) | `tests/parallel_phase_f.rs` | PASS (19/19) |
+| `sam_input_matches_bam_through_r3_dispatch` | `tests/parallel_phase_f.rs` | PASS |
+| `bismark_extractor` lib unit tests | `src/lib.rs` | PASS (105/105) |
+| `threaded_bam_reader_preserves_record_order` | `bismark-io/tests/integration_fixture_bam.rs:261` | PASS |
+| All other extractor test binaries (se_phase_b_smoke, etc.) | `tests/*.rs` | PASS |
+
+Full suite: `cargo test -p bismark-extractor` — every binary `ok`, 0 failed. Counts match plan expectation (`parallel_phase_f` 19, `lib` 105).
+
+## Gaps (detail)
+
+None. All Behavior, Implementation-outline, and Validation items are implemented as specified.
+The floor-at-2 worker fallback is explicitly pre-authorized by the plan (Validation #7 HARD
+gate + Assumptions section: "if it fails, the pre-authorized `config.parallel.max(2)` BAM-worker
+floor applies"), and the code comment documents the measured `--parallel 1` miss (~18.5 s) that
+triggered it. This is DONE-as-planned, not a deviation.
+
+## Verdict
+
+**COMPLETE.** Every Behavior item (1-5), every Implementation-outline step (1-7), and the
+in-repo Validation items (#1-#5, #7) are present in the code and pass their tests. The only
+outstanding plan item is the colossal byte-identity smoke (Validation #6), which the task
+instructions direct to record as pending/in-progress rather than as a coverage gap. No code
+changes are required for plan coverage.

--- a/plans/05262026_bismark-extractor/PERF_R3_DECODE_PLAN.md
+++ b/plans/05262026_bismark-extractor/PERF_R3_DECODE_PLAN.md
@@ -1,0 +1,197 @@
+# Plan — R3 productionized: fixed 2-thread parallel BGZF decode (#884)
+
+## Goal
+Make BAM decode use a **fixed 2-thread `MultithreadedReader`, always-on, decoupled from
+`--parallel`**, capturing the ~12–14 % wall-clock win on the real `.txt` path (and ~30 % on the
+decode floor) measured on oxy. Crucially, the **default `--parallel 1` must benefit** — the gap in
+the original #887 (which tied decode threads to `--parallel` and fell back to a single-threaded
+reader at N=1, so the default got nothing).
+
+## Revision history
+- **rev 1 (2026-05-30):** Folded dual plan-review (`PERF_R3_DECODE_PLAN_REVIEW_reviewer-{A,B}.md`).
+  Both APPROVE; both independently verified the byte-identity linchpin in the noodles source
+  (A also trial-applied the edits → 18/18 tests + clippy clean). Changes:
+  - **`--parallel 1` win [both flagged; B Critical] — RESOLVED: measure-first + pre-authorized
+    floor-at-2 fallback.** Ship `--parallel N = N` workers + fixed 2 decode threads; Validation #5
+    is now a HARD gate — if `--parallel 1` plain doesn't reach ~17.9s, apply `config.parallel.max(2)`
+    on the BAM path and re-measure before merge (pre-authorized).
+  - **[both] Validation #2** mis-cited a coord-sort test — it lives in `bismark-io`
+    (`read.rs` `check_not_coordinate_sorted`, unit-tested ~`:899`), not the extractor. Re-cited.
+  - **[B-I2] Multi-block ordering guard:** the extractor's 8199-record fixture may collapse to ≤2
+    BGZF blocks → add `bismark-io::threaded_bam_reader_preserves_record_order` (203-record real
+    BAM, worker_count=4) to the validation as the real parallel-inflate-ordering guard.
+  - **[B-I4] Add an extractor-level SAM-input test** to guard the new BAM-vs-SAM/CRAM dispatch.
+  - **[A-O3]** `NonZeroUsize::new(2).unwrap()` compiles as a const on rustc 1.95 — drop the hedge.
+  - Line numbers post-R1-batching are ~`:226` (reader open) / `:235` (header) / `:442`
+    (`producer_loop`), not the rev-0 `:210/:211/:365`.
+
+## Context
+
+**Measured (oxy, 10M PE, idle, 3 reps earlier + a focused trial):**
+| config | wall | CPU-cores |
+|---|---:|---:|
+| current (single-thread decode) `--mbias_only` | 18.8s | 1.8 |
+| current plain `.txt` | ~20.0s | 2.7 |
+| **2 decode threads** `--mbias_only` | **13.0s** | 3.1 |
+| 3 / 4 decode threads `--mbias_only` | 13.3 / 13.8s (no gain, slight regress) | ~3.0 |
+| **2 decode threads** plain `.txt` | **17.9s** (→17.4 at 4) | 3.2 |
+
+So: decode+extract (~18.8s) is the wall (writes only ~1s on fast disk); 2 decode threads is the
+**sweet spot** (3/4 add nothing). Net real-path win ≈ 12–14 %.
+
+**Prior art:** #887 (`d3dd289`, branch `perf-r3-parallel-decode`, CLOSED) wired
+`ThreadedBamReader` into the producer at `n_workers >= 2 && is_bam`, with a single-threaded
+fallback at N=1 — so `--parallel 1` (the default) got no benefit. d3dd289 was **`parallel.rs`-only
+(+50/−3)**. We adapt it with two design changes: **always-BAM** (drop the `n_workers >= 2` gate)
+and **fixed 2 threads** (a const, not `n_workers`).
+
+**Already present in current `b2af4e5` — no new dependency:**
+- `bismark_io::ThreadedBamReader` (`read.rs:305`, exported `lib.rs:33`):
+  `from_path(path, parallel: NonZeroUsize)` → `noodles_bgzf::io::MultithreadedReader::with_worker_count`
+  (`read.rs:318/323`), and `from_path_without_sort_check` (`read.rs:332`). We use `from_path`
+  (keeps the coordinate-sort rejection).
+- `AlignmentKind::from_path` (BAM/SAM/CRAM classification).
+- Current `parallel.rs`: `run_pipeline` opens via `open_reader(input, None)` (`:210`), uses the
+  header at `:211`/`:220`; `producer_loop` takes `AnyReader` (`:365`). These are the exact
+  adaptation points (identical to d3dd289's "before").
+
+## Behavior
+1. New const `DECODE_THREADS: NonZeroUsize = 2` (doc: oxy-measured sweet spot; 3/4 add nothing;
+   decoupled from `--parallel` so the default benefits — same rationale shape as
+   `output.rs::GZIP_COMPRESS_THREADS`).
+2. In `run_pipeline`, classify input via `AlignmentKind::from_path(input)`:
+   - **BAM** → `ProducerReader::Threaded(ThreadedBamReader::from_path(input, DECODE_THREADS))`
+     — **always**, regardless of `--parallel`.
+   - **SAM / CRAM** (not BGZF) → `ProducerReader::Any(open_reader(input, None))` (single-threaded, unchanged).
+3. `ProducerReader` enum `{ Any(AnyReader<…>), Threaded(ThreadedBamReader) }` with `header()` +
+   `records() -> Box<dyn Iterator<Item = Result<BismarkRecord, BismarkIoError>>>` (verbatim from d3dd289).
+4. `producer_loop` takes `ProducerReader` instead of `AnyReader`.
+5. **Edge:** `ThreadedBamReader::from_path` keeps the same coordinate-sort rejection as `open_reader`
+   (bismark BAMs are read-ordered; coord-sorted breaks PE adjacent-pairing). Use `from_path`, NOT
+   `from_path_without_sort_check`.
+
+## Implementation outline (`parallel.rs` only — adapt d3dd289)
+  *(Line numbers below are post-R1-batching, b2af4e5 — verify at impl time; rev-0 cited stale ones.)*
+1. Imports: extend the `bismark_io` use with `AlignmentKind, BismarkIoError, ThreadedBamReader`.
+2. Add `const DECODE_THREADS: std::num::NonZeroUsize = NonZeroUsize::new(2).unwrap();` with the
+   rationale doc-comment. (Confirmed const-evaluable on rustc 1.95 — no `match`/`expect` hedge needed.)
+3. Add the `ProducerReader` enum + `impl` (`header`, `records`) — copy from d3dd289.
+4. Replace `let reader = open_reader(input, None)?;` (~`:226`) with the `is_bam` selection:
+   `AlignmentKind::from_path(input)? == Bam` → `ProducerReader::Threaded(ThreadedBamReader::from_path(
+   input, DECODE_THREADS))`, else `ProducerReader::Any(open_reader(input, None)?)`. **Always** threaded
+   for BAM (NO `n_workers` gate); worker count stays `--parallel` (floor-at-2 only if Validation #7 fails).
+5. `reader.header()` call sites (~`:235` chr_table, header-provenance log) work unchanged via
+   `ProducerReader::header()`.
+6. Change `producer_loop`'s `reader` param type (~`:442`) `AnyReader<…>` → `ProducerReader`.
+7. Refresh the module doc (~`:11` "drives `open_reader().records()`") to note the BAM threaded-decode path.
+
+## Efficiency
+- +1 decode worker thread always-on → ~+1 CPU-core (1.8→3.1 on `--mbias_only`; 2.7→3.2 on plain).
+  Bounded; acceptable. Capped at 2 (3/4 measured no-gain — do NOT scale with `--parallel`).
+- Decode floor 18.8→13.0s; plain `.txt` ~20→~17.9s (~12 %). Makes Rust ≈ 7–8× over Perl's best
+  (vs ~5× today).
+- Memory: `MultithreadedReader` holds a small bounded set of in-flight BGZF blocks.
+
+## Integration
+- BAM decode parallelized; **record order preserved** (MultithreadedReader decompresses blocks in
+  parallel but emits records sequentially) → byte-identity to the single-threaded reader holds.
+- SAM/CRAM, M-bias, splitting-report, split-file output, gzip (R2), empty-sweep — all unchanged.
+- The byte-identity tests now exercise the threaded reader at **all** N (incl. N=1), since BAM
+  always uses it.
+
+## Assumptions
+- **[VERIFIED rev 1 — both reviewers, in noodles 0.47.0 source]**
+  `MultithreadedReader::with_worker_count(2)` yields records in the SAME order as the
+  single-threaded `bgzf::Reader` (reader thread enqueues per-block one-shot receivers FIFO in frame
+  order; consumer pops FIFO + blocks per block → inflate parallel, emission strictly file-order) →
+  byte-identical output. Still gated by the byte-identity suite (now runs the threaded path at N=1)
+  + the bismark-io ordering test.
+- `ThreadedBamReader::from_path` applies the same `check_not_coordinate_sorted` as `open_reader`
+  (shared code) → identical coord-sort rejection.
+- **1 worker (`--parallel 1`) + 2 decode threads reaches ~17.9s** — i.e. the extract worker is not
+  the bottleneck (CPU probe showed workers idle / decode-bound). **NOT directly measured (the trial
+  was 2 workers + 2 decode).** Resolution: Validation #7 is a hard gate; if it fails, the
+  pre-authorized `config.parallel.max(2)` BAM-worker floor applies → "default benefits" holds either way.
+- `AlignmentKind::from_path` classifies BAM correctly (magic/extension) for the gating.
+
+## Validation
+1. `cargo test -p bismark-extractor` byte-identity suite — esp. `parallel_phase_f`
+   legacy(single-threaded `extract_se/pe`) vs parallel at **N=1 and N=4** (parallel now uses the
+   threaded BAM reader at all N) → must be byte-identical; + the 8199-record multibatch test.
+2. **Ordering guard (rev 1, B-I2):** the in-repo guarantee that parallel inflate preserves record
+   order is `bismark-io::threaded_bam_reader_preserves_record_order` (203-record real Perl BAM,
+   worker_count=4) — confirm it passes (`cargo test -p bismark-io`). The extractor's 8199-record
+   `BamWriter` fixture may collapse to ≤2 BGZF blocks, so it is NOT a robust parallel-inflate
+   ordering test on its own. *(If cheap, also add an extractor fixture that spans ≥3 BGZF blocks.)*
+3. **SAM-input dispatch (rev 1, B-I4):** add/confirm an extractor-level test that **SAM** input
+   still runs end-to-end (exercises the new `is_bam ? Threaded : Any` branch's else-arm — SAM must
+   NOT take the threaded path). CRAM stays end-to-end-unsupported as today.
+4. **Coord-sort rejection** is enforced by the SHARED `check_not_coordinate_sorted` in
+   `ThreadedBamReader::from_path` == `open_reader` (unit-tested in `bismark-io` `read.rs` ~`:899`;
+   there is NO extractor-level coord-sort test — do not claim one). Confirm `from_path` (not
+   `from_path_without_sort_check`) is used.
+5. `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`.
+6. Colossal `phase_h_smoke` SE+PE, **plain AND `--gzip`** — binding byte-identity gate.
+7. **Perf re-measure (oxy) — HARD GATE (rev 1):** `--parallel 1` plain `.txt` must drop to
+   **~17.9s** (from ~20s) ⇒ the default benefits; `--mbias_only` ≈ 13s. **If `--parallel 1` does
+   NOT reach ~17.9s** (single extract worker bottlenecks), apply the **pre-authorized fallback**:
+   floor BAM extract workers at 2 (`config.parallel.max(2)` on the BAM path — `std::thread`
+   workers, no N=1 deadlock) and re-measure before merge. Record vs the ~20s baseline.
+
+## Questions or ambiguities
+- (Open, non-critical) `DECODE_THREADS` as a fixed const vs a hidden tuning flag/env — recommend
+  fixed const (matches `GZIP_COMPRESS_THREADS`); revisit only if a future workload wants it.
+- (Open, non-critical) SAM/CRAM stay single-threaded (not BGZF) — correct, no threaded path there.
+- No **Critical** ambiguities: mechanism + adaptation points + sweet-spot value are all measured/known.
+
+## Self-Review
+- **Logic:** the only functional change is the reader behind the producer; the pipeline, ordering
+  (`batch_seq`), and all output paths are untouched. ✓
+- **Edge cases:** empty BAM / single-record BAM (MultithreadedReader handles); coord-sorted BAM
+  (from_path rejects); SAM/CRAM (AnyReader path); `--mbias_only` (no writes — still decodes via
+  threaded reader, biggest beneficiary). ✓
+- **Byte-identity risk** (order preservation) is THE risk — mitigated by the existing suite now
+  running the threaded path at N=1 + the colossal smoke. If any test diverges, STOP (do not
+  loosen the assertion). ✓
+- **Efficiency:** capped at 2 (measured); always-on cost is ~+1 core — documented, acceptable. ✓
+- **Remaining risk:** the "1 worker + 2 decode threads ≈ 17.9s" assumption — if `--parallel 1`
+  doesn't realize the win (extract-bound at 1 worker), the default wouldn't benefit and we'd
+  reconsider (e.g. floor workers at 2). Flagged as the key perf-gate (Validation #5).
+
+## Implementation notes (2026-05-30 — IMPLEMENTED, all gates GREEN)
+**Shipped on branch `perf-r3-fixed2-decode`, `parallel.rs` + `tests/parallel_phase_f.rs` only:**
+- `40f3670` — always-on fixed-2-thread parallel BGZF decode for BAM (`DECODE_THREADS = 2` const,
+  decoupled from `--parallel`; `ProducerReader { Any, Threaded }` enum; SAM/CRAM keep the
+  single-threaded reader; `sam_input_matches_bam_through_r3_dispatch` test + `se_directional_records`
+  shared fixture).
+- `6f182f8` — floor BAM extract workers at 2 (`config.parallel.max(if is_bam {2} else {1})`): the
+  **pre-authorized fallback fired** (see Deviation below).
+
+**Validation results (mapped to the Validation list above):**
+- **#1 byte-identity suite — GREEN.** `cargo test -p bismark-extractor`: `parallel_phase_f` **19/19**,
+  lib **105**. Legacy vs parallel byte-identical at N=1 *and* N=4 (BAM now uses the threaded reader at all N).
+- **#2 ordering guard — PASS.** `bismark-io::threaded_bam_reader_preserves_record_order` (203-record
+  real BAM, worker_count=4).
+- **#3 SAM-input dispatch — PASS.** Added `sam_input_matches_bam_through_r3_dispatch` (SAM takes the
+  `Any` else-arm, not the threaded path).
+- **#4 coord-sort rejection — confirmed.** `from_path` (shared `check_not_coordinate_sorted`), not
+  `from_path_without_sort_check`.
+- **#5 clippy `-D warnings` + `fmt --check` — clean.**
+- **#6 real-data smoke — PASS (all 4).** oxy `phase_h_smoke` real 10M, SE+PE × {default, gzip},
+  finished 2026-05-30 12:39:58Z: every mode `exit=0`, all 8 files match (2 raw-identical +
+  6 sorted-equivalent). This is the multi-block parallel-inflate ordering proof the single-block unit
+  fixtures structurally cannot give.
+- **#7 perf re-measure (HARD gate) — PASSED, with the floor-at-2 fallback.** Final (oxy 10M PE):
+  `--parallel 1` plain `20.0→17.6 s`, `--mbias_only` `18.8→12.3 s`.
+
+**Deviation from plan — the pre-authorized floor-at-2 fallback fired (Validation #5/#7).** Without
+the floor, `--parallel 1` reached only ~18.5 s plain / ~16 s `--mbias_only` — a single extract worker
+cannot drain 2 decode threads, exactly the contingency both plan-reviewers flagged and Felix
+pre-authorized ("measure-first + floor fallback"). Applied `config.parallel.max(2)` on the BAM path
+(`6f182f8`) and re-measured → the default benefits fully. The floor is **byte-identity-invariant**
+(output reordered deterministically by `batch_seq` regardless of worker count), so it changes timing
+only, never bytes.
+
+**Reviews:** dual code-review **APPROVE** (no Critical/High/Medium; one Low — A-Low-2: normalize the
+three perf-number comment blocks in `parallel.rs` to one consistent story — addressed). plan-manager
+**COMPLETE** (0 gaps).

--- a/plans/05262026_bismark-extractor/PERF_R3_DECODE_PLAN_REVIEW_reviewer-A.md
+++ b/plans/05262026_bismark-extractor/PERF_R3_DECODE_PLAN_REVIEW_reviewer-A.md
@@ -1,0 +1,105 @@
+# Plan Review — PERF_R3_DECODE_PLAN.md (Reviewer A)
+
+**Target:** `/Users/fkrueger/Github/Bismark-extractor/plans/05262026_bismark-extractor/PERF_R3_DECODE_PLAN.md`
+**Code base:** worktree `/Users/fkrueger/Github/Bismark-extractor` (detached @ `b2af4e5`)
+**Reviewer:** A (independent, fresh context)
+**Verdict:** **APPROVE WITH MINOR CHANGES.** The single load-bearing risk (record-order preservation under the multithreaded reader) is *proven safe* by the noodles 0.47.0 source + an empirical test of the exact adaptation. No Critical findings. One Important finding (the "default benefits at 1 worker" perf assumption is the real open question and the plan correctly flags it as a perf-gate, not a correctness gate). A few Optional accuracy fixes to the plan text.
+
+I verified the plan by (a) reading the noodles `MultithreadedReader` source, (b) actually applying the plan's three edits to `parallel.rs` and running the full `parallel_phase_f` byte-identity suite + clippy, then reverting. **All 18 byte-identity tests passed; clippy clean.**
+
+---
+
+## 1. Logic review
+
+### 1a. Load-bearing risk: record-order preservation — RESOLVED (safe)
+This is THE risk and the plan rests its byte-identity contract on it. I did not take the "noodles contract" claim on faith — I read the pinned source.
+
+`noodles-bgzf =0.47.0`, `src/io/multithreaded_reader.rs`:
+- `spawn_reader` (`:364`) reads BGZF frames **sequentially** from the inner `File`. For each frame it creates a *per-block* one-shot channel `(buffered_tx, buffered_rx)` (`:383`), hands the compressed buffer to a shared inflate pool, and pushes `buffered_rx` onto the `read_tx` FIFO **in frame order** (`:385–386`).
+- The consumer side `recv_buffer` (`:352`) pops `buffered_rx` handles off `read_rx` in FIFO (= frame) order and blocks on that *specific* block's `buffered_rx.recv()`.
+
+So although inflaters (`spawn_inflaters` `:393`) run in parallel and may *finish* out of order, the consumer pulls inflated blocks back in **strict block order** via the per-block one-shot channels. The decompressed byte stream feeding `noodles_bam::io::Reader` is byte-for-byte identical to the single-threaded `bgzf::io::Reader`. Therefore record order is identical. **The plan's load-bearing assumption is correct by construction, not just by contract.**
+
+### 1b. Empirical confirmation of the adaptation
+I applied the plan's exact three edits (imports + `const DECODE_THREADS` + always-BAM selection + `ProducerReader` enum + `producer_loop` signature) and ran:
+- `cargo test -p bismark-extractor --test parallel_phase_f` → **18 passed, 0 failed**, incl. `legacy_vs_parallel_n1_*` (the new threaded-path-at-N=1 comparison), `parallel_se_byte_identical_across_n_1_2_4_8`, `parallel_pe_byte_identical_across_n_1_4_8`, the 8199-record multibatch, and the gzip-multibatch test.
+- `cargo clippy --all-targets` → clean (no warnings/errors).
+Then reverted via `git checkout`. The working tree is clean.
+
+This is the strongest possible evidence for "adaptation correctness" (plan scrutiny item 4): the change compiles, the const-init form works, and byte-identity holds at N=1 (now running the threaded reader) through N=8.
+
+### 1c. Adaptation cleanliness vs R1 batching divergence — CONFIRMED CLEAN
+Scrutiny item 4 asks whether R1 batching touches the reader in ways the plan misses. It does not. Grep of `parallel.rs` shows the reader is touched at exactly three sites:
+- `parallel.rs:211` `reader.header()` (chr_table)
+- `parallel.rs:220` `logger.header_provenance(reader.header())`
+- `parallel.rs:406` `let mut records_iter = reader.records();`
+
+All R1 batching logic (`flush_batch!`, `batch_seq`, PE pairing, error-slot retention) operates on `records_iter` (the `Box<dyn Iterator>`), never on the reader itself. The `ProducerReader` enum's `header()` + `records()` cover all three sites. The d3dd289 enum applies verbatim; the only delta from #887 is dropping the `n_workers >= 2` gate and using `DECODE_THREADS` instead of `n_workers`. **No hidden coupling.**
+
+### 1d. Sort-check + SAM/CRAM exclusion — CORRECT
+`ThreadedBamReader::from_path` (`read.rs:318`) calls `check_not_coordinate_sorted` (`:326`) — the **same** function `BamReader::new`/`open_reader` use (`:237`). Coordinate-sort rejection is preserved on the BAM path. The plan correctly mandates `from_path` (not `from_path_without_sort_check`). SAM/CRAM are correctly routed to `open_reader` (single-threaded) — they are not BGZF, so there is no threaded path to use. `AlignmentKind::from_path` (magic-byte sniff, `read.rs:111`) classifies BAM via the BGZF+`BAM\x01` payload check, so the `is_bam` gate is content-based, not extension-based — robust.
+
+### 1e. `records() -> Box<dyn Iterator>` boxing cost — NEGLIGIBLE
+Scrutiny item 6. The box is allocated **once** per `run_pipeline` invocation (one `reader.records()` call at `:406`), not per record. Per-record dispatch is one vtable indirection (~5–10 ns), already the status quo: `AnyReader::records()` (`read.rs:527`) already returns `Box<dyn Iterator>`, so the SAM/CRAM path is unchanged, and the new `ThreadedBamReader` arm adds the identical single-box pattern. No per-record allocation. Not a concern.
+
+---
+
+## 2. Assumptions
+
+| # | Assumption | Status |
+|---|---|---|
+| A1 | `MultithreadedReader::with_worker_count(2)` preserves record order | **VERIFIED SAFE** from source (§1a). The byte-identity suite at N=1 now exercises it (proven §1b). |
+| A2 | `ThreadedBamReader::from_path` applies the same sort-check | **VERIFIED** — same `check_not_coordinate_sorted` (§1d). |
+| A3 | **1 worker + 2 decode threads reaches ~17.9s** (default benefits) | **UNVERIFIED — the real open question.** See Important I1. The plan correctly flags this as the key perf-gate (Validation #5) and does NOT claim it as proven. |
+| A4 | `AlignmentKind::from_path` classifies BAM correctly | **VERIFIED** — magic-byte sniff + unit tests `from_path_detects_bam_via_bgzf_payload_on_fixture` etc. (`read.rs:765`). |
+
+The implicit assumption worth surfacing: **the win at 2 decode threads is independent of worker count.** #887 measured 2 decode threads coupled to 2 workers (`n_workers >= 2` ⇒ `with_worker_count(n_workers)`). The oxy table in the plan (`--mbias_only` 13.0s at "2 decode threads") was measured with `--mbias_only`, which has **no extract worker pipeline at all in the bottleneck sense** (no RoutedCall emission, no collector writes — it just decodes + accumulates). So the 13.0s `--mbias_only` number is genuinely a decode-floor measurement and transfers cleanly. The **plain `.txt` 17.9s** number is the one that depends on whether 1 extract worker keeps up — that is A3/I1.
+
+---
+
+## 3. Efficiency
+
+- **Always-on +1 decode thread:** bounded, ~+1 core (plan's 1.8→3.1 / 2.7→3.2). Acceptable. The `MultithreadedReader` holds `worker_count`-bounded in-flight buffers (`:185–191`: three `bounded(worker_count)` channels + `worker_count` recycled buffers), so memory is small and fixed at 2 — plan's claim is accurate.
+- **Capped at 2, not scaled with `--parallel`:** correct per the measured 3/4-no-gain data, and it avoids the over-subscription that would otherwise occur at high `--parallel` (e.g. `--parallel 8` would spawn 8 extract workers + 8 decode threads under #887's coupling; the plan's fixed-2 avoids that). This is a genuine improvement over #887, not just a default-benefit fix.
+- **`#887`'s "0.69× at worker_count=1" caveat:** This is a *perf* (not correctness) note and applies to `worker_count=1`, where `MultithreadedReader` still spawns a reader thread + 1 inflater thread (2 extra threads) for no parallelism gain — strictly worse than the single-threaded `bgzf::Reader`. The plan uses `worker_count=2`, which is the *measured-faster* configuration. So the 0.69× caveat does **not** apply. See Optional O2 for the one place this still matters (tiny CI fixtures).
+
+---
+
+## 4. Validation sufficiency
+
+**Strong overall.** The crucial property — that the byte-identity suite now genuinely exercises the threaded reader — is **confirmed**: the fixtures (`write_se_large_bam`, `write_pe_directional_bam`, etc. in `parallel_phase_f.rs:127+`) are written via `BamWriter::from_path` (real BGZF/BAM), and the legacy reference path (`extract_se`/`extract_pe` in `pipeline.rs:74/221`) uses single-threaded `open_reader`→`BamReader`. Under the always-BAM design the parallel path uses `ThreadedBamReader`. So `assert_dirs_byte_identical(legacy, parallel-n1)` is a true single-threaded-decode-vs-2-thread-decode comparison. An ordering regression *would* be caught. (Empirically confirmed: I ran it post-adaptation, all green.)
+
+**Gaps / inaccuracies:**
+- **V-gap-1 (Important→Optional):** Validation #2 claims "Coordinate-sorted-BAM **rejection** test still errors." There is **no such test at the extractor/integration level** — grep of `rust/bismark-extractor/tests/` for `UnsortedInput`/`SO:coordinate`/`b"coordinate"` returns nothing. The rejection is unit-tested only in `bismark-io` (`read.rs:899` `check_not_coordinate_sorted_rejects_coordinate`). Because `ThreadedBamReader::from_path` and `open_reader`/`BamReader` share the identical `check_not_coordinate_sorted` call, the behavior is preserved regardless — this is a **plan-text accuracy** issue, not a correctness risk. Either (a) soften Validation #2 to "the shared `bismark-io` sort-check unit test still applies (no extractor-level test exists; behavior is shared-code-guaranteed)", or (b) add a small extractor-level coord-sorted-BAM test that asserts `extract_se_parallel` returns `UnsortedInput`. (a) is sufficient.
+- **V-gap-2 (Optional):** Validation #5 (perf re-measure of `--parallel 1` plain `.txt` ≈ 17.9s) is the only check for A3/I1 and it is on **oxy**, not in CI. If oxy is unavailable at implementation time, A3 stays unverified and the "default benefits" claim is unproven. Recommend: make this a hard gate before claiming the headline win, and record the *baseline* re-measure too (the plan does say "Record vs the ~20s baseline" — good).
+- **V-good:** The empty-BAM fixture (`write_empty_bam`, `:234`) plus the `producer_panic_does_not_deadlock_workers` test cover the small-input/edge paths; the threaded reader on a header-only BAM is exercised. The 8199-record multibatch crosses `BATCH_SIZE` with the threaded reader. Good coverage.
+
+---
+
+## 5. Alternatives considered
+
+- **Floor workers at 2 (plan §self-review "remaining risk").** This is the most important design alternative and directly addresses A3/I1. If the perf re-measure shows `--parallel 1` does NOT realize ~17.9s (extract-bound at 1 worker), the cheapest fix is to floor the extract worker count at 2 *when input is BAM* (decode is parallel, so feeding 2 workers costs ~1 more core, total ~4 cores — still within the plan's measured 3.2-core envelope plus one). The plan defers this to "reconsider" — I agree it should NOT be pre-emptively adopted (it changes the default thread count and could regress tiny inputs), but the plan should state the **fallback decision rule** explicitly: "if Validation #5 shows <~5% improvement at `--parallel 1`, floor BAM workers at 2 and re-measure." Right now the fallback is vague ("reconsider e.g. floor workers at 2"). See Important I1.
+- **Hidden env/flag for `DECODE_THREADS`** (plan Q1): correctly rejected in favor of a fixed const matching `GZIP_COMPRESS_THREADS`. Agree.
+- **Reuse `AnyReader` by adding a `Threaded` variant** instead of a separate `ProducerReader` enum: rejected implicitly (the d3dd289 design adds a local enum). Correct — `AnyReader` is generic over `<R: BufRead, RC: Read+Seek>` and `ThreadedBamReader` is a concrete non-generic type wrapping `File`; bolting it onto `AnyReader` would pollute a shared `bismark-io` public type for an extractor-internal optimization. The local enum is the right scope.
+
+---
+
+## 6. Action items (prioritized)
+
+### Critical
+*(none)*
+
+### Important
+- **I1 — Make the A3 "default benefits" perf-gate a hard, decision-ruled gate.** The entire stated *Goal* ("the default `--parallel 1` must benefit") hinges on 1 extract worker keeping up with 2 decode threads on the plain `.txt` path — and this is **unverified**. The plan flags it (Validation #5, Self-Review) but the fallback is vague. Add an explicit decision rule to the plan: *if the oxy re-measure shows `--parallel 1` plain `.txt` does not drop to ≈17.9s (say <5% off the ~20s baseline), then floor BAM extract workers at 2 and re-measure before merging.* Without this rule the plan can "succeed" on tests yet miss its headline goal. (Plan §Validation #5, §Self-Review remaining-risk; `parallel.rs:206` `n_workers = config.parallel.max(1)`.)
+
+### Optional
+- **O1 — Fix Validation #2 wording (no extractor-level coord-sort test exists).** Either soften the claim to reference the shared `bismark-io` unit test (`read.rs:899`) or add an `extract_se_parallel` coord-sorted-BAM `UnsortedInput` test. Behavior is shared-code-safe either way. (Plan §Validation #2.)
+- **O2 — Note the tiny-fixture thread-spawn overhead is accepted, not free.** For 6-record CI fixtures, `with_worker_count(2)` spawns 1 reader + 2 inflater threads (`multithreaded_reader.rs:189–194`) vs the single-threaded reader's zero. This is correctness-neutral (proven: all 18 tests pass, suite runs in 0.37s) and perf-irrelevant on real workloads, but the plan's "MultithreadedReader handles empty/single-record BAM" (Self-Review edge cases) should add one clause: "thread-spawn overhead on tiny inputs is accepted (correctness-neutral; CI suite unaffected — measured 0.37s)." (Plan §Self-Review edge cases.)
+- **O3 — `const DECODE_THREADS` init form: `NonZeroUsize::new(2).unwrap()` compiles as const on the toolchain in use (rustc 1.95.0; `Option::unwrap` const-stable since 1.83).** I verified this directly. The plan's parenthetical "(or a match/expect const-init)" is unnecessary hedging — the simple `.unwrap()` form works. Either is fine; just don't waste an implementation cycle on it. (Plan §Implementation outline #2.)
+- **O4 — Update the module doc at `parallel.rs:11`** ("drives `open_reader().records()`") to mention the threaded-BAM decode path — the plan already lists this as outline step #7; just confirming it's a real stale-comment site (`parallel.rs:11`).
+
+---
+
+## 7. Summary
+
+The mechanism is sound and *proven* (noodles source + empirical test). The adaptation is mechanically clean and I ran it green. The only genuine open question is a **performance** one — whether 1 extract worker bottlenecks the plain-`.txt` default — and the plan correctly identifies it but should harden it into an explicit decision rule (I1). No correctness Critical findings. Approve once I1's fallback rule is written in and O1's validation wording is corrected.

--- a/plans/05262026_bismark-extractor/PERF_R3_DECODE_PLAN_REVIEW_reviewer-B.md
+++ b/plans/05262026_bismark-extractor/PERF_R3_DECODE_PLAN_REVIEW_reviewer-B.md
@@ -1,0 +1,341 @@
+# Plan Review — PERF_R3_DECODE_PLAN.md (Reviewer B)
+
+**Plan:** `plans/05262026_bismark-extractor/PERF_R3_DECODE_PLAN.md`
+**Code @ `b2af4e5`** (worktree `/Users/fkrueger/Github/Bismark-extractor`)
+**Reviewer:** B (independent; conclusions drawn from source, not the plan's self-assessment)
+**Verdict:** APPROVE WITH CHANGES. The core mechanism is sound and the load-bearing
+byte-identity claim is verifiable in the noodles source — but two of the plan's five
+validation items reference tests that **do not exist in this crate**, and the
+"`--parallel 1` benefits" success criterion rests on an unverified single-extract-worker
+throughput assumption that the plan itself flags but does not de-risk. Address the
+Critical/Important items below before implementation.
+
+---
+
+## 1. Logic review
+
+### 1.1 Record order under `MultithreadedReader` — VERIFIED SOUND (the linchpin)
+
+I traced the ordering contract directly in
+`~/.cargo/.../noodles-bgzf-0.47.0/src/io/multithreaded_reader.rs` (bismark-io pins
+`noodles-bgzf = "=0.47.0"`, `rust/bismark-io/Cargo.toml:24`):
+
+- A **single** `spawn_reader` thread reads raw BGZF frames *sequentially* and, per frame,
+  creates a per-block oneshot `(buffered_tx, buffered_rx)`, sends the work to the shared
+  inflater pool via `inflate_tx`, and pushes the **`buffered_rx` onto `read_tx` in file
+  order** (`multithreaded_reader.rs` `spawn_reader`, lines ~363–388).
+- The consumer (`recv_buffer` → `read_block`) pops `read_rx` strictly **FIFO** and blocks
+  on each block's oneshot `buffered_rx.recv()` (lines ~352–360, ~234–252).
+
+So decompression is parallel, but **emission to the BAM record reader is strict file
+order regardless of `worker_count`**. The decompressed byte stream handed to
+`noodles_bam::io::Reader` is byte-identical to the single-threaded `bgzf::io::Reader`.
+This is the noodles contract the plan's load-bearing assumption (§Assumptions bullet 1)
+depends on, and it holds. The plan is **not** unsound on this axis.
+
+Corroborating test already in-repo: `rust/bismark-io/tests/integration_fixture_bam.rs:261`
+`threaded_bam_reader_preserves_record_order` asserts qname-sequence equality between
+`BamReader` (single-threaded) and `ThreadedBamReader` at `worker_count=4` on the **real
+Perl-produced `tiny_pe_bismark.bam` (203 records, genuine multi-block)**. Plus
+`:295` strand-classification equality and `:231` record-count equality. These already
+exercise multi-worker decode against a real multi-block BAM and pass.
+
+**Judgment on the plan's "N=1 suite now runs the threaded path" sufficiency (its stated
+mitigation):** Necessary but *weak on its own*. See §4.1 — the extractor's own large
+fixture likely collapses into 1–2 BGZF blocks, so the extractor suite does **not** add a
+genuine multi-block ordered-content assertion; the only real multi-block ordering guard
+lives in bismark-io. That guard exists and is strong, but a plan that productionizes
+always-on threaded decode for the extractor should not *silently* rely on a sibling
+crate's fixture for its single most-important invariant. Recommend an explicit
+acknowledgement (cheap) — see Important I2.
+
+### 1.2 `producer_loop` touches `reader` only via `.records()` / `.header()` — VERIFIED
+
+`grep "reader\." parallel.rs` returns exactly three sites:
+- `:226` `build_chr_name_table(reader.header())`
+- `:235` `logger.header_provenance(reader.header())`
+- `:442` `let mut records_iter = reader.records();` (inside `producer_loop`)
+
+Both are covered by the `ProducerReader::{header, records}` enum methods copied from
+d3dd289. **No `AnyReader`-typed access leaks past the enum boundary**, no batching
+internal touches the reader. The enum + signature swap integrates cleanly with the
+post-R1-batching body. Confirmed for item §Independently-scrutinize #4.
+
+### 1.3 Sort-check / SAM / CRAM / CRAM-ref — VERIFIED CORRECT
+
+- `ThreadedBamReader::from_path` (`read.rs:318`) calls `check_not_coordinate_sorted`
+  (`:326`) — identical rejection to `BamReader::from_path` → `BamReader::new`
+  (`:237`). Same `BismarkIoError::UnsortedInput`. The plan correctly mandates `from_path`
+  (NOT `from_path_without_sort_check`). ✓
+- SAM/CRAM are routed to `ProducerReader::Any(open_reader(input, None))`, single-threaded,
+  unchanged. ✓ There is no threaded SAM/CRAM path (correct — SAM is text, CRAM is its own
+  container). ✓
+- CRAM-ref: the plan keeps `open_reader(input, None)` for the SAM/CRAM branch, so the
+  `cram_ref=None` → `MissingCramReference` path is **unchanged** (`read.rs:569–572`).
+  Note this is a pre-existing limitation, not introduced here: the extractor never wires a
+  `cram_ref`, so CRAM input has always errored with `MissingCramReference`. The plan does
+  not regress it. ✓ (If anything, worth a one-line note that CRAM remains unsupported
+  end-to-end — orthogonal to this PR.)
+
+### 1.4 Edge cases
+
+- **Empty BAM:** `write_empty_bam` (header + EOF block only). `MultithreadedReader`'s
+  reader thread hits `read_frame_into → Ok(None)` on the EOF block → loop breaks →
+  `recv_buffer` returns `None` → zero records. Then `producer_loop` emits zero batches
+  (the `if !items.is_empty()` guard at `:556`). Matches N=1 header-only finalize. Covered
+  by `parallel_empty_bam_at_n4_produces_header_only_files` (`:1065`), which will now run
+  through the threaded reader. ✓
+- **Single-record BAM:** one data block + EOF block → one buffered_rx in order → fine.
+- **Invalid-XM / unpaired-final / cross-chr:** these are post-decode kernel errors,
+  independent of the reader; unaffected. Covered at N=4 (`:976`, `:1003`, `:1029`).
+
+---
+
+## 2. Assumptions
+
+| # | Assumption (plan) | Status | Note |
+|---|---|---|---|
+| A1 | `MultithreadedReader(2)` emits records in single-threaded order | **VERIFIED** (noodles source, §1.1) | Strongest claim; holds at *any* worker count. |
+| A2 | `from_path` applies identical sort-check / errors | **VERIFIED** (`read.rs:326`) | Same `UnsortedInput`. |
+| A3 | 1 worker + 2 decode threads reaches ~17.9s (default benefits) | **UNVERIFIED — load-bearing for the *goal*** | Plan flags it (Validation #5 + Self-Review remaining-risk) but ships the design that bets on it. See §3.1 + I1. |
+| A4 | `AlignmentKind::from_path` classifies BAM correctly | **VERIFIED** (`read.rs:111`, magic-byte sniff incl. BGZF-payload `BAM\x01` check) | Robust; also handles mis-named files. |
+
+Hidden assumption the plan does **not** surface:
+
+- **H-1 (Critical-adjacent): the always-on threaded reader is never *slower* than the
+  current single-threaded reader on small inputs.** The d3dd289 commit message itself
+  records "0.69× at worker_count=1" and `read.rs:296–298` warns "For N==1 prefer
+  `BamReader::from_path` — the threaded constructor always spawns at least one worker
+  thread." The plan ships `worker_count=2` (not 1), and on every CI fixture + every
+  `bismark-io` integration test that now flows through the extractor. The plan asserts
+  "MultithreadedReader handles" small inputs but offers **no measurement that
+  worker_count=2 ≥ single-threaded** on tiny BAMs. With 2 inflater threads + 1 reader
+  thread spawned/torn-down per `run_pipeline`, the fixed thread-pool spawn cost is paid on
+  *every* invocation including `--mbias_only` on a 5-record BAM. This is almost certainly
+  fine for wall-clock correctness (tests assert *output*, not speed) but is an unstated
+  efficiency regression on the smallest inputs and on the test-suite runtime. See O1.
+
+---
+
+## 3. Efficiency
+
+### 3.1 Does `--parallel 1` actually get the win? (the recommended-stance item, #2)
+
+The measured win (17.9s plain `.txt`) was **2 extract workers + 2 decode threads**. The
+plan ships **`worker_count` = `--parallel` (default 1) + fixed 2 decode threads**, so the
+default = **1 extract worker + 2 decode threads**, a config that was *not* in the measured
+table. The plan's own Self-Review (lines 116–118) explicitly flags this as "the remaining
+risk."
+
+This is a real gap. The 17.9s figure decomposed as: decode floor ~13s (`--mbias_only`,
+2 decode threads), plain `.txt` ~17.9s. Under `--mbias_only` there is no write contention
+and the single extract worker does almost nothing → decode-bound → 1 worker is plausibly
+fine. But for plain `.txt` the single extract worker must also run `extract_calls` +
+routing + feed the collector. If extract+route per record exceeds decode-per-record, a
+single worker bottlenecks and the default lands above 17.9s — possibly close to today's
+~20s, i.e. **the headline "default benefits" goal partially fails** even though byte-
+identity is preserved.
+
+**My recommended stance (differs from the plan):** *Floor the extract workers at 2 when
+input is BAM*, i.e. `n_workers = config.parallel.max(2)` **only on the threaded-BAM path**
+(or unconditionally — the deadlock analysis in the module docs is about rayon, not
+`std::thread`; `std::thread` workers have no N=1 deadlock, and N=2 is strictly safer for
+the bounded-channel topology). Rationale:
+- The measured sweet spot was explicitly **2+2**, never **1+2**.
+- The plan already decouples decode threads from `--parallel` "so the default benefits" —
+  applying the same logic to the *extract* side (floor at 2) is the consistent move and is
+  what was actually measured.
+- Cost: one extra `std::thread` + the bounded channels at `n*4` (tiny).
+
+If the implementer instead keeps 1 worker, then **Validation #5 must be a hard gate, not
+a "re-measure"**: if `--parallel 1` plain `.txt` does not reach ≤ ~18s, the design must
+change before merge. As written, the plan treats #5 as a measurement to "record vs
+baseline" — it should be a *pass/fail* gate with the floor-at-2 fallback pre-authorized so
+the implementer doesn't stall.
+
+### 3.2 Decode-thread cap at 2 — SOUND
+
+3/4 threads measured no gain / slight regress; fixed const matches the
+`GZIP_COMPRESS_THREADS` precedent. Memory is bounded (`MultithreadedReader` channels are
+`bounded(worker_count)` = 2 in-flight buffers, `multithreaded_reader.rs` resume()). ✓
+
+### 3.3 Triple-sniff on the auto-detect path — MINOR
+
+In `--paired auto` mode (`main.rs:104`), the BAM is already opened twice today: `probe =
+open_reader` (`:108`, which internally calls `AlignmentKind::from_path`) then re-opened
+inside `run_pipeline` (`:210` `open_reader`, again sniffing). The plan **adds a third
+sniff**: an explicit `AlignmentKind::from_path(input)` in `run_pipeline` to choose the
+reader, *plus* — on the SAM/CRAM fallback — `open_reader` sniffs a 4th time. Each sniff is
+one `open(2)` + first-block inflate (~100–700µs per `read.rs:91–95` doc). Negligible vs a
+multi-second run, identical in shape to d3dd289, but worth a one-line acknowledgement that
+BAM is now sniffed 2–3× per run. Not a blocker. (O2)
+
+---
+
+## 4. Validation sufficiency
+
+### 4.1 The 8199-record "multibatch" test may NOT exercise multi-block decode ordering — IMPORTANT
+
+`write_se_large_bam` (`parallel_phase_f.rs:127`) writes 8199 tiny synthetic records via
+`BamWriter::from_path`. `BamWriter`/noodles flushes a BGZF block at ~64 KiB of *compressed*
+payload; 8199 records of ~5bp seq + minimal tags will very likely fit in **1–2 BGZF
+blocks**. So while this test will now *run through* `ThreadedBamReader`, it does **not
+reliably exercise the parallel-inflate-of-many-blocks ordering path** — with ≤2 blocks and
+2 workers, there's little reorder pressure. The plan's claim that the suite "now exercises
+the threaded reader at all N" is *technically true but thin* for the multi-block ordering
+case.
+
+The genuinely strong multi-block ordering guard is `bismark-io`'s
+`threaded_bam_reader_preserves_record_order` on the real 203-record Perl BAM (which has
+real multiple blocks) at worker_count=4. That exists and passes. But it is a *different
+crate's* test and is not part of the plan's Validation list.
+
+**Recommendation (I2):** Either (a) add the bismark-io order-preservation test to the
+plan's Validation list explicitly as the multi-block ordering guard, or (b) add one
+extractor-level assertion that runs the **real Phase-H fixture BAM** (or a deliberately
+many-block BAM) through `extract_se_parallel` at N=1 and N=2 and byte-compares to legacy
+`extract_se`. Option (a) is nearly free and sufficient given §1.1.
+
+### 4.2 Validation #2 references a NON-EXISTENT test — IMPORTANT (factual error in the plan)
+
+Validation #2: "Coordinate-sorted-BAM **rejection** test still errors (sort-check
+preserved)." I searched the extractor crate:
+`grep -rn "UnsortedInput|coordinate|SO:coordinate" rust/bismark-extractor/tests/` — **no
+such test exists.** Every extractor fixture uses `SO:unsorted` (e.g.
+`pe_phase_c.rs:1367/1388`, `mbias_writer_phase_d_smoke.rs:36`). Coordinate-sort rejection
+is tested only at the `bismark-io` unit level
+(`read.rs:899 check_not_coordinate_sorted_rejects_coordinate`) and in `bismark-dedup`.
+
+Since this PR **changes which reader BAM flows through** (`open_reader` → `ThreadedBamReader::from_path`),
+there is currently **no extractor-level regression guard** that a coord-sorted BAM is
+still rejected after the swap. The plan lists this as if it were an existing passing test
+to re-run. **Fix the plan**: either downgrade #2 to "covered by bismark-io unit test
+`check_not_coordinate_sorted_rejects_coordinate` (the threaded reader shares the same
+`check_not_coordinate_sorted`)" — which is honest — or *add* an extractor integration
+test that runs a `SO:coordinate` BAM through `extract_se_parallel` and asserts the error.
+Given that `ThreadedBamReader::from_path` and `BamReader::from_path` call the identical
+function, the bismark-io unit test is *technically* sufficient coverage; the plan just
+mis-describes where the coverage lives. (I prefer adding the 1 extractor test — it's the
+only place the new dispatch decision is made.)
+
+### 4.3 SAM input still works — NOT in the Validation list — IMPORTANT
+
+The plan changes `run_pipeline` to branch BAM-vs-(SAM/CRAM). The plan asserts SAM is
+"unchanged," but I found **no SAM-input integration test in the extractor `tests/`** that
+would catch a mistake in the `AlignmentKind::from_path` dispatch (e.g. accidentally
+routing SAM into the threaded BAM reader, which would then fail BGZF-detection). The
+extractor's SAM coverage is at the bismark-io reader level, not at the extractor pipeline
+level. The plan's Self-Review says "SAM/CRAM (AnyReader path)" as if covered. Recommend
+adding a one-record SAM-input smoke through `extract_se_parallel` to confirm the non-BAM
+branch survives. (I3 — lower than I2 because the branch logic is simple and the bismark-io
+SAM tests are solid, but the *dispatch* is new code here.)
+
+### 4.4 What IS sufficient
+
+- N=1 and N=4 legacy-vs-parallel byte-identity on **real on-disk BGZF BAMs** (fixtures use
+  `BamWriter::from_path` → real BGZF). Once always-on, these run the threaded reader. ✓
+- Empty / invalid-XM / unpaired-final / mbias-only at N=4. ✓
+- Colossal `phase_h_smoke` SE+PE plain **and** `--gzip` (Validation #4) — the binding
+  real-data byte-identity gate against Perl. Strong. ✓
+- clippy `-D warnings` + fmt. ✓ (Note: the implementer must add `use std::num::NonZeroUsize`
+  — not currently imported outside tests; `grep NonZero parallel.rs` returns only test
+  usages. Trivial but the plan's import list (§Implementation-outline #1) lists only the
+  `bismark_io` additions and not the `NonZeroUsize` import. Confirm both.)
+
+### 4.5 Perf gate sufficiency
+
+Validation #5 (`--parallel 1` plain ≈ 17.9s) is the **only** check on the headline goal,
+and as written it's a "record vs baseline," not a pass/fail. Given §3.1, this is the
+single most important gate and should block merge if unmet, with the floor-at-2 fallback
+pre-authorized. (Folds into I1.)
+
+---
+
+## 5. Alternatives
+
+1. **Floor extract workers at 2 on BAM (RECOMMENDED, see §3.1).** Reproduces the measured
+   2+2 sweet spot for the default. Smallest deviation from the plan's intent; one extra
+   `std::thread`. This is my top alternative and I'd make it the default design rather than
+   a fallback.
+
+2. **Min-size guard for the threaded reader.** Skip `ThreadedBamReader` (use
+   `open_reader`) when the BAM is below some byte threshold, to avoid the worker-pool spawn
+   on tiny CI fixtures (H-1). Trade-off: adds a `std::fs::metadata` stat + a magic number,
+   and risks a *different* code path on small vs large inputs (so the byte-identity suite
+   would test the single-threaded path for small fixtures and *not* the threaded path —
+   defeating the plan's "suite now runs threaded at N=1" mitigation). **Reject** — the
+   plan's always-on choice is better for test coverage; just accept the µs-scale small-
+   input overhead (O1).
+
+3. **Hidden env/flag for `DECODE_THREADS`.** The plan already considered + rejected this in
+   favor of a fixed const (matches `GZIP_COMPRESS_THREADS`). Agree — fixed const is right;
+   3/4 measured no-gain.
+
+4. **Keep d3dd289's `n_workers>=2` gate but add a `--parallel 2` default.** Changes the CLI
+   default rather than the decode coupling. Rejected: changes user-visible default
+   parallelism + CPU footprint for all users; the plan's decouple-decode approach is
+   cleaner and bounds the extra cost to ~1 core.
+
+---
+
+## 6. Action items (prioritized)
+
+### Critical
+- **C1 — Resolve the `--parallel 1` throughput bet before implementation (§3.1, A3).**
+  The headline goal ("default benefits, ~17.9s") rests on an *unmeasured* 1-worker+2-decode
+  config; the measured sweet spot was 2+2. Either (a) change the design to floor extract
+  workers at 2 on the threaded-BAM path (`config.parallel.max(2)`), which reproduces what
+  was measured, **or** (b) make Validation #5 a hard pass/fail gate (≤ ~18s) with the
+  floor-at-2 fallback pre-authorized so a failed measurement doesn't strand the
+  implementer. Do not ship the 1+2 design on the unverified assumption alone.
+
+### Important
+- **I1 — Promote Validation #5 to a blocking perf gate** (folds into C1): record the actual
+  `--parallel 1` plain `.txt` number and *fail the PR* if it doesn't beat the ~20s baseline
+  meaningfully.
+- **I2 — Fix the multi-block ordering coverage story (§4.1).** The extractor 8199-record
+  "multibatch" fixture likely produces ≤2 BGZF blocks, so it does NOT robustly exercise
+  parallel-inflate ordering. Add bismark-io's `threaded_bam_reader_preserves_record_order`
+  (real 203-record multi-block BAM, worker_count=4) to the plan's Validation list as the
+  named multi-block ordering guard, or add an extractor-level N=1-vs-legacy byte-compare on
+  a genuinely many-block BAM.
+- **I3 — Correct Validation #2 (§4.2).** No coordinate-sort rejection test exists in the
+  extractor crate. Either re-cite it to the bismark-io unit test
+  `check_not_coordinate_sorted_rejects_coordinate` (honest, and sufficient since both
+  readers share `check_not_coordinate_sorted`), or add an extractor integration test that
+  runs a `SO:coordinate` BAM through `extract_se_parallel` and asserts `UnsortedInput`.
+- **I4 — Add a SAM-input smoke through `extract_se_parallel` (§4.3)** to guard the new
+  BAM-vs-SAM/CRAM dispatch branch (the dispatch decision is *new code* this PR introduces;
+  nothing at the extractor pipeline level currently exercises non-BAM input through the
+  parallel path).
+
+### Optional
+- **O1 — Document the small-input overhead (H-1).** Note in the plan that worker_count=2 is
+  always-on incl. tiny CI fixtures + `--mbias_only`, paying a fixed 3-thread spawn/teardown
+  per run (d3dd289 noted 0.69× at worker_count=1). Confirm — even informally — that
+  worker_count=2 is not *slower* than single-threaded on the smallest fixtures, or simply
+  accept it (output correctness is unaffected; only µs-scale wall-time).
+- **O2 — Note the BAM is now sniffed 2–3× per run (§3.3)** (probe + run_pipeline classify +
+  open_reader fallback). Negligible, but the plan should say so.
+- **O3 — Stale line numbers.** Plan cites `:210/:211/:220/:365`; current `b2af4e5` has
+  header at `:226/:235`, `producer_loop` at `:364`, `reader.records()` at `:442` (R1
+  batching shifted them). d3dd289's diff was against a pre-R1-batching tree (`:207/:361`).
+  The mechanical adaptation still holds (the touched surface is localized), but the
+  implementer must re-locate rather than blind-apply.
+- **O4 — Confirm the `NonZeroUsize` import (§4.4).** `parallel.rs` does not import
+  `std::num::NonZeroUsize` outside `#[cfg(test)]`; the plan's import list (§Impl #1) lists
+  only `bismark_io` additions. Trivial, but make it explicit.
+- **O5 — One-line note that CRAM remains end-to-end unsupported** (extractor never passes
+  `cram_ref` → `MissingCramReference`). Pre-existing, not a regression; just clarity.
+
+---
+
+## Confidence notes
+- The byte-identity linchpin (record order under parallel decode) is **independently
+  verified in noodles source AND in an existing passing test** — high confidence the plan
+  is *correct* (won't produce wrong output).
+- The plan's *goal* (default `--parallel 1` realizes the win) is the genuine risk, and the
+  plan ships the one config that wasn't measured. That's why this is APPROVE-WITH-CHANGES,
+  not a clean APPROVE.
+- Two validation items (#2 rejection test, implied SAM coverage) describe coverage that
+  isn't where the plan implies — factual, fixable, not fatal.

--- a/rust/bismark-extractor/src/parallel.rs
+++ b/rust/bismark-extractor/src/parallel.rs
@@ -219,7 +219,18 @@ fn run_pipeline(
     config: &ResolvedConfig,
     is_paired: bool,
 ) -> Result<(), BismarkExtractorError> {
-    let n_workers = config.parallel.max(1);
+    // #884 R3: BAM decode uses the fixed-2-thread parallel-BGZF reader (always);
+    // SAM/CRAM (not BGZF) keep the single-threaded reader. Sniffed once, reused.
+    let is_bam = matches!(AlignmentKind::from_path(input)?, AlignmentKind::Bam);
+
+    // #884 R3 (perf gate, oxy 10M PE): floor BAM extract workers at 2 — a single
+    // extract worker can't drain the 2-thread parallel decode (`--parallel 1` on
+    // BAM measured ~18.5 s plain / ~16 s `--mbias_only`, vs ~17.8 s / ~13 s with
+    // ≥2 workers), so the common `--parallel 1` default benefits fully. SAM/CRAM
+    // (single-threaded decode) keep `max(1)` — extra workers can't beat serial decode.
+    // Output is byte-identical across worker counts (batch_seq reorder), so this
+    // floor changes timing only, not bytes.
+    let n_workers = config.parallel.max(if is_bam { 2 } else { 1 });
 
     // Open the reader on the main thread to get the header (for chr_table)
     // before we hand the reader off to the producer thread.
@@ -232,7 +243,7 @@ fn run_pipeline(
     // BGZF → keep the single-threaded reader. `ThreadedBamReader::from_path`
     // applies the SAME coordinate-sort rejection as `open_reader`, so the
     // read-order contract (PE adjacent-pairing) is unchanged.
-    let reader = if matches!(AlignmentKind::from_path(input)?, AlignmentKind::Bam) {
+    let reader = if is_bam {
         ProducerReader::Threaded(ThreadedBamReader::from_path(input, DECODE_THREADS)?)
     } else {
         ProducerReader::Any(open_reader(input, /*cram_ref=*/ None)?)

--- a/rust/bismark-extractor/src/parallel.rs
+++ b/rust/bismark-extractor/src/parallel.rs
@@ -8,7 +8,8 @@
 //!                 └─ worker N ─┘             (main thread)
 //! ```
 //!
-//! - **Producer** (single thread): drives `open_reader().records()`,
+//! - **Producer** (single thread): drives the reader's `records()` (BAM uses a
+//!   fixed 2-thread parallel-BGZF `ThreadedBamReader`, #884 R3; SAM/CRAM single-threaded),
 //!   accumulates `WorkerInputItem::Se | Pe | Err` into batches of up to
 //!   `BATCH_SIZE` (#884 R1), tags each batch with a monotonic `batch_seq`, and
 //!   sends one `InputBatch` per batch into a bounded MPMC channel. For PE the
@@ -70,7 +71,10 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use bismark_io::{BismarkPair, BismarkRecord, BismarkStrand, open_reader};
+use bismark_io::{
+    AlignmentKind, BismarkIoError, BismarkPair, BismarkRecord, BismarkStrand, ThreadedBamReader,
+    open_reader,
+};
 use crossbeam_channel::{Receiver, RecvError, Sender, bounded};
 
 use crate::call::{CytosineContext, MethCall, extract_calls};
@@ -96,6 +100,18 @@ use crate::state::ExtractState;
 /// *pattern* transfers, not its exact per-batch memory profile — our payload is
 /// a `Vec<RoutedCall>` fanning to ≤12 output files.
 pub(crate) const BATCH_SIZE: usize = 4096;
+
+/// #884 R3: decode worker threads for the parallel-BGZF BAM reader.
+///
+/// **Fixed at 2, decoupled from `--parallel` by design.** Single-threaded BGZF
+/// decode is the pipeline's ~19 s ceiling — the extract workers sit idle behind
+/// it (CPU probe: ~2.8 cores used regardless of `--parallel`). An oxy trial
+/// (10M PE) measured **2 decode threads as the sweet spot**: `--mbias_only`
+/// 18.3→13.0 s, plain `.txt` ~20→~17.9 s; 3–4 threads add nothing (even regress).
+/// Fixing it at 2 (vs tying to `--parallel`) lets the common `--parallel 1`
+/// default benefit — same rationale shape as `output.rs::GZIP_COMPRESS_THREADS`.
+/// Applies to BAM only (BGZF); SAM/CRAM keep the single-threaded reader.
+const DECODE_THREADS: std::num::NonZeroUsize = std::num::NonZeroUsize::new(2).unwrap();
 
 /// One unit of producer→worker work: a single SE record, a single PE pair, or
 /// a producer-side error that keeps its input slot. EOS is signaled by the
@@ -207,7 +223,20 @@ fn run_pipeline(
 
     // Open the reader on the main thread to get the header (for chr_table)
     // before we hand the reader off to the producer thread.
-    let reader = open_reader(input, /*cram_ref=*/ None)?;
+    //
+    // #884 R3: BAM decode uses a fixed-2-thread parallel-BGZF reader
+    // (`ThreadedBamReader`), ALWAYS — independent of `--parallel` (see
+    // `DECODE_THREADS`). Single-threaded BGZF decode was the ~19 s pipeline
+    // ceiling; 2 decode threads drop the decode floor ~18.3→13.0 s and the plain
+    // `.txt` wall ~20→~17.9 s, so even `--parallel 1` benefits. SAM/CRAM are not
+    // BGZF → keep the single-threaded reader. `ThreadedBamReader::from_path`
+    // applies the SAME coordinate-sort rejection as `open_reader`, so the
+    // read-order contract (PE adjacent-pairing) is unchanged.
+    let reader = if matches!(AlignmentKind::from_path(input)?, AlignmentKind::Bam) {
+        ProducerReader::Threaded(ThreadedBamReader::from_path(input, DECODE_THREADS)?)
+    } else {
+        ProducerReader::Any(open_reader(input, /*cram_ref=*/ None)?)
+    };
     let chr_table: Arc<[String]> = Arc::from(build_chr_name_table(reader.header())?);
 
     // Console diagnostics (#882) — emit once on the main thread while we still
@@ -349,6 +378,32 @@ fn run_pipeline(
 
 // ─── Producer ────────────────────────────────────────────────────────────────
 
+/// Producer-side reader (#884 R3): the single-threaded [`AnyReader`] (SAM/CRAM)
+/// or the fixed-2-thread parallel-BGZF [`ThreadedBamReader`] (BAM). Both expose
+/// `header()` + `records()` yielding the same `Result<BismarkRecord, _>`; this
+/// enum lets `run_pipeline` and `producer_loop` own and drive either uniformly,
+/// so neither body changes vs the single-reader version.
+enum ProducerReader {
+    Any(bismark_io::AnyReader<std::io::BufReader<std::fs::File>, std::fs::File>),
+    Threaded(ThreadedBamReader),
+}
+
+impl ProducerReader {
+    fn header(&self) -> &noodles_sam::Header {
+        match self {
+            ProducerReader::Any(r) => r.header(),
+            ProducerReader::Threaded(r) => r.header(),
+        }
+    }
+
+    fn records(&mut self) -> Box<dyn Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_> {
+        match self {
+            ProducerReader::Any(r) => Box::new(r.records()),
+            ProducerReader::Threaded(r) => Box::new(r.records()),
+        }
+    }
+}
+
 /// Producer loop: drive the reader's `records()` iterator, accumulate
 /// [`WorkerInputItem`]s into batches of up to [`BATCH_SIZE`] (in strict input
 /// order, tagged with a monotonic `batch_seq`), and send one [`InputBatch`] per
@@ -362,7 +417,7 @@ fn run_pipeline(
 /// before the producer short-circuits; dropping them would break byte-identity
 /// on error inputs). The producer still `return`s after the first error.
 fn producer_loop(
-    mut reader: bismark_io::AnyReader<std::io::BufReader<std::fs::File>, std::fs::File>,
+    mut reader: ProducerReader,
     is_paired: bool,
     tx_input: Sender<InputBatch>,
     logger: crate::logging::Logger,

--- a/rust/bismark-extractor/src/parallel.rs
+++ b/rust/bismark-extractor/src/parallel.rs
@@ -107,7 +107,7 @@ pub(crate) const BATCH_SIZE: usize = 4096;
 /// decode is the pipeline's ~19 s ceiling — the extract workers sit idle behind
 /// it (CPU probe: ~2.8 cores used regardless of `--parallel`). An oxy trial
 /// (10M PE) measured **2 decode threads as the sweet spot**: `--mbias_only`
-/// 18.3→13.0 s, plain `.txt` ~20→~17.9 s; 3–4 threads add nothing (even regress).
+/// 18.8→12.3 s, plain `.txt` 20.0→17.6 s; 3–4 threads add nothing (even regress).
 /// Fixing it at 2 (vs tying to `--parallel`) lets the common `--parallel 1`
 /// default benefit — same rationale shape as `output.rs::GZIP_COMPRESS_THREADS`.
 /// Applies to BAM only (BGZF); SAM/CRAM keep the single-threaded reader.
@@ -225,7 +225,7 @@ fn run_pipeline(
 
     // #884 R3 (perf gate, oxy 10M PE): floor BAM extract workers at 2 — a single
     // extract worker can't drain the 2-thread parallel decode (`--parallel 1` on
-    // BAM measured ~18.5 s plain / ~16 s `--mbias_only`, vs ~17.8 s / ~13 s with
+    // BAM measured ~18.5 s plain / ~16 s `--mbias_only`, vs ~17.6 s / ~12.3 s with
     // ≥2 workers), so the common `--parallel 1` default benefits fully. SAM/CRAM
     // (single-threaded decode) keep `max(1)` — extra workers can't beat serial decode.
     // Output is byte-identical across worker counts (batch_seq reorder), so this
@@ -238,8 +238,8 @@ fn run_pipeline(
     // #884 R3: BAM decode uses a fixed-2-thread parallel-BGZF reader
     // (`ThreadedBamReader`), ALWAYS — independent of `--parallel` (see
     // `DECODE_THREADS`). Single-threaded BGZF decode was the ~19 s pipeline
-    // ceiling; 2 decode threads drop the decode floor ~18.3→13.0 s and the plain
-    // `.txt` wall ~20→~17.9 s, so even `--parallel 1` benefits. SAM/CRAM are not
+    // ceiling; 2 decode threads drop the `--mbias_only` wall 18.8→12.3 s and the
+    // plain `.txt` wall 20.0→17.6 s, so even `--parallel 1` benefits. SAM/CRAM are not
     // BGZF → keep the single-threaded reader. `ThreadedBamReader::from_path`
     // applies the SAME coordinate-sort rejection as `open_reader`, so the
     // read-order contract (PE adjacent-pairing) is unchanged.

--- a/rust/bismark-extractor/tests/parallel_phase_f.rs
+++ b/rust/bismark-extractor/tests/parallel_phase_f.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 
 use bismark_extractor::cli::{Cli, ResolvedConfig};
 use bismark_extractor::{extract_pe, extract_pe_parallel, extract_se, extract_se_parallel};
-use bismark_io::{BamWriter, BismarkRecord};
+use bismark_io::{BamWriter, BismarkRecord, SamWriter};
 use bstr::BString;
 use clap::Parser;
 use flate2::read::GzDecoder;
@@ -82,38 +82,104 @@ fn synth_record(
     BismarkRecord::from_noodles_record(record).expect("synth produces a valid BismarkRecord")
 }
 
+/// The 5 SE-directional records (3 OT XR=CT XG=CT + 2 OB XR=CT XG=GA), covering
+/// CpG/CHG/CHH meth+unmeth. Shared by the BAM and SAM fixtures so the two
+/// containers hold byte-for-byte the same records (the #884 R3 dispatch test
+/// compares their extractor output).
+fn se_directional_records() -> Vec<BismarkRecord> {
+    vec![
+        synth_record(b"r_OT_1", b"CT", b"CT", b"Zz...", b"ACGTC", 100, 0),
+        synth_record(b"r_OT_2", b"CT", b"CT", b"..X.x", b"ACGTC", 200, 0),
+        synth_record(b"r_OT_3", b"CT", b"CT", b"H.h..", b"ACGTC", 300, 0),
+        synth_record(b"r_OB_1", b"CT", b"GA", b"Z....", b"ACGTC", 400, 0),
+        synth_record(b"r_OB_2", b"CT", b"GA", b"..h..", b"ACGTC", 500, 0),
+    ]
+}
+
 /// SE-directional BAM with mixed methylation contexts + both OT and OB strands.
 fn write_se_directional_bam(path: &Path) {
-    let header = header_with_chr1();
-    let mut writer = BamWriter::from_path(path, header).unwrap();
-    // 3 OT records (XR=CT XG=CT) covering CpG/CHG/CHH meth + unmeth.
-    writer
-        .write_record(&synth_record(
-            b"r_OT_1", b"CT", b"CT", b"Zz...", b"ACGTC", 100, 0,
-        ))
-        .unwrap();
-    writer
-        .write_record(&synth_record(
-            b"r_OT_2", b"CT", b"CT", b"..X.x", b"ACGTC", 200, 0,
-        ))
-        .unwrap();
-    writer
-        .write_record(&synth_record(
-            b"r_OT_3", b"CT", b"CT", b"H.h..", b"ACGTC", 300, 0,
-        ))
-        .unwrap();
-    // 2 OB records (XR=CT XG=GA).
-    writer
-        .write_record(&synth_record(
-            b"r_OB_1", b"CT", b"GA", b"Z....", b"ACGTC", 400, 0,
-        ))
-        .unwrap();
-    writer
-        .write_record(&synth_record(
-            b"r_OB_2", b"CT", b"GA", b"..h..", b"ACGTC", 500, 0,
-        ))
-        .unwrap();
+    let mut writer = BamWriter::from_path(path, header_with_chr1()).unwrap();
+    for rec in se_directional_records() {
+        writer.write_record(&rec).unwrap();
+    }
     writer.finish().unwrap();
+}
+
+/// Same records as [`write_se_directional_bam`], written as **SAM** (#884 R3:
+/// SAM is not BGZF, so it must take the single-threaded reader, not the
+/// `ThreadedBamReader`).
+fn write_se_directional_sam(path: &Path) {
+    let mut writer = SamWriter::from_path(path, header_with_chr1()).unwrap();
+    for rec in se_directional_records() {
+        writer.write_record(&rec).unwrap();
+    }
+    writer.finish().unwrap();
+}
+
+/// #884 R3 dispatch guard: SAM input must route to the single-threaded reader
+/// (NOT the BAM-only `ThreadedBamReader`) and yield the SAME methylation data as
+/// the equivalent BAM — which now goes through the fixed-2-thread parallel-BGZF
+/// reader. Identical records in → identical split-file calls out, regardless of
+/// container or decode threading. Guards the new `is_bam ? Threaded : Any` else-arm.
+#[test]
+fn sam_input_matches_bam_through_r3_dispatch() {
+    let workdir = tempfile::tempdir().unwrap();
+    let bam = workdir.path().join("se.bam");
+    let sam = workdir.path().join("se.sam");
+    write_se_directional_bam(&bam);
+    write_se_directional_sam(&sam);
+
+    let bam_dir = workdir.path().join("from_bam");
+    let sam_dir = workdir.path().join("from_sam");
+    extract_se_parallel(
+        &bam,
+        &resolved_config(&[
+            "--single-end",
+            "--parallel",
+            "4",
+            "--output_dir",
+            bam_dir.to_str().unwrap(),
+            bam.to_str().unwrap(),
+        ]),
+    )
+    .unwrap();
+    extract_se_parallel(
+        &sam,
+        &resolved_config(&[
+            "--single-end",
+            "--parallel",
+            "4",
+            "--output_dir",
+            sam_dir.to_str().unwrap(),
+            sam.to_str().unwrap(),
+        ]),
+    )
+    .unwrap();
+
+    // Compare the methylation split-data files (CpG/CHG/CHH) — these carry no
+    // input filename (unlike splitting_report), so SAM (single-threaded reader)
+    // vs BAM (threaded 2-decode reader) must be byte-equal. Same `se` basename
+    // ⇒ same filenames in both dirs.
+    let mut compared = 0usize;
+    for entry in fs::read_dir(&sam_dir).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if (name.starts_with("CpG_") || name.starts_with("CHG_") || name.starts_with("CHH_"))
+            && name.ends_with(".txt")
+        {
+            let sam_bytes = fs::read(entry.path()).unwrap();
+            let bam_bytes = fs::read(bam_dir.join(&name)).unwrap();
+            assert_eq!(
+                sam_bytes, bam_bytes,
+                "split file {name}: SAM (Any path) differs from BAM (threaded path)"
+            );
+            compared += 1;
+        }
+    }
+    assert!(
+        compared > 0,
+        "expected >=1 methylation split file to compare"
+    );
 }
 
 /// SE BAM with `n` records — used to cross the parallel pipeline's


### PR DESCRIPTION
## What

R3 of the #884 extractor perf work. BAM decode now uses an **always-on, fixed
2-thread parallel-BGZF reader** (`ThreadedBamReader`, `DECODE_THREADS = 2`),
**decoupled from `--parallel`** so the default `--parallel 1` benefits. SAM/CRAM
(not BGZF) keep the single-threaded reader. BAM extract workers are **floored at
2** so a single worker can't bottleneck the 2 decode threads.

Single-threaded BGZF decode was the pipeline's ~19 s ceiling — the extract
workers sat idle behind it (CPU probe: ~2.8 cores used regardless of
`--parallel`). Parallelizing decode across BGZF blocks removes that ceiling while
preserving record order: noodles' `MultithreadedReader` inflates blocks in
parallel but emits records strictly in file order, so output stays byte-identical
to the single-threaded reader.

## Perf (oxy, 10M PE, floor-at-2)

| config         | before | after  |
|----------------|-------:|-------:|
| plain `.txt`   | 20.0 s | 17.6 s |
| `--mbias_only` | 18.8 s | 12.3 s |

## Changes
- `parallel.rs`: `DECODE_THREADS` const; `ProducerReader { Any, Threaded }`
  dispatch; `is_bam` worker floor-at-2; `producer_loop` takes `ProducerReader`.
  SAM/CRAM keep the single-threaded `open_reader`.
- `tests/parallel_phase_f.rs`: `sam_input_matches_bam_through_r3_dispatch` +
  `se_directional_records` shared fixture.
- Plan + review artifacts under `plans/05262026_bismark-extractor/PERF_R3_*`.

## Validation — all gates green
- byte-identity suite `parallel_phase_f` **19/19** + lib **105** (legacy vs
  parallel at N=1 *and* N=4 — BAM now uses the threaded reader at all N)
- `bismark-io::threaded_bam_reader_preserves_record_order` PASS (multi-block
  parallel-inflate ordering proof the single-block unit fixtures can't give)
- SAM-input dispatch test PASS; coord-sort rejection via the shared `from_path` check
- `clippy -D warnings` + `fmt --check` clean
- **real-data smoke (oxy, real 10M, SE+PE × {default, gzip}): all 4 PASS** — every
  output byte-identical or sorted-equivalent vs Perl v0.25.1
- dual code-review **APPROVE**; plan-manager **COMPLETE**

Byte-identity is worker-count-invariant (deterministic `batch_seq` reorder), so
the floor-at-2 changes timing only, never bytes.

Closes #884.
