### PR TITLE
docs(rust): backfill status table (bam2nuc, NOMe_filtering, filter_non_conversion)

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -48,5 +48,8 @@ cargo build --release
 | `coverage2cytosine` | `bismark-coverage2cytosine` (`coverage2cytosine_rs`) | 1.0.0-alpha.1 | In progress — byte-identity golden tests through phase D |
 | `bismark_genome_preparation` | `bismark-genome-preparation` (`bismark_genome_preparation_rs`) | 1.0.0-alpha.1 | Converted CT/GA FASTA **byte-identical** to Perl v0.25.1 (indexing delegated to the external indexer) |
 | `methylation_consistency` | `bismark-methylation-consistency` (`methylation_consistency_rs`) | 1.0.0-beta.1 | **Byte-identical** output vs Perl v0.25.1 |
+| `bam2nuc` | `bismark-bam2nuc` (`bam2nuc_rs`) | 1.0.0-alpha.1 | **Byte-identical** to Perl v0.25.1 (mono/di-nucleotide stats; local goldens + oxy real-data gate) |
+| `NOMe_filtering` | `bismark-nome-filtering` (`NOMe_filtering_rs`) | 1.0.0-beta.1 | **Byte-identical** to Perl v0.25.1 (synthetic goldens + full 10M SE oxy gate) |
+| `filter_non_conversion` | `bismark-filter-nonconversion` (`filter_non_conversion_rs`) | 1.0.0-alpha.1 | **Byte-identical** to Perl v0.25.1 (9 golden cells + oxy 10M SE + PE × 4 decision modes) |
 
 Versions are the crate manifests on `rust/iron-chancellor`. "Byte-identical" = validated against Perl Bismark v0.25.1 per each crate's README/CHANGELOG + golden/real-data tests; speedups are full-scale where measured. Per-crate detail lives in each crate's `README.md` / `CHANGELOG.md`. `bismark-io` and `bismark-dedup` have early beta lines published to crates.io; later betas are queued for the next publish window.


### PR DESCRIPTION
The per-tool Status table in `rust/README.md` was three tools behind the merged state. Adds rows for the recently-merged ports:

| Perl tool | crate (binary) | version | 
|---|---|---|
| `bam2nuc` | `bismark-bam2nuc` (`bam2nuc_rs`) | 1.0.0-alpha.1 |
| `NOMe_filtering` | `bismark-nome-filtering` (`NOMe_filtering_rs`) | 1.0.0-beta.1 |
| `filter_non_conversion` | `bismark-filter-nonconversion` (`filter_non_conversion_rs`) | 1.0.0-alpha.1 |

Versions are manifest-grounded; state wording is grounded in each crate's CHANGELOG (byte-identical to Perl v0.25.1 + their real-data gates), matching the #924 convention. Docs-only; no source/behaviour change. Existing rows (incl. c2c 'in progress' and genome-prep) left untouched.