### PR TITLE
docs: refresh Rust-rewrite status (per-tool table + top-level pointer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Bismark is a program to map bisulfite treated sequencing reads to a genome of in
 - Alignment seed length, number of mismatches etc. are adjustable
 - Output discriminates between cytosine methylation in `CpG`, `CHG` and `CHH` context
 
+> **Rust rewrite in progress:** Bismark's post-alignment tools are being ported from Perl to Rust — faster, with byte-identical output. See [`rust/`](rust/) for the workspace and a per-tool status table.
+
 ## Documentation
 
 The Bismark documentation can be found with the code in the [docs](docs) subfolder and can also be read online: <https://felixkrueger.github.io/Bismark/>

--- a/rust/README.md
+++ b/rust/README.md
@@ -37,9 +37,16 @@ cd rust
 cargo build --release
 ```
 
-The workspace currently contains:
+## Status
 
-- **`bismark-io`** (library) at `1.0.0-beta.2` — shared BAM/SAM/CRAM I/O on noodles, with v1.1's `ThreadedBamReader` / `ThreadedBamWriter` for parallel BGZF (de)compression. `1.0.0-beta.1` is published to crates.io; `1.0.0-beta.2` is queued for the next publish window.
-- **`bismark-dedup`** (library + `deduplicate_bismark_rs` binary) at `1.1.0-beta.1` — Rust port of Perl `deduplicate_bismark`, byte-identical to v0.25.1 on real-data WGBS (10M PE + ~55M PE) with optional `--parallel N` BGZF threading. `1.0.0-beta.1` is published to crates.io; `1.1.0-beta.1` is queued for the next publish window.
+| Perl tool | Rust crate (binary) | Version | State |
+|---|---|---|---|
+| _(shared library)_ | `bismark-io` | 1.0.0-beta.8 | noodles BAM/SAM/CRAM I/O + `ThreadedBam{Reader,Writer}` (parallel BGZF); byte-equal output is a CI invariant for consumers |
+| `deduplicate_bismark` | `bismark-dedup` (`deduplicate_bismark_rs`) | 1.2.1-beta.1 | **Byte-identical** to Perl v0.25.1 on real-data WGBS (10M + ~55M PE); optional `--parallel N` BGZF threading |
+| `bismark_methylation_extractor` | `bismark-extractor` (`bismark-methylation-extractor-rs`) | 1.0.0-beta.1 | **Byte-identical** at full scale (WGBS PE/SE + RRBS, worker-count-invariant); **~4.8×** vs Perl `--multicore 12` |
+| `bismark2bedGraph` | `bismark-bedgraph` (`bismark2bedGraph_rs`) | 1.0.0-beta.1 | **Byte-identical** (decompressed content); **~3.4×** |
+| `coverage2cytosine` | `bismark-coverage2cytosine` (`coverage2cytosine_rs`) | 1.0.0-alpha.1 | In progress — byte-identity golden tests through phase D |
+| `bismark_genome_preparation` | `bismark-genome-preparation` (`bismark_genome_preparation_rs`) | 1.0.0-alpha.1 | Converted CT/GA FASTA **byte-identical** to Perl v0.25.1 (indexing delegated to the external indexer) |
+| `methylation_consistency` | `bismark-methylation-consistency` (`methylation_consistency_rs`) | 1.0.0-beta.1 | **Byte-identical** output vs Perl v0.25.1 |
 
-Additional binary crates (`bismark-extractor`, `bismark-bedgraph`, `bismark-coverage2cytosine`, etc.) land as their Phase 1 sub-issues are implemented.
+Versions are the crate manifests on `rust/iron-chancellor`. "Byte-identical" = validated against Perl Bismark v0.25.1 per each crate's README/CHANGELOG + golden/real-data tests; speedups are full-scale where measured. Per-crate detail lives in each crate's `README.md` / `CHANGELOG.md`. `bismark-io` and `bismark-dedup` have early beta lines published to crates.io; later betas are queued for the next publish window.


### PR DESCRIPTION
## What

Refresh the Rust-rewrite status docs so a reader landing on `rust/iron-chancellor` sees the *actual* maturity of the rewrite.

- **`rust/README.md`** — the "workspace currently contains" section was stale: it listed only **2 of 7** crates (`bismark-io` beta.2, `bismark-dedup`) and said the rest were "pending." Replaced with a **per-tool Status table** (Perl tool · crate · binary · version · state) covering all 7 crates.
- **top-level `README.md`** — had **zero** Rust mention; added a one-line pointer to `rust/`.

## Accuracy note

Statuses are grounded in each crate's **manifest + README/CHANGELOG + tests on this branch**, not memory (which lags/leads merged state). Notably `bismark-coverage2cytosine` is `1.0.0-alpha.1` with phase-B/C/D byte-identity golden tests — stated as "in progress," not the memory's "beta.1/complete." `bismark-io` corrected beta.2 → beta.8. Speedups claimed only where measured (extractor ~4.8×, bedgraph ~3.4×).

Docs-only; no source/behavior change.
