### PR TITLE
fix(c2c): allow large_enum_variant on ReportWriter (unblock workspace clippy)

### DIFF
--- a/rust/bismark-coverage2cytosine/src/report.rs
+++ b/rust/bismark-coverage2cytosine/src/report.rs
@@ -29,6 +29,12 @@ use crate::summary::ContextSummary;
 
 /// Output sink for a report file — plain or gzip, with an explicit `finish()`
 /// (Phase C). The context summary is never routed through this (always plain).
+// The `Gz` variant is intentionally larger than `Plain` (it wraps a
+// `GzEncoder`). This enum is constructed once per output file, so the size
+// disparity is immaterial; boxing would only add an allocation + indirection on
+// the hot write path. Suppress `large_enum_variant` (surfaced by a clippy
+// toolchain bump on otherwise-unchanged code).
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum ReportWriter {
     Plain(BufWriter<File>),
     Gz(GzEncoder<BufWriter<File>>),


### PR DESCRIPTION
**CI hygiene.** clippy 1.95 (floating `@stable`) now flags c2c's `ReportWriter` enum with `large_enum_variant` (Gz 248B vs Plain 32B). c2c #892 merged green under an older clippy; the toolchain bump surfaced it on otherwise-unchanged code, so `cargo clippy --workspace -- -D warnings` now fails on **rust/iron-chancellor and every open PR** (e.g. #913).

Fix: `#[allow(clippy::large_enum_variant)]` on the enum (constructed once per output file — size disparity is immaterial; boxing would only add write-path indirection). No behavior change; all c2c tests pass. Workspace clippy clean under CI conditions (`RUSTFLAGS=-D warnings`).