### PR TITLE
fix(release): strip sha256: prefix from Docker digest artifact filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,13 @@ jobs:
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
       - name: Export digest
         if: needs.check-release.outputs.is_dry_run != 'true'
-        run: mkdir -p /tmp/digests && touch "/tmp/digests/${{ steps.build.outputs.digest }}"
+        # Strip the "sha256:" prefix so the artifact filename is bare hex —
+        # actions/upload-artifact@v4 rejects ':' in paths, and the "Create
+        # manifest" step reconstructs digests as @sha256:<filename>.
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
       - uses: actions/upload-artifact@v4
         if: needs.check-release.outputs.is_dry_run != 'true'
         with:


### PR DESCRIPTION
## What
`release.yml` 'Export digest' wrote `/tmp/digests/${{ steps.build.outputs.digest }}` — i.e. `/tmp/digests/sha256:<hex>`. `actions/upload-artifact@v4` rejects `:` in paths, so the first real `beta.1` release (run 27070455393) failed at the Docker stage. **The image build + push-by-digest to GHCR itself succeeded**; only the digest-artifact upload (consumed by the manifest-merge job) failed → tag/release/publish all skipped, so nothing public was created.

## Fix
Strip the `sha256:` prefix so the filename is bare hex, matching the 'Create manifest' step's `$(printf '...@sha256:%s ' *)` reconstruction (the two steps were inconsistent).

## Why the dry-run didn't catch it
`Export digest`/`upload-artifact` are gated `if: is_dry_run != 'true'` and only produce a digest when `push: true` — a push-suppressed dry-run skips them entirely. First real release is the only place this surfaces.

## Next
Merge → re-dispatch `gh workflow run release.yml --ref rust/iron-chancellor` (re-pushes identical digests, this time tags + publishes).