### PR TITLE
docs(rust): one-command install/update UX for the Rust suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Bismark is a program to map bisulfite treated sequencing reads to a genome of in
 - Alignment seed length, number of mismatches etc. are adjustable
 - Output discriminates between cytosine methylation in `CpG`, `CHG` and `CHH` context
 
-> **Rust rewrite in progress:** Bismark's post-alignment tools are being ported from Perl to Rust — faster, with byte-identical output. See [`rust/`](rust/) for the workspace and a per-tool status table.
+> **Rust rewrite in progress:** Bismark's post-alignment tools are being ported from Perl to Rust — faster, with byte-identical output. See [`rust/`](rust/) for the workspace and a per-tool status table, and [Installing](rust/README.md#installing) to get the Rust suite (prebuilt binaries, container, or `cargo install`).
 
 ## Documentation
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -32,6 +32,55 @@ After v1.0 of the Rust port, the `_rs` suffix is dropped — the Rust binaries b
 - **Byte-equal output to Perl Bismark v0.25.1** is a CI gate for the tools we have validated.
 - Edition 2024; MSRV pinned in the workspace manifest.
 
+## Installing
+
+<!-- Maintainer: on a suite-version bump, update every `2.0.0-beta.3` / `beta.3` literal in this
+     section (the pinned `docker pull` tag + the `cargo install --tag`) AND `suite_tag` in `rust/justfile`.
+     The `--branch` command and the prebuilt/container `:beta` paths track latest automatically. -->
+
+Three ways to get the suite, easiest first — pick **one**.
+
+### 1. Prebuilt binaries (no Rust toolchain needed)
+
+Each [release](https://github.com/FelixKrueger/Bismark/releases) attaches prebuilt binaries for common Linux/macOS platforms. Download the archive for your platform, extract it, and put the binaries on your `PATH`. The Rust tools carry an `_rs` suffix (see [Binary naming during coexistence](#binary-naming-during-coexistence)).
+
+### 2. Container image (nothing to install)
+
+A multi-arch image is published to the GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/felixkrueger/bismark:beta          # latest beta
+docker pull ghcr.io/felixkrueger/bismark:2.0.0-beta.3  # pinned
+```
+
+Inside the container the tools are *additionally* exposed under their **canonical** names (`bismark`, `deduplicate_bismark`, …), so it is a drop-in for pipelines such as nf-core/methylseq.
+
+### 3. Build from source with `cargo install` (whole suite, one command)
+
+Requires a Rust toolchain (see Prerequisites below). This installs **all 12** binaries into `~/.cargo/bin` in a single invocation:
+
+```bash
+cargo install --git https://github.com/FelixKrueger/Bismark \
+  --tag bismark-rust-v2.0.0-beta.3 --locked \
+  bismark-genome-preparation bismark-aligner bismark-dedup bismark-extractor \
+  bismark-bedgraph bismark-coverage2cytosine bismark-methylation-consistency \
+  bismark-nome-filtering bismark-filter-nonconversion bismark-bam2nuc \
+  bismark-report bismark-summary
+```
+
+For the latest development build instead of a pinned release, swap `--tag bismark-rust-v2.0.0-beta.3` for `--branch rust/iron-chancellor`.
+
+> **Updating.** Re-run the **`--branch`** command and cargo picks up the newest commit automatically (it prints `Replacing …`). **Re-running the same `--tag` is a no-op** — cargo reports the package is already installed. To move to a newer release, bump the `--tag` to the new version (e.g. `…beta.4`), or add `--force` to reinstall in place.
+
+Compiling 12 crates from source is a non-trivial one-time build; cargo does not fully share dependency compilation across the listed packages.
+
+#### Prerequisites (cargo path)
+
+- **Rust** — latest stable recommended (`rustup update`). The workspace MSRV is **1.89**; the one-command install above was verified on **cargo 1.95** (older cargo may not resolve packages inside the `rust/` subdirectory).
+- A working **C linker** (`cc`) for a few transitive build dependencies.
+- **Alignment backends on `PATH`** — only the aligner and genome-preparation tools shell out to an external program: **Bowtie 2** + `bowtie2-build` (default), or optionally **HISAT2** + `hisat2-build`, or **minimap2**. `cargo install` builds the Rust tools, not these backends. *(No `samtools` is required — BAM/SAM I/O is pure-Rust `noodles`.)*
+- Ensure **`~/.cargo/bin` is on your `PATH`** to run the installed `*_rs` binaries.
+
 ## Building
 
 ```bash

--- a/rust/justfile
+++ b/rust/justfile
@@ -4,6 +4,11 @@
 # `just <target>` for an individual check. Install just: `cargo install just`.
 # All targets run from the workspace root (`rust/`); `just` cd's here.
 
+# Install/update config for the `install-suite*` recipes (bump `suite_tag` on release).
+repo := "https://github.com/FelixKrueger/Bismark"
+suite_tag := "bismark-rust-v2.0.0-beta.3"
+suite_crates := "bismark-genome-preparation bismark-aligner bismark-dedup bismark-extractor bismark-bedgraph bismark-coverage2cytosine bismark-methylation-consistency bismark-nome-filtering bismark-filter-nonconversion bismark-bam2nuc bismark-report bismark-summary"
+
 # Default: the portable CI check suite (lint + tests, both profiles).
 default: ci
 
@@ -36,6 +41,14 @@ test-release:
 # Build all 12 release binaries (target/release/*_rs).
 build:
     cargo build --workspace --release
+
+# Install all 12 `*_rs` binaries from the pinned release tag into ~/.cargo/bin.
+install-suite:
+    cargo install --git {{repo}} --tag {{suite_tag}} --locked {{suite_crates}}
+
+# Install all 12 from the latest dev branch; re-run to update (no --force needed).
+install-suite-dev:
+    cargo install --git {{repo}} --branch rust/iron-chancellor {{suite_crates}}
 
 # Print every suite binary's --version (provenance + suite-version check).
 version: build


### PR DESCRIPTION
## What

Adds a friendly **one-command install/update** path for the whole Bismark Rust suite, plus docs.

- `rust/README.md` — new `## Installing` section: three install paths (prebuilt tarballs, GHCR container, `cargo install --git`), a single command that installs **all 12 `*_rs` binaries** (tag-pinned with `--locked`, plus a `--branch` dev variant that auto-updates on re-run), a prominent **Updating** callout, corrected prerequisites, and a cross-link to the `_rs` naming section.
- `rust/justfile` — `install-suite` / `install-suite-dev` recipes wrapping that command (+ `repo`/`suite_tag`/`suite_crates` vars).
- `README.md` (top-level) — pointer to the install section.

**Docs + tooling only — zero source/manifest changes.**

## Why

Beta-runway item #1 toward the nf-core announcement: a single, Rust-native way to install/update *everything* (not per-tool).

## Decision (Option A vs meta-crate)

The workspace's 12-crate layout (no root `Cargo.toml`; workspace in `rust/`) makes a single **multi-arg `cargo install --git`** the zero-risk path. The four enabling cargo mechanics were measured on cargo 1.95: `--git` searches the whole repo and reaches the `rust/` members; one invocation installs many named packages; re-running a `--branch` install auto-updates with no `--force`. A **meta-crate** for a shorter command was costed (≈12 bespoke `main.rs` would need a uniform entrypoint, or a fragile `[[bin]] path`→sibling-mains variant) and **deferred** — it buys only a shorter string on a byte-identity-gated project.

## Verification

- **Dual plan-review + dual code-review → APPROVE; plan-manager → COMPLETE.**
- Verified against the live repo / `bismark-rust-v2.0.0-beta.3` tag / GitHub release / GHCR: the 12 crate names match the manifests exactly, `Cargo.lock` is committed (so `--locked` holds), the `:beta`/`:2.0.0-beta.3` image tags + the 3 prebuilt tarballs exist, "no samtools" matches the source (`grep Command::new`), and `just --dry-run install-suite` is byte-equivalent to the README command.
- **Deferred (documented):** the full real-repo install of all 12 from the tag (a ~20–40 min full-LTO build) — disproportionate for a docs change; it's the natural release/CI gate. `just install-suite` runs it on demand.

Plan + reviews: `plans/06092026_bismark-beta/PLAN_install_ux.md` (+ `*_REVIEW_*`, `COVERAGE_install_ux.md`).
