### PR TITLE
feat(docker): canonical tool names in the suite image (nf-core/methylseq drop-in)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,23 @@ jobs:
           docker run --rm "$IMG" bismark_methylation_extractor_rs --version
           docker run --rm "$IMG" bowtie2 --version
           docker run --rm "$IMG" samtools --version | head -1
+          # Canonical names (methylseq drop-in) resolve to the _rs binaries.
+          docker run --rm "$IMG" bismark --help >/dev/null
+          docker run --rm "$IMG" coverage2cytosine --help >/dev/null
+          docker run --rm "$IMG" deduplicate_bismark --help >/dev/null
+          # Version probe: BOTH methylseq parser shapes must capture EXACTLY 0.25.1
+          # from `bismark` (the provenance line must NOT leak — the contract that
+          # keeps methylseq's versions.yml + nf-test snapshots unchanged).
+          p1=$(docker run --rm "$IMG" bismark --version | grep Version | sed -e 's/Bismark Version: v//' | xargs)
+          p2=$(echo $(docker run --rm "$IMG" bismark -v 2>&1) | sed 's/^.*Bismark Version: v//; s/Copyright.*$//' | xargs)
+          echo "version capture: parser1='$p1' parser2='$p2'"
+          [ "$p1" = "0.25.1" ] || { echo "FAIL: align-module parser captured '$p1'"; exit 1; }
+          [ "$p2" = "0.25.1" ] || { echo "FAIL: versions.yml parser captured '$p2' (provenance leak?)"; exit 1; }
+          # Tools methylseq shells out to (genomeprep → *-build; extractor → gzip).
+          # NB assert each individually — `command -v a b c` only resolves the FIRST
+          # operand (POSIX), so a single multi-arg call would silently pass.
+          docker run --rm "$IMG" sh -c 'for t in gzip sed printf bowtie2-build hisat2-build samtools; do command -v "$t" >/dev/null || { echo "missing: $t"; exit 1; }; done' \
+            || { echo "FAIL: a required co-resident tool is missing"; exit 1; }
 
   # Create the tag + a DRAFT release (gated on the image building OK). Drafting
   # means no PUBLIC release exists until binaries are uploaded + the image is

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ LABEL org.opencontainers.image.source="https://github.com/FelixKrueger/Bismark"
 LABEL org.opencontainers.image.description="Bismark Rust suite (beta) — bisulfite aligner + methylation tools, byte-identical to Perl v0.25.1"
 LABEL org.opencontainers.image.licenses="GPL-3.0-only"
 
-# The micromamba base ends on `USER mambauser` (UID 1000); installing into the
+# The micromamba base ends on `USER mambauser` (an unprivileged user); installing into the
 # base env + copying binaries into root-owned /usr/local/* needs root.
 USER root
 
@@ -60,6 +60,34 @@ COPY --from=builder \
     /build/rust/target/release/bismark2summary_rs \
     /usr/local/bin/
 
+# ── Canonical tool names (nf-core/methylseq drop-in) ─────────
+# methylseq calls the Bismark tools by canonical name (no `_rs`) and captures the
+# suite version from the `bismark` binary via `bismark -v`/`--version`. Exposing
+# canonical names lets a methylseq container-swap PR use only a `withName` override
+# (no module script edits):
+#   - `bismark` is a version-probe WRAPPER — its `-v`/`--version` output is kept
+#     byte-identical to the Perl v0.25.1 oracle so methylseq's versions.yml + the
+#     bismark nf-test snapshots are unchanged (docker/bismark-canonical-wrapper.sh).
+#   - the other 11 are plain symlinks (methylseq scrapes ONLY `bismark`, so their
+#     `--version` stays the truthful Rust-suite banner).
+ARG BISMARK_SUITE_VERSION=unknown
+COPY docker/bismark-canonical-wrapper.sh /tmp/bismark-wrapper.sh
+RUN set -eu; \
+    sed "s|__SUITE_VERSION__|${BISMARK_SUITE_VERSION}|" /tmp/bismark-wrapper.sh \
+        > /usr/local/bin/bismark; \
+    chmod +x /usr/local/bin/bismark; \
+    rm /tmp/bismark-wrapper.sh; \
+    for t in deduplicate_bismark bismark_methylation_extractor bismark2bedGraph \
+             coverage2cytosine bismark_genome_preparation bam2nuc NOMe_filtering \
+             filter_non_conversion methylation_consistency bismark2report bismark2summary; do \
+      ln -s "${t}_rs" "/usr/local/bin/${t}"; \
+    done
+
 # License + third-party notices.
 COPY license.txt /usr/local/share/bismark/LICENSE
 COPY rust/THIRD-PARTY-NOTICES.md /usr/local/share/bismark/THIRD-PARTY-NOTICES.md
+
+# Drop back to the non-root base user (nf-core/Apptainer convention). The binaries
+# in /usr/local/bin + the conda env in /opt/conda are world-executable, so the
+# unprivileged base user (`mambauser`) runs them fine.
+USER mambauser

