### PR TITLE
docs: Rust suite install section + faq base-path fix

### DIFF
--- a/docs/src/content/docs/faq/index.md
+++ b/docs/src/content/docs/faq/index.md
@@ -5,7 +5,7 @@ description: "This will be a collection of fairly common issues that arise fairl
 
 This will be a collection of fairly common issues that arise fairly regularly. Started on 03 Sept 2019
 
-- [Single-cell and PBAT libraries](/faq/single-cell-pbat/)
-- [Low mapping efficiency of paired-end libraries](/faq/low-mapping/)
-- [Context change between coverage and cytosine reports](/faq/changing-context/)
-- [Bisulfite conversion efficiency](/faq/conversion-efficiency/)
+- [Single-cell and PBAT libraries](./single-cell-pbat/)
+- [Low mapping efficiency of paired-end libraries](./low-mapping/)
+- [Context change between coverage and cytosine reports](./changing-context/)
+- [Bisulfite conversion efficiency](./conversion-efficiency/)

--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -9,9 +9,6 @@ Bismark is written in Perl and is executed from the command line. To install Bis
 tar xzf bismark_v0.X.Y.tar.gz
 ```
 
-<!-- maintainer: on a Bismark-Rust suite bump, update the `2.0.0-beta.3` literals below AND
-     rust/README.md "## Installing" + rust/justfile `suite_tag` (keep all three consistent). -->
-
 ## Bismark Rust suite (beta)
 
 A faster, lower-memory reimplementation of the Bismark tools in Rust is available as a public beta, producing **byte-identical** output to Perl Bismark `v0.25.1`. There are three ways to install it.

--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -9,6 +9,45 @@ Bismark is written in Perl and is executed from the command line. To install Bis
 tar xzf bismark_v0.X.Y.tar.gz
 ```
 
+<!-- maintainer: on a Bismark-Rust suite bump, update the `2.0.0-beta.3` literals below AND
+     rust/README.md "## Installing" + rust/justfile `suite_tag` (keep all three consistent). -->
+
+## Bismark Rust suite (beta)
+
+A faster, lower-memory reimplementation of the Bismark tools in Rust is available as a public beta, producing **byte-identical** output to Perl Bismark `v0.25.1`. There are three ways to install it.
+
+### Prebuilt binaries (no toolchain)
+
+Each [release](https://github.com/FelixKrueger/Bismark/releases) attaches prebuilt binaries for common Linux/macOS platforms — download the archive for your platform, extract it, and put the binaries on your `PATH`. The Rust tools carry an `_rs` suffix (e.g. `bismark_rs`, `deduplicate_bismark_rs`) so they sit alongside the Perl scripts on the same `PATH` without clashing.
+
+### Container image
+
+A multi-arch image is published to the GitHub Container Registry, exposing the tools under their **canonical** names — so it is a drop-in for pipelines such as nf-core/methylseq:
+
+```bash
+docker pull ghcr.io/felixkrueger/bismark:beta          # latest beta
+docker pull ghcr.io/felixkrueger/bismark:2.0.0-beta.3  # pinned
+```
+
+### Install from source with `cargo`
+
+Installs all 12 binaries into `~/.cargo/bin` in a single command (requires a Rust toolchain — see Prerequisites):
+
+```bash
+cargo install --git https://github.com/FelixKrueger/Bismark \
+  --tag bismark-rust-v2.0.0-beta.3 --locked \
+  bismark-genome-preparation bismark-aligner bismark-dedup bismark-extractor \
+  bismark-bedgraph bismark-coverage2cytosine bismark-methylation-consistency \
+  bismark-nome-filtering bismark-filter-nonconversion bismark-bam2nuc \
+  bismark-report bismark-summary
+```
+
+For the latest development build instead of a pinned release, replace `--tag bismark-rust-v2.0.0-beta.3` with `--branch rust/iron-chancellor`. **Updating:** re-run the `--branch` command and cargo picks up the newest commit automatically; to move between pinned releases, bump the `--tag` (re-running the same `--tag` is a no-op — add `--force` to reinstall in place).
+
+**Prerequisites (source install):** a Rust toolchain (latest stable recommended; minimum supported Rust 1.89, the one-command install verified on cargo 1.95); a working C linker; and the alignment backend(s) on your `PATH` — **Bowtie 2** (+ `bowtie2-build`), or optionally **HISAT2** (+ `hisat2-build`) or **minimap2**. No `samtools` is required (BAM/SAM I/O is pure-Rust). Make sure `~/.cargo/bin` is on your `PATH`.
+
+> The `_rs` suffix on host installs lets the Rust binaries coexist with the Perl Bismark scripts; inside the container they are exposed under the canonical names. At the v1.0 release the `_rs` suffix is dropped and the Rust binaries become the defaults.
+
 ## Dependencies
 
 Bismark requires a working of Perl and [Bowtie 2](http://bowtie-bio.sourceforge.net/bowtie2) (or [HISAT2](https://ccb.jhu.edu/software/hisat2/index.shtml)) to be installed on your machine. Bismark will assume that the Bowtie 2/ HISAT2 executable is in your path unless the path to Bowtie/ HISAT2 is specified manually with:

--- a/rust/README.md
+++ b/rust/README.md
@@ -35,7 +35,8 @@ After v1.0 of the Rust port, the `_rs` suffix is dropped — the Rust binaries b
 ## Installing
 
 <!-- Maintainer: on a suite-version bump, update every `2.0.0-beta.3` / `beta.3` literal in this
-     section (the pinned `docker pull` tag + the `cargo install --tag`) AND `suite_tag` in `rust/justfile`.
+     section (the pinned `docker pull` tag + the `cargo install --tag`), `suite_tag` in `rust/justfile`,
+     AND the matching section in the docs site (`docs/src/content/docs/installation.md`).
      The `--branch` command and the prebuilt/container `:beta` paths track latest automatically. -->
 
 Three ways to get the suite, easiest first — pick **one**.


### PR DESCRIPTION
## What

A small docs follow-up to the new Astro + Starlight site (#964), folding two changes into one PR:

**(A) Add a "Bismark Rust suite (beta)" install section** to `installation.md` — the three install paths (prebuilt binaries, GHCR container, `cargo install`) for the byte-identical Rust reimplementation. The `cargo install` block is **character-identical** to `rust/README.md`'s Installing section + `rust/justfile` `suite_crates`/`suite_tag`. External links only (base-safe); the `_rs`-suffix note is inline (no cross-page anchor).

**(B) Fix the `faq/index.md` base-path 404s** — the four index links were root-absolute (`/faq/...`), which ignore `base: '/Bismark/'` and 404 on the deployed site. Changed to relative (`./<slug>/`), matching the site's relative-link convention.

## Why

Closes the install-docs "currency gap": the migrated `installation.md` covered only the legacy Perl install. The faq fix removes four deployed 404s.

## Verification (local — `docs.yml` is push-triggered, so it runs only *after* merge; these are the pre-merge gates)

- `cd docs && npm ci && npm run build` → **23 pages, clean** (no errors).
- Link grep on both edited files → no root-absolute `](/...)` or dead `](#...)` anchors.
- Built HTML: the faq body links resolve to `/Bismark/faq/<slug>/` (relative `./<slug>/` against the trailing-slash `/Bismark/faq/` URL); the Rust section renders (`Bismark Rust suite` / `cargo install` / `ghcr.io/...`).

Touches only `installation.md` + `faq/index.md` — no `modules/`, no `astro.config.mjs` sidebar.

> After this + #964 are live, enable **Settings → Pages → Source → "GitHub Actions"** for the site to publish.
