### PR TITLE
ci/chore: master infra — register release workflow + Linguist language-bar fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# GitHub Linguist — keep the repository language bar reflecting the actual
+# source (Perl + Rust), not vendored web assets or documentation.
+#
+# The plot.ly bundle (literally named `plot.ly`) is mis-detected as "LilyPond"
+# via its `.ly` extension, and the plotly HTML assets dominate as "HTML" — both
+# are vendored third-party report assets, not Bismark source.
+
+# Vendored web assets (plot.ly bundle + embedded HTML report templates).
+*.ly               linguist-vendored
+plotly/**          linguist-vendored
+**/plotly/**       linguist-vendored
+*.html             linguist-vendored
+
+# Documentation (not counted as a language).
+Docs/**            linguist-documentation
+docs/**            linguist-documentation
+*.md               linguist-documentation
+license.txt        linguist-documentation
+
+# Generated.
+rust/Cargo.lock    linguist-generated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,296 @@
+name: Release (Bismark Rust suite)
+
+# ------------------------------------------------------------------
+# Beta release machinery for the Bismark Rust SUITE (12 binaries + the
+# bismark-io lib). Modeled on the Trim Galore Rust release workflow, adapted
+# for a multi-binary workspace.
+#
+# Release invariant: never push a `bismark-rust-v*` tag manually — this workflow
+# creates and pushes the tag itself. For validation, dispatch with dry_run=true:
+# all destructive side effects (tag push, GHCR push, GH release) are suppressed.
+#
+# Versioning: the SUITE version is the single-source `rust/VERSION` file (NOT a
+# crate version — the workspace is virtual). Tag = `bismark-rust-v<version>`
+# (distinct from the Perl `v*` tags and the per-crate `bismark-io-v*` tags).
+#
+# Branch guard (beta track): prereleases only from `rust/iron-chancellor`
+# (version carries a `-beta`/`-rc` suffix); GA (no suffix) only from `master`.
+#
+# NO crates.io publish: deferred to GA (the immutable-publish / no-bump-during-
+# beta / exact-pin-cascade trap — see plans/06062026_rust-suite-packaging/PLAN.md).
+# ------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — build, test, validate without pushing tags/images or creating a release.'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  check-release:
+    name: Check release
+    runs-on: ubuntu-latest
+    outputs:
+      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+      is_dry_run: ${{ steps.check.outputs.is_dry_run }}
+      version: ${{ steps.check.outputs.version }}        # suite version, e.g. 2.0.0-beta.1
+      tag: ${{ steps.check.outputs.tag }}                # bismark-rust-v<version>
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: true
+      - name: Detect release
+        id: check
+        run: |
+          RAW_VERSION=$(tr -d '[:space:]' < rust/VERSION)
+          [ -n "$RAW_VERSION" ] || { echo "::error::rust/VERSION is empty"; exit 1; }
+          IS_PRERELEASE=false
+          [[ "$RAW_VERSION" == *-* ]] && IS_PRERELEASE=true
+
+          # Branch guard: GA only from master; prereleases from iron-chancellor.
+          if [ "${{ github.ref_name }}" = "master" ]; then
+            : # GA (or prerelease) from master is allowed
+          elif [ "${{ github.ref_name }}" = "rust/iron-chancellor" ] && [ "$IS_PRERELEASE" = "true" ]; then
+            : # prereleases only from the integration branch
+          else
+            echo "::error::Release must be from master, or a prerelease (version with a '-' suffix) from rust/iron-chancellor; got ${{ github.ref_name }} with $RAW_VERSION"
+            exit 1
+          fi
+
+          TAG="bismark-rust-v$RAW_VERSION"
+          if [ "${{ inputs.dry_run }}" != "true" ] && git tag -l "$TAG" | grep -q .; then
+            echo "::error::Tag $TAG already exists"; exit 1
+          fi
+
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "is_dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+          echo "version=$RAW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Detected: $TAG (prerelease=$IS_PRERELEASE, dry_run=${{ inputs.dry_run }})"
+
+  build-binaries:
+    name: Build ${{ matrix.name }}
+    needs: [check-release]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macos-aarch64
+            os: macos-latest
+            target: aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Build the whole suite
+        env:
+          BISMARK_SUITE_VERSION: ${{ needs.check-release.outputs.version }}
+        run: cargo build --release --locked --manifest-path rust/Cargo.toml --target ${{ matrix.target }}
+      - name: Package the suite tarball
+        id: package
+        run: |
+          ARCHIVE="bismark-rust-${{ needs.check-release.outputs.version }}-${{ matrix.name }}"
+          BINDIR="rust/target/${{ matrix.target }}/release"
+          mkdir -p "staging/${ARCHIVE}"
+          for b in bismark_rs deduplicate_bismark_rs bismark_methylation_extractor_rs \
+                   bismark2bedGraph_rs coverage2cytosine_rs bismark_genome_preparation_rs \
+                   bam2nuc_rs NOMe_filtering_rs filter_non_conversion_rs \
+                   methylation_consistency_rs bismark2report_rs bismark2summary_rs; do
+            cp "${BINDIR}/${b}" "staging/${ARCHIVE}/"
+          done
+          cp license.txt "staging/${ARCHIVE}/LICENSE"
+          cp rust/THIRD-PARTY-NOTICES.md "staging/${ARCHIVE}/"
+          cp rust/README.md "staging/${ARCHIVE}/" 2>/dev/null || true
+          tar czf "${ARCHIVE}.tar.gz" -C staging "${ARCHIVE}"
+          shasum -a 256 "${ARCHIVE}.tar.gz" > "${ARCHIVE}.tar.gz.sha256"
+          echo "archive=${ARCHIVE}.tar.gz" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.name }}
+          path: |
+            ${{ steps.package.outputs.archive }}
+            ${{ steps.package.outputs.archive }}.sha256
+          retention-days: 1
+
+  smoke-test-binaries:
+    name: Smoke test binaries (all 12)
+    needs: [check-release, build-binaries]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: binary-linux-x86_64
+          path: /tmp/binaries
+      - name: Smoke test every binary
+        run: |
+          cd /tmp/binaries
+          tar xzf bismark-rust-${{ needs.check-release.outputs.version }}-linux-x86_64.tar.gz
+          DIR="bismark-rust-${{ needs.check-release.outputs.version }}-linux-x86_64"
+          for b in bismark_rs deduplicate_bismark_rs bismark_methylation_extractor_rs \
+                   bismark2bedGraph_rs coverage2cytosine_rs bismark_genome_preparation_rs \
+                   bam2nuc_rs NOMe_filtering_rs filter_non_conversion_rs \
+                   methylation_consistency_rs bismark2report_rs bismark2summary_rs; do
+            echo "--- $b ---"
+            "$DIR/$b" --version
+            "$DIR/$b" --help > /dev/null
+          done
+          echo "✓ all 12 binaries smoke-tested"
+
+  docker-build:
+    name: Docker ${{ matrix.platform }}
+    needs: [check-release]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BISMARK_SUITE_VERSION=${{ needs.check-release.outputs.version }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ needs.check-release.outputs.is_dry_run != 'true' }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+      - name: Export digest
+        if: needs.check-release.outputs.is_dry_run != 'true'
+        run: mkdir -p /tmp/digests && touch "/tmp/digests/${{ steps.build.outputs.digest }}"
+      - uses: actions/upload-artifact@v4
+        if: needs.check-release.outputs.is_dry_run != 'true'
+        with:
+          name: digests-${{ matrix.runner }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-merge:
+    name: Docker merge + tag
+    needs: [check-release, docker-build]
+    if: needs.check-release.outputs.is_dry_run != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@v4
+        with: { pattern: digests-*, path: /tmp/digests, merge-multiple: true }
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest
+        working-directory: /tmp/digests
+        run: |
+          V="${{ needs.check-release.outputs.version }}"
+          if [ "${{ needs.check-release.outputs.is_prerelease }}" = "true" ]; then
+            TAGS="-t ghcr.io/${{ env.IMAGE_NAME }}:beta -t ghcr.io/${{ env.IMAGE_NAME }}:$V"
+          else
+            TAGS="-t ghcr.io/${{ env.IMAGE_NAME }}:latest -t ghcr.io/${{ env.IMAGE_NAME }}:$V"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf 'ghcr.io/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+  # Smoke-test the pushed multi-arch image (real runs only — dry_run never
+  # pushes, so there's nothing to pull; the dry_run docker-build still validates
+  # the Dockerfile *builds*). Verifies a suite binary + a bundled aligner resolve.
+  smoke-test-docker:
+    name: Smoke test Docker image
+    needs: [check-release, docker-merge]
+    if: needs.check-release.outputs.is_dry_run != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+      - name: Pull + test
+        run: |
+          IMG="ghcr.io/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}"
+          docker run --rm "$IMG" bismark_rs --version
+          docker run --rm "$IMG" bismark_methylation_extractor_rs --version
+          docker run --rm "$IMG" bowtie2 --version
+          docker run --rm "$IMG" samtools --version | head -1
+
+  # Create the tag + a DRAFT release (gated on the image building OK). Drafting
+  # means no PUBLIC release exists until binaries are uploaded + the image is
+  # smoke-tested (finalize-release). NB the tag IS pushed here — a failure before
+  # finalize leaves a draft + tag that must be deleted before re-running
+  # (the check-release collision guard).
+  create-release:
+    name: Create tag + draft release
+    needs: [check-release, build-binaries, smoke-test-binaries, docker-build]
+    if: needs.check-release.outputs.is_dry_run != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tag + draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRERELEASE_FLAG: ${{ needs.check-release.outputs.is_prerelease == 'true' && '--prerelease' || '' }}
+        run: |
+          git tag "${{ needs.check-release.outputs.tag }}"
+          git push origin "${{ needs.check-release.outputs.tag }}"
+          gh release create "${{ needs.check-release.outputs.tag }}" \
+            --target "${{ github.sha }}" \
+            --title "Bismark Rust suite ${{ needs.check-release.outputs.version }}" \
+            --generate-notes --draft $PRERELEASE_FLAG
+
+  upload-binaries:
+    name: Upload binaries to draft release
+    needs: [check-release, create-release, build-binaries]
+    if: needs.check-release.outputs.is_dry_run != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { pattern: binary-*, path: /tmp/binaries, merge-multiple: true }
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ needs.check-release.outputs.tag }}" /tmp/binaries/*.tar.gz /tmp/binaries/*.sha256
+
+  # Publish (un-draft) ONLY after binaries are uploaded AND the image passed its
+  # smoke test — no public release without complete, validated artifacts.
+  finalize-release:
+    name: Finalize (publish) release
+    needs: [check-release, upload-binaries, smoke-test-docker]
+    if: needs.check-release.outputs.is_dry_run != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "${{ needs.check-release.outputs.tag }}" --draft=false


### PR DESCRIPTION
Adds `release.yml` to the **default branch** so the Bismark Rust suite release workflow becomes **dispatchable**.

## Why this is on master
`workflow_dispatch` workflows are only discoverable/dispatchable once their file exists on the repo's default branch (`master`). This PR registers it. Crucially:
- It is **`on: workflow_dispatch` ONLY** — it has **no** push/PR/schedule trigger, so it **never auto-runs on `master`** and has zero effect on the Perl suite.
- Once registered, it can be run against any ref — e.g. a beta dry-run from the integration branch: `gh workflow run release.yml --ref rust/iron-chancellor -f dry_run=true`.
- The workflow's own `check-release` **branch guard** enforces policy: prereleases only from `rust/iron-chancellor`, GA only from `master`.

## Relationship to #951
The full packaging implementation (versioning, `_rs` normalization, `Dockerfile`, `justfile`, the suite binaries this workflow builds) lands via **#951** (`rust/suite-packaging` → `rust/iron-chancellor`). This PR carries **only** `release.yml` so the dry-run can be exercised. The file here is identical to #951's.

After merge: `gh workflow run release.yml --ref rust/suite-packaging -f dry_run=true` validates the whole pipeline (3-target binaries + smoke-test all 12 + multi-arch Docker build) with **every** push/publish suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)