### PR TITLE
docs(rust): maintain rust/README.md as the Rust-rewrite status journal

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -39,18 +39,44 @@ cargo build --release
 
 ## Status
 
+One headline per module — current state at a glance. Per-crate detail lives in each crate's `README.md` / `CHANGELOG.md`; the dated shipping log is under [Milestones](#milestones). Rows are in rough pipeline order. State key: ✅ shipped on `rust/iron-chancellor` · 🚧 in progress · ⬜ planned.
+
 | Perl tool | Rust crate (binary) | Version | State |
 |---|---|---|---|
-| _(shared library)_ | `bismark-io` | 1.0.0-beta.8 | noodles BAM/SAM/CRAM I/O + `ThreadedBam{Reader,Writer}` (parallel BGZF); byte-equal output is a CI invariant for consumers |
-| `deduplicate_bismark` | `bismark-dedup` (`deduplicate_bismark_rs`) | 1.2.1-beta.1 | **Byte-identical** to Perl v0.25.1 on real-data WGBS (10M + ~55M PE); optional `--parallel N` BGZF threading |
-| `bismark_methylation_extractor` | `bismark-extractor` (`bismark-methylation-extractor-rs`) | 1.0.0-beta.1 | **Byte-identical** at full scale (WGBS PE/SE + RRBS, worker-count-invariant); **~4.8×** vs Perl `--multicore 12` |
-| `bismark2bedGraph` | `bismark-bedgraph` (`bismark2bedGraph_rs`) | 1.0.0-beta.1 | **Byte-identical** (decompressed content); **~3.4×** |
-| `coverage2cytosine` | `bismark-coverage2cytosine` (`coverage2cytosine_rs`) | 1.0.0-alpha.1 | In progress — byte-identity golden tests through phase D |
-| `bismark_genome_preparation` | `bismark-genome-preparation` (`bismark_genome_preparation_rs`) | 1.0.0-alpha.1 | Converted CT/GA FASTA **byte-identical** to Perl v0.25.1 (indexing delegated to the external indexer) |
-| `methylation_consistency` | `bismark-methylation-consistency` (`methylation_consistency_rs`) | 1.0.0-beta.1 | **Byte-identical** output vs Perl v0.25.1 |
-| `bam2nuc` | `bismark-bam2nuc` (`bam2nuc_rs`) | 1.0.0-alpha.1 | **Byte-identical** to Perl v0.25.1 (mono/di-nucleotide stats; local goldens + oxy real-data gate) |
-| `NOMe_filtering` | `bismark-nome-filtering` (`NOMe_filtering_rs`) | 1.0.0-beta.1 | **Byte-identical** to Perl v0.25.1 (synthetic goldens + full 10M SE oxy gate) |
-| `filter_non_conversion` | `bismark-filter-nonconversion` (`filter_non_conversion_rs`) | 1.0.0-alpha.1 | **Byte-identical** to Perl v0.25.1 (9 golden cells + oxy 10M SE + PE × 4 decision modes) |
-| `bismark2report` | `bismark-report` (`bismark2report_rs`) | 1.0.0-alpha.1 | **Byte-identical** HTML vs Perl v0.25.1 (modulo the `localtime` timestamp line); validated on synthetic + real WGBS PE (10M + ~55M) |
+| _(shared library)_ | `bismark-io` | 1.0.0-beta.8 | ✅ noodles BAM/SAM/CRAM I/O + `ThreadedBam{Reader,Writer}` (parallel BGZF); byte-equal output is a CI invariant for consumers |
+| `bismark_genome_preparation` | `bismark-genome-preparation` (`bismark_genome_preparation_rs`) | 1.0.0-alpha.2 | ✅ Converted CT/GA FASTA **byte-identical** to Perl v0.25.1 + `--genomic_composition` (indexing delegated to the external indexer) |
+| `bismark` (aligner) | `bismark-aligner` (`bismark_rs`) | _(unreleased)_ | 🚧 In progress on `rust/aligner` — Bowtie2 backend, Phases 0–4 (read-conversion C→T/G→A, single-instance align, N-way merge + MAPQ); BAM + first byte-identity gate next. The ~74% runtime "big beast". HISAT2/minimap2 backends planned (v1.x) |
+| `deduplicate_bismark` | `bismark-dedup` (`deduplicate_bismark_rs`) | 1.2.1-beta.1 | ✅ **Byte-identical** to Perl v0.25.1 on real-data WGBS (10M + ~55M PE); UMI/RRBS modes; optional `--parallel N` BGZF threading |
+| `filter_non_conversion` | `bismark-filter-nonconversion` (`filter_non_conversion_rs`) | 1.0.0-alpha.1 | ✅ **Byte-identical** to Perl v0.25.1 (9 golden cells + oxy 10M SE + PE × 4 decision modes) |
+| `NOMe_filtering` | `bismark-nome-filtering` (`NOMe_filtering_rs`) | 1.0.0-beta.1 | ✅ **Byte-identical** to Perl v0.25.1 (synthetic goldens + full 10M SE oxy gate); **~3.4×** |
+| `bismark_methylation_extractor` | `bismark-extractor` (`bismark_methylation_extractor_rs`) | 1.0.0-beta.1 | ✅ **Byte-identical** at full scale (WGBS PE/SE + RRBS, worker-count-invariant); **~4.8×** vs Perl `--multicore 12` |
+| `bismark2bedGraph` | `bismark-bedgraph` (`bismark2bedGraph_rs`) | 1.0.0-beta.1 | ✅ **Byte-identical** (decompressed content); **~3.4×** |
+| `coverage2cytosine` | `bismark-coverage2cytosine` (`coverage2cytosine_rs`) | 1.0.0-alpha.1 _(tag `…beta.2`)_ | ✅ **Byte-identical** core + niche modes (`--gc`/`--nome-seq`/`--drach`/`--ffs`) vs Perl v0.25.1; 15-cell full-hg38 oxy gate; **~12×** CpG-report / **~2.6×** `--CX` |
+| `bam2nuc` | `bismark-bam2nuc` (`bam2nuc_rs`) | 1.0.0-alpha.1 | ✅ **Byte-identical** to Perl v0.25.1 (mono/di-nucleotide stats; local goldens + oxy real-data gate) |
+| `methylation_consistency` | `bismark-methylation-consistency` (`methylation_consistency_rs`) | 1.0.0-beta.1 | ✅ **Byte-identical** output vs Perl v0.25.1 |
+| `bismark2report` | `bismark-report` (`bismark2report_rs`) | 1.0.0-alpha.1 | ✅ **Byte-identical** HTML vs Perl v0.25.1 (modulo the `localtime` timestamp line); synthetic + real WGBS PE (10M + ~55M) |
+| `bismark2summary` | `bismark-summary` (`bismark2summary_rs`) | 1.0.0-beta.1 | ✅ **Byte-identical** project-level multi-sample summary (HTML + `.txt`) vs Perl v0.25.1 |
 