--- a/docker/bismark-canonical-wrapper.sh
+++ b/docker/bismark-canonical-wrapper.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Canonical-name `bismark` shim for the Rust-suite container (nf-core/methylseq drop-in).
+#
+# methylseq's 7 Bismark modules ALL capture the suite version from the `bismark`
+# binary (verified against methylseq master), via two parser shapes:
+#   Parser-1 (align, topic: versions): `bismark --version | grep Version | sed -e 's/Bismark Version: v//' | xargs`
+#   Parser-2 (the other 6 modules):    `echo $(bismark -v 2>&1) | sed 's/^.*Bismark Version: v//; s/Copyright.*$//'`
+#
+# To keep the captured value BYTE-IDENTICAL to the Perl v0.25.1 oracle (so the
+# modules' versions.yml — and their nf-test snapshots — are unchanged), we
+# reproduce the Perl `bismark -v` banner shape: a `Bismark Version: v0.25.1`
+# line + a `Copyright`-prefixed line, then honest Rust-suite provenance on
+# line(s) AFTER `Copyright` containing NO "Version" token. Result:
+#   Parser-1 → "0.25.1"   Parser-2 → "0.25.1 "   (exactly the Perl oracle).
+#
+# The `Bismark Version: v0.25.1` token is the FIXED byte-identity oracle version
+# (= the suite's behavioural target + methylseq's pinned container tag), NOT the
+# Rust suite version; only the provenance line carries the suite version
+# (__SUITE_VERSION__, injected from $BISMARK_SUITE_VERSION at image build).
+#
+# Every NON-version invocation execs the unchanged `bismark_rs` binary (argv,
+# stdin/stdout/stderr, exit code all preserved). methylseq always passes the
+# version flag as the sole argument, so matching `$1` is sufficient.
+case "$1" in
+  --version|-v)
+    printf 'Bismark Version: v0.25.1\nCopyright 2010-25 Felix Krueger, Altos Bioinformatics\nhttps://github.com/FelixKrueger/Bismark\n(Bismark Rust suite __SUITE_VERSION__ — byte-identical reimplementation of Bismark v0.25.1)\n'
+    exit 0 ;;
+esac
+exec bismark_rs "$@"

--- a/rust/README.md
+++ b/rust/README.md
@@ -23,6 +23,8 @@ Rust binaries take an `_rs` suffix through approximately v0.26 → v1.0 so they 
 
 After v1.0 of the Rust port, the `_rs` suffix is dropped — the Rust binaries become the default `deduplicate_bismark` etc., and the Perl scripts move to a `legacy/` directory.
 
+**Inside the published container image** the tools are *additionally* exposed under their **canonical names** (`bismark`, `deduplicate_bismark`, `coverage2cytosine`, …): a container has no Perl Bismark to collide with, so canonical names make it a drop-in for pipelines that call the tools by name (e.g. nf-core/methylseq). The `bismark` canonical name is a thin wrapper that answers `-v`/`--version` with a `Bismark v0.25.1`-compatible banner (so the pipeline's version capture is byte-identical to the Perl oracle) and otherwise execs `bismark_rs`; the rest are symlinks. Host installs keep the `_rs` suffix for Perl coexistence.
+
 ## Architecture decisions
 
 - **BAM/SAM/CRAM I/O via pure-Rust `noodles`** — no `rust-htslib` (no htslib C build-time dep), no `samtools` subprocess (no external runtime dep).


### PR DESCRIPTION
## Summary
Makes the Bismark Rust-suite GHCR image a **zero-edit drop-in** for nf-core/methylseq's 7 Bismark modules — so the (separate, follow-on) methylseq container-swap PR needs only a `withName` container override.

- **`docker/bismark-canonical-wrapper.sh` (new):** the `bismark` canonical wrapper — `-v`/`--version` emits the Perl-v0.25.1-shaped banner (`Bismark Version: v0.25.1` + `Copyright` line + Rust-suite provenance AFTER `Copyright`, no "Version" token); all other args `exec bismark_rs`. Keeps methylseq's version capture **byte-identical to the Perl oracle** (both parser shapes → `0.25.1`), so `versions.yml` + the bismark nf-test snapshots are unchanged.
- **`Dockerfile`:** sed the suite version into `/usr/local/bin/bismark` + symlink the other 11 canonical names → their `_rs` binaries (methylseq scrapes only the `bismark` binary, so the rest keep their truthful Rust `--version`); restore `USER mambauser` (non-root). bowtie2/hisat2/samtools already pinned + present.
- **`release.yml`:** smoke-test canonical-name resolution + assert BOTH methylseq version parsers capture exactly `0.25.1` + per-tool co-resident-tool checks.

## Validation
- Both methylseq parser pipelines capture `0.25.1` from the banner (verified locally; no provenance leak).
- Dual `/code-reviewer` **APPROVE-WITH-CHANGES** (HIGH no-op smoke check + LOWs fixed) + `/plan-manager` **COMPLETE**. Both reviewers independently re-fetched all 7 live methylseq modules and confirmed they all capture from the `bismark` binary (→ the symlink-for-the-other-11 approach is correct).
- Full image build is the CI/publish gate (bioconda not reachable in the dev sandbox).

Container only; the methylseq container-swap PR + the methylseq proof run are separate follow-ons. Plan: `plans/06092026_bismark-beta/PLAN_canonical_container.md`.