### PR TITLE
docs(rust): document combined-index alignment modes + refresh stale --help text

### DIFF
--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -45,6 +45,8 @@ For the latest development build instead of a pinned release, replace `--tag bis
 
 > The `_rs` suffix on host installs lets the Rust binaries coexist with the Perl Bismark scripts; inside the container they are exposed under the canonical names. At the v1.0 release the `_rs` suffix is dropped and the Rust binaries become the defaults.
 
+The Rust aligner also adds an opt-in, lower-memory [combined-index alignment mode](/Bismark/usage/alignment/) (one combined C→T + G→A index instead of separate per-strand instances) — see the Alignment page.
+
 ## Dependencies
 
 Bismark requires a working of Perl and [Bowtie 2](http://bowtie-bio.sourceforge.net/bowtie2) (or [HISAT2](https://ccb.jhu.edu/software/hisat2/index.shtml)) to be installed on your machine. Bismark will assume that the Bowtie 2/ HISAT2 executable is in your path unless the path to Bowtie/ HISAT2 is specified manually with:

--- a/docs/src/content/docs/usage/alignment.md
+++ b/docs/src/content/docs/usage/alignment.md
@@ -121,3 +121,33 @@ Expanding on our observation that single-cell BS-seq, or PBAT libraries in gener
 
 **Please note** that we still do not recommend using local alignments as a means to _magically_ increase mapping efficiencies (please see [here](https://sequencing.qcfail.com/articles/soft-clipping-of-reads-may-add-potentially-unwanted-alignments-to-repetitive-regions/)), but we do acknowledge that PBAT/scBSs-seq/scNMT-seq are exceptional applications where local alignments might indeed make a difference (there is only so much data to be had from a single cell...).
 We didn't have the time yet to set more appropriate or stringent default values for local alignments (suggestions welcome), nor did we investigate whether the methylation extraction will require an additional `--ignore` flag if a read was found to the be soft-clipped (the so called 'micro-homology domains'). This might be added in the near future.
+
+## Combined-index alignment (Rust suite beta, opt-in)
+
+The [Bismark Rust suite](/Bismark/installation/) adds an opt-in **combined-index** alignment mode to `bismark_rs`. Instead of running 2 (directional) or 4 (non-directional) separate per-strand aligner instances, it aligns against a **single combined C→T + G→A index** in one both-strands pass per read-conversion.
+
+It is **opt-in, never-silent, and concordance-gated — NOT byte-identical** to the faithful per-strand default (a small, benign churn vs the per-strand oracle: directional ~0.013%, non-directional ~0.022–0.044%, pbat ~0.044%, almost all unique↔ambiguous flips). The faithful default path is unchanged; combined mode is used only when you ask for it. minimap2 and `--multicore` are not supported in combined mode (they fail loudly).
+
+**Build the combined index once** (genome preparation adds a `Bisulfite_Genome/Combined/` directory):
+
+```bash
+bismark_genome_preparation_rs --combined_genome /path/to/genome/   # add --hisat2 for a HISAT2 combined index
+```
+
+**Coverage:** single-end and paired-end · Bowtie 2 and HISAT2 · directional / non-directional / pbat.
+
+| Flag | What it does | Scope |
+|------|--------------|-------|
+| `--combined_index` | One both-strands pass per read-conversion. Non-directional uses the default parallel model (two concurrent passes). | SE+PE · Bowtie 2+HISAT2 · dir/non-dir/pbat |
+| `--combined_index_sequential` | Faithful low-memory variant for non-directional: the two both-strands passes run **one at a time** (one index resident → ~½ the peak memory). **Byte-identical** to the default parallel combined run. | non-dir · SE+PE · Bowtie 2+HISAT2 |
+| `--combined_index_single_pass` | One pass over conversion-tagged interleaved reads (one index load). **Not byte-identical / not decision-equivalent** to the parallel run (the read-name tag perturbs Bowtie 2's RNG) — ground-truth-validated, never the default. | non-dir · SE+PE · Bowtie 2 only |
+
+```bash
+# directional, combined index, one both-strands pass:
+bismark_rs --combined_index --genome /path/to/genome/ -p 16 reads.fq.gz
+
+# non-directional, faithful low-memory (one index resident at a time):
+bismark_rs --combined_index --non_directional --combined_index_sequential --genome /path/to/genome/ -p 16 reads.fq.gz
+```
+
+**Memory.** At human-genome scale the combined index is one *large* index, so the memory saving comes specifically from the **low-memory non-directional variants** (`--combined_index_sequential` / `--combined_index_single_pass`): on a real 10M-read WGBS GRCh38 run they held peak RSS to ~11 GB (one index resident) versus ~16 GB for the faithful 4-instance non-directional run and ~19 GB for the parallel combined run — roughly a third to two-fifths less. Combined directional/pbat use a single index load (and the fastest wall times) but are not themselves a memory win, since one large combined index is comparable to the two small per-strand indices they replace.

--- a/rust/README.md
+++ b/rust/README.md
@@ -82,6 +82,47 @@ Compiling 12 crates from source is a non-trivial one-time build; cargo does not 
 - **Alignment backends on `PATH`** — only the aligner and genome-preparation tools shell out to an external program: **Bowtie 2** + `bowtie2-build` (default), or optionally **HISAT2** + `hisat2-build`, or **minimap2**. `cargo install` builds the Rust tools, not these backends. *(No `samtools` is required — BAM/SAM I/O is pure-Rust `noodles`.)*
 - Ensure **`~/.cargo/bin` is on your `PATH`** to run the installed `*_rs` binaries.
 
+## Combined-index alignment (v2, opt-in — beta)
+
+`bismark_rs` can align against a **single combined CT+GA index** instead of the faithful 2 (directional) / 4
+(non-directional) separate per-strand aligner instances. It is **opt-in, never-silent, and concordance-gated —
+NOT byte-identical** to the faithful default (a small benign churn vs the per-strand oracle: directional ~0.013 %,
+non-directional ~0.022–0.044 %, pbat ~0.044 %, almost all unique↔ambiguous flips). The faithful default path is
+unchanged; use combined mode only when you opt in.
+
+**Prerequisite — build the combined index once** (genome-prep adds `Bisulfite_Genome/Combined/`):
+
+```bash
+bismark_genome_preparation_rs --combined_genome /path/to/genome/   # add --hisat2 for a HISAT2 combined index
+```
+
+**Coverage:** single-end **and** paired-end · **Bowtie 2 and HISAT2** · directional / non-directional / pbat — all
+concordance-gated against the faithful per-strand path. (minimap2-combined and `--multicore` + combined are **not**
+supported and fail loud.)
+
+**The flags:**
+
+| Flag | What it does | Scope |
+|------|--------------|-------|
+| `--combined_index` | One both-strands pass per read-conversion over the combined index. Non-directional uses the default **parallel** model (a) (two concurrent passes). | SE+PE · Bowtie 2+HISAT2 · dir/non-dir/pbat |
+| `--combined_index_sequential` | **Faithful** low-RAM variant for non-directional: run the two both-strands passes **one at a time** (pass 1 spills + its aligner exits, freeing the index, before pass 2 starts) — one index resident → ~½ the peak RSS. **Byte-identical** to model (a). | non-dir only · SE+PE · Bowtie 2+HISAT2 |
+| `--combined_index_single_pass` | Model (b): ONE pass over conversion-tagged interleaved reads (one index load). **NOT byte-identical / NOT decision-equivalent** to model (a) (the qname tag perturbs Bowtie 2's read-name RNG) — opt-in, ground-truth-validated, never the default. | non-dir only · SE+PE · **Bowtie 2 only** |
+
+```bash
+# directional, combined index, one both-strands pass (16 threads):
+bismark_rs --combined_index --genome /path/to/genome/ -p 16 reads.fq.gz
+
+# non-directional, faithful low-RAM (one index resident at a time):
+bismark_rs --combined_index --non_directional --combined_index_sequential --genome /path/to/genome/ -p 16 reads.fq.gz
+```
+
+**Memory characteristics** (real 10M WGBS SE, GRCh38, 16-core budget — see
+`plans/06092026_bismark-beta/BENCHMARK_RESULTS_alignment_modes.md`): the combined index is one *large* index
+(~9.5 GB resident), so the **RAM win is the low-RAM non-directional variants**, not combined-parallel: non-dir
+faithful **16.3 GB** / 4 small indices · combined parallel (a) **19.0 GB** / 2 large · combined
+**sequential / single-pass 11.1 GB / 1 large** (−32 % vs faithful, −41 % vs parallel (a)). Combined directional /
+pbat are one index load (fastest walls) but ~11 GB ≈/> the faithful 2-small-index layout, so they are not a RAM win.
+
 ## Building
 
 ```bash

