### PR TITLE
chore(rust): version coherence — promote shipped crates to beta (manifest-only)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-bam2nuc"
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.1"
 dependencies = [
  "assert_cmd",
  "bismark-io",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-coverage2cytosine"
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-filter-nonconversion"
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.1"
 dependencies = [
  "assert_cmd",
  "bismark-io",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-genome-preparation"
-version = "1.0.0-alpha.2"
+version = "1.0.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "bismark-report"
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/rust/bismark-bam2nuc/CHANGELOG.md
+++ b/rust/bismark-bam2nuc/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this crate are documented here. Versions follow the
 sibling Rust-port convention (`1.0.0-alpha.N` during the initial port).
 
+## 1.0.0-beta.1 — version-coherence bump
+
+Promoted `alpha.1` → `beta.1` to reflect shipped + byte-identical status (no
+functional change), aligning with the sibling Rust ports' "beta = shipped +
+validated" convention.
+
 ## 1.0.0-alpha.1 — initial Rust port
 
 Port of Perl `bam2nuc` v0.25.1 (mono-/di-nucleotide coverage QC).

--- a/rust/bismark-bam2nuc/Cargo.toml
+++ b/rust/bismark-bam2nuc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-bam2nuc"
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.1"
 description = "Rust port of Bismark Perl's bam2nuc script (mono-/di-nucleotide coverage QC)"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-coverage2cytosine/Cargo.toml
+++ b/rust/bismark-coverage2cytosine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-coverage2cytosine"
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.2"
 description = "Rust port of Bismark Perl's coverage2cytosine script (Phase A: scaffold + CLI + genome reader)"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-filter-nonconversion/CHANGELOG.md
+++ b/rust/bismark-filter-nonconversion/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to `bismark-filter-nonconversion` are documented here.
 Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.0-beta.1] — 2026-06-03
+
+Version-coherence bump (no functional change): promoted to `beta` to reflect
+shipped + byte-identical status.
+
 ## [1.0.0-alpha.1] — 2026-05-31
 
 Initial Rust port of Bismark Perl's `filter_non_conversion` (v0.25.1). Binary

--- a/rust/bismark-filter-nonconversion/Cargo.toml
+++ b/rust/bismark-filter-nonconversion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-filter-nonconversion"
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.1"
 description = "Rust port of Bismark Perl's filter_non_conversion script"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-genome-preparation/CHANGELOG.md
+++ b/rust/bismark-genome-preparation/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `bismark-genome-preparation` will be documented in this f
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.1] — 2026-06-03
+
+Version-coherence bump (no functional change): promoted to `beta` to reflect
+shipped + byte-identical status.
+
 ## [1.0.0-alpha.2] — 2026-05-31
 
 Implements **`--genomic_composition`** (previously accepted-and-ignored in

--- a/rust/bismark-genome-preparation/Cargo.toml
+++ b/rust/bismark-genome-preparation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-genome-preparation"
-version = "1.0.0-alpha.2"
+version = "1.0.0-beta.1"
 description = "Rust port of Bismark Perl's bismark_genome_preparation script"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/bismark-report/CHANGELOG.md
+++ b/rust/bismark-report/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `bismark-report` crate (Rust port of Perl `bismark2report`).
 
+## [1.0.0-beta.1] — 2026-06-03
+
+Version-coherence bump (no functional change): promoted to `beta` to reflect
+shipped + byte-identical HTML status.
+
 ## [1.0.0-alpha.1] — 2026-06-01
 
 Initial implementation. Rust port of the Perl `bismark2report` per-sample graphical HTML report generator.

--- a/rust/bismark-report/Cargo.toml
+++ b/rust/bismark-report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bismark-report"
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.1"
 description = "Rust port of Bismark Perl's bismark2report script (per-sample graphical HTML report)"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Version coherence — promote shipped crates to beta (manifest-only)

Reconciles `rust/` crate manifest versions so **"beta" consistently means "shipped + byte-identical to Perl v0.25.1"**. **No code, no behavior change, no new tags** — manifests + `Cargo.lock` + CHANGELOGs only.

| Crate | From | To | Why |
|---|---|---|---|
| `coverage2cytosine` | `1.0.0-alpha.1` | `1.0.0-beta.2` | manifest was **behind** its release tag `…beta.2` — the one genuine inconsistency |
| `bam2nuc` | `1.0.0-alpha.1` | `1.0.0-beta.1` | shipped + byte-identical (#922) |
| `filter-nonconversion` | `1.0.0-alpha.1` | `1.0.0-beta.1` | shipped + byte-identical (#927) |
| `report` | `1.0.0-alpha.1` | `1.0.0-beta.1` | shipped + byte-identical (#931) |
| `genome-preparation` | `1.0.0-alpha.2` | `1.0.0-beta.1` | shipped + byte-identical (#913/#925) |

**Untouched (deliberately):** `bismark-io` (`beta.8`; shared lib, pinned `=1.0.0-beta.8` by `dedup`) and `bismark-aligner` (`alpha.1`; in progress); the already-beta crates.

### Safety
All 5 targets are **leaf binary crates** with **no `=version` path-dep pins** on them (verified workspace-wide), so the bump cannot break a sibling's pinned dependency. `cargo build --workspace` updated `Cargo.lock` cleanly; **450 tests pass; `clippy --all-targets -D warnings` + `fmt --check` clean.** Plan + self-coverage at `plans/06032026_rust-version-coherence/`.
