### PR TITLE
test(aligner): fix combined_index scope-guard cli test for the HISAT2-SE gate-lift

### DIFF
--- a/rust/bismark-aligner/tests/cli.rs
+++ b/rust/bismark-aligner/tests/cli.rs
@@ -2762,9 +2762,24 @@ fn combined_index_scope_guard_rejects_unsupported() {
 
     // (--pbat is now SUPPORTED — Phase 7; tested in the pbat e2e cells below.)
 
-    // --hisat2
+    // --minimap2 (combined-index unsupported). NB: --hisat2 SE is now ACCEPTED
+    // (Phase 1, v2.x) — covered by config unit tests + the oxy concordance gate.
     bin()
         .arg("--combined_index")
+        .arg("--minimap2")
+        .arg("--genome")
+        .arg(genome.path())
+        .arg(&read)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not supported with --minimap2"));
+
+    // C2 guard: the single-pass exec model stays Bowtie-2-only (HISAT2 non-dir
+    // combined uses the default parallel model (a)).
+    bin()
+        .arg("--combined_index")
+        .arg("--non_directional")
+        .arg("--combined_index_single_pass")
         .arg("--hisat2")
         .arg("--genome")
         .arg(genome.path())


### PR DESCRIPTION
Follow-up to #967. The integration test `tests/cli.rs::combined_index_scope_guard_rejects_unsupported` still asserted `--combined_index --hisat2` → 'requires Bowtie 2', but Phase 1 made HISAT2-SE accepted → CI red on `cargo test --workspace` (my local run was `--lib`, which skips `tests/`). Replaced the stale case with the now-correct rejections (--minimap2 + the C2 single_pass+hisat2 guard). Full suite green: 322 lib + 75 integ. Test-only.