### PR TITLE
fix(aligner): drop stale Phase-1 "no alignment performed" line from config summary

### DIFF
--- a/rust/bismark-aligner/src/cli.rs
+++ b/rust/bismark-aligner/src/cli.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
-/// The Bismark aligner wrapper (Rust port). Phase 1: parse + discover + detect.
+/// The Bismark aligner wrapper (Rust port): parse + discover + detect, then convert, align, and merge.
 #[derive(Parser, Debug)]
 #[command(
     name = "bismark_rs",

--- a/rust/bismark-aligner/src/config.rs
+++ b/rust/bismark-aligner/src/config.rs
@@ -796,8 +796,7 @@ impl RunConfig {
                large index:    {}\n\
                FASTA(s):       {} file(s) ({:?})\n\
                aligner_options: {}\n\
-               output:         BAM, dir={:?}, basename={:?}\n\
-             (Phase 1: parse + discover + detect only — no alignment performed.)",
+               output:         BAM, dir={:?}, basename={:?}",
             self.aligner.name(),
             self.detected_aligner.version,
             self.detected_aligner.path.display(),


### PR DESCRIPTION
## What
`RunConfig::summary()` ended with a leftover Phase-1 dev line:

```
(Phase 1: parse + discover + detect only — no alignment performed.)
```

That hasn't been true for many phases — the wrapper now runs the full convert → align → merge pipeline. The line is printed by `run()` **right before alignment is dispatched** (`lib.rs`), so it actively misleads anyone reading the resolved-config banner into thinking no alignment happened. Also reworded the matching stale `Cli` doc-comment in `cli.rs`.

## Why it's safe
- **Cosmetic only** — pure string/doc change; no logic touched.
- The removed line carried **no format args**, so the `format!` arg list is unchanged.
- **No test asserted the string** (grep across the crate is clean).

## Verification (local, off iron-chancellor `a1b2837`)
- `cargo fmt -p bismark-aligner -- --check` ✓
- `cargo clippy -p bismark-aligner --all-targets -- -D warnings` ✓
- `cargo test -p bismark-aligner` ✓ — **397 tests** (322 lib + 75 integ), 0 failed

## How it was found
Surfaced while benchmarking aligner `-p` scaling for the beta (investigating the `-p ≥ 2` requirement, which turned out to be a faithful replication of Perl). The summary line was the one genuine — if cosmetic — wrinkle.