### PR TITLE
fix(bedgraph): finish_gz surfaces I/O error instead of panicking (#939)

### DIFF
--- a/rust/bismark-bedgraph/src/output.rs
+++ b/rust/bismark-bedgraph/src/output.rs
@@ -48,14 +48,33 @@ fn open_par_gz(path: PathBuf, threads: usize) -> Result<GzWriter, BismarkBedgrap
 }
 
 /// Flush a [`GzWriter`] and finalize the gzip stream (flush remaining blocks,
-/// join the worker threads, write the gzip trailer). Must be called — drop
-/// alone does not finalize a `ParCompress`.
-fn finish_gz(w: GzWriter) -> Result<(), BismarkBedgraphError> {
-    let mut par = w
-        .into_inner()
-        .map_err(|e| BismarkBedgraphError::Io(e.into_error()))?;
-    par.finish().map_err(std::io::Error::other)?;
-    Ok(())
+/// join the worker threads, write the gzip trailer), surfacing any I/O error as
+/// `BismarkBedgraphError::Io` instead of panicking (#939). Must be called —
+/// drop alone does not finalize a `ParCompress`.
+///
+/// `flush()` pushes the buffered bytes into the `ParCompress` (gzp `flush` is
+/// `flush_last(false)` — no footer); then `get_mut().finish()` writes the footer
+/// and joins the workers. On the **error** path gzp 0.11.3's `finish()` returns
+/// from `flush_last(true)?` BEFORE it `take()`s its channels/handle, so the
+/// `ParCompress`'s `Drop` would re-run `finish().unwrap()` → PANIC
+/// (`par/compress.rs:312`). gzp exposes no way to disarm that `Drop`, so we
+/// `mem::forget` the writer on error to suppress it — leaking an already-dead
+/// worker thread on the catastrophic-I/O abort path (e.g. ENOSPC) where the run
+/// is failing anyway; the success path drops normally. We use `flush()` +
+/// `get_mut().finish()` rather than `into_inner()` because a failed
+/// `into_inner()` strands the un-finished `ParCompress` in the `IntoInnerError`,
+/// whose drop re-introduces the same panic.
+///
+/// Mirrors the sibling fix `bismark-extractor::output::SplitWriter::Gzip::finish`
+/// (regression-tested there by `split_writer_gzip_finish_surfaces_error_not_panic`).
+fn finish_gz(mut w: GzWriter) -> Result<(), BismarkBedgraphError> {
+    let flush_res = w.flush();
+    let finish_res = w.get_mut().finish().map_err(std::io::Error::other);
+    let result: std::io::Result<()> = flush_res.and(finish_res);
+    if result.is_err() {
+        std::mem::forget(w);
+    }
+    result.map_err(BismarkBedgraphError::Io)
 }
 
 /// Write the bedGraph + coverage (+ optional zero) outputs from a populated
@@ -114,4 +133,44 @@ pub fn write_outputs(cfg: &ResolvedConfig, agg: Aggregator) -> Result<(), Bismar
         z.flush()?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A sink that fails every write/flush. `ParCompress` type-erases its sink
+    /// (a worker thread owns it), so a `GzWriter` can wrap one — letting us
+    /// prove `finish_gz` returns `Err` (gzp surfaces the sink error as
+    /// `GzpError::Io`) instead of panicking via `ParCompress`'s `Drop`-time
+    /// `finish().unwrap()` (#939). Sibling of `bismark-extractor`'s
+    /// `split_writer_gzip_finish_surfaces_error_not_panic`.
+    struct FailingWriter;
+    impl Write for FailingWriter {
+        fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("sink write failed"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::other("sink flush failed"))
+        }
+    }
+
+    #[test]
+    fn finish_gz_surfaces_error_not_panic() {
+        let par = ParCompressBuilder::<Gzip>::new()
+            .num_threads(1)
+            .expect("1 is nonzero")
+            .compression_level(Compression::new(GZIP_LEVEL))
+            .from_writer(FailingWriter);
+        let mut w: GzWriter = BufWriter::with_capacity(64 * 1024, par);
+        // Buffer a bedGraph-shaped row so the gzip worker has data to push to
+        // the failing sink.
+        let _ = w.write_all(b"chr1\t0\t1\t100.0\n");
+        // #939: must return Err (gzp surfaces the sink error), NOT panic via
+        // ParCompress's Drop-time finish().unwrap().
+        assert!(
+            finish_gz(w).is_err(),
+            "finish_gz over a failing sink must return Err, not panic"
+        );
+    }
 }


### PR DESCRIPTION
## bedgraph `finish_gz` — surface I/O error instead of panicking (#939)

Fixes the latent panic in `bismark2bedGraph`'s gzip finalizer. A **verbatim port** of the merged `bismark-extractor` fix (#938, `SplitWriter::Gzip::finish`). `rust/bismark-bedgraph/src/output.rs` only.

### Bug
`finish_gz` panicked on a finalization I/O error (e.g. **ENOSPC** writing the bedGraph/coverage footer): gzp 0.11.3's `ZWriter::finish` returns from `flush_last(true)?` *before* `take()`ing its channels, so the `ParCompress`'s `Drop` re-runs `finish().unwrap()` → panic (`par/compress.rs:312`). The old `into_inner()?` early-return path additionally stranded the un-finished `ParCompress` in an `IntoInnerError` whose drop panicked the same way.

### Fix
`finish_gz` now `flush()`es the buffer into the `ParCompress`, then `get_mut().finish()` writes the footer + joins the workers (error → `BismarkBedgraphError::Io`), and `mem::forget`s the writer **on the error path only** to suppress gzp's re-panicking `Drop` (leaks an already-dead worker on the catastrophic-I/O abort path; the success path drops normally). Both `.gz` streams (bedGraph + coverage) covered.

### Verification
- New failing-sink regression test `finish_gz_surfaces_error_not_panic` (asserts `Err`, not panic; cross-references the extractor sibling test).
- **Byte-identical to Perl v0.25.1 (decompressed level) preserved**; 83 tests pass; `clippy --all-targets -D warnings` + `fmt --check` clean.
- Single plan-review + single code-review (APPROVE, port verified line-for-line + `mem::forget` sound vs gzp source) + plan-manager COMPLETE. Artifacts under `plans/06022026_bedgraph-finish-panic/`.

Closes **#939**. _(Base is `rust/iron-chancellor`, not the default branch → closed manually on merge.)_
