### PR TITLE
fix(c2c): graceful empty coverage for --nome-seq + --gc (methylseq NOMe wall)

### DIFF
--- a/rust/bismark-coverage2cytosine/src/error.rs
+++ b/rust/bismark-coverage2cytosine/src/error.rs
@@ -118,9 +118,17 @@ pub enum BismarkC2cError {
         len: usize,
     },
 
-    /// The coverage file contained no data lines. Mirrors Perl's
-    /// "No last chromosome was defined" die (`:472-474`) — raised before any
-    /// uncovered-chromosome pass, even when `--coverage_threshold == 0`.
+    /// Historically raised when the coverage file contained no data lines
+    /// (Perl's "No last chromosome was defined" die, `:472-474`).
+    ///
+    /// **No longer constructed (plan 06142026, NOMe follow-up):** an empty-but-
+    /// validly-read coverage file is now handled GRACEFULLY in every mode (the
+    /// report writers produce the correct empty/all-zero output, exit 0) so
+    /// nf-core/methylseq survives a no-alignment sample. A genuine read failure
+    /// (missing file, corrupt gzip, malformed line) surfaces via `Io`/
+    /// `MalformedCovLine` *before* the empty check could fire, so this variant
+    /// is retained (public API; a `.gz`-without-extension mishap could still
+    /// reasonably map here in future) but is currently unreachable.
     #[error(
         "no data found in the coverage file — something went wrong reading it (wrong path, or a gzipped file given without a .gz extension?)"
     )]