--- a/rust/bismark-aligner/src/cli.rs
+++ b/rust/bismark-aligner/src/cli.rs
@@ -85,10 +85,13 @@ pub struct Cli {
     #[arg(long)]
     pub slam: bool,
     /// EXPERIMENTAL (v2, opt-in, never-silent): align against a single combined
-    /// CT+GA index (`Bisulfite_Genome/Combined/BS_combined`) in one both-strands
-    /// Bowtie 2 pass instead of separate per-strand instances, recovering strand
+    /// CT+GA index (`Bisulfite_Genome/Combined/BS_combined`, built by
+    /// `bismark_genome_preparation --combined_genome`) in one both-strands pass per
+    /// read-conversion instead of separate per-strand instances, recovering strand
     /// from the RNAME suffix × FLAG. Concordance-gated, NOT byte-identical to the
-    /// faithful default. This phase: single-end directional only.
+    /// faithful default (a small benign churn). Supports single-end + paired-end,
+    /// Bowtie 2 + HISAT2, directional / non-directional / pbat. minimap2-combined and
+    /// `--multicore` + combined are not supported (fail loud).
     #[arg(long = "combined_index")]
     pub combined_index: bool,
 
@@ -96,7 +99,8 @@ pub struct Cli {
     /// execution model for `--combined_index --non_directional`. Aligns ONE
     /// Bowtie 2 pass over conversion-tagged interleaved reads (one combined index
     /// load instead of two — lower peak RSS) instead of model (a)'s two parallel
-    /// passes. Requires `--combined_index --non_directional` (single-end Bowtie 2).
+    /// passes. Requires `--combined_index --non_directional`; single-end or
+    /// paired-end; **Bowtie 2 only** (the qname-tag mechanism is Bowtie-2-specific).
     /// NOT byte-identical AND NOT decision-equivalent to model (a): the qname tag
     /// perturbs Bowtie 2's read-name-seeded RNG, so a tiny fraction of co-optimal
     /// reads get a different (validated-equally-accurate) alignment. Ground-truth
@@ -106,13 +110,13 @@ pub struct Cli {
 
     /// EXPERIMENTAL (v2, opt-in, never-silent): the SEQUENTIAL low-memory
     /// execution model for `--combined_index --non_directional`. Runs model (a)'s
-    /// two both-strands Bowtie 2 passes ONE AT A TIME (pass 1's Bowtie 2 exits,
-    /// freeing the index, before pass 2 starts) instead of concurrently — one
-    /// combined index resident at a time (~half the peak RSS). BYTE-IDENTICAL to
-    /// the default parallel path (Bowtie 2 output is independent of when each pass
-    /// runs); the trade is wall time (the passes no longer overlap). Requires
-    /// `--combined_index --non_directional` (single-end Bowtie 2); mutually
-    /// exclusive with `--combined_index_single_pass`.
+    /// two both-strands passes ONE AT A TIME (pass 1's aligner exits, freeing the
+    /// index, before pass 2 starts) instead of concurrently — one combined index
+    /// resident at a time (~half the peak RSS). BYTE-IDENTICAL to the default
+    /// parallel path (the aligner's output is independent of when each pass runs);
+    /// the trade is wall time (the passes no longer overlap). Requires
+    /// `--combined_index --non_directional`; single-end or paired-end; Bowtie 2 or
+    /// HISAT2; mutually exclusive with `--combined_index_single_pass`.
     #[arg(long = "combined_index_sequential")]
     pub combined_index_sequential: bool,
 


### PR DESCRIPTION
The combined-index v2.x epic (#955–975) shipped SE+PE × Bowtie 2+HISAT2 × dir/non-dir/pbat + the sequential/single-pass low-RAM variants, but it was **undocumented for users** and the CLI `--help` text was stale. Per Felix's request to update the docs for beta.4.

**rust/README.md** — new `## Combined-index alignment (v2, opt-in — beta)` section: what it is (1 combined CT+GA index vs 2–4 per-strand instances), the `bismark_genome_preparation --combined_genome` prereq, the 3 flags + coverage matrix, and the **benchmark memory characteristics** (the low-RAM non-dir variants are the RSS win — ~11 GB/1 index vs ~16 GB faithful / ~19 GB parallel at 10M GRCh38; combined dir/pbat aren't a RAM win).

**Docs site** — the same content as a 'Combined-index alignment (Rust suite beta, opt-in)' section in `usage/alignment.md` + an `installation.md` cross-link pointer. Plain markdown (no new sidebar entry; no HTML comments / base-missing links — the known docs footguns).

**cli.rs `--help`** — refreshed 3 stale flag descriptions: `--combined_index` no longer says 'single-end directional only' (now SE+PE × BT2+HISAT2 × dir/non-dir/pbat); `--combined_index_sequential` now says SE+PE / Bowtie 2 or HISAT2 (Phase 6/7); `--combined_index_single_pass` now SE+PE / Bowtie 2-only. **Doc-strings only — no logic, no test churn** (no `--help` snapshot test).

**Verified:** `cargo build` + `clippy -D` + `fmt --check` clean; docs `npm run build` 23 pages clean; built-HTML link grep — cross-links resolve to real `/Bismark/…` paths, no base-missing root-absolute links.