### PR TITLE
feat(aligner): rammap in-process SamStream, feature-gated — epic phase 1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bismark-aligner"
 version = "1.0.0-alpha.1"
 dependencies = [
@@ -110,6 +125,7 @@ dependencies = [
  "noodles-core 0.20.0",
  "noodles-sam",
  "predicates",
+ "rammap-core",
  "tempfile",
  "thiserror 2.0.0",
  "which",
@@ -505,6 +521,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +734,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -725,7 +778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -844,6 +897,12 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lzma-rust2"
@@ -1180,6 +1239,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rammap-core"
+version = "1.1.1"
+source = "git+https://github.com/jwanglab/rammap?rev=5ea62cd5e2f7875fef5234d57ada12ac5a30dbba#5ea62cd5e2f7875fef5234d57ada12ac5a30dbba"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bitflags",
+ "byteorder",
+ "flate2",
+ "hashbrown 0.15.5",
+ "log",
+ "memchr",
+ "rayon",
+ "rustc-hash",
+ "serde",
+ "thiserror 2.0.0",
+ "wasm-bindgen",
+ "web-time",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1295,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+ "wasm_sync",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -1542,6 +1644,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm_sync"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -40,6 +40,22 @@ noodles-core = "=0.20.0"
 # Pinned to bismark-io's transitive choice so the workspace links one shared noodles-bam.
 noodles-bam = "=0.89.0"
 bstr = "=1.10.0"
+# Phase 1 (epic 06152026): the in-process rammap backend (`inprocess::InProcessAlignerStream`).
+# OPTIONAL + gated behind the default-OFF `rammap-inprocess` feature (Rev 2.1, Felix
+# decision) so the default/local/Mac `cargo build` NEVER compiles rammap-core; the
+# experimental in-process backend is a compile-time opt-in (release Linux binaries ship
+# with the feature ON). Pinned to a git REV (rammap v1.1.1 = the tagged commit, matching
+# `aligner::PINNED_RAMMAP_VERSION`) for reproducibility. The crate's lib name is `rammap`
+# (workspace member `rammap-core`); imported as `rammap::{Aligner, Preset, Strand, MapOpts,
+# Mapping}`. `default-features = false` drops rammap-core's own `parallel`/`wasm-threads`
+# defaults; we re-add `parallel` explicitly. rammap pulls NO noodles (the tight noodles
+# pins are safe); its `flate2 = "1"` is satisfied by our `=1.1.9` pin (one shared flate2).
+rammap-core = { git = "https://github.com/jwanglab/rammap", rev = "5ea62cd5e2f7875fef5234d57ada12ac5a30dbba", default-features = false, features = ["parallel"], optional = true }
+
+[features]
+# Default-OFF: compiles the in-process rammap backend (`inprocess.rs`) + its rammap-typed
+# tests. The feature-independent CIGAR-reconstruction unit test runs on ANY toolchain.
+rammap-inprocess = ["dep:rammap-core"]
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"

--- a/rust/bismark-aligner/src/inprocess.rs
+++ b/rust/bismark-aligner/src/inprocess.rs
@@ -1,0 +1,679 @@
+//! In-process rammap [`SamStream`] — the load-bearing seam for byte-identical
+//! `bismark_rs --rammap` WITHOUT spawning the `rammap` subprocess (epic
+//! `06152026_rammap-library-integration`, Phase 1).
+//!
+//! For each converted FastQ read, [`InProcessAlignerStream`] calls
+//! `rammap::Aligner::map_seq_with` and yields a [`SamRecord`] **field-identical
+//! to what the subprocess [`AlignerStream`](crate::align::AlignerStream) parses
+//! from the CLI's SAM** — so the existing (byte-frozen) merge → XM → output
+//! produces identical results. The stream is a third `SamStream` impl; the merge
+//! cannot tell it apart from the subprocess one.
+//!
+//! ## Feature gate (Rev 2.1)
+//!
+//! `rammap-core` is an OPTIONAL dependency behind the **default-OFF
+//! `rammap-inprocess`** Cargo feature. Everything that names a `rammap::*` type
+//! (the [`InProcessAlignerStream`], [`build_sam_record`], the rammap-typed tests)
+//! is `#[cfg(feature = "rammap-inprocess")]`; the pure-Rust CIGAR-reconstruction
+//! helpers ([`reconstruct_cigar`] / [`consumed_read_len`]) compile on ANY
+//! toolchain (so the feature-independent CIGAR unit test always runs). Phase 1
+//! adds the module only — `lib.rs`/`config.rs` routing is Phase 2.
+//!
+//! ## The CIGAR is THE load-bearing field (Rev 2)
+//!
+//! The Phase-0 spike found the rammap library reproduces the subprocess CLI's
+//! per-read primary alignment 100% on rname/POS/strand/AS/MD — the ONLY gap is
+//! the CIGAR **soft-clip flanks**: the library returns the aligned-CORE CIGAR
+//! (`46M3I7M`), while the SAM convention wraps it with `{query_start}S` +
+//! `{read_len − query_end}S` (`297S46M3I7M1379S`). [`reconstruct_cigar`] rebuilds
+//! that. This is load-bearing because `methylation::
+//! extract_corresponding_genomic_sequence_single_end` fully parses the CIGAR and
+//! a wrong consumed-length **silently skips the read** (`lib.rs` length guard) —
+//! no wrong base, a *missing record*. So the reconstruction MUST make
+//! `consumed_read_len(cigar) == read_len` exactly.
+
+// `SamStream`/`SamRecord` are used only by the feature-gated stream + builder; the
+// pure CIGAR helpers don't need them, so the imports are feature-gated to keep the
+// default (feature-OFF) build warning-clean under `-D warnings`.
+#[cfg(feature = "rammap-inprocess")]
+use crate::align::{SamRecord, SamStream};
+#[cfg(feature = "rammap-inprocess")]
+use crate::error::{AlignerError, Result};
+#[cfg(feature = "rammap-inprocess")]
+use std::io::BufRead;
+#[cfg(feature = "rammap-inprocess")]
+use std::sync::Arc;
+
+// ===========================================================================
+// Pure CIGAR helpers (feature-INDEPENDENT — compile + tested on any toolchain).
+// ===========================================================================
+
+/// Reconstruct the SAM CIGAR from the rammap library's aligned-core CIGAR by
+/// re-adding the query soft-clip flanks (the Phase-0 finding), **strand-aware**.
+///
+/// rammap's `Mapping.query_start`/`query_end` are in the read's ORIGINAL FORWARD
+/// orientation (the minimap2/PAF convention). For a SAM line the CIGAR is written
+/// in REFERENCE orientation, so on the reverse strand the SAM SEQ is the
+/// reverse-complement and the soft-clip flanks SWAP:
+/// - **forward:** `soft(query_start) + core + soft(read_len − query_end)`
+/// - **reverse:** `soft(read_len − query_end) + core + soft(query_start)`
+///
+/// `soft(n) = "{n}S"` if `n > 0` else `""` (a zero-length soft clip is omitted,
+/// matching the CLI's SAM, which never emits `0S`). The aligned CORE is identical
+/// for both strands (the rammap library already returns it in reference
+/// orientation, exactly as the CLI's SAM).
+///
+/// > 🔴 The strand swap was MISSED in the original Phase-0/Rev-2 reconstruction
+/// > (the spike's 5k sample showed only the flank *lengths*, not their order vs
+/// > strand) and CAUGHT by the Phase-1 record-level cross-check: every reverse
+/// > (FLAG 0x10) read had the leading/trailing soft clips swapped. A swapped flank
+/// > keeps `consumed_read_len == read_len` (so the methylation guard would NOT skip
+/// > it) but mis-places the soft clip → a WRONG genomic window in
+/// > `extract_corresponding_genomic_sequence_single_end` → a silent miscall. The
+/// > cross-check is exactly the gate that surfaced it.
+///
+/// # Guards (Rev 2)
+///
+/// - `debug_assert!` the `core` does NOT already contain `S` — the library
+///   returns the aligned core only; if it ever included a soft clip we would
+///   DOUBLE-clip (wrong length → silent skip). Caught in debug builds; release
+///   builds rely on the cross-check's `consumed_read_len == read_len` assertion.
+/// - `query_end <= read_len` (else a soft clip underflows). A violation is a logic
+///   bug in the caller / library contract.
+///
+/// NB: this does NOT itself assert `consumed_read_len == read_len` — that is the
+/// cross-check's job (it needs the parsed runs), and a *core* CIGAR with an
+/// internal `D` legitimately consumes fewer query bases than `target` span. The
+/// soft-clip arithmetic here only restores the QUERY flanks.
+pub fn reconstruct_cigar(
+    query_start: usize,
+    query_end: usize,
+    read_len: usize,
+    reverse: bool,
+    core: &str,
+) -> String {
+    debug_assert!(
+        !core.contains('S'),
+        "rammap core CIGAR already contains a soft clip ('S'); soft-clip reconstruction would \
+         double-clip and break the read-length identity: core={core:?}"
+    );
+    debug_assert!(
+        query_end <= read_len,
+        "query_end ({query_end}) > read_len ({read_len}); soft clip would underflow"
+    );
+    let fwd_lead = query_start;
+    let fwd_trail = read_len.saturating_sub(query_end);
+    // Reverse strand → the SAM CIGAR is in reference orientation, so the flanks swap.
+    let (leading, trailing) = if reverse {
+        (fwd_trail, fwd_lead)
+    } else {
+        (fwd_lead, fwd_trail)
+    };
+    let mut out = String::new();
+    if leading > 0 {
+        out.push_str(&format!("{leading}S"));
+    }
+    out.push_str(core);
+    if trailing > 0 {
+        out.push_str(&format!("{trailing}S"));
+    }
+    out
+}
+
+/// The number of QUERY bases a CIGAR consumes — `M`, `I`, `S`, `=`, `X` advance
+/// the query; `D`, `N`, `H`, `P` do not. Used by the cross-check to assert the
+/// reconstructed CIGAR consumes exactly `read_len` (else the methylation length
+/// guard silently skips the read). Returns `None` on a malformed CIGAR (the same
+/// digit/op parse as `methylation::parse_cigar`, kept local + total here so the
+/// helper is feature-independent and never panics on input from a real run).
+pub fn consumed_read_len(cigar: &str) -> Option<usize> {
+    if cigar == "*" {
+        return Some(0);
+    }
+    let bytes = cigar.as_bytes();
+    let mut i = 0;
+    let mut total: usize = 0;
+    while i < bytes.len() {
+        let start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == start || i == bytes.len() {
+            return None; // missing length or trailing length with no op
+        }
+        let len: usize = cigar[start..i].parse().ok()?;
+        let op = bytes[i];
+        i += 1;
+        match op {
+            // query-consuming ops
+            b'M' | b'I' | b'S' | b'=' | b'X' => total += len,
+            // reference-only / no-query ops
+            b'D' | b'N' | b'H' | b'P' => {}
+            _ => return None,
+        }
+    }
+    Some(total)
+}
+
+// ===========================================================================
+// SamRecord builder (feature-gated — names `rammap::Mapping`).
+// ===========================================================================
+
+/// Build a [`SamRecord`] from a converted read + its rammap primary [`Mapping`]
+/// (or `None` for unmapped), matching what the subprocess CLI SAM parses on every
+/// merge-consumed field.
+///
+/// - **Mapped:** `flag` = `0x10` if `Strand::Reverse` else `0`; `rname` =
+///   `m.target_name`; `pos` = `m.target_start + 1` (0-based → 1-based); `cigar` =
+///   [`reconstruct_cigar`] over `m.cigar`; `mapq` = `m.mapq`; `alignment_score` =
+///   `Some(m.score)`; `second_best` = `None` (rammap's `s2:i:` chaining 2nd-best is
+///   IGNORED, exactly as the subprocess parse drops it); `md_tag` = `m.md`.
+/// - **`seq`/`qual`** (Q1, Rev 2 — DOWNSTREAM-DEAD: SE output re-reads the original
+///   `seq_uc`, never `bowtie_sequence`): the input read fwd for `+`, the nucleotide
+///   reverse-complement for `-` (the CLI SAM convention), so it is faithful but NOT
+///   gate-critical. `qual` likewise (reversed for `-`).
+/// - **`raw_line`:** a reconstructed 11-column SAM line that round-trips through
+///   `SamRecord::parse` (Q2 — only consumed by `--ambig_bam`/combined-index, neither
+///   reached by rammap; the round-trip is a safeguard).
+/// - **Unmapped** (`None`): `flag = 0x4`, `rname = "*"`, `pos = 0`, `cigar = "*"`,
+///   `mapq = 0`, scores/`md` `None` — the shape `SamRecord::parse` yields for an
+///   unmapped CLI line.
+#[cfg(feature = "rammap-inprocess")]
+pub fn build_sam_record(
+    qname: &str,
+    read: &[u8],
+    qual: &[u8],
+    m: Option<&rammap::Mapping>,
+) -> SamRecord {
+    match m {
+        None => {
+            // Unmapped: SEQ/QUAL still carry the forward read (as the CLI emits for
+            // a FLAG-4 line); the merge ignores them (only the FLAG matters).
+            let seq = String::from_utf8_lossy(read).into_owned();
+            let qual_s = String::from_utf8_lossy(qual).into_owned();
+            let raw_line = format!(
+                "{qname}\t4\t*\t0\t0\t*\t*\t0\t0\t{seq}\t{qual_s}",
+                seq = if seq.is_empty() {
+                    "*".to_string()
+                } else {
+                    seq.clone()
+                },
+                qual_s = if qual_s.is_empty() {
+                    "*".to_string()
+                } else {
+                    qual_s.clone()
+                },
+            );
+            SamRecord {
+                qname: qname.to_string(),
+                flag: 4,
+                rname: "*".to_string(),
+                pos: 0,
+                mapq: 0,
+                cigar: "*".to_string(),
+                seq: if seq.is_empty() { "*".to_string() } else { seq },
+                qual: if qual_s.is_empty() {
+                    "*".to_string()
+                } else {
+                    qual_s
+                },
+                alignment_score: None,
+                second_best: None,
+                md_tag: None,
+                raw_line,
+            }
+        }
+        Some(m) => {
+            let reverse = m.strand == rammap::Strand::Reverse;
+            let flag: u16 = if reverse { 0x10 } else { 0 };
+            // 0-based target_start → 1-based SAM POS.
+            let pos = (m.target_start as u32) + 1;
+            // The library returns the aligned-core CIGAR; re-add the soft-clip
+            // flanks (strand-aware — reverse swaps the flanks).
+            let core = m.cigar.as_deref().unwrap_or_default();
+            let cigar = reconstruct_cigar(m.query_start, m.query_end, read.len(), reverse, core);
+            // SEQ/QUAL: the CLI emits the reverse-complement (and reversed qual) for a
+            // reverse-strand alignment. Downstream-dead, emitted for fidelity only.
+            let (seq_bytes, qual_bytes) = if reverse {
+                (crate::output::revcomp(read), {
+                    let mut q = qual.to_vec();
+                    q.reverse();
+                    q
+                })
+            } else {
+                (read.to_vec(), qual.to_vec())
+            };
+            let seq = String::from_utf8_lossy(&seq_bytes).into_owned();
+            let qual_s = String::from_utf8_lossy(&qual_bytes).into_owned();
+            let mapq: u8 = m.mapq.clamp(0, u8::MAX as i32) as u8;
+            let alignment_score = Some(m.score as i64);
+            let md_tag = m.md.clone();
+
+            // raw_line: an 11+-column SAM line that round-trips through
+            // SamRecord::parse (the merge re-derives every field; raw_line itself is
+            // only consumed by --ambig_bam/combined-index, neither reached by rammap).
+            let as_value = m.score as i64;
+            let mut raw_line = format!(
+                "{qname}\t{flag}\t{rname}\t{pos}\t{mapq}\t{cigar}\t*\t0\t0\t{seq}\t{qual_s}\tAS:i:{as_value}",
+                rname = m.target_name,
+            );
+            if let Some(md) = md_tag.as_deref() {
+                raw_line.push_str(&format!("\tMD:Z:{md}"));
+            }
+
+            SamRecord {
+                qname: qname.to_string(),
+                flag,
+                rname: m.target_name.to_string(),
+                pos,
+                mapq,
+                cigar,
+                seq,
+                qual: qual_s,
+                alignment_score,
+                second_best: None,
+                md_tag,
+                raw_line,
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// InProcessAlignerStream (feature-gated — holds an `Arc<rammap::Aligner>`).
+// ===========================================================================
+
+/// A converted-read source presented as a [`SamStream`], backed by an in-process
+/// `rammap::Aligner` (NO subprocess). One record look-ahead (`current`) mirrors
+/// [`AlignerStream`](crate::align::AlignerStream): `new` loads the first record,
+/// `advance` maps the next read. Emits exactly ONE primary record per read in
+/// INPUT ORDER (the merge's lockstep join requires it).
+///
+/// `reads` is the SAME converted FastQ bytes the subprocess CLI reads (the
+/// per-instance `_C_to_T`/`_G_to_A` source), so the merge sees identical reads in
+/// identical order.
+#[cfg(feature = "rammap-inprocess")]
+pub struct InProcessAlignerStream<R: BufRead> {
+    aligner: Arc<rammap::Aligner>,
+    reads: R,
+    current: Option<SamRecord>,
+    // scratch buffers reused per record (4-line FastQ), to avoid per-read allocs.
+    id: Vec<u8>,
+    seq: Vec<u8>,
+    id2: Vec<u8>,
+    qual: Vec<u8>,
+}
+
+#[cfg(feature = "rammap-inprocess")]
+impl<R: BufRead> InProcessAlignerStream<R> {
+    /// Build the stream and read up to the first record (`None` for an empty
+    /// source). The `Arc<Aligner>` is shared (Phase 2 — 2 indexes for 4 instances).
+    pub fn new(aligner: Arc<rammap::Aligner>, reads: R) -> Result<Self> {
+        let mut s = InProcessAlignerStream {
+            aligner,
+            reads,
+            current: None,
+            id: Vec::new(),
+            seq: Vec::new(),
+            id2: Vec::new(),
+            qual: Vec::new(),
+        };
+        s.current = s.map_next()?;
+        Ok(s)
+    }
+
+    /// Read the next converted FastQ record (4 lines, mirroring `convert.rs`'s
+    /// `read_until('\n')` + truncated-tail drop), map it, and build the `SamRecord`.
+    /// `Ok(None)` at EOF.
+    fn map_next(&mut self) -> Result<Option<SamRecord>> {
+        self.id.clear();
+        self.seq.clear();
+        self.id2.clear();
+        self.qual.clear();
+        let n1 = self.reads.read_until(b'\n', &mut self.id)?;
+        let n2 = self.reads.read_until(b'\n', &mut self.seq)?;
+        let n3 = self.reads.read_until(b'\n', &mut self.id2)?;
+        let n4 = self.reads.read_until(b'\n', &mut self.qual)?;
+        // `last unless ($id and $seq and $id2 and $qual)` — any missing line ends
+        // the stream; a truncated final record is dropped (matches convert.rs).
+        if n1 == 0 || n2 == 0 || n3 == 0 || n4 == 0 {
+            return Ok(None);
+        }
+
+        // QNAME = the `@id` line minus the leading `@` and trailing newline (what
+        // the aligner SAM emits; the converted file always prefixes `@`).
+        let id_line = chomp(&self.id);
+        let qname_bytes = id_line.strip_prefix(b"@").unwrap_or(id_line);
+        let qname = std::str::from_utf8(qname_bytes).map_err(|e| {
+            AlignerError::Validation(format!("converted read ID is not valid UTF-8: {e}"))
+        })?;
+        let read = chomp(&self.seq);
+        let qual = chomp(&self.qual);
+
+        let result = self.aligner.map_seq_with(
+            qname,
+            read,
+            rammap::MapOpts {
+                cs: None,
+                md: Some(true),
+            },
+        );
+        // Primary = the one non-supplementary primary mapping (Q3: supplementary-only
+        // → treated as unmapped for the stream's single record).
+        let primary = result
+            .mappings
+            .iter()
+            .find(|m| m.is_primary && !m.is_supplementary);
+
+        Ok(Some(build_sam_record(qname, read, qual, primary)))
+    }
+}
+
+#[cfg(feature = "rammap-inprocess")]
+impl<R: BufRead> SamStream for InProcessAlignerStream<R> {
+    fn current(&self) -> Option<&SamRecord> {
+        self.current.as_ref()
+    }
+    fn advance(&mut self) -> Result<()> {
+        self.current = self.map_next()?;
+        Ok(())
+    }
+}
+
+/// Strip a single trailing `\n` (and a preceding `\r`) from a line — the
+/// converted FastQ uses `\n` terminators (cf. `convert::chomp_newline`).
+#[cfg(feature = "rammap-inprocess")]
+fn chomp(line: &[u8]) -> &[u8] {
+    let mut end = line.len();
+    if end > 0 && line[end - 1] == b'\n' {
+        end -= 1;
+        if end > 0 && line[end - 1] == b'\r' {
+            end -= 1;
+        }
+    }
+    &line[..end]
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- Feature-INDEPENDENT: CIGAR reconstruction (runs on any toolchain) ----
+
+    /// The Phase-0 spike example (FORWARD): core `46M3I7M`, query_start 297,
+    /// query_end 353, read_len 1732 → `297S46M3I7M1379S` (trailing 1732 − 353 = 1379).
+    #[test]
+    fn reconstruct_cigar_spike_example_forward() {
+        assert_eq!(
+            reconstruct_cigar(297, 353, 1732, false, "46M3I7M"),
+            "297S46M3I7M1379S"
+        );
+    }
+
+    /// REVERSE strand swaps the flanks (the bug the Phase-1 cross-check caught):
+    /// the SAME forward query coords (qs=297, qe=353, len=1732) on the reverse
+    /// strand → leading = 1732 − 353 = 1379, trailing = 297 → `1379S46M3I7M297S`.
+    #[test]
+    fn reconstruct_cigar_spike_example_reverse_swaps_flanks() {
+        assert_eq!(
+            reconstruct_cigar(297, 353, 1732, true, "46M3I7M"),
+            "1379S46M3I7M297S"
+        );
+        // The forward and reverse reconstructions are flank-mirrors of each other.
+        assert_eq!(
+            reconstruct_cigar(84, 84 + 100, 4664, true, "100M"),
+            "4480S100M84S" // leading = 4664 − 184 = 4480, trailing = 84
+        );
+    }
+
+    /// No leading clip (query_start 0) → no `0S` prefix; no trailing clip
+    /// (query_end == read_len) → no `0S` suffix (forward strand).
+    #[test]
+    fn reconstruct_cigar_omits_zero_length_clips() {
+        assert_eq!(reconstruct_cigar(0, 10, 10, false, "10M"), "10M");
+        assert_eq!(reconstruct_cigar(0, 8, 10, false, "8M"), "8M2S");
+        assert_eq!(reconstruct_cigar(3, 10, 10, false, "7M"), "3S7M");
+        // reverse: qs=0/qe=8/len=10 → leading = read_len-qe = 2, trailing = qs = 0.
+        assert_eq!(reconstruct_cigar(0, 8, 10, true, "8M"), "2S8M");
+    }
+
+    /// A core with internal `D`/`I` consumes FEWER query bases than its target span;
+    /// the soft-clip arithmetic is on the QUERY flanks only, and the reconstructed
+    /// CIGAR must still consume exactly `read_len` query bases (asserted in the
+    /// round-trip test below). The second spike example: core `20M1D4M2I4M4I10M3D4M`,
+    /// query_start 229, query_end 277 (= 229 + 48 query-consumed), read_len 1000 →
+    /// trailing 1000 − 277 = 723.
+    #[test]
+    fn reconstruct_cigar_with_internal_indels() {
+        let core = "20M1D4M2I4M4I10M3D4M"; // 20+4+2+4+4+10+4 = 48 query bases
+        let cig = reconstruct_cigar(229, 277, 1000, false, core);
+        assert_eq!(cig, "229S20M1D4M2I4M4I10M3D4M723S");
+    }
+
+    /// `consumed_read_len` counts query-consuming ops (M/I/S/=/X), ignores
+    /// reference-only ops (D/N/H/P), and the reconstructed CIGAR (with flanks)
+    /// consumes exactly `read_len`.
+    #[test]
+    fn consumed_read_len_counts_query_ops_and_matches_read_len() {
+        assert_eq!(
+            consumed_read_len("297S46M3I7M1379S"),
+            Some(297 + 46 + 3 + 7 + 1379)
+        );
+        assert_eq!(consumed_read_len("297S46M3I7M1379S"), Some(1732)); // == read_len
+        // D / N do NOT consume query.
+        assert_eq!(consumed_read_len("10M2D5M"), Some(15));
+        assert_eq!(consumed_read_len("5M3N5M"), Some(10));
+        // unmapped sentinel.
+        assert_eq!(consumed_read_len("*"), Some(0));
+        // malformed.
+        assert_eq!(consumed_read_len("10"), None);
+        assert_eq!(consumed_read_len("10Z"), None);
+    }
+
+    /// End-to-end on a `D`-bearing core: reconstruct then assert consumed ==
+    /// read_len, for BOTH strands (the flank swap must preserve the total).
+    #[test]
+    fn reconstruct_then_consumed_len_round_trip_with_deletion() {
+        let core = "20M1D4M2I4M4I10M3D4M"; // 48 query bases
+        let (qs, read_len) = (229usize, 1000usize);
+        let qe = qs + 48;
+        assert_eq!(
+            consumed_read_len(&reconstruct_cigar(qs, qe, read_len, false, core)),
+            Some(read_len)
+        );
+        assert_eq!(
+            consumed_read_len(&reconstruct_cigar(qs, qe, read_len, true, core)),
+            Some(read_len)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "already contains a soft clip")]
+    fn reconstruct_cigar_rejects_pre_clipped_core_in_debug() {
+        // The library returns the aligned core only; a core that already has `S`
+        // would double-clip. Guarded by debug_assert.
+        let _ = reconstruct_cigar(5, 10, 20, false, "5S5M");
+    }
+
+    // ---- Feature-GATED: build_sam_record on canned rammap::Mapping ----
+
+    #[cfg(feature = "rammap-inprocess")]
+    #[allow(clippy::too_many_arguments)] // a test fixture builder; clarity > arg count
+    fn canned_mapping(
+        rname: &str,
+        target_start: usize,
+        query_start: usize,
+        query_end: usize,
+        strand: rammap::Strand,
+        cigar: &str,
+        score: i32,
+        mapq: i32,
+        md: &str,
+    ) -> rammap::Mapping {
+        rammap::Mapping {
+            target_name: std::sync::Arc::from(rname),
+            target_id: 0,
+            target_len: 1_000_000,
+            target_start,
+            target_end: target_start + 50,
+            query_start,
+            query_end,
+            strand,
+            mapq,
+            is_primary: true,
+            is_supplementary: false,
+            is_spliced: false,
+            trans_strand: None,
+            matches: 50,
+            block_len: 50,
+            edit_distance: 0,
+            cigar: Some(cigar.to_string()),
+            cigar_ops: None,
+            cs: None,
+            md: Some(md.to_string()),
+            score,
+            divergence: 0.0,
+        }
+    }
+
+    #[cfg(feature = "rammap-inprocess")]
+    #[test]
+    fn build_sam_record_forward_mapped() {
+        // read length 10, forward, full match.
+        let read = b"ACGTACGTAC";
+        let qual = b"IIIIIIIIII";
+        let m = canned_mapping(
+            "chr1_CT_converted",
+            99, // 0-based → POS 100
+            0,
+            10,
+            rammap::Strand::Forward,
+            "10M",
+            -3,
+            42,
+            "10",
+        );
+        let r = build_sam_record("r1", read, qual, Some(&m));
+        assert_eq!(r.qname, "r1");
+        assert_eq!(r.flag, 0); // forward
+        assert_eq!(r.rname, "chr1_CT_converted"); // suffix kept raw
+        assert_eq!(r.pos, 100); // target_start 99 + 1
+        assert_eq!(r.mapq, 42);
+        assert_eq!(r.cigar, "10M"); // no soft-clip flanks (qs=0, qe=read_len)
+        assert_eq!(r.alignment_score, Some(-3));
+        assert_eq!(r.second_best, None); // s2 ignored by construction
+        assert_eq!(r.md_tag.as_deref(), Some("10"));
+        assert_eq!(r.seq, "ACGTACGTAC"); // forward read unchanged
+        assert_eq!(r.qual, "IIIIIIIIII");
+        // raw_line round-trips through the subprocess parser to the same record.
+        assert_eq!(SamRecord::parse(&r.raw_line).unwrap(), r);
+        // consumed query length == read_len (no silent skip).
+        assert_eq!(consumed_read_len(&r.cigar), Some(read.len()));
+    }
+
+    #[cfg(feature = "rammap-inprocess")]
+    #[test]
+    fn build_sam_record_reverse_mapped_soft_clipped() {
+        // read length 14, reverse strand, soft-clipped core + an internal indel.
+        // ASYMMETRIC flanks so the strand swap is actually exercised (a symmetric
+        // sample would pass even WITH the swap bug the cross-check caught).
+        let read = b"ACGTACGTACGTAC"; // len 14
+        let qual = b"ABCDEFGHIJKLMN";
+        // core 4M1I3M consumes 8 query bases; qs=2, qe=10. Forward flanks would be
+        // 2S … 4S; REVERSE swaps them → 4S … 2S.
+        let m = canned_mapping(
+            "chr2_GA_converted",
+            199, // POS 200
+            2,
+            10,
+            rammap::Strand::Reverse,
+            "4M1I3M",
+            -7,
+            30,
+            "3A4",
+        );
+        let r = build_sam_record("r2", read, qual, Some(&m));
+        assert_eq!(r.flag, 0x10); // reverse bit
+        assert_eq!(r.rname, "chr2_GA_converted");
+        assert_eq!(r.pos, 200);
+        assert_eq!(r.mapq, 30);
+        assert_eq!(r.cigar, "4S4M1I3M2S"); // reverse: flanks SWAPPED (4S lead, 2S trail)
+        assert_eq!(r.alignment_score, Some(-7));
+        assert_eq!(r.second_best, None);
+        assert_eq!(r.md_tag.as_deref(), Some("3A4"));
+        // reverse SEQ = nucleotide revcomp of the read; QUAL reversed.
+        assert_eq!(
+            r.seq,
+            String::from_utf8(crate::output::revcomp(read)).unwrap()
+        );
+        assert_eq!(r.qual, "NMLKJIHGFEDCBA"); // qual reversed (len 14)
+        assert_eq!(SamRecord::parse(&r.raw_line).unwrap(), r);
+        // 4 + 4 + 1 + 3 + 2 = 14 == read_len.
+        assert_eq!(consumed_read_len(&r.cigar), Some(read.len()));
+    }
+
+    #[cfg(feature = "rammap-inprocess")]
+    #[test]
+    fn build_sam_record_unmapped() {
+        let read = b"ACGTACGT";
+        let qual = b"IIIIIIII";
+        let r = build_sam_record("r3", read, qual, None);
+        assert_eq!(r.flag, 0x4);
+        assert!(r.is_unmapped());
+        assert_eq!(r.rname, "*");
+        assert_eq!(r.pos, 0);
+        assert_eq!(r.cigar, "*");
+        assert_eq!(r.mapq, 0);
+        assert_eq!(r.alignment_score, None);
+        assert_eq!(r.second_best, None);
+        assert_eq!(r.md_tag, None);
+        // round-trips to the same unmapped shape the subprocess parse yields.
+        assert_eq!(SamRecord::parse(&r.raw_line).unwrap(), r);
+    }
+
+    /// The stream reads converted FastQ records in input order and yields one
+    /// primary record per read; an empty source → `None` immediately. Uses a
+    /// canned `Aligner` built from in-memory sequences (no `.mmi` / no subprocess),
+    /// so this is hermetic but still exercises the real `map_seq_with` + the
+    /// FastQ-record reader + the builder.
+    #[cfg(feature = "rammap-inprocess")]
+    #[test]
+    fn stream_yields_one_record_per_read_in_input_order() {
+        use std::io::Cursor;
+        use std::sync::Arc;
+
+        // A tiny reference: one contig with a recognisable region.
+        let reference = b"\
+ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
+ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT"
+            .to_vec();
+        let aligner = Arc::new(rammap::Aligner::from_seqs(
+            vec![("chr1_CT_converted".to_string(), reference.clone())],
+            rammap::Preset::MapOnt,
+        ));
+
+        // Converted FastQ: 2 records (`@` prefix as the converted file writes it).
+        let fq = "@readA\nACGTACGTACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIIIIIIIIIII\n\
+                  @readB\nTTTTTTTTTTTTTTTTTTTTTTTT\n+\nIIIIIIIIIIIIIIIIIIIIIIII\n";
+        let mut s =
+            InProcessAlignerStream::new(aligner.clone(), Cursor::new(fq.as_bytes())).unwrap();
+
+        // Record 1 = readA, in input order.
+        let c1 = s.current().expect("first record");
+        assert_eq!(c1.qname, "readA");
+        s.advance().unwrap();
+        // Record 2 = readB.
+        let c2 = s.current().expect("second record");
+        assert_eq!(c2.qname, "readB");
+        s.advance().unwrap();
+        assert!(s.current().is_none()); // EOF
+
+        // Empty source → None immediately.
+        let empty = InProcessAlignerStream::new(aligner, Cursor::new(&b""[..])).unwrap();
+        assert!(empty.current().is_none());
+    }
+}

--- a/rust/bismark-aligner/src/lib.rs
+++ b/rust/bismark-aligner/src/lib.rs
@@ -33,7 +33,16 @@ pub mod convert;
 pub mod discovery;
 pub mod error;
 pub mod genome;
+pub mod inprocess;
 pub mod mapq;
+
+// Phase 1 (epic 06152026): re-export the `rammap-core` crate (its lib name is
+// `rammap`) under the `rammap-inprocess` feature so integration tests (a separate
+// crate that does NOT inherit the parent crate's normal deps) can construct an
+// `Arc<rammap::Aligner>` for the record-level cross-check. Default/Mac build never
+// sees this. The extern crate is `rammap` (the package `rammap-core`'s lib name).
+#[cfg(feature = "rammap-inprocess")]
+pub use ::rammap;
 pub mod merge;
 pub mod methylation;
 pub mod options;

--- a/rust/bismark-aligner/tests/rammap_inprocess_crosscheck.rs
+++ b/rust/bismark-aligner/tests/rammap_inprocess_crosscheck.rs
@@ -1,0 +1,279 @@
+//! 🔑 Record-level cross-check (the Phase-1 fidelity gate, epic
+//! `06152026_rammap-library-integration`).
+//!
+//! Runs the production [`InProcessAlignerStream`] AND parses the subprocess
+//! `rammap` CLI SAM on the SAME converted-read sample, then asserts the
+//! `SamRecord`s are **field-identical on every merge-consumed field**
+//! (flag / rname / pos / **cigar** / mapq / alignment_score / second_best /
+//! md_tag), PLUS (a) `consumed_read_len(cigar) == read_len` for every mapped read
+//! (else the methylation length guard at `lib.rs` SILENTLY skips it), and (b)
+//! **in-process mapped count == subprocess mapped count** (the no-silent-skip
+//! proof). `seq` is diffed for fidelity but is NOT gate-blocking (downstream-dead,
+//! Rev 2).
+//!
+//! This is the proof that the merge produces identical output BEFORE Phase 2 wires
+//! the stream into `lib.rs`/`config.rs`.
+//!
+//! ## Gating
+//!
+//! - **Feature:** the whole file is `#[cfg(feature = "rammap-inprocess")]` (it names
+//!   `rammap::*` types) — it never compiles in the default/Mac build.
+//! - **Env (data):** skipped (NOT failed) unless these three env vars are set, so it
+//!   is hermetic on a CI runner without the rammap binary / index / data —
+//!   `RAMMAP_BIN` (the `rammap` CLI binary), `RAMMAP_MMI` (a `.mmi` index, e.g.
+//!   `BS_CT.mmi`), and `RAMMAP_READS` (a converted FastQ file, the `@id`-prefixed
+//!   `_C_to_T` form, whose sample MUST include reads with leading-S, trailing-S,
+//!   internal `I`, and `D` ops).
+//!
+//! Run on oxy with:
+//! ```text
+//! RAMMAP_BIN=~/rammap/target/release/rammap \
+//! RAMMAP_MMI=~/bismark_benchmarks/genome/Bisulfite_Genome/CT_conversion/BS_CT.mmi \
+//! RAMMAP_READS=/var/tmp/conv_sample_C_to_T.fastq \
+//! cargo test -p bismark-aligner --features rammap-inprocess --test rammap_inprocess_crosscheck -- --nocapture
+//! ```
+
+#![cfg(feature = "rammap-inprocess")]
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Cursor};
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+
+use bismark_aligner::align::{SamRecord, SamStream};
+use bismark_aligner::inprocess::{InProcessAlignerStream, consumed_read_len};
+use bismark_aligner::rammap;
+
+/// Read the three env vars; `None` (→ skip) if any is missing.
+fn env_inputs() -> Option<(PathBuf, PathBuf, PathBuf)> {
+    let bin = std::env::var_os("RAMMAP_BIN")?;
+    let mmi = std::env::var_os("RAMMAP_MMI")?;
+    let reads = std::env::var_os("RAMMAP_READS")?;
+    Some((bin.into(), mmi.into(), reads.into()))
+}
+
+/// Parse the subprocess `rammap` SAM (skip `@` header lines), keyed by QNAME →
+/// the FIRST record per QNAME (the primary, emitted first under `--secondary=no`)
+/// — exactly what the subprocess `AlignerStream` feeds the merge.
+fn subprocess_sam_by_qname(
+    bin: &PathBuf,
+    mmi: &PathBuf,
+    reads: &PathBuf,
+) -> HashMap<String, SamRecord> {
+    // The same invocation shape the Rust subprocess backend uses (Perl 7022/7025):
+    // `<opts> <index>.mmi <input>`, with `--secondary=no` so the primary is first.
+    let out = Command::new(bin)
+        .args([
+            "-a",
+            "--MD",
+            "--secondary=no",
+            "-t",
+            "1",
+            "-x",
+            "map-ont",
+            "-K",
+            "250K",
+        ])
+        .arg(mmi)
+        .arg(reads)
+        .output()
+        .expect("failed to run the rammap subprocess");
+    assert!(
+        out.status.success(),
+        "rammap subprocess exited unsuccessfully: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let mut by_qname: HashMap<String, SamRecord> = HashMap::new();
+    for line in out.stdout.split(|&b| b == b'\n') {
+        if line.is_empty() || line[0] == b'@' {
+            continue;
+        }
+        let s = String::from_utf8_lossy(line);
+        let rec = SamRecord::parse(&s).expect("subprocess SAM line must parse");
+        // Keep the FIRST record per qname (primary). A supplementary (later) line
+        // for the same qname is dropped, matching the subprocess stream's store-first.
+        by_qname.entry(rec.qname.clone()).or_insert(rec);
+    }
+    by_qname
+}
+
+/// Index the converted FastQ by qname → (read_len) so the cross-check can assert
+/// `consumed_read_len == read_len` per read (the converted file is the SAME bytes
+/// the subprocess + in-process stream both consume).
+fn read_lengths_by_qname(reads: &PathBuf) -> HashMap<String, usize> {
+    let f = std::fs::File::open(reads).expect("open RAMMAP_READS");
+    let mut r = BufReader::new(f);
+    let (mut id, mut seq, mut id2, mut qual) = (Vec::new(), Vec::new(), Vec::new(), Vec::new());
+    let mut out = HashMap::new();
+    loop {
+        id.clear();
+        seq.clear();
+        id2.clear();
+        qual.clear();
+        let n1 = r.read_until(b'\n', &mut id).unwrap();
+        let n2 = r.read_until(b'\n', &mut seq).unwrap();
+        let n3 = r.read_until(b'\n', &mut id2).unwrap();
+        let n4 = r.read_until(b'\n', &mut qual).unwrap();
+        if n1 == 0 || n2 == 0 || n3 == 0 || n4 == 0 {
+            break;
+        }
+        let qname = String::from_utf8_lossy(&id)
+            .trim_end()
+            .trim_start_matches('@')
+            .to_string();
+        let len = seq
+            .iter()
+            .take_while(|&&b| b != b'\n' && b != b'\r')
+            .count();
+        out.insert(qname, len);
+    }
+    out
+}
+
+#[test]
+fn inprocess_matches_subprocess_record_for_record() {
+    let Some((bin, mmi, reads)) = env_inputs() else {
+        eprintln!(
+            "SKIP rammap cross-check: set RAMMAP_BIN / RAMMAP_MMI / RAMMAP_READS to run \
+             (needs the rammap binary, a .mmi index, and a converted-read sample)."
+        );
+        return;
+    };
+
+    // --- in-process: drive the production stream over the converted reads. ---
+    let mmi_str = mmi.to_str().expect("RAMMAP_MMI must be UTF-8");
+    let aligner = Arc::new(
+        rammap::Aligner::from_index(mmi_str, rammap::Preset::MapOnt)
+            .expect("load .mmi via rammap::Aligner::from_index"),
+    );
+    // Read the whole converted file into memory so the in-process stream consumes
+    // the identical bytes the subprocess CLI reads.
+    let bytes = std::fs::read(&reads).expect("read RAMMAP_READS");
+    let mut stream =
+        InProcessAlignerStream::new(aligner, Cursor::new(bytes)).expect("build in-process stream");
+
+    let read_lens = read_lengths_by_qname(&reads);
+    let sub = subprocess_sam_by_qname(&bin, &mmi, &reads);
+
+    let mut total = 0usize;
+    let mut inproc_mapped = 0usize;
+    let mut field_matches = 0usize;
+    let mut field_mismatches = 0usize;
+    let mut seq_mismatches = 0usize;
+    // op-coverage proof: the sample MUST exercise leading-S / trailing-S / I / D.
+    let (mut saw_lead_s, mut saw_trail_s, mut saw_i, mut saw_d) = (false, false, false, false);
+
+    while let Some(rec) = stream.current() {
+        total += 1;
+        let qname = rec.qname.clone();
+        let s = sub.get(&qname).unwrap_or_else(|| {
+            panic!("qname {qname} present in-process but missing from subprocess SAM")
+        });
+
+        // FLAG carries mapped/unmapped; compare the merge-consumed fields.
+        assert_eq!(rec.flag, s.flag, "FLAG mismatch for {qname}");
+        let mapped_inproc = !rec.is_unmapped();
+        let mapped_sub = !s.is_unmapped();
+        assert_eq!(
+            mapped_inproc, mapped_sub,
+            "mapped/unmapped disagreement for {qname}"
+        );
+
+        if mapped_inproc {
+            inproc_mapped += 1;
+            // Every merge-consumed field, field by field.
+            let same = rec.rname == s.rname
+                && rec.pos == s.pos
+                && rec.cigar == s.cigar
+                && rec.mapq == s.mapq
+                && rec.alignment_score == s.alignment_score
+                && rec.second_best == s.second_best
+                && rec.md_tag == s.md_tag;
+            if same {
+                field_matches += 1;
+            } else {
+                field_mismatches += 1;
+                eprintln!(
+                    "FIELD MISMATCH {qname}:\n  inproc: rname={} pos={} cigar={} mapq={} AS={:?} 2nd={:?} md={:?}\n  subpro: rname={} pos={} cigar={} mapq={} AS={:?} 2nd={:?} md={:?}",
+                    rec.rname,
+                    rec.pos,
+                    rec.cigar,
+                    rec.mapq,
+                    rec.alignment_score,
+                    rec.second_best,
+                    rec.md_tag,
+                    s.rname,
+                    s.pos,
+                    s.cigar,
+                    s.mapq,
+                    s.alignment_score,
+                    s.second_best,
+                    s.md_tag,
+                );
+            }
+            // seq is downstream-dead (Rev 2) — diff for fidelity, non-blocking.
+            if rec.seq != s.seq {
+                seq_mismatches += 1;
+            }
+
+            // 🔴 consumed_read_len == read_len (else the methylation guard skips it).
+            let rl = *read_lens
+                .get(&qname)
+                .unwrap_or_else(|| panic!("no read length for mapped {qname}"));
+            assert_eq!(
+                consumed_read_len(&rec.cigar),
+                Some(rl),
+                "reconstructed CIGAR {} for {qname} does not consume read_len {rl} \
+                 (the methylation length guard would SILENTLY skip this read)",
+                rec.cigar
+            );
+
+            // op coverage on the reconstructed (in-process) CIGAR. A leading soft
+            // clip = the FIRST CIGAR run is `S` (i.e. `^\d+S`): the run terminator
+            // immediately after the leading digits is `S`.
+            let first_op = rec.cigar.trim_start_matches(|c: char| c.is_ascii_digit());
+            if first_op.starts_with('S') {
+                saw_lead_s = true;
+            }
+            if rec.cigar.ends_with('S') {
+                saw_trail_s = true;
+            }
+            if rec.cigar.contains('I') {
+                saw_i = true;
+            }
+            if rec.cigar.contains('D') {
+                saw_d = true;
+            }
+        }
+
+        stream.advance().expect("advance in-process stream");
+    }
+
+    let sub_mapped = sub.values().filter(|r| !r.is_unmapped()).count();
+
+    eprintln!(
+        "rammap cross-check: total={total} inproc_mapped={inproc_mapped} sub_mapped={sub_mapped} \
+         field_matches={field_matches} field_mismatches={field_mismatches} seq_mismatches={seq_mismatches} \
+         (lead_S={saw_lead_s} trail_S={saw_trail_s} I={saw_i} D={saw_d})"
+    );
+
+    // --- the gate ---
+    assert!(total > 0, "no reads processed — check RAMMAP_READS");
+    assert_eq!(
+        field_mismatches, 0,
+        "{field_mismatches} record(s) differ on a merge-consumed field"
+    );
+    // no-silent-skip proof: in-process mapped count == subprocess mapped count.
+    assert_eq!(
+        inproc_mapped, sub_mapped,
+        "in-process mapped count {inproc_mapped} != subprocess mapped count {sub_mapped} \
+         (a silent skip / extra map)"
+    );
+    // op coverage: the sample MUST exercise all four ops (Rev 2 hardening).
+    assert!(
+        saw_lead_s && saw_trail_s && saw_i && saw_d,
+        "the cross-check sample must include leading-S / trailing-S / internal-I / D reads \
+         (got lead_S={saw_lead_s} trail_S={saw_trail_s} I={saw_i} D={saw_d}); pick a larger / more diverse sample"
+    );
+}


### PR DESCRIPTION
## What

**Epic phase 1** of the rammap in-process library integration (`plans/06152026_rammap-library-integration/`).
Adds an **in-process `rammap-core` alignment path**: a third `align::SamStream` impl
(`InProcessAlignerStream`, `Arc<Aligner>`-backed) that maps each converted read via `Aligner::map_seq_with`
and yields a `SamRecord` **field-identical to the subprocess `--rammap` CLI parse**. The stream-generic
merge consumes it unchanged, so `bismark_rs --rammap` can become byte-identical to the subprocess path —
loading each converted index **once** (`Arc`-shared across the 4 logical instances) instead of 4× via
subprocesses (the benchmark measured ~27 GB library vs 67.6 GB subprocess, below minimap2's 38.4 GB).

**No production wiring in this phase** (`lib.rs`/`config.rs` routing is phase 2). The module is inert
until the feature + the wiring land.

## Dependency — opt-in, gated, zero default-build impact

`rammap-core` is an **optional git dependency, rev-pinned to v1.1.1 (`5ea62cd`)**, behind a **default-OFF
Cargo feature `rammap-inprocess`**. The default/local build never compiles it (verified absent from
`cargo tree`); the in-process path + its tests compile only with `--features rammap-inprocess`
(Linux/CI/release). Edition 2024 / rust 1.89 workspace → no MSRV bump; no `noodles` pulled.

## Fidelity (the load-bearing detail)

rammap's `map_seq` returns the aligned-core CIGAR; the SAM CIGAR is reconstructed as
`{query_start}S + core + {read_len-query_end}S`, with the **flanks swapped on the reverse strand**
(rammap query coords are forward/PAF orientation; SAM CIGAR is reference orientation). A record-level
cross-check vs the subprocess oracle (real `BS_CT.mmi`, 5k converted ONT reads) confirmed **545/545 mapped
reads field-identical** (flag/rname/pos/cigar/mapq/AS/second_best/md), **in-process count == subprocess
count** (no silent read-drop), `consumed_read_len == read_len` for all, sample exercising leading-S /
trailing-S / I / D ops.

## Tests / verification

- Default feature-OFF: 415 lib tests + the feature-independent `reconstruct_cigar` tests, `clippy -D`,
  `fmt` clean; **rammap-core absent from the build**.
- `--features rammap-inprocess` (oxy, Linux stable): feature-gated `build_sam_record` unit tests + the
  record-level cross-check (feature + env gated; skips cleanly without test data).
- Dual code-review APPROVE + plan-manager COMPLETE.
- Byte-frozen Bowtie2/HISAT2/minimap2/subprocess-rammap + merge/output paths unchanged.

## Follow-ups (tracked)

- Phase 2 routes `--rammap` through the in-process path; phase 3 = oxy byte-identity gate (the gate runs
  the subprocess oracle at production `-t 2` — the cross-check here used `-t 1`, proven thread-invariant).
- A CI job building `--features rammap-inprocess` (the default CI doesn't compile the gated code).
