### PR TITLE
ci(rust): gate live-Perl byte-identity oracles in CI (#796)

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -69,3 +69,65 @@ jobs:
           components: rustfmt
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
+
+  perl-oracle:
+    name: perl-oracle byte-identity
+    # Runs the live-Perl byte-identity oracle tests (issue #796): install Perl
+    # Bismark's tooling, run the per-crate oracles that diff Rust output against
+    # the in-repo Perl v0.25.1 scripts, and PROVE all of them ran (they auto-skip
+    # when tooling is absent, which would otherwise pass green without comparing).
+    runs-on: ubuntu-latest # intentionally Linux-only: oracle parity with the Perl
+                           # environment; the fake-indexer plumbing is #[cfg(unix)].
+    timeout-minutes: 15    # guard against a hung Perl subprocess
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.89"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+      - name: Install samtools
+        run: |
+          sudo apt-get update || sudo apt-get update # transient-mirror retry
+          sudo apt-get install -y --no-install-recommends samtools
+      - name: Preflight — assert oracle tooling present
+        # This job must NEVER add a Bismark install / the repo root to PATH —
+        # doing so would erode bismark-extractor's phase_g_discovery "not-found"
+        # test. The oracle scripts are invoked by relative path, not via PATH.
+        run: |
+          set -euo pipefail
+          command -v perl     >/dev/null || { echo "perl missing";     exit 1; }
+          command -v gzip     >/dev/null || { echo "gzip missing";     exit 1; }
+          command -v gunzip   >/dev/null || { echo "gunzip missing";   exit 1; }
+          command -v samtools >/dev/null || { echo "samtools missing"; exit 1; }
+          perl -v
+          samtools --version >/dev/null
+      - name: Run live-Perl byte-identity oracles (fail-loud + prove all 10 ran)
+        env:
+          BISMARK_REQUIRE_PERL: "1"
+        run: |
+          set -euo pipefail
+          EXPECTED=10
+          out=$(cargo test -p bismark-genome-preparation -p bismark-methylation-consistency \
+                  -- --exact \
+                  perl_vs_rust_byte_identical_mfa \
+                  perl_vs_rust_byte_identical_single_fasta \
+                  perl_vs_rust_edge_inputs_mfa \
+                  perl_vs_rust_mixed_case_glob_order \
+                  perl_vs_rust_slam \
+                  perl_vs_rust_genomic_composition \
+                  perl_vs_rust_gzip_input \
+                  perl_vs_rust_se_three_way \
+                  perl_vs_rust_pe_three_way \
+                  perl_vs_rust_chh_se \
+                  2>&1 | tee /dev/stderr)
+          n=$(printf '%s\n' "$out" | grep -cE '^test .* \.\.\. ok$' || true)
+          test "$n" -eq "$EXPECTED" || { echo "::error::expected $EXPECTED oracle tests, $n ran ok"; exit 1; }
+          if printf '%s\n' "$out" | grep -q '^skipping:'; then
+            echo "::error::an oracle silently skipped"; exit 1
+          fi

--- a/rust/bismark-genome-preparation/tests/integration.rs
+++ b/rust/bismark-genome-preparation/tests/integration.rs
@@ -45,6 +45,22 @@ fn have_perl() -> bool {
         .unwrap_or(false)
 }
 
+/// CI sets `BISMARK_REQUIRE_PERL=1` so a "missing tool" turns the silent skip
+/// into a hard failure — the point of issue #796. `== "1"` (not `is_some`) so an
+/// accidental empty export doesn't trip local dev.
+fn require_perl() -> bool {
+    std::env::var("BISMARK_REQUIRE_PERL").as_deref() == Ok("1")
+}
+
+/// Skip the oracle (local dev without Perl/tools) or panic (CI, where a missing
+/// tool means the byte-identity check would silently not run — see #796).
+fn skip_or_panic(reason: &str) {
+    if require_perl() {
+        panic!("BISMARK_REQUIRE_PERL=1 but {reason}");
+    }
+    eprintln!("skipping: {reason}");
+}
+
 #[test]
 fn binary_end_to_end_mfa_bytes() {
     let tmp = tempfile::tempdir().unwrap();
@@ -173,7 +189,7 @@ fn binary_no_fasta_dir_errors() {
 #[test]
 fn perl_vs_rust_byte_identical_mfa() {
     if !have_perl() {
-        eprintln!("skipping perl_vs_rust_byte_identical_mfa: perl not available");
+        skip_or_panic("perl_vs_rust_byte_identical_mfa: perl not available");
         return;
     }
     let perl = perl_script();
@@ -240,7 +256,7 @@ fn perl_vs_rust_byte_identical_mfa() {
 #[test]
 fn perl_vs_rust_byte_identical_single_fasta() {
     if !have_perl() {
-        eprintln!("skipping perl_vs_rust_byte_identical_single_fasta: perl not available");
+        skip_or_panic("perl_vs_rust_byte_identical_single_fasta: perl not available");
         return;
     }
     let perl = perl_script();
@@ -332,7 +348,7 @@ fn bad_path_to_aligner_fails_before_conversion() {
 /// Auto-skips if `perl` is absent.
 fn oracle_compare(setup: impl Fn(&Path), extra_args: &[&str], rel_files: &[&str]) {
     if !have_perl() {
-        eprintln!("skipping oracle test: perl not available");
+        skip_or_panic("oracle test: perl not available");
         return;
     }
     let perl = perl_script();
@@ -476,7 +492,7 @@ fn perl_vs_rust_genomic_composition() {
 #[test]
 fn perl_vs_rust_gzip_input() {
     if !have_perl() || !have_cmd("gzip") {
-        eprintln!("skipping perl_vs_rust_gzip_input: perl or gzip not available");
+        skip_or_panic("perl_vs_rust_gzip_input: perl or gzip not available");
         return;
     }
     oracle_compare(

--- a/rust/bismark-methylation-consistency/tests/integration.rs
+++ b/rust/bismark-methylation-consistency/tests/integration.rs
@@ -465,6 +465,22 @@ fn perl_script() -> Option<std::path::PathBuf> {
     Some(script)
 }
 
+/// CI sets `BISMARK_REQUIRE_PERL=1` so a "missing tool" turns the silent skip
+/// into a hard failure — the point of issue #796. `== "1"` (not `is_some`) so an
+/// accidental empty export doesn't trip local dev.
+fn require_perl() -> bool {
+    std::env::var("BISMARK_REQUIRE_PERL").as_deref() == Ok("1")
+}
+
+/// Skip the oracle (local dev without Perl/samtools) or panic (CI, where a
+/// missing tool means the byte-identity check would silently not run — #796).
+fn skip_or_panic(reason: &str) {
+    if require_perl() {
+        panic!("BISMARK_REQUIRE_PERL=1 but {reason}");
+    }
+    eprintln!("skipping: {reason}");
+}
+
 /// One record line per output record (no header — so the samtools `@PG`
 /// provenance lines that Perl injects but the Rust port omits are excluded),
 /// with optional tags compared as an order-independent set (SPEC §7).
@@ -499,7 +515,7 @@ fn samtools_record_set(path: &Path) -> Vec<String> {
 /// populated bucket's records match (header `@PG` provenance excluded).
 fn assert_perl_rust_identical(records: &[RecordBuf], so: Option<&str>, extra_args: &[&str]) {
     let Some(script) = perl_script() else {
-        eprintln!("skipping Perl-vs-Rust byte-identity: perl/samtools/script not available");
+        skip_or_panic("Perl-vs-Rust byte-identity: perl/samtools/script not available");
         return;
     };
 


### PR DESCRIPTION
## What

Closes #796 (rescoped to its one remaining valuable piece). Adds a CI gate that **runs the per-crate live-Perl byte-identity oracle tests on every `rust/**` PR and proves they ran**, instead of letting them silently auto-skip when Perl/samtools are absent — which today passes green without ever comparing Rust output to Perl Bismark v0.25.1.

## Why

The oracle tests (`bismark-genome-preparation` + `bismark-methylation-consistency`) shell out to the in-repo Perl scripts and diff the output byte-for-byte. When a tool is missing they `return` early — so `cargo test` reports green without comparing. `samtools` isn't on the default CI runner, so the methylation-consistency oracles skip in CI today. This was only caught by manual `oxy` runs.

## Change

**Test source** — add `require_perl()` / `skip_or_panic()` helpers to both integration test files and convert their Perl-oracle skip branches:
- With `BISMARK_REQUIRE_PERL=1` (set only in CI) a missing tool **panics** (test fails) instead of skipping.
- Without the flag (local dev) the graceful skip is preserved.
- genome-preparation: 4 skip sites cover its **7** oracles (incl. the recently-added `perl_vs_rust_genomic_composition`); methylation-consistency: 1 site covers 3.

**`rust_ci.yml`** — new `perl-oracle` job:
- installs `samtools` (apt, with a transient-mirror retry + `--no-install-recommends`);
- preflights `perl`/`gzip`/`gunzip`/`samtools` (fails fast, attributable);
- runs the **10** oracles by `--exact` name with the flag;
- asserts exactly **10** `... ok` lines — so a future rename/removal/`#[ignore]` of an oracle fails the job (the "never-ran" hole the panic flag alone can't catch);
- `timeout-minutes: 15`.

The oracle scripts are invoked by **relative path** (in-repo Perl v0.25.1), so only tool *binaries* are installed — **never Bismark on PATH** — to avoid perturbing `bismark-extractor`'s `phase_g_discovery` "not-found" test. The job is `-p`-scoped to the two crates (the extractor crate isn't even compiled here).

## Validation (run locally against this branch's base)

- fmt `--check` ✓ · clippy `-D warnings` (both crates) ✓ · YAML valid ✓
- **10/10** oracles pass under `BISMARK_REQUIRE_PERL=1`; count assertion `10 == 10`; no `skipping:` lines
- **Fail-loud verified**: with `samtools` hidden + the flag set, the oracle **FAILS** with `BISMARK_REQUIRE_PERL=1 but …` (panic), not a skip
- **Local ergonomics preserved**: same missing tool with the flag *unset* → graceful skip, suite green

## Notes

- No user-facing change (CI + test infrastructure only); no new project dependency (`samtools` is a CI-runner tool).
- The build/fmt/clippy/test matrix from the original #796 epic already shipped; the reproducibility/provenance/real-data sub-issues were dropped per the 2026-06-01 rescope.