--- a/rust/bismark-coverage2cytosine/src/gpc.rs
+++ b/rust/bismark-coverage2cytosine/src/gpc.rs
@@ -35,9 +35,11 @@ use crate::report::{self, Context, ReportWriter, classify_context, perl_substr, 
 /// Generate the GpC-context report + cov (Perl `generate_GC_context_report`).
 ///
 /// Re-reads the coverage file and walks every `GC` dinucleotide of each covered
-/// chromosome's genome sequence. Always runs *after* the core report, so an
-/// empty coverage file has already produced [`BismarkC2cError::EmptyCoverageInput`]
-/// before this point — the GpC walk never sees one.
+/// chromosome's genome sequence. Runs *after* the core report. On an empty
+/// coverage file it is empty-graceful **by construction** — the read loop no-ops
+/// and the report/cov writers are finished empty (there is no
+/// `EmptyCoverageInput` guard here, and as of plan 06142026 the core report no
+/// longer errors on empty either, so `--gc`/`--nome-seq` complete with exit 0).
 pub fn run_gpc(config: &ResolvedConfig, genome: &Genome) -> Result<(), BismarkC2cError> {
     // Perl bumps the threshold to 1 inside this function (`:758-761`); the core
     // report already ran at the user's threshold. A LOCAL value — never mutate

--- a/rust/bismark-coverage2cytosine/src/report.rs
+++ b/rust/bismark-coverage2cytosine/src/report.rs
@@ -450,17 +450,19 @@ fn run_single(
     // Perl's "No last chromosome was defined" die. A genuine read error
     // (corrupt gzip, missing file, I/O) has ALREADY propagated via `?` on
     // `read_until`/`parse_cov_line` above; reaching `None` here means a
-    // cleanly-read but EMPTY coverage file. On the STANDARD report path
-    // (`threshold == 0`, NOT `--nome-seq`, NOT `--gc`) we fall through (do
-    // nothing) so control reaches the uncovered-chromosome pass below — which,
-    // with `seen` empty, writes all-zero rows for EVERY genome chromosome (the
-    // genome-wide all-zero report methylseq needs). On every other path
-    // (`--nome-seq`/`--gc`/`threshold>0`), which RELIES on this guard, still
-    // error.
-    let empty_standard_path = config.threshold == 0 && !config.nome && !config.gc_context;
+    // cleanly-read but EMPTY coverage file — graceful on EVERY mode. Each mode
+    // yields its own SEMANTICALLY-CORRECT empty output:
+    //   - standard / `--gc` (threshold 0, non-NOMe): the uncovered pass below
+    //     runs → all-zero genome-wide report (what methylseq needs).
+    //   - `--nome-seq`: uncovered pass SKIPPED (NOMe = covered positions only) →
+    //     a correct EMPTY report; unblocks methylseq's NOMe-seq c2c step.
+    //   - `threshold>0`: uncovered pass skipped → correct empty report.
+    // The `--gc`/`--nome-seq` GpC pass (gpc.rs, run after this in lib.rs) is
+    // itself empty-graceful (its loop no-ops + finishes empty writers), so no
+    // guard is needed here. Deliberate divergence from Perl (which dies
+    // "No last chromosome was defined" on empty).
     match cur_chr.take() {
-        None if !empty_standard_path => return Err(BismarkC2cError::EmptyCoverageInput),
-        None => { /* empty + standard path: fall through to the uncovered pass */ }
+        None => { /* empty-but-valid: fall through; per-mode report path handles it */ }
         Some(prev) => {
             let (bytes, cov_bytes) =
                 chromosome_report_bytes(&prev, genome, &buffer, config, true, summary);
@@ -539,19 +541,17 @@ fn run_split(
     // The final cov chromosome is flushed here (never in the loop). On a
     // cleanly-read but EMPTY coverage file, `cur_chr` is `None`.
     //
-    // Plan 06142026_empty-sample-extractor-c2c — DELIBERATE divergence from
-    // Perl's "No last chromosome was defined" die (same as `run_single`): on
-    // the STANDARD path (`threshold == 0`, NOT `--nome-seq`, NOT `--gc`) an
-    // empty cov falls through so the uncovered pass below flushes EVERY genome
-    // chromosome (all-zero rows) and sets the summary path. `last_summary_path`
-    // is now `Option<PathBuf>` — `None` only when empty + standard path AND the
-    // genome has zero chromosomes (degenerate); the summary is then skipped.
-    // On every other path (`--nome-seq`/`--gc`/`threshold>0`) an empty cov
-    // still errors. (methylseq uses the standard non-split path, so this branch
-    // is not on the critical path, but it is kept consistent with `run_single`.)
-    let empty_standard_path = config.threshold == 0 && !config.nome && !config.gc_context;
+    // Plan 06142026_empty-sample-extractor-c2c (+ NOMe follow-up) — DELIBERATE
+    // divergence from Perl's "No last chromosome was defined" die (same as
+    // `run_single`): an empty-but-valid cov falls through on EVERY mode (a
+    // genuine read error surfaced earlier via `?`). standard/`--gc` → uncovered
+    // pass → all-zero report; `--nome-seq`/`threshold>0` → uncovered pass skipped
+    // → correct EMPTY report; the GpC pass (gpc.rs) is itself empty-graceful.
+    // `last_summary_path` is `Option<PathBuf>` — `None` when no chromosome was
+    // flushed (empty + NOMe/threshold, or the degenerate zero-chromosome genome);
+    // the summary is then written to the default path (below) so it always exists.
+    // (methylseq uses the standard non-split path; kept consistent with `run_single`.)
     let mut last_summary_path: Option<PathBuf> = match cur_chr.take() {
-        None if !empty_standard_path => return Err(BismarkC2cError::EmptyCoverageInput),
         None => None,
         Some(prev) => Some(flush_split_chromosome(
             &prev, genome, &buffer, config, true, summary,
@@ -570,13 +570,14 @@ fn run_split(
         }
     }
 
-    // Full summary → only the LAST chromosome reopened (others stay empty).
-    // `None` only on the degenerate empty + standard + zero-chromosome genome.
-    if let Some(last_summary_path) = last_summary_path {
-        let mut sw = BufWriter::new(File::create(&last_summary_path)?);
-        summary.write_to(&mut sw)?;
-        sw.flush()?;
-    }
+    // Full summary → the LAST chromosome reopened (others stay empty), or the
+    // default summary path when no chromosome was flushed (empty + NOMe/threshold,
+    // or the degenerate zero-chromosome genome) so the file always exists —
+    // matching `run_single` + methylseq's required `*cytosine_context_summary.txt`.
+    let summary_dest = last_summary_path.unwrap_or_else(|| summary_path(config, None));
+    let mut sw = BufWriter::new(File::create(&summary_dest)?);
+    summary.write_to(&mut sw)?;
+    sw.flush()?;
     Ok(())
 }
 

--- a/rust/bismark-coverage2cytosine/tests/golden_phase_b.rs
+++ b/rust/bismark-coverage2cytosine/tests/golden_phase_b.rs
@@ -275,11 +275,29 @@ fn empty_coverage_corrupt_gzip_with_gz_name_errors() {
         .failure();
 }
 
+/// Assert a graceful empty c2c run produced a report file + a cytosine-context
+/// summary (methylseq's required outputs) in `dir`.
+fn assert_report_and_summary_present(dir: &std::path::Path) {
+    let names: Vec<String> = std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().into_owned()))
+        .collect();
+    assert!(
+        names.iter().any(|n| n.contains("report")),
+        "expected a c2c report file in {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n.contains("cytosine_context_summary")),
+        "expected a cytosine_context_summary file in {names:?}"
+    );
+}
+
 #[test]
-fn empty_coverage_threshold_still_errors() {
-    // GUARD: graceful-empty is standard-path-only. With `--coverage_threshold`
-    // the uncovered pass is skipped (no all-zero report), so an empty cov must
-    // STILL error — unchanged.
+fn empty_coverage_threshold_emits_empty_report() {
+    // NOMe follow-up (plan 06142026): graceful-empty now covers EVERY mode
+    // except `--gc`. With `--coverage_threshold` the uncovered pass is skipped,
+    // so an empty cov yields a correct EMPTY report (no position meets the
+    // threshold) + summary at exit 0 — instead of erroring.
     let tmp = tempfile::tempdir().unwrap();
     let gdir = tmp.path().join("g");
     std::fs::create_dir(&gdir).unwrap();
@@ -298,16 +316,18 @@ fn empty_coverage_threshold_still_errors() {
         .args(["--coverage_threshold", "1"])
         .arg(&cov)
         .assert()
-        .failure()
-        .code(1)
-        .stderr(predicates::str::contains("no data found"));
+        .success();
+    assert_report_and_summary_present(tmp.path());
 }
 
 #[test]
-fn empty_coverage_nome_still_errors() {
-    // GUARD: `--nome-seq` relies on the EmptyCoverageInput guard (NOMe reports
-    // covered positions only — no uncovered all-zero pass). An empty cov must
-    // STILL error.
+fn empty_coverage_nome_emits_empty_report() {
+    // NOMe follow-up (plan 06142026): `--nome-seq` on an empty cov is now
+    // GRACEFUL. NOMe reports covered positions only (the uncovered pass is
+    // skipped), so zero coverage → a correct EMPTY report + summary at exit 0.
+    // This is methylseq's NOMe-seq c2c step (the `--nome-seq` wall) — the fix
+    // that unblocks a no-alignment GpC/NOMe sample. Deliberate divergence from
+    // Perl (which dies "No last chromosome was defined").
     let tmp = tempfile::tempdir().unwrap();
     let gdir = tmp.path().join("g");
     std::fs::create_dir(&gdir).unwrap();
@@ -326,16 +346,17 @@ fn empty_coverage_nome_still_errors() {
         .arg("--nome-seq")
         .arg(&cov)
         .assert()
-        .failure()
-        .code(1)
-        .stderr(predicates::str::contains("no data found"));
+        .success();
+    assert_report_and_summary_present(tmp.path());
 }
 
 #[test]
-fn empty_coverage_gc_still_errors() {
-    // GUARD: `--gc` reaches gpc::run_gpc which documents it relies on the guard
-    // firing first (no uncovered pass; covered chromosomes only). An empty cov
-    // must STILL error.
+fn empty_coverage_gc_emits_empty_report() {
+    // NOMe follow-up (plan 06142026): `--gc` on an empty cov is now GRACEFUL.
+    // run_report produces the all-zero core report + summary (uncovered pass runs:
+    // threshold 0, non-NOMe), and the GpC pass (gpc.rs) is itself empty-graceful
+    // (no guard — its loop no-ops + finishes empty writers). exit 0. The stale
+    // "gpc relies on the guard" doc was over-cautious; gpc handles empty fine.
     let tmp = tempfile::tempdir().unwrap();
     let gdir = tmp.path().join("g");
     std::fs::create_dir(&gdir).unwrap();
@@ -354,9 +375,8 @@ fn empty_coverage_gc_still_errors() {
         .arg("--gc")
         .arg(&cov)
         .assert()
-        .failure()
-        .code(1)
-        .stderr(predicates::str::contains("no data found"));
+        .success();
+    assert_report_and_summary_present(tmp.path());
 }
 
 #[test]


### PR DESCRIPTION
## Problem
beta.7 made `coverage2cytosine` graceful on an empty `.cov` **only for the standard path**. A no-alignment **NOMe-seq (GpC)** sample then crashed nf-core/methylseq at `BISMARK_COVERAGE2CYTOSINE` (`coverage2cytosine --gzip --nome-seq` → exit 1, `no data found in the coverage file`).

## Root cause of the scoping miss
- `--nome-seq` sets **both** `config.nome` **and** `config.gc_context`, so the beta.7 `!gc_context` gate excluded NOMe.
- `gpc::run_gpc` was *documented* as relying on the `EmptyCoverageInput` guard, but its code is actually **empty-graceful** (loop no-ops, finishes empty writers). The stale doc misled the beta.7 review + me.

## Fix
Remove the `EmptyCoverageInput` guard entirely (`run_single` + `run_split`). A genuine read error (corrupt gzip / missing file) already surfaces earlier via `?`, so the post-loop `None` arm always means a cleanly-read **empty** file — and every mode then yields its correct empty output: standard/`--gc` (threshold 0) → all-zero genome-wide report; `--nome-seq`/`threshold>0` → correct empty report; the GpC pass is itself empty-graceful. `run_split` summary falls back to the default path so it always exists. Deliberate divergence from Perl (which dies); **non-empty byte-identical**.

## Validation
- **Verified end-to-end:** `coverage2cytosine --gzip --nome-seq` on an empty `.cov` → exit 0 with `NOMe.CpG_report.txt.gz` + `NOMe.GpC_report.txt.gz` + `cytosine_context_summary.txt` (methylseq's required outputs). `--gc` likewise graceful.
- `cargo test`/clippy/fmt all green. Inverted the nome/threshold/gc empty tests to graceful; kept the genuine-read-error (missing-file, corrupt-gz) tests erroring.

⚠️ Needs a new release (beta.8 already published) — **beta.9** + methylseq pin bump after merge.