-Versions are the crate manifests on `rust/iron-chancellor`. "Byte-identical" = validated against Perl Bismark v0.25.1 per each crate's README/CHANGELOG + golden/real-data tests; speedups are full-scale where measured. Per-crate detail lives in each crate's `README.md` / `CHANGELOG.md`. `bismark-io` and `bismark-dedup` have early beta lines published to crates.io; later betas are queued for the next publish window.
+Versions are the crate manifests on `rust/iron-chancellor` (a release **git tag** such as `…beta.2` may lead its manifest version). "Byte-identical" = validated against Perl Bismark v0.25.1 per each crate's README/CHANGELOG + golden/real-data tests; speedups are full-scale where measured. `bismark-io` and `bismark-dedup` have early beta lines published to crates.io; later betas are queued for the next publish window.
+
+> **Keeping this journal current:** every module-merge PR into `rust/iron-chancellor` should update that tool's row above **and** add a dated line to [Milestones](#milestones). The helper scripts (`copy_bismark_files_for_release.pl`, the `merge_*coverage*` Python utilities) are out of scope for the Rust port.
+
+## Milestones
+
+Reverse-chronological log of the main Rust-rewrite shipping events (merges into `rust/iron-chancellor`). One headline per event; per-crate detail is in the crate READMEs/CHANGELOGs.
+
+- **2026-06-02** — `coverage2cytosine` **v1.x niche modes** (`--gc`/`--nome-seq`/`--drach`/`--ffs`) merged (#934); 15-cell full-hg38 oxy gate byte-identical to Perl v0.25.1, tag `…beta.2`. **c2c port complete.**
+- **2026-06-01** — `bismark2summary` ported (#932) — byte-identical project-level summary; the **last post-alignment module**.
+- **2026-06-01** — `bismark2report` ported (#931) — byte-identical per-sample HTML report.
+- **2026-06-01** — `filter_non_conversion` ported (#927) — byte-identical non-CpG / incomplete-conversion read filter.
+- **2026-06-01** — `bam2nuc` ported (#922) — byte-identical mono/di-nucleotide coverage QC.
+- **2026-06-01** — CI **`perl-oracle byte-identity`** gate added (#933) — runs the live Perl tools in CI and byte-compares.
+- **2026-06-01** — `NOMe_filtering` ported (#928) — byte-identical standalone NOMe filter.
+- **2026-05-31** — `bismark_genome_preparation` ported (#913) + `--genomic_composition` (#925) — byte-identical converted FASTA.
+- **2026-05-31** — `coverage2cytosine` **v1.0** core merged (#892) — byte-identical CpG/CX report + `--merge_CpGs`; ~12× on the CpG-report path.
+- **2026-05-30** — `bismark2bedGraph` ported (#893, epic #797) — byte-identical coverage/bedGraph; mimalloc perf (#915).
+- **2026-05-30** — `methylation_consistency` ported (#896, epic #890) — byte-identical.
+- **2026-05-26 → 05-29** — `bismark_methylation_extractor` ported (Phases A–G, #847–#883) — byte-identical at full scale, **~4.8×**; the ~16% runtime hot-spot.
+- **2026-05-24 → 05-26** — `deduplicate_bismark` v1.2 UMI/RRBS modes (#819–#844) — byte-identical.
+- _(earlier)_ — `bismark-io` shared library — the noodles BAM/SAM/CRAM foundation all consumers build on.
+- 🚧 **Next:** the `bismark` aligner (the ~74% runtime "big beast") — in progress on `rust/aligner`.


### PR DESCRIPTION
## Maintain `rust/README.md` as the Rust-rewrite status journal

Turns the per-tool `## Status` table in `rust/README.md` into the canonical, always-current journal of **all** Bismark module reimplementations, and adds a dated **Milestones** log. No code changes — `rust/README.md` only.

### Why
The status table had drifted: `coverage2cytosine` still read "in progress through phase D" (it's now v1.x complete + merged), `bismark2summary` was missing, and the in-progress aligner wasn't listed. A status doc only stays useful if there's an update discipline.

### What changed
- **Refreshed the Status table** (now in rough pipeline order, with ✅/🚧/⬜ state markers):
  - `coverage2cytosine` → v1.x complete (`--gc`/`--nome-seq`/`--drach`/`--ffs`, 15-cell full-hg38 oxy gate byte-identical, tag `…beta.2`).
  - `bismark_genome_preparation` → `1.0.0-alpha.2` + `--genomic_composition`.
  - Fixed the extractor binary-name typo (`bismark_methylation_extractor_rs`, underscores).
- **Added the two missing rows:** `bismark2summary` (#932, shipped) and the in-progress `bismark` aligner (`rust/aligner`).
- **Added a `## Milestones` section** — a reverse-chronological log of the main shipping events with dates + PR refs.
- **Added a maintenance convention:** every module-merge PR into `rust/iron-chancellor` updates its row and adds a Milestones line.

### Verification
Markdown-only change; the table rows that weren't stale keep their exact prior wording. Versions are read from each crate's `Cargo.toml` on `iron-chancellor`; milestone dates/PRs are from the `iron-chancellor` git history.
