### PR TITLE
feat(genomeprep): implement --genomic_composition (#919)

### DIFF
--- a/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_CODE_REVIEW_A.md
+++ b/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_CODE_REVIEW_A.md
@@ -1,0 +1,144 @@
+# Code Review A — `--genomic_composition` (Bismark #919)
+
+**Reviewer:** A (independent; a second reviewer runs concurrently)
+**Date:** 2026-05-31
+**Scope:** Rust port of Perl `bismark_genome_preparation`'s genomic mono-/di-nucleotide
+frequency table (`genomic_nucleotide_frequencies.txt`).
+**Branch / worktree:** `rust/genomeprep-genomic-composition` @ `/Users/fkrueger/Github/Bismark-genomeprep`
+**Acceptance gate:** byte-identity of `genomic_nucleotide_frequencies.txt` to Perl Bismark v0.25.1.
+**Mode:** REPORT-ONLY (no source edited).
+
+---
+
+## Summary
+
+**Verdict: No correctness issues found. Ship it.**
+
+The implementation is a careful, faithful port. I read `composition.rs` in full, traced
+the Perl original (`get_genomic_frequencies` / `process_sequence` / `read_genome_into_memory`
+/ `extract_chromosome_name`), hand-recomputed the two trickiest expected byte strings, and
+ran the suite. All 10 byte-identity invariants from the brief hold. The live Perl-oracle test
+(`perl_vs_rust_genomic_composition`) passes, which is the strongest available signal short of
+the real-data gate.
+
+Test results (run with `dangerouslyDisableSandbox: true` in the worktree, matching the
+author's report):
+
+- `cargo test -p bismark-genome-preparation --lib` → **59 passed; 0 failed** (incl. all 20
+  `composition::tests`).
+- `cargo test -p bismark-genome-preparation` (integration) → **13 passed; 0 failed**, including
+  the live Perl oracle `perl_vs_rust_genomic_composition` and `perl_vs_rust_*` peers.
+- `cargo clippy -p bismark-genome-preparation --all-targets` → **clean** (no warnings).
+
+The only findings are Low/informational (no behavioural impact on the gate).
+
+---
+
+## Byte-identity invariants — verification
+
+| # | Invariant | Verdict | Notes |
+|---|-----------|---------|-------|
+| 1 | Freq pass `uc`-only, NOT the `[^ATCGN]→N` conversion; IUPAC + stray bytes are their own keys; only literal `N` skipped (mono) / excludes a di-mer if EITHER base is `N` | ✅ | `count_bytes` does `to_ascii_uppercase` then `if u != b'N' { mono++ }` and `if p != b'N' && u != b'N' { di++ }`. No `[^ATCGN]→N` map. Matches Perl `unless ($mono eq 'N')` + `index($di,'N') < 0`. Confirmed against `convert::map_into` (the *other* path that DOES map to N) — they are correctly distinct. |
+| 2 | `prev` (di-carry) reset per file AND at every header | ✅ | `prev` is a local in `count_file` (per file); set to `None` after every in-file `>` header (line 108). Tests `di_does_not_span_chromosomes` / `di_does_not_span_files` pin it. |
+| 3 | `chomp` then `s/\r//` (first `\r` only); di-carry continues across the removed byte | ✅ | `count_sequence_line` drops one trailing `\n`, then `position(== b'\r')` removes only the FIRST `\r`, counting the two segments with a **shared** `prev` — exactly reproducing Perl's post-`s/\r//` adjacency. Hand-traced `A\r\rC` (see below). |
+| 4 | Output sorted by Perl `sort keys %freqs` (plain byte cmp over mixed 1-byte mono + 2-byte di keys); NOT `fasta_name_cmp` | ✅ | `write_counts` iterates leading byte `b` ascending, emitting the 1-byte mono key first then its `[b, c]` di block for `c` ascending. A 1-byte key is a strict prefix of its 2-byte extensions, so it sorts before them; smaller leading bytes come first → exact global byte-lexical order. Uses raw `b as u8` indices, **not** the case-folding `fasta_name_cmp` (which is only used for the glob). |
+| 5 | Error before any write (dup chromosome / non-`>` first line) | ✅ | `write_genomic_composition` counts **all** files (`count_file` can `Err`) and only **then** calls `write_table`. `count_file`/`check_header` return `Err` before `write_table` is reached → no orphan file. Tests `*_errors_and_no_file` / `*_no_orphan_file` assert the file does not exist. Pipeline runs this with `?` *before* `convert_split`, so a converted FASTA isn't written either. |
+| 6 | First line unconditionally a header; empty file → NotFasta | ✅ | `count_file` reads the first line; `n == 0` → `NotFasta`; otherwise `check_header` (which errors if first byte ≠ `>`). Header never counted. Tests `first_line_not_header_errors_and_no_file`, `empty_file_errors_and_no_file`, `bare_gt_first_line_is_not_counted`. |
+| 7 | `Mus_musculus.NCBIM37.fa` excluded from counting but NOT conversion | ✅ | `write_genomic_composition` `continue`s on `file_name() == "Mus_musculus.NCBIM37.fa"` (byte match). `convert.rs` has no such skip. Confirmed Perl has the `next if ...` ONLY at line 694 in `read_genome_into_memory`, not in `process_sequence_files`. Test `mus_musculus_file_excluded_from_counting`. |
+| 8 | Non-fatal write (warn + skip on open/write/flush error); empty / N-only → 0-byte file | ✅ | `write_table` swallows `File::create` and `write_counts`/`flush` errors into `logger.note`, returns `()`, and `write_genomic_composition` returns `Ok(())`. Empty counters → `write_counts` emits nothing → a 0-byte file (still `File::create`d). Tests `n_only_genome_is_zero_byte_file`, `header_only_record_is_zero_byte_file`. |
+| 9 | Wiring: AFTER `create_tree`, BEFORE `convert_split` | ✅ | `pipeline.rs` Step I.5 (lines 47–54) sits between `folders::create_tree` (line 42) and `convert::convert_split` (line 58). Matches Perl `create_bisulfite_genome_folders` → `get_genomic_frequencies` → `process_sequence_files`. |
+| 10 | `to_ascii_uppercase` == Perl `uc` for the gate | ✅ | Perl's default `uc` (no `unicode_strings`/locale) folds only ASCII a–z on a byte string; bytes ≥ 0x80 are unchanged. `to_ascii_uppercase` folds exactly a–z (0x61–0x7A) and leaves all other bytes (incl. ≥ 0x80) unchanged. Identical for every byte. |
+
+### Dup-detection semantics (insert-at-header-read vs Perl store-at-next-header)
+
+Verified the two strategies detect the **same set of duplicates with the same (no-file)
+outcome**. Perl stores a name into `%chromosomes` deferred by one header (it checks
+`exists $chromosomes{$prev_name}` when it reads the *next* header / hits EOF), whereas Rust
+inserts into `seen` at the moment each header is read. Traced `>A … >A … >B` and
+`>A` immediately followed by `>A`: Perl dies one header later than Rust, but both die, and
+on the identical condition (a name appearing ≥2 times). Because every header is read by Rust
+and eventually stored by Perl, the inserted **set** is identical, so any name occurring ≥2×
+trips both. Error *text* is STDERR-only (not byte-gated). The `seen` set is also shared
+across files (cross-file dup), matching Perl's global `%chromosomes`; test
+`duplicate_across_files_errors` covers it. **Equivalent — no divergence.**
+
+---
+
+## Hand-recomputed tricky expectations (both correct)
+
+**`carriage_return_first_only_removed`** — input seq line `A\r\rC\n`:
+- chomp → `A\r\rC`; `s/\r//` removes first `\r` → segments `A` and `\rC` (shared `prev`).
+- mono: `A`=1, `\r`(0x0D)=1, `C`=1. di: `A\r`=1 (prev `A`→`\r`), `\rC`=1 (`\r`→`C`).
+- Emit (leading byte asc, mono before its di-block): `\r`(0x0D) mono, `\rC` di; `A`(0x41) mono,
+  `A\r` di; `C`(0x43) mono.
+- → `\r\t1\n\rC\t1\nA\t1\nA\r\t1\nC\t1\n`. **Matches the test literal.** ✓
+
+**`stray_space_counted_as_own_key`** — input seq line `A C\n`:
+- mono `A`=1, ` `(0x20)=1, `C`=1. di `A ` (A→space)=1, ` C` (space→C)=1.
+- Emit: ` `(0x20) mono, ` C` di; `A`(0x41) mono, `A ` di; `C`(0x43) mono.
+- → ` \t1\n C\t1\nA\t1\nA \t1\nC\t1\n`. **Matches the test literal.** ✓
+
+Both confirm the byte-lexical interleave (1-byte key directly before its 2-byte extensions,
+including a sub-0x41 leading byte's keys sorting ahead of `A`'s).
+
+---
+
+## Issues by area
+
+### Logic / correctness
+None. The N-handling, di-carry (including the across-the-removed-`\r` continuation), per-file
+`prev` reset, header non-counting, dup-before-write ordering, and sort all match Perl.
+
+### Efficiency
+- `[u64; 256]` mono + `vec![0u64; 65536]` di is allocation-free on the hot path (no per-base
+  `Vec<u8>` keys). The `write_counts` final pass is a fixed 256×257 scan regardless of genome
+  size — negligible. `count_sequence_line` allocates nothing in the common (no-`\r`) case. Good.
+
+### Errors / robustness
+- Write path is correctly non-fatal and never propagates from `write_table`. Read/count errors
+  propagate via `?` *before* any write. Both match Perl.
+
+### Structure / style
+- Module is well-documented, the doc comments correctly flag the load-bearing distinctions
+  (NOT the conversion path; first-`\r`-only; byte sort not `fasta_name_cmp`). Clippy clean.
+
+---
+
+## Recommendations (priority)
+
+- **Low (informational, no fix needed):** The CHANGELOG entry says "20 unit tests" — there are
+  exactly 20 `#[test]` fns in `composition.rs`, so this is **accurate**. (I flag it only because
+  the SKILL.md count and brief mentioned "59 lib"; the per-module 20 is correct.) No action.
+
+- **Low (optional, future hardening):** There is no unit/oracle test for a **high byte (≥0x80)**
+  in a sequence line (e.g. `0xFF` counted as its own mono/di key and sorted after `T`). The
+  `to_ascii_uppercase`/`uc` equivalence for such bytes is reasoned correct (and the `[u8;256]`
+  arrays cover the full range), but a 1-line oracle case would pin invariant #10's tail
+  explicitly. Not required for the gate (real genomes are ACGTN + occasional IUPAC); recommend
+  only if a future input might carry stray high bytes.
+
+- **Low (optional):** `perl_vs_rust_genomic_composition` is excellent but does not include a
+  CRLF record or a stray-`\r` line in its oracle genome (those are pinned by unit tests with
+  hand-computed expectations, not against live Perl). Adding a CRLF chromosome to that oracle's
+  synthetic genome would close the last gap between "unit-verified" and "Perl-verified" for the
+  `s/\r//` path. Again, not blocking — the conversion-path oracle (`perl_vs_rust_edge_inputs_mfa`)
+  already exercises CRLF/CR end-to-end against Perl, and the composition `s/\r//` logic is the
+  same shape.
+
+---
+
+## Files reviewed
+
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/src/composition.rs` (full)
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/src/pipeline.rs`
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/src/convert.rs`
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/src/discovery.rs`
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/src/error.rs`
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/src/cli.rs`
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/src/lib.rs`
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/src/logging.rs`
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/tests/integration.rs`
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/tests/byte_identity_real_data.rs`
+- `/Users/fkrueger/Github/Bismark-genomeprep/rust/bismark-genome-preparation/CHANGELOG.md` + `Cargo.toml`
+- Perl original `/Users/fkrueger/Github/Bismark/bismark_genome_preparation` (lines 186–192, 518–582, 665–751)
+- Plan `GENOMIC_COMPOSITION_PLAN.md` (rev 1)

--- a/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_CODE_REVIEW_B.md
+++ b/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_CODE_REVIEW_B.md
@@ -1,0 +1,78 @@
+# Code Review B — `--genomic_composition` (issue #919)
+
+**Reviewer:** B (independent)
+**Date:** 2026-05-31
+**Branch / worktree:** `rust/genomeprep-genomic-composition` @ `/Users/fkrueger/Github/Bismark-genomeprep`
+**Acceptance gate:** `genomic_nucleotide_frequencies.txt` **byte-identical** to Perl `bismark_genome_preparation` v0.25.1.
+
+## Verdict
+
+**APPROVE — ship.** The implementation is byte-identical to Perl across every edge case I could construct, including ones the in-tree tests do not cover (interior `\r`, blank CRLF lines, high bytes ≥0x80, large counts, multi-file di non-spanning, orphan-file suppression). No correctness defects found. Counters are allocation-free and bounds-safe. Recommendations below are all **Low** (cosmetic / optional).
+
+## What I verified
+
+### Live byte-identity against real Perl v0.25.1 (the strongest evidence)
+I built the Rust binary (`bismark_genome_preparation_rs`) and ran both it and the real Perl script (`/Users/fkrueger/Github/Bismark/bismark_genome_preparation`) with `--genomic_composition` on a fake-indexer harness, comparing only `genomic_nucleotide_frequencies.txt` byte-for-byte. **17/17 cases byte-identical (or "neither file written", as appropriate):**
+
+| Case | Input | Result |
+|------|-------|--------|
+| basic | multi-record, lowercase, IUPAC (`NRYK`), final no-newline | identical |
+| single interior `\r` | `AB\rCD` (di must bridge removed `\r`) | identical |
+| double `\r` | `A\r\rC` (first removed, 2nd survives, sorts before `A`) | identical |
+| blank LF line | `AC\n\nGT` (di carries across blank) | identical |
+| blank CRLF line | `AC\r\n\r\nGT\r\n` | identical |
+| stray space+tab | `A C\tG` (counted as own keys) | identical |
+| all-N | `NNNN` | both 0-byte |
+| bare `>` header | `>\nACGT` | identical |
+| leading-ws header | `>   chrX  desc` | identical |
+| high byte ≥0x80 | `A\xc3\xa9C` (UTF-8 `é`) — `uc` vs `to_ascii_uppercase` | identical |
+| lowercase `n` | `AnCg` (uppercased to `N`, then skipped) | identical |
+| **duplicate chr** | `>dup…>dup…` | **neither file written** (orphan check OK) |
+| Mus_musculus skip | mouse file + real chr | identical (mouse excluded) |
+| multi-file di | two `.fa`, di must not span files | identical |
+| gzip `.fa.gz` | gzipped multi-line | identical |
+| `ANC` (prev-past-N) | A, C monos; **no** di | identical |
+| large counts | 64 kbp wrapped, repeated motif (`A 12000`, `KA 3999`) | identical |
+
+The `KA 3999` vs `K 4000` result confirms the per-chromosome trailing-base correctly drops the final di, and IUPAC codes are counted as their own keys (NOT mapped to N — the load-bearing divergence from the conversion path).
+
+### Test suite + lint
+- `cargo test -p bismark-genome-preparation`: **all pass** (59 lib unit tests incl. 20 in `composition::tests`; 13 integration incl. the live `perl_vs_rust_genomic_composition` oracle; 2 binary e2e). `11.67s`.
+- `cargo clippy -p bismark-genome-preparation --all-targets`: **clean** (no warnings).
+
+## Targeted failure-mode findings (the items the brief asked me to hunt)
+
+1. **Di adjacency direction / order** — Correct. `count_bytes` records `(prev, current)` as `di[p*256 + u]` in source order; reproduced exactly by the live oracle (e.g. `AR`/`RC`, `RY`/`YK`). The last base of a chromosome produces no trailing di because `prev` is reset (`None`) before the next chromosome and never has a successor at end-of-file.
+
+2. **`s/\r//` first-only + di bridge** — Correct. `count_sequence_line` splits at the *first* `\r` and calls `count_bytes` on the two segments **in order with a shared `prev`**, so (a) only the first `\r` is removed, the second is counted as its own byte, and (b) the byte before and the byte after the removed `\r` become an adjacent di-mer. `A\r\rC` → mono `\r`,`A`,`C`; di `A\r`,`\rC`. Matches Perl (`composition.rs:140-155`, test `carriage_return_first_only_removed`, and my `c3_double_cr` live case).
+
+3. **Sort correctness over mixed 1-/2-byte keys** — Correct. For each leading byte `b` ascending, the 1-byte mono key is emitted *before* its 2-byte di block (`[b,c]`, `c` ascending). This equals Perl's `sort keys %freqs` because a 1-byte key is a prefix of (hence `lt`) every 2-byte extension, and all keys with a smaller leading byte sort first. I tried to construct a counterexample with the space (0x20) interleaving against `A`-keys — `stray_space_counted_as_own_key` expects `" \t1\n C\t1\nA\t1\nA \t1\nC\t1\n"`, which my `c6_space_tab` live run confirmed identical to Perl. No counterexample exists.
+
+4. **Counter bounds** — Safe. `mono: [u64;256]` indexed by a `u8` (0–255). `di: vec![0u64; 256*256]` (= 65536) indexed `p*256+u` with max `255*256+255 = 65535`. No possible OOB.
+
+5. **Allocation / perf on a 3 Gbp genome** — Clean. Counters are stack/heap-once (`[u64;256]` + one 512 KiB `Vec`). The hot `count_bytes` loop does no allocation. `count_sequence_line`'s no-`\r` fast path takes the `None` branch and slices `body` directly — **no allocation**. The only per-key allocation is in `write_table`/`emit` (`count.to_string()`), which runs ≤ 65 792 times total (once per non-zero key), not per base. `read_until(b'\n', &mut line)` reuses the same `line` buffer across the file (cleared, not reallocated). Good.
+
+6. **Error path leaves no orphan file** — Correct and verified live. `write_genomic_composition` counts **all** files first (`count_file` can return `Err`), and only then calls `write_table`. A `DuplicateChromosome` / `NotFasta` propagates via `?` before `write_table` is reached. My `c1`/`A_dup_orphan` live case confirms neither Perl nor Rust writes a table on a dup name; `duplicate_chromosome_errors_and_no_orphan_file` asserts the same.
+
+7. **Wiring order & no double-globbing** — Correct. `pipeline::run` discovers `files` once (`discovery::find_fasta_files`, line 32) and **reuses** that slice for composition (line 52) and conversion (line 59). No re-glob. Even if a later glob ran, the `.txt` output cannot match any FASTA extension group (`.fa`/`.fa.gz`/`.fasta`/`.fasta.gz` — see `discovery::in_group`). Placement is after `create_tree`, before `convert_split` — mirrors Perl's `get_genomic_frequencies()` → `process_sequence_files()`.
+
+8. **`Mus_musculus.NCBIM37.fa` skip** — Correct. Matched on raw `file_name().as_encoded_bytes()` against the byte literal (`composition.rs:63`), only inside the composition loop; the conversion path (`convert_split`) iterates the same `files` slice and is **not** filtered, so the mouse file is still converted. Verified by `B_mus_skip` (excluded from counts) — the conversion side is covered by existing convert tests.
+
+9. **N-handling (mono vs di vs prev-advance)** — Correct. Mono skips only `N`; di skips if `p == N || u == N`; `prev` advances unconditionally (`*prev = Some(u)` after the checks). `ANC` → monos `A`,`C`, no di — confirmed live identical to Perl.
+
+10. **`to_ascii_uppercase` vs Perl `uc`** — No divergence for any real genome. Perl's `uc` without `use feature 'unicode_strings'`/locale only folds ASCII `a`–`z`; bytes ≥ 0x80 are left unchanged — same as `to_ascii_uppercase`. My `c10_highbyte` case (UTF-8 `é` = `0xc3 0xa9`) confirms byte-identical output. (Genomes are ASCII; this is belt-and-braces.)
+
+## Recommendations (all Low / optional — none block the gate)
+
+- **[Low] Double blank line on STDERR.** `pipeline.rs:53` calls `logger.note("Finished processing genomic nucleotide frequencies\n")`; `Logger::note` uses `eprintln!`, which appends its own `\n`, so the message is followed by **two** newlines. This is STDERR-only (explicitly *not* byte-gated per `error.rs`/`logging.rs` docs) and harmlessly mirrors Perl's `warn "...\n\n"`. Optional: drop the trailing `\n` for a single blank line, or leave as-is to match Perl's `\n\n`. No action required.
+
+- **[Low] `extract_chromosome_name` borrows `line` while `seen` is mutated — fine, but note the lifetime.** `check_header` extracts `name: &[u8]` borrowing `line`, then does `seen.insert(name.to_vec())`. Correct (the `to_vec` copies before any conflicting borrow). No issue; flagging only that the `.to_vec()` is load-bearing for the borrow checker, not just for ownership — keep it.
+
+- **[Low] `write_table` reports the genome-folder path in the warning, matching Perl's text intent but not byte-for-byte.** Perl's warn is `"Failed to write out file ${genome_folder}genomic_nucleotide_frequencies.txt because of: $!. Skipping..."`. The Rust message is equivalent in content. STDERR is not gated, so this is purely informational. No action.
+
+- **[Low] CHANGELOG accuracy check — passes.** Claims "20 unit tests" (exactly 20 `#[test]` in `composition::tests`), "2 binary end-to-end" (present), live oracle + `#[ignore]` real-data gate (present). `cli.rs` doc no longer says "deferred/ignored" — confirmed (now "Calculate the genomic mono-/di-nucleotide composition…"). The `pipeline.rs` accept-and-ignore `logger.note` block is removed. Version bumped `1.0.0-alpha.1 → alpha.2` in `Cargo.toml` and `Cargo.lock`. All consistent.
+
+## Files reviewed
+- NEW `rust/bismark-genome-preparation/src/composition.rs` (full)
+- `src/pipeline.rs`, `src/convert.rs` (open_fasta + map_into), `src/lib.rs`, `src/cli.rs`, `src/discovery.rs` (extract_chromosome_name, find_fasta_files), `src/error.rs`, `src/logging.rs`
+- `tests/integration.rs`, `tests/byte_identity_real_data.rs`, `CHANGELOG.md`, `Cargo.toml`, `Cargo.lock`

--- a/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_COVERAGE.md
+++ b/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_COVERAGE.md
@@ -1,0 +1,80 @@
+# Plan Coverage Report — `--genomic_composition`
+
+**Mode:** B (code vs. plan)
+**Plan:** `GENOMIC_COMPOSITION_PLAN.md` (rev 1)
+**Codebase:** worktree `/Users/fkrueger/Github/Bismark-genomeprep`, branch `rust/genomeprep-genomic-composition`
+**Implementation crate:** `rust/bismark-genome-preparation/`
+**Date:** 2026-05-31
+**Verdict:** **COMPLETE** — every plan §1–§5 requirement and every §4 test maps to real code/tests; full suite green (72 passed / 0 failed; 3 real-data gates correctly `#[ignore]`).
+
+## Summary
+
+- Total items: 27
+- DONE: 27
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED: 0
+
+## Coverage ledger — requirements (§1–§3, §5)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | New module `src/composition.rs` with `write_genomic_composition` | §2 | DONE | `composition.rs:48` `pub fn write_genomic_composition(files, genome_folder, logger)` exact signature |
+| 2 | Array-indexed counters, no per-base allocation (`[u64;256]` mono + flat `vec![u64;65536]` di) | §2 rev-1(g) | DONE | `composition.rs:56-57` `mono = [0u64;256]`, `di = vec![0u64; 256*256]`; di flat-indexed `p*256 + u` (`:174`) |
+| 3 | NOT `[^ATCGN]→N`: ambiguity codes counted; only literal `N` skipped (mono); di skipped if either base is N | §1, §3 | DONE | `count_bytes` (`:161-178`): `if u != b'N' { mono+=1 }`; di guarded by `p != b'N' && u != b'N'`. No conversion-style mapping. Verified by `ambiguity_code_counted_not_mapped_to_n` |
+| 4 | First line = header unconditionally; `NotFasta` if not `>`; header NOT counted | §1, §2, §5.4 | DONE | `count_file` (`:91-95`) reads first line, `n==0`→`NotFasta`, else `check_header`; loop body never counts header lines (`:106-110` `continue`) |
+| 5 | Own dup-name check erroring BEFORE the table is written (no orphan file) | §2, §5.2 | DONE | `check_header` (`:120-132`) inserts into `seen` HashSet, returns `DuplicateChromosome`; `write_table` reached only after all files counted error-free (`:66-70`). `?` propagation in `count_file` short-circuits before `write_table` |
+| 6 | `s/\r//` removes the FIRST `\r` only; `chomp` strips one trailing `\n` | §1, §2 | DONE | `count_sequence_line` (`:140-155`): drops single trailing `\n`, then `position(\r)` removes only first occurrence (counts `[..i]` then `[i+1..]`, carrying same `prev`) |
+| 7 | `prev` (di-carry) reset per file AND at each header; spans line boundaries within a chromosome | §1, §3 | DONE | `prev` declared per-file (`:99`), reset to `None` at each in-file header (`:108`); carries across sequence lines (loop reuses it). No reset across sequence/blank lines |
+| 8 | Byte sort (NOT `fasta_name_cmp`) via array-iteration emit order | §2 rev-1(f) | DONE | `write_counts` (`:213-227`) iterates leading byte `b` ascending, emits mono `[b]` then di `[b,c]` block ascending → plain byte-lexical, no case-fold. Doc comment explicitly contrasts `fasta_name_cmp` |
+| 9 | Reuse `convert::open_fasta`, made `pub(crate)` | §2 rev-1(e) | DONE | `convert.rs:111` `pub(crate) fn open_fasta`; `composition.rs:26` imports + uses it (`:86`). No duplicated gz detection |
+| 10 | `Mus_musculus.NCBIM37.fa` excluded from counting | §1, §3 | DONE | `SKIP_FILENAME` const (`:35`); `write_genomic_composition` skips on byte-match of `file_name()` (`:63-65`). Verified by `mus_musculus_file_excluded_from_counting` |
+| 11 | gzip input handled (MultiGzDecoder via open_fasta) | §1, §3 | DONE | Inherited from `open_fasta` (gz-aware); `perl_vs_rust_gzip_input` integration test exercises `.fa.gz` |
+| 12 | Non-fatal write; empty/N-only → 0-byte file | §1, §5.1, §5.3 | DONE | `write_table` (`:183-204`) logs `note` + returns on File::create or write/flush error (no error propagated). Empty counters → `write_counts` emits nothing → 0-byte file. Verified by `n_only_genome_is_zero_byte_file`, `header_only_record_is_zero_byte_file` |
+| 13 | Wiring into `pipeline.rs` Step I.5 (after create_tree, before convert_split) | §2 | DONE | `pipeline.rs:42` `create_tree` → `:47-54` Step I.5 `if config.genomic_composition { write_genomic_composition(...)? }` → `:58` `convert_split`. Error propagation via `?` |
+| 14 | Accept-and-ignore note removed; cli.rs doc updated | §2 | DONE | No "deferred/ignored/not yet" note remains for the flag (grep clean except unrelated `combined.rs`). `cli.rs:82-85` doc rewritten to describe real behavior |
+
+## Coverage ledger — tests (§4)
+
+| # | Plan §4 test scenario | Test function | File | Status |
+|---|------|--------|------|--------|
+| 15 | ACGT-only (mono + di present) | `acgt_only_mono_and_di` | composition.rs | DONE |
+| 16 | N-skipping (mono N skipped, di-with-N skipped, di across N split) | `n_skipped_mono_and_di` | composition.rs | DONE |
+| 17 | Ambiguity code (`R`) counted as mono + in di | `ambiguity_code_counted_not_mapped_to_n` | composition.rs | DONE |
+| 18 | Di across a line boundary (multi-line record) | `di_spans_line_boundary_within_chromosome` | composition.rs | DONE |
+| 19 | Di NOT across chromosomes (two records in one file) | `di_does_not_span_chromosomes` | composition.rs | DONE |
+| 20 | Di NOT across files (`prev` reset per file) | `di_does_not_span_files` | composition.rs | DONE |
+| 21 | Blank line mid-chromosome preserves `prev` | `blank_line_preserves_di_carry` | composition.rs | DONE |
+| 22 | Exact sort order (mono-before-its-di; ambiguity interleaved by byte) | `acgt_only_mono_and_di` + `ambiguity_code_...` + `stray_space_counted_as_own_key` | composition.rs | DONE | Sort order asserted in every byte-exact table test; space (0x20<'A') and `\r` (0x0D) cases prove byte ordering across non-ACGT keys |
+| 23 | Error: first line not `>` → `NotFasta` + no table | `first_line_not_header_errors_and_no_file` (+ `empty_file_errors_and_no_file`) | composition.rs | DONE |
+| 24 | Bare `>` first line → empty name, not counted | `bare_gt_first_line_is_not_counted` | composition.rs | DONE |
+| 25 | Duplicate chromosome name → `DuplicateChromosome` AND no table file | `duplicate_chromosome_errors_and_no_orphan_file` (+ `duplicate_across_files_errors`) | composition.rs | DONE |
+| 26 | `s/\r//` first-`\r`-only (`A\r\rC` → second `\r` survives) | `carriage_return_first_only_removed` | composition.rs | DONE |
+| 27 | Final line with no trailing `\n` counted fully | `final_line_without_newline_counted` | composition.rs | DONE |
+| — | Perl-oracle integration comparing `genomic_nucleotide_frequencies.txt` | `perl_vs_rust_genomic_composition` | tests/integration.rs:447 | DONE | Auto-skips if `perl` absent (`oracle_compare` `:334-336`) |
+| — | Addition to `byte_identity_real_data.rs` `#[ignore]` gate | `byte_identity_real_data_genomic_composition` | tests/byte_identity_real_data.rs:158 | DONE | `#[ignore]`, compares `genomic_nucleotide_frequencies.txt` |
+| — | CLI no longer emits the deferred note; file produced | `binary_genomic_composition_freq_table_bytes` + `binary_no_genomic_composition_flag_writes_no_table` | tests/integration.rs:111,136 | DONE | Binary E2E asserts the table bytes and that the flag-off case writes no file |
+
+**Bonus tests beyond §4 (no gaps, extra coverage):** `lowercase_is_uppercased`, `crlf_line_terminator_stripped`, `stray_space_counted_as_own_key`, `header_only_record_is_zero_byte_file`.
+
+## Notable implementation detail (faithful, not a gap)
+
+- Dup-name detection inserts into `seen` at **header-read time** rather than Perl's store-on-next-header time. The plan (§2 footnote, code doc `:116-119`) accepts this: it detects the same set of duplicates (any name appearing ≥2×) and matches `crate::convert`'s behavior. Confirmed by `duplicate_chromosome_errors_and_no_orphan_file` and `duplicate_across_files_errors`.
+- `prev` advances for every byte including `N` (`count_bytes:176` unconditional `*prev = Some(u)`), so `N` correctly separates neighbours (the di across an `N` is dropped, but the bases on either side do not form a di — matches Perl `index($di,'N')<0` on the concatenated sequence). Verified by `n_skipped_mono_and_di`.
+
+## Test verification
+
+| Test binary | running | passed | failed | ignored |
+|-------------|---------|--------|--------|---------|
+| unittests src/lib.rs (incl. 20 composition.rs tests) | 59 | 59 | 0 | 0 |
+| unittests src/main.rs | 0 | 0 | 0 | 0 |
+| tests/byte_identity_real_data.rs (real-data gates) | 3 | 0 | 0 | 3 (`#[ignore]`, by design) |
+| tests/integration.rs | 13 | 13 | 0 | 0 |
+| Doc-tests | 0 | 0 | 0 | 0 |
+| **Total** | **75** | **72** | **0** | **3** |
+
+Command: `cd /Users/fkrueger/Github/Bismark-genomeprep/rust && cargo test -p bismark-genome-preparation` — all pass. The 3 ignored are the real-data byte-identity gates requiring `BISMARK_GENOMEPREP_REAL_GENOME_DIR` + Perl (run on oxy, not locally).
+
+## Verdict
+
+**COMPLETE.** Every requirement in plan §1–§3 and §5, every unit test in §4, the Perl-oracle integration test, the `#[ignore]` real-data gate addition, and the CLI behavior change are implemented and verified. No PARTIAL, MISSING, or DEVIATED items. No source code was modified during this audit.

--- a/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_PLAN.md
+++ b/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_PLAN.md
@@ -1,0 +1,80 @@
+# PLAN — `--genomic_composition` (genomeprep follow-up #919)
+
+**Status:** REVISED rev 1 (2026-05-31) — manual review ✅, **dual plan-review folded in** (`GENOMIC_COMPOSITION_PLAN_REVIEW_A.md`/`_B.md`). **Awaiting implementation trigger. Do not implement** until an explicit trigger.
+**Rev 1 (review fold-in):** (a) **first line of each file is unconditionally a header** (error if not `>`; NOT counted as sequence) — mirror `extract_chromosome_name`; (b) the freq pass does its **own duplicate-chromosome-name check and errors BEFORE writing the table** (Perl dies in the freq step before any output — "rely on the conversion's dup-check" was wrong: it would leave an orphan table file); (c) `s/\r//` = remove the **first `\r` anywhere** (not just trailing); (d) `prev` (di-carry) reset **per file** (at file start + each header); (e) reuse `convert::open_fasta` (make it `pub(crate)`); (f) **byte sort, NOT `fasta_name_cmp`** (that case-folds); (g) **array-indexed counters** (`[u64;256]` mono + flat `[u64;65536]` di) — no per-base allocation on GB genomes; (h) decisions resolved: write non-fatal, empty genome → 0-byte file.
+**Branch:** `rust/genomeprep-genomic-composition` (off `rust/iron-chancellor`). **Issue:** #919 (deferred from epic #912). **Companion:** the genomeprep `SPEC.md` §2.7 / §5.3 (same dir).
+**Acceptance gate:** `genomic_nucleotide_frequencies.txt` **byte-identical** to Perl Bismark v0.25.1.
+
+---
+
+## 1. What it does (Perl contract — `bismark_genome_preparation:518–570, 665–751`)
+
+When `--genomic_composition` is given, *before* the bisulfite conversion, read the genome and write a **mono- + di-nucleotide frequency table** to `<genome>/genomic_nucleotide_frequencies.txt`. Currently the Rust port **accepts-and-ignores** the flag (with a note); this implements it.
+
+**The frequency path is NOT the conversion path** (load-bearing): `read_genome_into_memory` does **`uc` only** — it does **NOT** apply the conversion's `[^ATCGN]→N` substitution. So the counter sees **raw uppercased bytes**:
+- **Mono:** for every byte of the (uppercased) sequence, `freqs{byte}++` **unless the byte is `N`**. → IUPAC ambiguity codes (`R`,`Y`,`S`,`W`,`K`,`M`,`B`,`D`,`H`,`V`) and even stray non-ACGTN bytes (e.g. a space) become their own keys; only literal `N` is skipped.
+- **Di:** for each position `i` in `0..len-1` with `i+2 <= len`, `di = seq[i..i+2]`; `freqs{di}++` **unless `di` contains `N`** (`index($di,'N') < 0`). Di-mers are counted on the **concatenated** chromosome sequence, so they **span line boundaries but NOT chromosome boundaries** (each chromosome is counted separately).
+- Counts are summed across all chromosomes into one hash (order-independent — addition commutes; Perl iterates `keys %chromosomes` in hash order, which is fine).
+
+**Output:** `"$key\t$count\n"` per key, **sorted by key** (Perl `sort` = byte-wise `cmp`), written to `${genome_folder}genomic_nucleotide_frequencies.txt` (the **genome folder**, not `Bisulfite_Genome/`). **Non-fatal:** if the file can't be opened, Perl `warn`s and skips the table (does not die).
+
+**Other faithful details:**
+- Same FASTA discovery as the conversion (extension precedence `.fa`→`.fa.gz`→`.fasta`→`.fasta.gz`, first non-empty group; reuse `discovery::find_fasta_files`).
+- **Skip the legacy hardcoded `Mus_musculus.NCBIM37.fa`** filename (line 694) — that file is excluded from frequency counting (but NOT from the conversion).
+- Sequence lines: Perl `chomp` (strip trailing `\n`) then `s/\r//` (remove the **first** `\r`), then `uc`. For normal/CRLF genomes this = strip the line terminator; an interior/multiple-`\r` line is pathological (Perl removes only the first `\r`) — document, don't over-engineer.
+- gzip input read in-process (`MultiGzDecoder`), as the conversion does.
+- `#74` (a Perl cwd bug) is **fixed in v0.25.1 and irrelevant to Rust** (absolute paths, no `chdir`) — nothing to reproduce.
+
+---
+
+## 2. Implementation outline
+
+**New module `src/composition.rs`:**
+- **Counters (array-indexed — no per-base allocation, rev-1):** `let mut mono = [0u64; 256]; let mut di = vec![0u64; 256*256];` (di flat-indexed `p*256 + u`). At the end, emit in **byte-lexical key order** by iterating: for `b in 0..=255`: if `mono[b] > 0` emit the 1-byte key `[b]`; **then** for `c in 0..=255`: if `di[b*256+c] > 0` emit the 2-byte key `[b,c]`. This yields exactly Perl's `sort` order (mono `A` before its di `AA`,`AC`,… because for each leading byte we emit the mono then its di block; and across leading bytes ascending) — **plain byte order, NOT `fasta_name_cmp`** (which case-folds). *(Equivalent to a `BTreeMap<Vec<u8>>` but allocation-free on the 3 Gbp hot path.)*
+- `pub fn write_genomic_composition(files: &[PathBuf], genome_folder: &Path, logger: &Logger) -> Result<(), GenomePrepError>`:
+  - `let mut seen: HashSet<Vec<u8>>` for the dup-name check (see below).
+  - For each file: **skip if `file_name() == "Mus_musculus.NCBIM37.fa"`** (byte match). `reuse convert::open_fasta` (make it `pub(crate)`) — gz-aware; do NOT duplicate the gz detection.
+    - `prev: Option<u8> = None` (declared **per file** — di never spans files or chromosomes).
+    - **First line = header, unconditionally** (mirror `convert_split`): `read_until(b'\n')`; if 0 bytes → empty file → `NotFasta` (Perl: undef first line → die). Else `extract_chromosome_name(&line, file)?` (errors if first byte ≠ `>`); **dup-name check:** `if !seen.insert(name.to_vec()) { return Err(DuplicateChromosome(...)) }` — **BEFORE any table is written** (Perl `die`s here, leaving no file). The header line is **NOT counted**.
+    - Then loop `read_until(b'\n')`:
+      - If the line starts with `>` (in-file header): `extract_chromosome_name` + dup-check (as above); `prev = None`; do NOT count.
+      - Else (sequence line): strip the trailing `\n`, then remove the **first `\r` anywhere** in the line (Perl `chomp` then `s/\r//` — note: first `\r`, not all). For each remaining byte `b`: `u = b.to_ascii_uppercase()`; **mono:** `if u != b'N' { mono[u as usize] += 1 }`; **di:** `if let Some(p) = prev { if p != b'N' && u != b'N' { di[p as usize*256 + u as usize] += 1 } }`; `prev = Some(u)`.
+  - **Write the table** (only now — after all files counted, so a dup-name/`NotFasta` error above leaves NO file): build the output to `genome_folder.join("genomic_nucleotide_frequencies.txt")` by iterating the counters in the byte-lexical order above, each line = key bytes + `b"\t"` + decimal count + `b"\n"`. **Non-fatal on open/write/close error:** log a warning and return `Ok(())` (match Perl's warn-and-skip; §5.1).
+
+**Wiring (`pipeline.rs`):** after `create_tree` (Step I) and **before** `convert_split` (Step II) — matching Perl's order — `if config.genomic_composition { composition::write_genomic_composition(&files, &config.genome_folder, &logger)?; }`. The dup-name/`NotFasta` errors here therefore fire **before** the conversion runs and before any table is written (matches Perl). Remove the current accept-and-ignore note (`pipeline.rs` + the `cli.rs` doc). `map_into`/conversion untouched (separate read path; **no `[^ATCGN]→N` mapping** here).
+
+---
+
+## 3. Edge cases
+
+- **N-skipping:** mono skips only `N`; di skips any 2-mer containing `N`. Ambiguity codes (R/Y/…) are **counted** (NOT mapped to N — unlike conversion).
+- **Di across line boundaries (within a chromosome):** the cross-line carry (`prev`) is essential; reset at each header.
+- **Di NOT across chromosomes:** `prev = None` at every `>` header.
+- **Last base of a chromosome / genome:** no trailing di (no next byte) — handled (di only fires when there's a `prev`).
+- **Empty / N-only genome:** empty `freqs` → an empty table file (Perl writes an empty file — confirm).
+- **`Mus_musculus.NCBIM37.fa`** present → excluded from counting.
+- **gzip input** (`.fa.gz`/`.fasta.gz`): counted the same (MultiGzDecoder).
+- **Stray bytes** (space/tab inside a sequence line): counted as their own keys (faithful — no N-mapping in this path).
+- **Sort:** byte-lexical (`BTreeMap<Vec<u8>>` iteration = Perl `sort` for byte keys). `A` < `AA` < `AC` … < `AT` < `C` … (prefix sorts first).
+
+---
+
+## 4. Tests
+
+- **Unit (`composition.rs`):** a known short genome (temp file) → exact expected table bytes. Cover: ACGT-only (mono A/C/G/T + the di present); a sequence with `N` (mono N skipped, di-with-N skipped, di across the N split correctly); an **ambiguity code** (`R` counted as mono + in di); **di across a line boundary** (multi-line record → cross-line di counted); **di NOT across chromosomes** (two records in one file → no di spanning them); **di NOT across files** (`prev` reset per file); **blank line mid-chromosome** preserves `prev` (di spans the blank line — Perl concatenates non-empty + empty lines, but a blank line contributes no bytes, so `prev` carries across it); the exact **sort order** (mono-before-its-di, e.g. `A` < `AA` < `AC`; ambiguity-code keys interleaved by byte). **Error paths (rev-1):** **first line not `>`** → `NotFasta` (+ no table); **bare `>` first line** → empty name, fine, first line not counted; **duplicate chromosome name** → `DuplicateChromosome` AND **the table file is NOT created**; **`s/\r//` first-`\r`-only** (`A\r\rC` → counts `A`,`\r`,`C` i.e. the SECOND `\r` survives); a **final line with no trailing `\n`** counted fully.
+- **Integration / Perl-oracle:** add a `--genomic_composition` case to `tests/integration.rs` `oracle_compare` (or a dedicated test) comparing `genomic_nucleotide_frequencies.txt` byte-for-byte vs the real Perl script on a small synthetic genome (auto-skip if `perl` absent). Add `genomic_nucleotide_frequencies.txt` to the `tests/byte_identity_real_data.rs` `#[ignore]` gate's compared outputs (real E. coli on oxy).
+- **CLI:** `--genomic_composition` no longer emits the "deferred/ignored" note; the file is produced.
+
+---
+
+## 5. Decisions (RESOLVED via dual plan-review)
+1. **Write-failure handling → NON-FATAL** (warn + skip the table, continue), matching Perl. Applies to open **and** write/close errors.
+2. **Duplicate chromosome name → the freq pass does its OWN check and errors BEFORE writing the table** (both reviewers; reverses the rev-0 recommendation). Perl runs the freq step before conversion and `die`s on a dup name in `read_genome_into_memory` with **no table written**; "rely on the conversion's dup-check" would write the full table then die later → an orphan file Perl never creates. (Cheap: a `HashSet` populated at each header.)
+3. **Empty / N-only genome → a 0-byte file IS created** (both reviewers confirmed from source). Match (iterate empty counters → write nothing → empty file).
+4. **(rev-1) First line of each file is unconditionally a header** — error (`NotFasta`) if its first byte isn't `>`, and it is **never counted as sequence** (Perl reads `<CHR_IN>` as the header with no `/^>/` test). Mirror `extract_chromosome_name` / `convert_split`.
+
+---
+
+## 6. Out of scope
+- No change to the conversion, indexer, or `--combined_genome` paths.
+- The frequency table is only produced under `--genomic_composition` (default off, unchanged).

--- a/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_PLAN_REVIEW_A.md
+++ b/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_PLAN_REVIEW_A.md
@@ -1,0 +1,131 @@
+# PLAN REVIEW A — `--genomic_composition` (genomeprep #919)
+
+**Reviewer:** A (independent, fresh context)
+**Target:** `GENOMIC_COMPOSITION_PLAN.md` (rev 0, 2026-05-31)
+**Perl source of truth:** `bismark_genome_preparation` — `get_genomic_frequencies` (518–543), `process_sequence` (546–570), `read_genome_into_memory` (665–751), top-level flow (184–194).
+**Companion:** genomeprep `SPEC.md` §2.7 / §5.3.
+
+**Verdict:** Sound plan. The core algorithm (streaming `prev`-carry, `BTreeMap` sort, `uc`-only counting, N-skipping) is byte-faithful. I found **0 Critical**, **4 Important**, **5 Optional** items — all are precision/test-coverage gaps rather than logic errors that would silently break byte-identity on real genomes, but two of the Important items (empty-line carry; `chomp` final-`\r` semantics) are genuine fidelity hazards on pathological inputs and must at least be pinned by a test or an explicit decision.
+
+---
+
+## 1. Logic review
+
+### 1.1 Di-mer index alignment — CORRECT (verified against Perl)
+Perl `process_sequence` (552–568): outer loop `$index` in `0..len-1`; di fires `unless (($index+2) > len)`, i.e. for `$index` in `0..len-2`, emitting `substr($seq,$index,2) = (seq[index], seq[index+1])`.
+
+The plan's streaming model (§2 bullet "di"): at the byte logically at position `i` (current `u`, `prev = p = seq[i-1]`), it emits `(p,u) = (seq[i-1], seq[i])` — equivalent to Perl's di at `$index = i-1`. As `i` runs `1..len-1`, `$index` runs `0..len-2`. **Exact match, no off-by-one.** The plan's §3 "Last base of a chromosome / genome: no trailing di" is correct: the final byte has no successor, so no di is emitted — matching Perl, where at `$index = len-1` the di condition `(len-1+2) > len` is true → skipped.
+
+### 1.2 "NOT ambiguity→N" distinction — CORRECT and load-bearing
+`read_genome_into_memory` line 733 does `$sequence .= uc$_;` — **`uc` only**, no `tr`/`s///` mapping. `process_sequence` then counts the raw uppercased bytes, skipping only literal `'N'` (mono, 559) and any 2-mer containing `'N'` (di, 565). The plan (§1 "The frequency path is NOT the conversion path", §2 di/mono bullets, §3 N-skipping) reproduces this precisely and explicitly does **not** reuse `convert::map_into`'s `[^ATCGN]→N` step. This is the single most important correctness point and the plan gets it right. IUPAC codes (`R/Y/S/W/K/M/B/D/H/V`) and stray bytes (space/tab) become their own keys. Confirmed.
+
+One sharpening (Optional, see §5 below): the plan should note that `uc` in Perl uppercases only ASCII `a–z` under the C locale (and the bytes Bismark cares about); a high byte ≥ 0x80 is left unchanged by both Perl `uc` and Rust `b.to_ascii_uppercase()`, so they agree. Worth one sentence so the implementer doesn't reach for a Unicode uppercase.
+
+### 1.3 Sort order — CORRECT, no locale concern
+Perl line 534 `sort keys %genomic_freqs` with no comparator and no `use locale` → default string `cmp`, which is **byte-wise** on the underlying bytes. `BTreeMap<Vec<u8>, u64>` iterates in `Ord for Vec<u8>` order = lexicographic byte compare. **These match.** Crucially, this is the *opposite* situation to `discovery::fasta_name_cmp` (which had to case-fold to mimic Perl's `glob`/`bsd_glob` ordering). Here there is **no glob, no locale, no fold** — plain `cmp` on hash keys. The plan (§1 output bullet, §3 "Sort", §4 "sort order" test) is right, including the mono-before-its-di interleave (`A`(0x41) < `AA`(0x41 0x41): a prefix sorts before any extension of it, both in Perl `cmp` and in `Vec<u8>` Ord). **The plan should explicitly state that this case must NOT use `fasta_name_cmp`** — an implementer reusing the discovery module's "Perl sort = our `fasta_name_cmp`" mental model would introduce a case-fold bug here. See Important #3.
+
+### 1.4 Chromosome-boundary carry reset — CORRECT
+Perl counts per chromosome: `get_genomic_frequencies` (523–526) calls `process_sequence($chromosomes{$chr})` once per chromosome, on the isolated per-chromosome string. So a di-mer never spans two chromosomes. The plan's "set `prev = None` at each `>` header" (§2, §3) reproduces this. Counts accumulate into one shared `%freqs` across chromosomes (560/566) — order-independent because addition commutes, which the plan notes (§1).
+
+### 1.5 Output path — CORRECT
+Perl writes to `"${genome_folder}genomic_nucleotide_frequencies.txt"` (532). `$genome_folder` always carries a trailing `/` (forced at lines 93–94 / 101–102), so the Perl string is `<dir>/genomic_nucleotide_frequencies.txt`. The Rust `config.genome_folder` is a `canonicalize`'d `PathBuf` (cli.rs:191) with **no** trailing slash, so `config.genome_folder.join("genomic_nucleotide_frequencies.txt")` yields the identical path. The plan's choice (§2) is correct. (Note: `canonicalize` resolves symlinks, which Perl `chdir`+`getcwd` also does; no divergence for the filename.)
+
+### 1.6 Mus_musculus.NCBIM37.fa skip — CORRECT, but match-on-bytes
+Perl line 694 `next if ($chromosome_filename eq 'Mus_musculus.NCBIM37.fa');` skips by exact basename in the freq path **only** (the conversion path, `create_bisulfite_genome_folders`/`process_sequence_files`, does NOT skip it). The plan (§1, §2 "skip ... by file_name", §3) is correct that this skip lives only in the composition path. **Consistency hazard (Important #1):** the comparison must be on the raw `file_name()` bytes (`b"Mus_musculus.NCBIM37.fa"`), not via `to_str()`, to match `discovery.rs`'s deliberate non-UTF-8 handling (the "M1: match on bytes" convention). The plan says "by file_name" but does not pin byte-vs-str; an implementer using `to_str() == "..."` would be inconsistent with the rest of the crate (harmless for this literal ASCII name in practice, but a real inconsistency a reviewer should flag).
+
+### 1.7 Wiring order — CORRECT
+Perl flow (184–192): `create_bisulfite_genome_folders()` → `if ($genomic_composition){ get_genomic_frequencies(); %chromosomes=(); }` → `process_sequence_files()`. So composition runs **after** folder creation, **before** conversion. The plan wires it after `create_tree` (Step I) and before `convert_split` (Step II) — exact match. The `%chromosomes = ()` reset (189) is a Perl memory hygiene step that has **no Rust analogue** (the streaming counter holds no genome in memory), correctly implied by the plan's "no shared state."
+
+---
+
+## 2. Assumptions — validated / flagged
+
+| # | Assumption | Status |
+|---|---|---|
+| A | `sort keys` is plain byte `cmp`, no locale → `BTreeMap<Vec<u8>>` matches | **VALID** (no `use locale` in script; default sort) |
+| B | `read_genome_into_memory` does `uc` only, no `[^ATCGN]→N` | **VALID** (line 733) |
+| C | Di never crosses chromosomes; resets at `>` | **VALID** (per-chromosome `process_sequence`) |
+| D | `genome_folder.join(...)` == Perl `${genome_folder}file` | **VALID** (trailing-slash forcing 93–102 vs canonicalized PathBuf) |
+| E | Empty/N-only genome → empty (0-byte) file | **PLAUSIBLE but UNVERIFIED** — see Important #4 / Open Decision 3. Perl opens the filehandle and writes nothing inside the `foreach sort keys` loop, so it produces a 0-byte file (and still `close`s it). The plan flags this as "confirm" — it is verifiable from the source *now* (no real run needed): empty `%genomic_freqs` ⇒ `open` succeeds ⇒ loop body never runs ⇒ 0-byte file ⇒ `close`. The plan should assert this rather than leave it open. |
+| F | gzip input handled by `open_fasta` (`MultiGzDecoder`) | **VALID** — but see Important #2: `open_fasta` is currently a **private** fn in `convert.rs`; reuse requires making it `pub(crate)` or duplicating. Plan says "reuse the gz-aware opener" without noting the visibility change. |
+
+---
+
+## 3. The `chomp` + `s/\r//` semantics (extra-scrutiny area)
+
+Perl per sequence line (712–713): `chomp;` then `$_ =~ s/\r//;`.
+- `chomp` removes the trailing `$/` (a single `\n`), if present — exactly one, only if it is the last char.
+- `s/\r//` (no `/g`) removes the **first** `\r` anywhere in the (post-chomp) string, exactly once.
+
+For a normal `...seq\n` line: chomp → `...seq`; `s/\r//` → no `\r`, unchanged. For CRLF `...seq\r\n`: chomp → `...seq\r`; `s/\r//` → `...seq`. **Match** with "strip trailing `\n` then first `\r`."
+
+**Pathological cases the plan currently under-specifies (Important #2 below merges these):**
+1. **Interior single `\r`** (e.g. `AC\rGT\n`): Perl chomp→`AC\rGT`, `s/\r//`→`ACGT` (the `\r` is *deleted from the middle*, joining `AC`+`GT`). A naive Rust implementation that only strips a *trailing* `\r` (after stripping `\n`) would keep the interior `\r` as a counted byte (`\r` mono key, plus `C\r` and `\rG` di keys) — **divergent**. The plan's §2 says "strip the trailing `\n` then first `\r`" which, read literally as "trailing", does NOT match Perl's "first `\r` anywhere." This is a real fidelity gap on `\r`-containing lines.
+2. **Multiple `\r`** (e.g. `A\r\rC\n`): Perl chomp→`A\r\rC`, `s/\r//`→`A\rC` (only the FIRST `\r` removed; a second survives and is counted). A "strip all `\r`" implementation would diverge here, and a "strip trailing `\r`" implementation would also diverge.
+3. **Bare `\r\n` with content then `\r` at end** etc.
+
+The plan acknowledges this is "pathological" and says "document, don't over-engineer" (§1) — but the *correct* faithful behavior is specifically "delete the FIRST `\r` (anywhere)", which is neither "strip trailing `\r`" nor "strip all `\r`". The plan's own §2 wording ("strip the trailing `\n` then first `\r`") is slightly self-contradictory (it says "first `\r`" in §1 and §2-prose but the §2 algorithm step phrasing leans "trailing"). **This must be made unambiguous in the plan, and pinned by a test**, even if the team decides real genomes never contain interior `\r` — because if they choose the simpler "strip trailing `\r`" they are knowingly accepting a (tiny) byte-divergence, which should be a recorded decision, not an accident. Note: `convert.rs` solves the analogous problem differently (it keeps `\r` in the keep-set and never strips it, because it re-emits raw lines), so there is **no existing helper to reuse** — the composition path needs its own line-trim that mirrors `chomp`+`s/\r//`.
+
+---
+
+## 4. Validation sufficiency
+
+The proposed tests (§4) cover the main risks well: ACGT mono+di, N split, ambiguity-as-key, di across line boundary, di NOT across chromosome, sort order incl. mono-before-di, plus a Perl-oracle integration test and a real-data E.coli gate. That is a strong matrix. Gaps:
+
+1. **No test for the `\r` semantics** (interior/multiple `\r`). Given §3, at minimum a unit test pinning the chosen behavior on `AC\rGT` and `A\r\rC` is required, and ideally an oracle comparison so the choice is validated against Perl. (Important.)
+2. **No test for an empty sequence line mid-chromosome** carrying `prev` across it. Perl: a blank line chomps to `""`, adds nothing, so the di spans it (e.g. `>c\nAC\n\nGT\n` → di `CG` IS counted across the blank line). The streaming model preserves `prev` when a line has zero bytes — correct — but this is exactly the kind of carry interaction that an implementer could break (e.g. by resetting `prev` on any non-`>` line, or by treating EOF/blank specially). **Add a unit test.** (Important, folded into #4.)
+3. **No test for the trailing-record-with-no-final-newline** case in the di carry (e.g. a chromosome whose last line lacks `\n`): the last byte must still produce its di with the previous byte but no di after it. (Optional — the index logic in §1.1 already guarantees this, but a cheap regression pin.)
+4. **No test that the output file is created in the genome folder, not `Bisulfite_Genome/`** (the §1.5 path). A one-line integration assertion. (Optional.)
+5. **Oracle test environment:** the plan auto-skips if `perl` is absent — good, matches the existing `integration.rs` pattern — but the real byte-identity gate (`byte_identity_real_data.rs`, `#[ignore]`) is where the empty-file and `\r` decisions get their final confirmation. The plan should state the empty-genome case is also exercised there (or by a dedicated tiny oracle synthetic), since §3 Open Decision can be closed purely by source-reading + a synthetic oracle without needing the E.coli run.
+
+No scenario where the code could **silently** produce a wrong table goes entirely unguarded *except* the `\r` semantics and the empty-line carry — hence those two are Important.
+
+---
+
+## 5. Open decisions (§5) — recommendations assessed
+
+1. **Write-failure non-fatal** — *Sound.* Perl (532–542) `warn`s and skips, does NOT `die`. The plan's recommendation (non-fatal: log warning, return `Ok(())`) matches exactly. **One nuance to pin:** Perl distinguishes *open* failure (warn, skip table) from a failed `close` (538: `close FREQS or warn`). In Rust the analogue is a write/flush error *after* a successful create. The plan says "Non-fatal on open/write error" — that is *more* lenient than Perl on the write path? Actually no: Perl's `print FREQS` failures are silently ignored (no checking), and `close` failure only warns. So Rust treating any open OR write OR flush error as warn-and-continue is faithful (Perl never dies in this sub). **Recommendation: accept non-fatal for the whole open+write+flush, log one warning. Confirm the warning text need not be byte-matched** (it goes to stderr, not the gated file — correct, stderr is not byte-gated per SPEC).
+
+2. **Duplicate-chr in freq path** — *Sound, with a caveat.* The plan recommends relying on the conversion's dup-check and NOT re-checking in the freq path. **But note the ORDER:** composition runs *before* conversion (§1.7). So on a genuine duplicate-name genome, Perl's `read_genome_into_memory` (716–718/737–739) would `die` **inside the composition step, before the conversion runs** — i.e. Perl errors *earlier* than the Rust plan, which would silently count the dup (its streaming counter doesn't key by name) and only fail later in `convert_split`. The end result (a hard error, no output) is the same, and `genomic_nucleotide_frequencies.txt` is written by Perl only *after* the dup-die would have already fired (so Perl writes no freq file on a dup genome either)... **wait — verify:** Perl `get_genomic_frequencies` calls `read_genome_into_memory` (522) which dies on dup *before* `process_sequence`/the write (532). So Perl produces **no** freq file on a dup genome. The Rust plan would: (a) stream-count successfully, (b) **write the freq file**, (c) then fail in `convert_split`. That is a **behavioral divergence on the dup-genome edge: Rust would leave a `genomic_nucleotide_frequencies.txt` on disk that Perl never creates.** This is niche (real genomes have unique names) and the final exit is non-zero either way, but if strict byte/artifact-identity matters on error paths, the freq path should detect dup names (cheap: track a `HashSet<Vec<u8>>` of header names and error before writing) so it dies before writing, exactly like Perl. **Reviewer recommendation: Important — either replicate the dup-die in the freq path (preferred, trivially cheap, removes a real divergence) OR explicitly document that on a dup-name genome the Rust port leaves a stray freq file whereas Perl does not, and accept it.** The plan currently leans "rely on conversion's check" without noticing the ordering means Perl dies *before* writing while Rust writes *then* dies.
+
+3. **Empty-table output** — *Sound but should be closed now.* As noted (§2 assumption E), this is determinable from the source without a run: empty `%freqs` ⇒ 0-byte file. The plan should change "confirm Perl writes a 0-line file" to an asserted fact + a unit/oracle test, not leave it open.
+
+---
+
+## 6. Efficiency
+
+Negligible concern. The Rust plan **streams** (`read_until`) and counts into a `BTreeMap` — strictly better than Perl, which **slurps the whole genome into `%chromosomes`** then iterates (SPEC §8.12 explicitly calls the Perl path a memory consideration). `BTreeMap<Vec<u8>, u64>` has at most a few hundred keys (256 mono + up to 65536 di, realistically <300), so per-byte `entry(vec![...])` allocations (1–2 byte `Vec`) are the only inefficiency. Optional micro-opt: key on a fixed `[u8; 2]` + length, or `u16`/`SmallVec`, to avoid a heap alloc per byte — but at ~3 GB genome × 1 alloc/byte this *is* measurable. **Optional**: use a stack key (e.g. `[u8;2]` with a discriminant, or two `[u64; 256]` / `[u64; 65536]` count arrays then emit sorted) to avoid per-byte heap churn; emit by iterating the arrays in byte order (mono index, then di) — naturally sorted, no `BTreeMap` needed. This also sidesteps the `Vec<u8>` allocation entirely. Not required for correctness; flag for the implementer since this is the hot loop over the whole genome.
+
+---
+
+## 7. Alternatives
+
+- **Count arrays instead of `BTreeMap`** (see §6): `[u64;256]` mono + `[u64;65536]` di. Emitting in order = iterate 0..256 (mono `b`, skip `N`=0x4E and zero-count), then 0..65536 (di `hi,lo`, skip any with `N`, skip zero-count). Byte-sorted-by-key requires interleaving mono and di in a single ordered stream — which `BTreeMap` does for free. So the array approach trades the alloc-free hot loop for slightly more fiddly merge-emit. Given correctness-first and the plan's byte-identity stakes, **`BTreeMap` is the safer choice; keep it** and note the array option only if profiling on human genomes shows the alloc to matter.
+- **Reusing `convert::open_fasta`** requires a visibility bump (Important #2). Alternative: a tiny private opener in `composition.rs` duplicating the 12-line `open_fasta`. Duplication is mildly worse than bumping `open_fasta` to `pub(crate)`; recommend the visibility bump and a doc note that both paths share the gz semantics.
+
+---
+
+## 8. Action items
+
+### Critical
+*(none)*
+
+### Important
+1. **`\r` semantics must be unambiguous + tested.** The plan's §1 says "first `\r`" but §2's algorithm phrasing leans "trailing `\r`". Perl's `s/\r//` deletes the **first** `\r` *anywhere* in the post-`chomp` line (interior `\r` joins the flanks; a second `\r` survives and is counted). Pin the exact rule in the plan and add unit tests on `AC\rGT` (→ `ACGT`) and `A\r\rC` (→ `A\rC`, the surviving `\r` counted). If the team chooses the simpler "strip trailing `\r`" for speed, record it as an accepted divergence — do not leave it implicit. No reusable helper exists (`convert.rs` keeps `\r`), so this is new code.
+2. **Empty-sequence-line carry test + `open_fasta` visibility.** (a) Add a unit test that a blank line mid-chromosome does NOT reset `prev` (`>c\nAC\n\nGT\n` ⇒ di `CG` counted). (b) The plan says "reuse the gz-aware opener" but `convert::open_fasta` is private — note the required `pub(crate)` bump (or a small local duplicate).
+3. **Explicitly forbid `fasta_name_cmp` for the key sort.** State in the plan that the freq-table sort is plain byte `cmp` (`BTreeMap<Vec<u8>>`), NOT the case-folding `discovery::fasta_name_cmp` used for the glob — these are different Perl constructs (`sort keys` has no locale/fold; `glob` does). Prevents an easy copy-paste fold bug. Add the existing §4 sort-order test asserting `A` before `AA` and case-distinct keys in byte order.
+4. **Resolve the dup-name ordering divergence (Open Decision 2).** Composition runs *before* conversion, so on a duplicate-chromosome genome Perl `die`s inside `read_genome_into_memory` **before writing any freq file**, whereas the Rust plan would stream-count, **write `genomic_nucleotide_frequencies.txt`, then** fail in `convert_split` — leaving a stray file Perl never creates. Either replicate the dup-die in the freq path (cheap `HashSet<Vec<u8>>` of header names, error before write) — preferred — or document and accept the stray-file divergence on this error path.
+
+### Optional
+5. **Close Open Decision 3 from source now:** empty/N-only genome ⇒ empty `%freqs` ⇒ 0-byte file (open succeeds, write-loop never runs). Change "confirm" to an asserted fact and add a unit + tiny synthetic-oracle test.
+6. **`Mus_musculus.NCBIM37.fa` skip on bytes,** not `to_str()`, to match the crate's non-UTF-8 `file_name` convention (`discovery.rs` "match on bytes" M1). Harmless for this ASCII literal but keeps the convention consistent.
+7. **One sentence on `uc` ASCII-only equivalence** (Perl C-locale `uc` vs Rust `to_ascii_uppercase`): both leave bytes ≥ 0x80 unchanged, so they agree; don't reach for Unicode uppercase.
+8. **Trailing-no-newline + last-base regression test** (chromosome whose final line lacks `\n`): last byte produces its di with `prev` and none after.
+9. **Hot-loop alloc micro-opt (defer unless profiled):** per-byte `entry(vec![..])` allocates over the whole genome; `[u64;256]`+`[u64;65536]` count arrays avoid it but complicate sorted emit. Keep `BTreeMap` for correctness-first; note the option for the implementer.
+
+---
+
+## Summary
+**0 Critical, 4 Important, 5 Optional.** The plan's central byte-identity claims — `uc`-only counting (not the conversion transform), per-chromosome di carry with header reset, N-skipping (mono: only `N`; di: any 2-mer with `N`), and byte-wise `BTreeMap` sort — are all **verified correct against the Perl source** (lines 518–570, 665–751), with no off-by-one in the di index mapping. The Important items are fidelity/precision gaps, not algorithm errors: (1) the `s/\r//` "first `\r` anywhere" rule is under-specified vs the plan's "trailing" phrasing and untested; (2) the empty-line carry and the private `open_fasta` reuse need pinning; (3) the sort must be explicitly distinguished from `fasta_name_cmp`; (4) the dup-name path has a real before-vs-after-write ordering divergence with Perl that produces a stray file on the error path. Closing these (plus the optional tests) makes the plan ready to implement.
+
+**File:** `/Users/fkrueger/Github/Bismark-genomeprep/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_PLAN_REVIEW_A.md`

--- a/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_PLAN_REVIEW_B.md
+++ b/plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_PLAN_REVIEW_B.md
@@ -1,0 +1,125 @@
+# GENOMIC_COMPOSITION_PLAN — Plan Review B
+
+**Reviewer:** B (independent, fresh context)
+**Plan:** `GENOMIC_COMPOSITION_PLAN.md` (rev 0, 2026-05-31)
+**Perl source of truth:** `bismark_genome_preparation` — `get_genomic_frequencies` (518–543), `process_sequence` (546–570), `extract_chromosome_name` (572–582), `read_genome_into_memory` (665–751), flow (184–194).
+**Verdict:** Sound core algorithm; the mono/di/N/sort logic is faithful and I verified it empirically. But there are **2 real divergences in the header / first-line handling** and an **error-path side-effect divergence** that the plan currently under-specifies or under-states. Acceptance gate (byte-identical `genomic_nucleotide_frequencies.txt`) is achievable with the fixes below.
+
+Counts: **Critical 1 · Important 3 · Optional 4**
+
+---
+
+## What I verified empirically (Perl oracle)
+
+All run against system `perl` on the actual snippets.
+
+1. **`process_sequence` output for `chr1="ACGTNRACG"`, `chr2="GGCC"` (counted separately):**
+   ```
+   A 2 / AC 2 / C 4 / CC 1 / CG 2 / G 4 / GC 1 / GG 1 / GT 1 / R 1 / RA 1 / T 1
+   ```
+   Confirms: mono skips only `N`; ambiguity `R` is counted as mono **and** in di (`RA`); di skips any 2-mer containing `N`; di does **not** span the chr boundary (no `G`+`G` di joining `…ACG` to `GGCC`). The plan's `prev`-carry with reset-at-header reproduces this. ✔
+2. **Sort order:** Perl default `sort` on keys `{ , \t, 9, 9A, A, AA, AB, AC, AT, C, R, RA, Z, a}` is **identical** to `LC_ALL=C sort` (byte/`cmp`). So `BTreeMap<Vec<u8>>` iteration matches Perl. Digits < uppercase < lowercase; mono `A`(0x41) sorts before its di `AA` (prefix-first). ✔ (Plan §2/§3 correct.)
+3. **di-N skip equivalence:** `index($di,'N') < 0` ⇔ plan's `p != N && u != N` for the 2-byte key. ✔
+4. **Empty `%genomic_freqs` → a 0-byte file IS created** (the `open` succeeds, the `foreach` writes nothing). Plan Decision #3's recommendation (write an empty file, not "no file") is **correct**. ✔
+5. **`chomp` + `s/\r//`** removes the trailing `\n` then the **first** `\r` anywhere; an interior-only `\r` (`AC\rGT\n`) becomes `ACGT`, and a doubled `\r` (`AC\r\rGT\n`) leaves a literal `\r` in the sequence (→ a `\r` mono key + `C\r`/`\rG` di). ✔ (Plan acknowledges this as pathological.)
+6. **`uc` on Latin-1 high bytes** (`\xe9\xff\xc0\x80a`) in this Perl build leaves high bytes untouched and folds only ASCII `a→A` — i.e. **byte-equivalent to Rust `to_ascii_uppercase`**, matching the already-gated `convert.rs`. No divergence. ✔
+7. **Dup-name ordering** (see Critical C1 / Important I1).
+
+---
+
+## Logic review
+
+### C1 (Critical) — The first line of each file is UNCONDITIONALLY a header in Perl; the plan's "starts with `>`" rule diverges on a non-header first line.
+
+`read_genome_into_memory` reads the first line with a bare `my $first_line = <CHR_IN>;` (line 703), `chomp`s + `s/\r//`s it, and passes it **straight to `extract_chromosome_name`** (line 708) — with **no `/^>/` test**. `extract_chromosome_name` (575) `die`s if the line does not start with `>`. Consequences the plan does not capture:
+
+- **The first line's bytes are NEVER counted**, even if it doesn't start with `>`. The plan's §2 rule ("if the line starts with `>`: header (also handles the first line); else: sequence line") means that **if a file's first line is NOT a header, the Rust code would count those bytes as sequence**, whereas Perl `die`s ("not in FASTA format"). Verified: `extract_chromosome_name("ACGT")` → `die`.
+- This is the **same root cause** as a file that starts with a blank line: Perl consumes the blank first line as a (failed) header and `die`s; the plan would treat it as an (empty) sequence line and proceed.
+
+**Why it matters:** silent wrong output (extra counts) where Perl aborts. The existing `convert.rs` already handles this correctly — `convert_split` reads the first line, then `handle_header` calls `extract_chromosome_name` which returns `Err(NotFasta)` on a non-`>` first line (and `empty_file_errors`/`NotFasta` are tested). The composition path **must mirror that structure**: read the first line, require it to be a header (else `NotFasta`), and only `/^>/`-test **subsequent** lines.
+
+**Fix:** Rewrite §2's loop to match Perl/`convert.rs`: (a) read the first line; if `read_until` returns 0 → `NotFasta` (empty file, as Perl's undef first line); call `extract_chromosome_name` on it (propagating `NotFasta` if it doesn't start with `>`) and set `prev = None`; (b) then loop the remaining lines with the `/^>/` test. Do **not** rely on a generic "first line counts as header because it starts with `>`" — a malformed first line must error, not be counted.
+
+---
+
+### I1 (Important) — Dup-name error path: Perl writes NO table; the plan writes the table then dies in conversion. (Open Decision #2 understated.)
+
+Flow (184–194): `get_genomic_frequencies()` runs **before** `process_sequence_files()`. Inside it, `read_genome_into_memory` (522) `die`s on a duplicate chromosome name (716–719 / 737–740) **before** the table-write block (532). I verified: on a dup-name genome Perl leaves **no** `genomic_nucleotide_frequencies.txt`.
+
+The plan's stream-counter does **not** key by chromosome name, so it would **not** detect the dup → it **writes the (complete) table**, and only then does the later conversion step (`convert_split`, which *does* dup-check via `seen`) error out. Net divergence:
+
+| genome with dup chr name | Perl v0.25.1 | Rust plan as written |
+|---|---|---|
+| `genomic_nucleotide_frequencies.txt` | **not created** | **created (full table)** |
+| exit | dies in freq step | dies in conversion step |
+
+Decision #2's text ("both error out before/around the table") is wrong on the side-effect: Perl errors **before** the table exists; Rust leaves an orphan table on disk on a failed run. The byte-identity gate only compares on success, so this is not a gate failure — but it's a real, observable divergence (a stale artifact from a failed invocation) and the kind of thing a reviewer should not wave away.
+
+**Fix (pick one, document it):**
+- **(preferred, faithful + cheap):** have the composition pass do its **own** dup-name check keyed by `extract_chromosome_name` (reuse a `HashSet<Vec<u8>>` exactly like `convert.rs`'s `seen`) and return `DuplicateChromosome` **before** opening/writing the table. This reproduces Perl's "die before any table is written" precisely and is trivial since the code already extracts the name at each header. This **supersedes** Decision #2's "rely on the conversion's dup-check."
+- **(weaker):** keep relying on the conversion, but then explicitly document that the Rust freq path leaves an orphan table on a dup-name genome where Perl leaves none — and confirm that is acceptable. Note this still doesn't reproduce Perl's behavior of dying *in the freq step*.
+
+---
+
+### I2 (Important) — `prev` must reset at file boundaries; plan must declare `prev` scope.
+
+Perl calls `process_sequence` **once per chromosome** (523–526), so di-mers never span chromosomes **or files**. The plan's reset is "`prev = None` at every `>` header." That is correct **only because** every file's first line is a header (per C1). The plan never states whether `prev` is declared inside or outside the per-file loop. If declared **outside** and combined with the (incorrect) "first line counts as header iff it starts with `>`" rule, then a second file whose first byte is sequence would carry `prev` across the file boundary — a cross-file di-mer Perl never produces.
+
+**Fix:** Once C1 is fixed (first line of each file is forced to be a header → resets `prev`), this is automatically correct. To be safe and unambiguous, **declare `prev` inside the per-file loop** (initialized to `None` per file) and additionally set it `None` at every header. State this explicitly in §2.
+
+---
+
+### I3 (Important) — Tests do not cover the C1/I1 error paths or the multi-file/file-boundary di reset.
+
+§4's unit tests cover ACGT-only, N-skip, ambiguity, line-boundary di, two-records-in-one-file (no cross-record di), and sort order — good. **Missing:**
+- A file whose **first line is not a `>` header** (and an **empty file**) → must error (`NotFasta`), not count bytes (C1).
+- A **dup chromosome name** genome → must error **and not leave a `genomic_nucleotide_frequencies.txt`** behind (I1).
+- A **multi-file** genome (two `.fa` files) → di-mers must **not span the file boundary** (I2). The current "two records" test only covers two records in one file.
+- The **empty/N-only genome → 0-byte file** assertion (Decision #3): assert the file exists and is exactly 0 bytes.
+
+Add these to §4. The integration/Perl-oracle case should include a multi-file genome and at least one ambiguity code + one N to exercise the interesting paths byte-for-byte.
+
+---
+
+## Assumptions
+
+- **Reuse of `convert_split`'s `files` slice** (same glob precedence/order as Perl's independent re-glob in `read_genome_into_memory` at 671–685): valid — both use identical precedence and `discovery::find_fasta_files` is the single source. ✔ But note the **`Mus_musculus.NCBIM37.fa` skip is composition-only** (Perl line 694); the conversion does *not* skip it. The plan correctly skips it in the composition loop only. Confirm the skip is an **exact, case-sensitive byte match on `file_name()`** (`name == b"Mus_musculus.NCBIM37.fa"`), matching Perl's `eq`, and works for non-UTF-8 names (use `as_encoded_bytes()`/`OsStr` bytes, consistent with `discovery.rs`'s byte-matching M1 fix). (Optional O1.)
+- **Output path** `genome_folder.join("genomic_nucleotide_frequencies.txt")`: equals Perl's `"${genome_folder}genomic_nucleotide_frequencies.txt"` because Perl forces a trailing slash on `$genome_folder` (lines 93–94) and Rust's config canonicalizes the folder (cli.rs:191) then `join`s. ✔
+- **Non-fatal write (Decision #1):** Perl `warn`s and skips on `open` failure (540–542). The plan's "log a warning and return `Ok(())`" matches. ✔ But see O2 — the plan only mentions the **open** failure; Perl also `warn`s (not dies) on **close** failure (538) and does **not** check per-`print` write errors. Decide whether a mid-write I/O error is non-fatal too (it should be, to match Perl's `print`-without-error-check). The current `error.rs` makes all I/O `?`-propagating; the composition writer must deliberately swallow write errors to be faithful — call this out so the implementer doesn't `?`-propagate a write error into a hard exit.
+
+---
+
+## Efficiency
+
+- `BTreeMap<Vec<u8>, u64>` with 1–2 byte keys: fine. Each key allocates a tiny `Vec` — for whole-human-genome di-counting the number of **distinct** keys is ~bounded (≤ ~26 mono + ~26² di + stray bytes), so the map is tiny; the per-2-mer `entry(vec![p,u])` allocates a `Vec` on **insert only** (BTreeMap reuses the key thereafter), so it's not per-base allocation for existing keys — **but** `entry(vec![…])` constructs the `Vec` on **every** call to compute the lookup key. For a 3 Gbp genome that's ~3e9 transient 2-byte `Vec` allocations. **Optimization (O3):** key on `[u8; 2]` / a small inline type, or use a fixed `u64`/`u16`-indexed array for the 256×256 di + 256 mono space and emit sorted at the end — avoids per-base heap traffic. Perl is the slow baseline ("may take several minutes"), so even the naive version beats it, but the array approach is both faster and trivially byte-sortable. Not required for correctness.
+- Streaming (not slurping) is **better** than Perl, which slurps the whole genome into `%chromosomes` (SPEC §8 #12 flags this as Perl's memory cost). Plan's streaming avoids it. ✔ Worth stating as an accepted, beneficial divergence.
+
+---
+
+## Alternatives
+
+- **Array-indexed counters** (O3 above) instead of `BTreeMap<Vec<u8>>` — faster, still byte-sortable on emit. Trade-off: must iterate 256/256² slots and skip zero-count keys; mono/di interleave on output is reconstructed by merging two sorted streams, which is more code than `BTreeMap`'s free ordering. Given the map is tiny, `BTreeMap` keyed by `[u8;2]`/`SmallVec` is the sweet spot.
+- **Reuse `convert.rs::open_fasta`** rather than a new opener — the plan says "reuse the gz-aware opener," but `open_fasta` is currently **private** to `convert.rs`. Either make it `pub(crate)` or factor it into a shared module; don't duplicate the gz-detection logic (it must stay identical to the conversion path). (Optional O4.)
+
+---
+
+## Action items
+
+### Critical
+- **C1** — Fix §2's loop so the **first line of each file is unconditionally treated as a header** (require `>` via `extract_chromosome_name`, else `NotFasta`; empty file → `NotFasta`), mirroring `convert_split`/`read_genome_into_memory` (Perl 703–708). Only `/^>/`-test **subsequent** lines. As written, a non-header first line is silently counted instead of erroring.
+
+### Important
+- **I1** — Resolve Open Decision #2 in favor of an **own dup-name check in the freq pass that errors before writing the table** (Perl dies before the table exists; verified). Correct the decision text: Perl writes **no** table on a dup-name genome; the plan as written leaves an orphan table.
+- **I2** — Declare `prev` **per-file** (reset `None` at each file start and each header); state it explicitly in §2.
+- **I3** — Add tests: non-header/empty first line → error; dup-name → error + no table file left; **multi-file** genome di-reset; empty/N-only → exactly 0-byte file.
+
+### Optional
+- **O1** — Specify the `Mus_musculus.NCBIM37.fa` skip as an exact case-sensitive **byte** match on `file_name()` (non-UTF-8-safe), consistent with `discovery.rs`.
+- **O2** — Make the non-fatal contract explicit for **write/close** errors (not just `open`): swallow per-write I/O errors + warn (Perl never checks `print` errors and only `warn`s on `close`). Ensure the writer doesn't `?`-propagate.
+- **O3** — Consider array-indexed counters (or `BTreeMap<[u8;2], …>`) to avoid ~per-base `vec![p,u]` allocations on a 3 Gbp genome.
+- **O4** — Reuse `convert.rs::open_fasta` (make it `pub(crate)`) instead of duplicating gz-detection; add a test asserting `.fa.gz` input counts identically to plain `.fa`.
+
+---
+
+## Summary
+The mono/di/N/sort algorithm is correct and empirically matches Perl, and the non-fatal-write + empty-table decisions are right. The gaps are all in **header/first-line/error-path fidelity**: (C1) the first line must be forced to be a header and error otherwise — as `convert.rs` already does — not opportunistically counted; (I1) a dup-name genome must not leave a table file behind; (I2/I3) `prev` reset scope and the missing error-path/multi-file tests. Fix C1 and I1 and the byte-identity gate is reachable.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-genome-preparation"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/rust/bismark-genome-preparation/CHANGELOG.md
+++ b/rust/bismark-genome-preparation/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to `bismark-genome-preparation` will be documented in this f
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-alpha.2] — 2026-05-31
+
+Implements **`--genomic_composition`** (previously accepted-and-ignored in
+alpha.1). Tracking issue:
+[#919](https://github.com/FelixKrueger/Bismark/issues/919).
+
+### Added
+
+- **`--genomic_composition`** — calculates the genome's **mono- and
+  di-nucleotide frequencies** and writes
+  `<genome>/genomic_nucleotide_frequencies.txt` (in the genome folder, not
+  `Bisulfite_Genome/`). Runs **before** the bisulfite conversion, mirroring Perl
+  (`get_genomic_frequencies` → `process_sequence_files`). The table is
+  **byte-identical** to Perl `bismark_genome_preparation` v0.25.1.
+- **NOT the conversion path** (load-bearing): this pass `uc`s the sequence but
+  does **not** apply the conversion's `[^ATCGN]→N` mapping — so IUPAC ambiguity
+  codes (`R`/`Y`/`S`/`W`/`K`/`M`/`B`/`D`/`H`/`V`) and stray bytes are counted as
+  their own keys; only a literal `N` is skipped (mono), and a di-mer is skipped
+  if **either** base is `N`. Di-mers span line boundaries but **not**
+  chromosome/file boundaries.
+- **Allocation-free counters** (`[u64; 256]` mono + flat `[u64; 65536]` di) — no
+  per-base allocation on multi-Gbp genomes — emitted in **plain byte-lexical key
+  order** (each mono key immediately before its di block), reproducing Perl's
+  `sort keys %freqs` exactly. (Plain byte sort — *not* the case-folding glob
+  order.)
+- **Faithful edge behaviour:** the legacy `Mus_musculus.NCBIM37.fa` filename is
+  excluded from counting (but not conversion); `chomp` then `s/\r//` removes only
+  the **first** `\r`; a duplicate chromosome name / non-`>` first line errors
+  **before** any table is written (Perl `die`s in `read_genome_into_memory`, so
+  no orphan file is left); an empty / `N`-only genome yields a 0-byte file. Write
+  failures are **non-fatal** (warn and skip, matching Perl).
+- **Tests:** 20 unit tests (counter logic + all edge cases) + 2 binary
+  end-to-end + a live `perl_vs_rust_genomic_composition` oracle + a `#[ignore]`
+  real-data gate (`genomic_nucleotide_frequencies.txt` vs real Perl).
+
 ## [1.0.0-alpha.1] — 2026-05-31
 
 First **public pre-release** of `bismark-genome-preparation` — a Rust port of

--- a/rust/bismark-genome-preparation/Cargo.toml
+++ b/rust/bismark-genome-preparation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-genome-preparation"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 description = "Rust port of Bismark Perl's bismark_genome_preparation script"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-genome-preparation/README.md
+++ b/rust/bismark-genome-preparation/README.md
@@ -21,7 +21,12 @@ bismark_genome_preparation_rs [OPTIONS] <GENOME_FOLDER>
 
 Key options (Perl-compatible spellings): `--bowtie2` (default) / `--hisat2` /
 `--minimap2`, `--path_to_aligner <DIR>`, `--parallel <N>`, `--single_fasta`,
-`--large-index`, `--slam` (deprecated), `--verbose`, `--version`, `--help`.
+`--large-index`, `--genomic_composition`, `--slam` (deprecated), `--verbose`,
+`--version`, `--help`.
+
+`--genomic_composition` writes a genomic mono-/di-nucleotide frequency table
+(`<genome>/genomic_nucleotide_frequencies.txt`) before the conversion —
+byte-identical to Perl v0.25.1.
 
 Bismark-Rust extension: `--combined_genome` additionally builds a single
 combined CT+GA reference + index (opt-in; for a future Rust aligner).

--- a/rust/bismark-genome-preparation/src/cli.rs
+++ b/rust/bismark-genome-preparation/src/cli.rs
@@ -79,8 +79,8 @@ pub struct Cli {
     #[arg(long = "large-index")]
     pub large_index: bool,
 
-    /// (Deferred) write genomic_nucleotide_frequencies.txt. Accepted but not
-    /// produced in this version.
+    /// Calculate the genomic mono-/di-nucleotide composition and write
+    /// `<genome>/genomic_nucleotide_frequencies.txt` (before conversion).
     #[arg(long = "genomic_composition")]
     pub genomic_composition: bool,
 
@@ -119,7 +119,7 @@ pub struct ResolvedConfig {
     pub slam: bool,
     /// Force large index.
     pub large_index: bool,
-    /// `--genomic_composition` requested (deferred; accepted-and-ignored).
+    /// `--genomic_composition` requested — write the nucleotide-frequency table.
     pub genomic_composition: bool,
     /// `--combined_genome` requested.
     pub combined_genome: bool,

--- a/rust/bismark-genome-preparation/src/composition.rs
+++ b/rust/bismark-genome-preparation/src/composition.rs
@@ -1,0 +1,461 @@
+//! `--genomic_composition`: the mono- + di-nucleotide frequency table
+//! `<genome>/genomic_nucleotide_frequencies.txt`, **byte-identical** to Perl
+//! `bismark_genome_preparation`'s `get_genomic_frequencies` / `process_sequence`
+//! / `read_genome_into_memory` (lines 518–570, 665–751).
+//!
+//! **This is NOT the conversion path** (load-bearing). `read_genome_into_memory`
+//! `uc`s the sequence but does **NOT** apply the conversion's `[^ATCGN]→N`
+//! substitution. So the counter sees the *raw uppercased bytes*:
+//! - **Mono:** every byte is counted **unless it is `N`** — IUPAC ambiguity
+//!   codes (`R`,`Y`,`S`,`W`,`K`,`M`,`B`,`D`,`H`,`V`) and even stray bytes (a
+//!   space) become their own keys; only a literal `N` is skipped.
+//! - **Di:** each adjacent pair within a chromosome is counted **unless either
+//!   base is `N`** (Perl `index($di,'N') < 0`). Di-mers span line boundaries but
+//!   **NOT** chromosome/file boundaries.
+//!
+//! Perl runs this pass **before** the bisulfite conversion, and it `die`s in
+//! `read_genome_into_memory` *before* `get_genomic_frequencies` writes the
+//! table. So a duplicate-chromosome-name or not-FASTA error here must fire
+//! **before any table is written** — never leave an orphan file Perl wouldn't.
+
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{BufRead, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use crate::convert::open_fasta;
+use crate::discovery::extract_chromosome_name;
+use crate::error::GenomePrepError;
+use crate::logging::Logger;
+
+/// The legacy TopHat mouse-genome filename Perl explicitly skips in the
+/// frequency pass (`next if ... eq 'Mus_musculus.NCBIM37.fa'`, line 694) —
+/// excluded from **counting**, but NOT from the conversion. Matched on raw
+/// `file_name()` bytes.
+const SKIP_FILENAME: &[u8] = b"Mus_musculus.NCBIM37.fa";
+
+/// The frequency table's fixed basename, written into the **genome folder**
+/// (not `Bisulfite_Genome/`).
+const FREQ_FILENAME: &str = "genomic_nucleotide_frequencies.txt";
+
+/// Count mono- and di-nucleotides across all `files` and write the frequency
+/// table to `<genome_folder>/genomic_nucleotide_frequencies.txt`.
+///
+/// Mirrors Perl's order (`get_genomic_frequencies` → `process_sequence_files`):
+/// run **before** the conversion. A `DuplicateChromosome` / `NotFasta` error
+/// raised while counting propagates **before** [`write_table`] is reached, so no
+/// table is written — matching Perl's `die` in `read_genome_into_memory`.
+pub fn write_genomic_composition(
+    files: &[PathBuf],
+    genome_folder: &Path,
+    logger: &Logger,
+) -> Result<(), GenomePrepError> {
+    // Array-indexed counters: NO per-base allocation on a multi-Gbp genome.
+    // `di` is flat-indexed `prev*256 + cur`. Emitting them in byte order (see
+    // `write_table`) reproduces Perl's `sort keys %freqs` exactly.
+    let mut mono = [0u64; 256];
+    let mut di = vec![0u64; 256 * 256];
+    // Cross-file uniqueness check (Perl's global `%chromosomes`).
+    let mut seen: HashSet<Vec<u8>> = HashSet::new();
+
+    for file in files {
+        // Perl: `next if ($chromosome_filename eq 'Mus_musculus.NCBIM37.fa')`.
+        if file.file_name().map(|n| n.as_encoded_bytes()) == Some(SKIP_FILENAME) {
+            continue;
+        }
+        count_file(file, &mut seen, &mut mono, &mut di)?;
+    }
+
+    // Only now — after every file counted without error — write the table.
+    write_table(genome_folder, &mono, &di, logger);
+    Ok(())
+}
+
+/// Stream one FASTA file, accumulating mono/di counts. The first line is the
+/// header **unconditionally** (Perl reads `<CHR_IN>` and feeds it straight to
+/// `extract_chromosome_name`, which `die`s if it isn't a `>` header — so an
+/// empty file or a non-`>` first line is [`GenomePrepError::NotFasta`]); the
+/// header is never counted as sequence. A repeated chromosome name is
+/// [`GenomePrepError::DuplicateChromosome`].
+fn count_file(
+    file: &Path,
+    seen: &mut HashSet<Vec<u8>>,
+    mono: &mut [u64; 256],
+    di: &mut [u64],
+) -> Result<(), GenomePrepError> {
+    let mut reader = open_fasta(file)?;
+    let mut line: Vec<u8> = Vec::new();
+
+    // First line = header. Empty file → Perl's `<CHR_IN>` is undef →
+    // `extract_chromosome_name` die → NotFasta (same as `convert_split`).
+    let n = reader.read_until(b'\n', &mut line)?;
+    if n == 0 {
+        return Err(GenomePrepError::NotFasta(file.to_path_buf()));
+    }
+    check_header(&line, file, seen)?;
+
+    // Di never spans chromosomes or files: `prev` is per-file and reset at each
+    // in-file header.
+    let mut prev: Option<u8> = None;
+    loop {
+        line.clear();
+        let n = reader.read_until(b'\n', &mut line)?;
+        if n == 0 {
+            break;
+        }
+        if line.first() == Some(&b'>') {
+            check_header(&line, file, seen)?;
+            prev = None;
+            continue;
+        }
+        count_sequence_line(&line, &mut prev, mono, di);
+    }
+    Ok(())
+}
+
+/// Extract + uniqueness-check a chromosome name (errors **before** any table is
+/// written). Inserting at header-read time (rather than at Perl's
+/// store-on-next-header time) detects exactly the same set of duplicates —
+/// every name that appears ≥2 times — and the same as [`crate::convert`].
+fn check_header(
+    line: &[u8],
+    file: &Path,
+    seen: &mut HashSet<Vec<u8>>,
+) -> Result<(), GenomePrepError> {
+    let name = extract_chromosome_name(line, file)?;
+    if !seen.insert(name.to_vec()) {
+        return Err(GenomePrepError::DuplicateChromosome(
+            String::from_utf8_lossy(name).into_owned(),
+        ));
+    }
+    Ok(())
+}
+
+/// Count one sequence line. Perl does `chomp` (strip a single trailing `\n`)
+/// then `s/\r//` (remove the **first** `\r` *anywhere*, not all) then `uc`,
+/// appending to the chromosome sequence. Removing only the first `\r` makes the
+/// byte before it and the byte after it adjacent, so the di-carry must continue
+/// across the removed byte — handled by counting the two segments in order with
+/// the same `prev`.
+fn count_sequence_line(line: &[u8], prev: &mut Option<u8>, mono: &mut [u64; 256], di: &mut [u64]) {
+    // chomp: drop a single trailing '\n' if present (no-op on a final line that
+    // ends without one).
+    let body = match line.last() {
+        Some(&b'\n') => &line[..line.len() - 1],
+        _ => line,
+    };
+    // s/\r//: remove the FIRST '\r' only. Common (no-\r) case allocates nothing.
+    match body.iter().position(|&b| b == b'\r') {
+        None => count_bytes(body, prev, mono, di),
+        Some(i) => {
+            count_bytes(&body[..i], prev, mono, di);
+            count_bytes(&body[i + 1..], prev, mono, di);
+        }
+    }
+}
+
+/// Tally `bytes` into the counters, uppercasing each byte and carrying `prev`
+/// for the di-mer. `prev` advances for **every** byte (including `N`), because a
+/// di-mer at index `i` uses `seq[i]` and `seq[i+1]`: an `N` is skipped as a
+/// counted base but still separates its neighbours.
+fn count_bytes(bytes: &[u8], prev: &mut Option<u8>, mono: &mut [u64; 256], di: &mut [u64]) {
+    for &b in bytes {
+        // `to_ascii_uppercase` matches Perl's default `uc` on a byte string
+        // (no `use feature 'unicode_strings'`/locale → only ASCII a–z fold;
+        // bytes ≥ 0x80 are left unchanged by both).
+        let u = b.to_ascii_uppercase();
+        if u != b'N' {
+            mono[u as usize] += 1;
+        }
+        if let Some(p) = *prev
+            && p != b'N'
+            && u != b'N'
+        {
+            di[p as usize * 256 + u as usize] += 1;
+        }
+        *prev = Some(u);
+    }
+}
+
+/// Write the frequency table in Perl's `sort keys %freqs` order. **Non-fatal:**
+/// on any open/write/flush error, `warn` and skip the table (Perl's
+/// warn-and-continue), never propagating an error from this step.
+fn write_table(genome_folder: &Path, mono: &[u64; 256], di: &[u64], logger: &Logger) {
+    let path = genome_folder.join(FREQ_FILENAME);
+    let file = match File::create(&path) {
+        Ok(f) => f,
+        Err(e) => {
+            logger.note(&format!(
+                "Failed to write out file {} because of: {e}. \
+                 Skipping writing out genomic frequency table",
+                path.display()
+            ));
+            return;
+        }
+    };
+    let mut w = BufWriter::new(file);
+    if let Err(e) = write_counts(&mut w, mono, di).and_then(|()| w.flush()) {
+        logger.note(&format!(
+            "Failed to write out file {} because of: {e}. \
+             Skipping writing out genomic frequency table",
+            path.display()
+        ));
+    }
+}
+
+/// Emit `"<key>\t<count>\n"` for every non-zero counter in **byte-lexical key
+/// order**. Iterating each leading byte `b` ascending — its 1-byte mono key
+/// first, then its 2-byte di keys `[b, c]` for `c` ascending — reproduces Perl's
+/// global `sort` of the mixed mono+di string keys exactly: a 1-byte key is a
+/// prefix of (so sorts before) its 2-byte extensions, and all keys with a
+/// smaller leading byte sort first. **Plain byte order — NOT the case-folding
+/// `fasta_name_cmp` used for the glob.**
+fn write_counts(w: &mut impl Write, mono: &[u64; 256], di: &[u64]) -> std::io::Result<()> {
+    let mut buf = Vec::new();
+    for (b, &mono_count) in mono.iter().enumerate() {
+        if mono_count > 0 {
+            emit(&mut buf, &[b as u8], mono_count);
+        }
+        let base = b * 256;
+        for (c, &di_count) in di[base..base + 256].iter().enumerate() {
+            if di_count > 0 {
+                emit(&mut buf, &[b as u8, c as u8], di_count);
+            }
+        }
+    }
+    w.write_all(&buf)
+}
+
+/// Append one `"<key>\t<count>\n"` record (key bytes, TAB, decimal count, LF).
+/// `count.to_string()` is Perl's default integer stringification.
+fn emit(buf: &mut Vec<u8>, key: &[u8], count: u64) {
+    buf.extend_from_slice(key);
+    buf.push(b'\t');
+    buf.extend_from_slice(count.to_string().as_bytes());
+    buf.push(b'\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    /// Write `files` into a fresh genome dir, run the composition pass, and
+    /// return the produced table bytes (or `None` if no file was written).
+    fn run(files: &[(&str, &[u8])]) -> Option<Vec<u8>> {
+        let d = tempdir().unwrap();
+        let gdir = d.path().join("genome");
+        fs::create_dir_all(&gdir).unwrap();
+        let mut paths = Vec::new();
+        for (name, content) in files {
+            let p = gdir.join(name);
+            fs::write(&p, content).unwrap();
+            paths.push(p);
+        }
+        let logger = Logger::new(false);
+        write_genomic_composition(&paths, &gdir, &logger).unwrap();
+        let out = gdir.join(FREQ_FILENAME);
+        if out.exists() {
+            Some(fs::read(out).unwrap())
+        } else {
+            None
+        }
+    }
+
+    /// Run and assert the table file was created (panics on error / no file).
+    fn table(files: &[(&str, &[u8])]) -> Vec<u8> {
+        run(files).expect("table file should be written")
+    }
+
+    /// Run expecting an error; return `(error, table-file-exists?)`.
+    fn run_err(files: &[(&str, &[u8])]) -> (GenomePrepError, bool) {
+        let d = tempdir().unwrap();
+        let gdir = d.path().join("genome");
+        fs::create_dir_all(&gdir).unwrap();
+        let mut paths = Vec::new();
+        for (name, content) in files {
+            let p = gdir.join(name);
+            fs::write(&p, content).unwrap();
+            paths.push(p);
+        }
+        let logger = Logger::new(false);
+        let err = write_genomic_composition(&paths, &gdir, &logger).unwrap_err();
+        let exists = gdir.join(FREQ_FILENAME).exists();
+        (err, exists)
+    }
+
+    #[test]
+    fn acgt_only_mono_and_di() {
+        // "ACGT": mono A,C,G,T=1; di AC,CG,GT=1. Sorted byte-lexically with each
+        // mono immediately before its di block.
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\nACGT\n")]),
+            b"A\t1\nAC\t1\nC\t1\nCG\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn lowercase_is_uppercased() {
+        // `uc` → identical to the uppercase input.
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\nacgt\n")]),
+            table(&[("chr1.fa", b">chr1\nACGT\n")])
+        );
+    }
+
+    #[test]
+    fn n_skipped_mono_and_di() {
+        // "ACNGT": mono skips N; di CN and NG (contain N) skipped; AC, GT kept.
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\nACNGT\n")]),
+            b"A\t1\nAC\t1\nC\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn ambiguity_code_counted_not_mapped_to_n() {
+        // "ARC": R counted as its own mono key + in di (unlike the conversion
+        // path, which would map R→N).
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\nARC\n")]),
+            b"A\t1\nAR\t1\nC\t1\nR\t1\nRC\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn di_spans_line_boundary_within_chromosome() {
+        // Two lines, one record → "ACGT": CG spans the line break.
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\nAC\nGT\n")]),
+            b"A\t1\nAC\t1\nC\t1\nCG\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn di_does_not_span_chromosomes() {
+        // chr1="AC", chr2="GT" in ONE file → no CG (prev reset at >chr2).
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\nAC\n>chr2\nGT\n")]),
+            b"A\t1\nAC\t1\nC\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn di_does_not_span_files() {
+        // Two files; prev reset per file → no CG. (a.fa < b.fa by glob order.)
+        assert_eq!(
+            table(&[("a.fa", b">chr1\nAC\n"), ("b.fa", b">chr2\nGT\n")]),
+            b"A\t1\nAC\t1\nC\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn blank_line_preserves_di_carry() {
+        // "AC" <blank> "GT" → sequence "ACGT"; CG spans the (empty) blank line.
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\nAC\n\nGT\n")]),
+            b"A\t1\nAC\t1\nC\t1\nCG\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn final_line_without_newline_counted() {
+        // No trailing \n on the sequence line → still counted fully.
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\nACGT")]),
+            b"A\t1\nAC\t1\nC\t1\nCG\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn carriage_return_first_only_removed() {
+        // "A\r\rC": chomp \n, s/\r// removes the FIRST \r → "A\rC". The SECOND
+        // \r survives and is counted as its own byte (0x0D < 'A' < 'C').
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\nA\r\rC\n")]),
+            b"\r\t1\n\rC\t1\nA\t1\nA\r\t1\nC\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn crlf_line_terminator_stripped() {
+        // "ACGT\r\n": chomp \n → "ACGT\r", s/\r// → "ACGT". Same as the LF case.
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\r\nACGT\r\n")]),
+            b"A\t1\nAC\t1\nC\t1\nCG\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn stray_space_counted_as_own_key() {
+        // A space inside the sequence is counted (no N-mapping in this path).
+        // "A C": bytes A, ' ', C → mono A,' ',C; di "A " (A→space) and " C"
+        // (space→C). Space (0x20) sorts before 'A' (0x41), so its keys lead.
+        assert_eq!(
+            table(&[("chr1.fa", b">chr1\nA C\n")]),
+            b" \t1\n C\t1\nA\t1\nA \t1\nC\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn n_only_genome_is_zero_byte_file() {
+        // All N → empty counters → an empty (0-byte) table file IS created.
+        assert_eq!(table(&[("chr1.fa", b">chr1\nNNNN\n")]), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn header_only_record_is_zero_byte_file() {
+        // No sequence at all → 0-byte file.
+        assert_eq!(table(&[("chr1.fa", b">chr1\n")]), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn bare_gt_first_line_is_not_counted() {
+        // Bare `>` → empty chromosome name (not an error); first line not counted.
+        assert_eq!(
+            table(&[("chr1.fa", b">\nACGT\n")]),
+            b"A\t1\nAC\t1\nC\t1\nCG\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn mus_musculus_file_excluded_from_counting() {
+        // The legacy mouse file is skipped in the freq pass; only chr1 counts.
+        assert_eq!(
+            table(&[
+                ("chr1.fa", b">chr1\nACGT\n"),
+                ("Mus_musculus.NCBIM37.fa", b">mouse\nGGGGCCCC\n"),
+            ]),
+            b"A\t1\nAC\t1\nC\t1\nCG\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn first_line_not_header_errors_and_no_file() {
+        let (err, exists) = run_err(&[("chr1.fa", b"ACGT\n")]);
+        assert!(matches!(err, GenomePrepError::NotFasta(_)));
+        assert!(!exists, "no table file when the first line isn't a header");
+    }
+
+    #[test]
+    fn empty_file_errors_and_no_file() {
+        let (err, exists) = run_err(&[("chr1.fa", b"")]);
+        assert!(matches!(err, GenomePrepError::NotFasta(_)));
+        assert!(!exists);
+    }
+
+    #[test]
+    fn duplicate_chromosome_errors_and_no_orphan_file() {
+        // Perl `die`s in read_genome_into_memory BEFORE writing the table.
+        let (err, exists) = run_err(&[("chr1.fa", b">chr1\nAC\n>chr1\nGT\n")]);
+        assert!(matches!(err, GenomePrepError::DuplicateChromosome(_)));
+        assert!(!exists, "a dup name must leave NO orphan table file");
+    }
+
+    #[test]
+    fn duplicate_across_files_errors() {
+        let (err, _) = run_err(&[("a.fa", b">chr1\nAC\n"), ("b.fa", b">chr1\nGT\n")]);
+        assert!(matches!(err, GenomePrepError::DuplicateChromosome(_)));
+    }
+}

--- a/rust/bismark-genome-preparation/src/convert.rs
+++ b/rust/bismark-genome-preparation/src/convert.rs
@@ -106,8 +106,9 @@ fn header_line(name: &[u8], side: Side, out: &mut Vec<u8>) {
 }
 
 /// Open a FASTA file for reading, transparently decompressing `.gz`
-/// (multi-member safe). Returns a buffered byte reader.
-fn open_fasta(path: &Path) -> Result<Box<dyn BufRead>, GenomePrepError> {
+/// (multi-member safe). Returns a buffered byte reader. Shared with the
+/// `--genomic_composition` read path ([`crate::composition`]).
+pub(crate) fn open_fasta(path: &Path) -> Result<Box<dyn BufRead>, GenomePrepError> {
     let f = File::open(path)?;
     let is_gz = path
         .file_name()

--- a/rust/bismark-genome-preparation/src/lib.rs
+++ b/rust/bismark-genome-preparation/src/lib.rs
@@ -22,6 +22,7 @@
 
 pub mod cli;
 pub mod combined;
+pub mod composition;
 pub mod convert;
 pub mod discovery;
 pub mod error;

--- a/rust/bismark-genome-preparation/src/pipeline.rs
+++ b/rust/bismark-genome-preparation/src/pipeline.rs
@@ -5,7 +5,7 @@
 use crate::cli::{Aligner, Cli};
 use crate::error::GenomePrepError;
 use crate::logging::Logger;
-use crate::{BISMARK_VERSION, combined, convert, discovery, folders, indexer};
+use crate::{BISMARK_VERSION, combined, composition, convert, discovery, folders, indexer};
 
 fn aligner_label(a: Aligner) -> &'static str {
     match a {
@@ -27,13 +27,6 @@ pub fn run(cli: Cli) -> Result<(), GenomePrepError> {
              and NOT in BISULFITE MODE",
         );
     }
-    if config.genomic_composition {
-        logger.note(
-            "note: --genomic_composition is deferred in this version and is ignored \
-             (no genomic_nucleotide_frequencies.txt is produced).",
-        );
-    }
-
     // ── Step I — discover FASTA, validate explicit aligner path, make folders ──
     logger.info("Bismark Genome Preparation - Step I: Preparing folders");
     let files = discovery::find_fasta_files(&config.genome_folder)?;
@@ -47,6 +40,18 @@ pub fn run(cli: Cli) -> Result<(), GenomePrepError> {
         None => None,
     };
     let (ct_dir, ga_dir) = folders::create_tree(&config.genome_folder, &logger)?;
+
+    // ── Step I.5 — optional genomic composition (Perl runs `get_genomic_frequencies`
+    // BEFORE `process_sequence_files`). Errors here (duplicate chromosome / not
+    // FASTA) fire before any frequency table OR converted FASTA is written. ──
+    if config.genomic_composition {
+        logger.note(
+            "Calculating genomic nucleotide frequencies (this may take several minutes \
+             depending on genome size) ...",
+        );
+        composition::write_genomic_composition(&files, &config.genome_folder, &logger)?;
+        logger.note("Finished processing genomic nucleotide frequencies\n");
+    }
 
     // ── Step II — bisulfite conversion (the byte-identity core) ──
     logger.info("Bismark Genome Preparation - Step II: Bisulfite converting reference genome");

--- a/rust/bismark-genome-preparation/tests/byte_identity_real_data.rs
+++ b/rust/bismark-genome-preparation/tests/byte_identity_real_data.rs
@@ -155,6 +155,17 @@ fn byte_identity_real_data_mfa() {
 
 #[test]
 #[ignore = "requires BISMARK_GENOMEPREP_REAL_GENOME_DIR + Perl bismark_genome_preparation"]
+fn byte_identity_real_data_genomic_composition() {
+    // The mono-/di-nucleotide frequency table lands in the genome folder root.
+    gate(
+        "real-data genomic_composition",
+        &["--genomic_composition"],
+        &["genomic_nucleotide_frequencies.txt"],
+    );
+}
+
+#[test]
+#[ignore = "requires BISMARK_GENOMEPREP_REAL_GENOME_DIR + Perl bismark_genome_preparation"]
 fn byte_identity_real_data_single_fasta() {
     // Per-chromosome file set is compared by re-globbing the Perl output dir and
     // diffing each against the Rust counterpart.

--- a/rust/bismark-genome-preparation/tests/integration.rs
+++ b/rust/bismark-genome-preparation/tests/integration.rs
@@ -108,6 +108,52 @@ fn binary_combined_genome_is_ct_concat_ga() {
 }
 
 #[test]
+fn binary_genomic_composition_freq_table_bytes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let genome = tmp.path().join("genome");
+    fs::create_dir_all(&genome).unwrap();
+    fs::write(genome.join("g.fa"), b">chr1\nACGT\n").unwrap();
+    let bin = fake_indexer_dir(tmp.path());
+
+    Command::cargo_bin("bismark_genome_preparation_rs")
+        .unwrap()
+        .env("BISMARK_BIN", &bin)
+        .arg("--genomic_composition")
+        .arg(&genome)
+        .assert()
+        .success();
+
+    // "ACGT" → mono A,C,G,T=1; di AC,CG,GT=1; byte-lexical (mono before its di).
+    let freq = fs::read(genome.join("genomic_nucleotide_frequencies.txt")).unwrap();
+    assert_eq!(
+        freq,
+        b"A\t1\nAC\t1\nC\t1\nCG\t1\nG\t1\nGT\t1\nT\t1\n".to_vec()
+    );
+}
+
+/// Without `--genomic_composition`, the frequency table is NOT produced.
+#[test]
+fn binary_no_genomic_composition_flag_writes_no_table() {
+    let tmp = tempfile::tempdir().unwrap();
+    let genome = tmp.path().join("genome");
+    fs::create_dir_all(&genome).unwrap();
+    fs::write(genome.join("g.fa"), b">chr1\nACGT\n").unwrap();
+    let bin = fake_indexer_dir(tmp.path());
+
+    Command::cargo_bin("bismark_genome_preparation_rs")
+        .unwrap()
+        .env("BISMARK_BIN", &bin)
+        .arg(&genome)
+        .assert()
+        .success();
+
+    assert!(
+        !genome.join("genomic_nucleotide_frequencies.txt").exists(),
+        "freq table must not exist without --genomic_composition"
+    );
+}
+
+#[test]
 fn binary_no_fasta_dir_errors() {
     let tmp = tempfile::tempdir().unwrap();
     let genome = tmp.path().join("empty_genome");
@@ -388,6 +434,41 @@ fn perl_vs_rust_slam() {
             "Bisulfite_Genome/CT_conversion/genome_mfa.CT_conversion.fa",
             "Bisulfite_Genome/GA_conversion/genome_mfa.GA_conversion.fa",
         ],
+    );
+}
+
+/// `--genomic_composition`: the mono/di-nucleotide frequency table vs real
+/// Perl. Exercises lowercase (`uc`), IUPAC ambiguity codes (**counted**, NOT
+/// mapped to `N` — unlike the conversion path), `N`-skipping, di across line
+/// boundaries (within `chr1`), multi-record + multi-file (no di across
+/// chromosomes/files), and a final line without a trailing newline.
+///
+/// `chr4.fa` additionally pins the `s/\r//`-first-only path and the high-byte
+/// (`uc` vs `to_ascii_uppercase`) tail against **live Perl**: a CRLF header, a
+/// double-`\r` line (first `\r` removed, second survives + counted), a stray
+/// high byte (`0xc3 0xa9`, UTF-8 `é`, counted as its own keys), and a lowercase
+/// `n` (uppercased to `N`, then skipped). Since `oracle_compare` diffs Perl's
+/// output against Rust's, no hand-computed expectation is needed. The table
+/// lands in the genome folder root, not `Bisulfite_Genome/`.
+#[test]
+fn perl_vs_rust_genomic_composition() {
+    oracle_compare(
+        |dir| {
+            fs::create_dir_all(dir).unwrap();
+            fs::write(
+                dir.join("chr1.fa"),
+                b">chr1 desc\nACGTacgtNRYK\nTTTTCCCCGGGG\n>chr2\nGATTACA\n",
+            )
+            .unwrap();
+            fs::write(dir.join("chr3.fa"), b">chr3\nGGGCCCttt").unwrap();
+            fs::write(
+                dir.join("chr4.fa"),
+                b">chr4\r\nAC\r\rGT\r\nGG\xc3\xa9CCnnTT\r\n",
+            )
+            .unwrap();
+        },
+        &["--genomic_composition"],
+        &["genomic_nucleotide_frequencies.txt"],
     );
 }
 


### PR DESCRIPTION
Implements `--genomic_composition` for the Rust `bismark_genome_preparation` port: writes the mono- and di-nucleotide frequency table `genomic_nucleotide_frequencies.txt`, **byte-identical to Perl Bismark v0.25.1** (the acceptance gate). Previously accepted-and-ignored.

## What
- **New `src/composition.rs`** — streams each FASTA with allocation-free counters (`[u64;256]` mono + flat `[u64;65536]` di) and emits in plain byte-lexical key order (each mono key, then its di block), reproducing Perl's `sort keys %freqs` exactly.
- Wired into `pipeline.rs` as **Step I.5** (after `create_tree`, before `convert_split`), mirroring Perl's `create_bisulfite_genome_folders → get_genomic_frequencies → process_sequence_files`.
- `convert::open_fasta` made `pub(crate)` (shared gz-aware reader); CLI doc + CHANGELOG updated; crate bumped to `1.0.0-alpha.2`.

## Byte-identity-critical fidelity (vs Perl `get_genomic_frequencies` / `process_sequence` / `read_genome_into_memory`)
- **NOT the conversion path**: `uc` only, no `[^ATCGN]→N`. IUPAC codes (R/Y/S/W/K/M/B/D/H/V) and stray bytes are counted as their own keys; only a literal `N` is skipped (mono) / excludes a di-mer (if either base is `N`).
- Plain **byte sort**, not the case-folding `fasta_name_cmp`.
- `prev` (di-carry) reset per file + at each header → di spans line boundaries but never chromosomes/files.
- `chomp` then `s/\r//` (**first `\r` only**); first line is unconditionally a header; **duplicate-name / not-FASTA errors before any table is written** (no orphan file Perl wouldn't leave); `Mus_musculus.NCBIM37.fa` excluded from counting (not conversion); non-fatal write; empty / N-only genome → 0-byte file.

## Tests & validation
- 20 unit + 2 binary e2e + a live `perl_vs_rust_genomic_composition` oracle (incl. CRLF / double-`\r` / high-byte ≥0x80 / lowercase-`n` torture, diffed against real Perl). Full crate suite: **59 unit + 13 integration** green; clippy + fmt clean.
- **oxy real-data gate**: `genomic_nucleotide_frequencies.txt` **byte-identical** to Perl v0.25.1 on E. coli `NC_010473.fa.gz` (gzipped → `MultiGzDecoder` path).
- Dual independent code-review (both APPROVE / ship — 0 correctness issues across 27 verified invariants/cases) + plan-manager coverage (**COMPLETE**, 27/27 DONE). Reports: `plans/05302026_bismark-genome-preparation/GENOMIC_COMPOSITION_{CODE_REVIEW_A,CODE_REVIEW_B,COVERAGE}.md`.

Base branch: `rust/iron-chancellor`.

Closes #919