### PR TITLE
fix(release): GH_REPO in upload-binaries + finalize-release (publish-path checkout-less gh)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,6 +287,9 @@ jobs:
         with: { pattern: binary-*, path: /tmp/binaries, merge-multiple: true }
       - env:
           GH_TOKEN: ${{ github.token }}
+          # This job has no checkout, so gh can't infer the repo from a git
+          # remote — set GH_REPO explicitly (else: "fatal: not a git repository").
+          GH_REPO: ${{ github.repository }}
         run: gh release upload "${{ needs.check-release.outputs.tag }}" /tmp/binaries/*.tar.gz /tmp/binaries/*.sha256
 
   # Publish (un-draft) ONLY after binaries are uploaded AND the image passed its
@@ -299,4 +302,6 @@ jobs:
     steps:
       - env:
           GH_TOKEN: ${{ github.token }}
+          # No checkout here either — same GH_REPO fix as upload-binaries.
+          GH_REPO: ${{ github.repository }}
         run: gh release edit "${{ needs.check-release.outputs.tag }}" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,13 @@ jobs:
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
       - name: Export digest
         if: needs.check-release.outputs.is_dry_run != 'true'
-        run: mkdir -p /tmp/digests && touch "/tmp/digests/${{ steps.build.outputs.digest }}"
+        # Strip the "sha256:" prefix so the artifact filename is bare hex —
+        # actions/upload-artifact@v4 rejects ':' in paths, and the "Create
+        # manifest" step reconstructs digests as @sha256:<filename>.
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
       - uses: actions/upload-artifact@v4
         if: needs.check-release.outputs.is_dry_run != 'true'
         with:


### PR DESCRIPTION
## What
Second + third real-run-only bugs in the beta.1 publish path, found while cutting `bismark-rust-v2.0.0-beta.1`.

`upload-binaries` and `finalize-release` have **no `actions/checkout`**, so `gh release upload`/`edit` can't infer the repo from a git remote → `fatal: not a git repository`. (`create-release` works because it checks out for `git tag`/`push`.) The 2nd real release reached `Create tag + draft release` ✅ then failed at `upload-binaries`; `finalize-release` had the identical latent defect (caught by auditing the whole publish tail, not just the failing step).

## Fix
Set `GH_REPO: ${{ github.repository }}` on both steps so `gh` resolves the repo without a checkout.

## Validated so far (2nd real run, 27071015426)
Digest fix (#953) confirmed working: Docker build+push, **merge+tag**, **Docker image smoke**, all-12 binary smoke, and **Create tag + draft release** all ✅. Only the checkout-less `gh` calls remained.

## Why dry-runs miss it
Both jobs are gated `if: is_dry_run != 'true'` — never exercised by a push-suppressed dry-run. The publish path is only fully validated by a real release.

Branch reused (merged iron-chancellor in → clean diff = just the 2 GH_REPO blocks). Next: merge → delete-tag-already-done → re-dispatch.