### PR TITLE
feat(aligner): route --rammap in-process (driver wiring) — epic phase 2

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -55,6 +55,36 @@ jobs:
       - name: cargo clippy -D warnings
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  rammap-inprocess:
+    name: cargo build/test (rammap-inprocess feature)
+    # The default `test`/`clippy` jobs build FEATURE-OFF, so the in-process rammap
+    # backend (`inprocess.rs` + the `lib.rs`/`config.rs` wiring, all
+    # `#[cfg(feature = "rammap-inprocess")]`) is otherwise NEVER compiled in CI. This
+    # job compiles + tests it (epic 06152026 Phase 2). `rammap-core` is an OPTIONAL
+    # git-dep — the runner fetches it from GitHub (network); the env-gated
+    # `rammap_inprocess_crosscheck` test auto-skips here (no `.mmi`/binary) and the
+    # oxy byte-identity gate covers the real cross-check.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.89"
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+      - name: cargo build -p bismark-aligner --features rammap-inprocess
+        run: cargo build -p bismark-aligner --all-targets --features rammap-inprocess
+      - name: cargo clippy -p bismark-aligner --features rammap-inprocess -D warnings
+        run: cargo clippy -p bismark-aligner --all-targets --features rammap-inprocess -- -D warnings
+      - name: cargo test -p bismark-aligner --features rammap-inprocess
+        run: cargo test -p bismark-aligner --features rammap-inprocess
+
   fmt:
     name: cargo fmt --check
     runs-on: ubuntu-latest

--- a/rust/bismark-aligner/src/cli.rs
+++ b/rust/bismark-aligner/src/cli.rs
@@ -73,6 +73,14 @@ pub struct Cli {
     /// Folder containing `rammap`.
     #[arg(long = "path_to_rammap", value_name = "PATH")]
     pub path_to_rammap: Option<PathBuf>,
+    /// `[v2/experimental]` Force the subprocess `rammap` backend even when the
+    /// in-process backend is compiled in (the `rammap-inprocess` feature). With the
+    /// feature ON, `--rammap` defaults to the in-process `rammap-core` path; this flag
+    /// forces the legacy subprocess path. Its primary use is the byte-identity gate
+    /// oracle (in-process vs subprocess on the same binary) — not a long-term knob.
+    /// Requires `--rammap`. No effect on a feature-OFF binary (subprocess is the only path).
+    #[arg(long = "rammap_subprocess")]
+    pub rammap_subprocess: bool,
     /// Folder containing `samtools`.
     #[arg(long = "samtools_path", value_name = "PATH")]
     pub samtools_path: Option<PathBuf>,

--- a/rust/bismark-aligner/src/config.rs
+++ b/rust/bismark-aligner/src/config.rs
@@ -169,6 +169,13 @@ pub struct RunConfig {
     pub command_line: String,
     /// Selected aligner (Bowtie 2, HISAT2, or minimap2).
     pub aligner: Aligner,
+    /// `[v2/experimental]` `--rammap_subprocess`: force the subprocess `rammap`
+    /// backend even when the in-process backend (`rammap-inprocess` feature) is
+    /// compiled in. With the feature ON, `--rammap` defaults to the in-process path;
+    /// this flag forces the subprocess path (the Phase-3 byte-identity gate oracle).
+    /// Read on BOTH builds by `lib::use_se_inprocess_rammap` (always-compiled) so it is
+    /// never a feature-off dead field. `resolve` requires `--rammap` whenever it is set.
+    pub rammap_subprocess: bool,
     /// Library type.
     pub library: LibraryType,
     /// Read layout + files.
@@ -268,6 +275,17 @@ fn hisat2_multicore_threads(aligner: Aligner, cli_multicore: Option<u32>) -> Opt
 /// Resolve a parsed [`Cli`] + the verbatim command line into a [`RunConfig`].
 pub fn resolve(cli: &Cli, command_line: String) -> Result<RunConfig> {
     let aligner = resolve_aligner(cli)?;
+    // `--rammap_subprocess` (force the subprocess rammap backend even when the
+    // in-process backend is compiled in; primarily the Phase-3 byte-identity gate
+    // oracle) is meaningful only with `--rammap` — fail loud otherwise (never-silent;
+    // mirrors the rammap conflict dies in `resolve_aligner`).
+    if cli.rammap_subprocess && !cli.rammap {
+        return Err(AlignerError::Validation(
+            "--rammap_subprocess requires --rammap: it forces the subprocess rammap backend, \
+             which only applies to a --rammap run."
+                .into(),
+        ));
+    }
     // The minimap2-only preset/length flags (Perl 8329-8356): outside minimap2
     // mode every `--mm2_*` flag dies (the `unless($mm2)` block); in minimap2 mode
     // `--mm2_maximum_length` is range-checked + defaults to 10000. Returns the
@@ -394,6 +412,8 @@ pub fn resolve(cli: &Cli, command_line: String) -> Result<RunConfig> {
     Ok(RunConfig {
         command_line,
         aligner,
+        // Phase 2 (epic 06152026): force-subprocess flag (guarded above: requires --rammap).
+        rammap_subprocess: cli.rammap_subprocess,
         library,
         layout,
         format,
@@ -1165,6 +1185,26 @@ mod tests {
             m.contains("--rammap") && m.contains("by design") && !m.contains("--minimap2"),
             "rammap --local must reject naming --rammap with the 'by design' rationale; got: {m}"
         );
+    }
+
+    /// Epic 06152026 Phase 2 (V6): `--rammap_subprocess` requires `--rammap`. The guard
+    /// fires right after `resolve_aligner` (before genome discovery), so no on-disk index
+    /// is needed (mirrors `rammap_rejects_local`).
+    #[test]
+    fn rammap_subprocess_requires_rammap() {
+        let err = resolve(&cli_from(&["--rammap_subprocess"]), "cmd".into()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("--rammap_subprocess requires --rammap"),
+            "got: {err}"
+        );
+    }
+
+    /// Epic 06152026 Phase 2 (V6): the `--rammap_subprocess` flag parses and is off by default.
+    #[test]
+    fn rammap_subprocess_flag_parses() {
+        assert!(cli_from(&["--rammap", "--rammap_subprocess"]).rammap_subprocess);
+        assert!(!cli_from(&["--rammap"]).rammap_subprocess);
     }
 
     #[test]

--- a/rust/bismark-aligner/src/lib.rs
+++ b/rust/bismark-aligner/src/lib.rs
@@ -130,10 +130,39 @@ pub fn run(cli: &cli::Cli, command_line: String) -> Result<()> {
     // minimap2. Emitted here (the `hisat2_multicore_remap_notice` precedent), NOT in
     // `resolve()` (which would spam every rammap unit test).
     if config.aligner == Aligner::Rammap {
+        // Name the active backend by reusing the ONE selection predicate, so the
+        // printed backend can never disagree with the path actually taken (the
+        // in-process branch in `process_se_chunk` uses the same `use_se_inprocess_rammap`).
+        // It reads `config.rammap_subprocess` on both builds (feature-off → always
+        // false → "subprocess"), so the config field is never a feature-off dead field.
+        let inprocess = use_se_inprocess_rammap(&config);
+        let backend = if inprocess {
+            "in-process rammap-core backend"
+        } else {
+            "subprocess rammap binary"
+        };
         eprintln!(
-            "Note: --rammap uses the rammap pure-Rust minimap2 reimplementation. \
-             Alignments are concordance-validated, NOT byte-identical to minimap2."
+            "Note: --rammap uses the rammap pure-Rust minimap2 reimplementation \
+             ({backend}). Alignments are concordance-validated, NOT byte-identical to minimap2."
         );
+        // Never-silent fallback notices: the in-process backend is compiled in and not
+        // force-disabled (`--rammap_subprocess`), but a run condition routes to the
+        // subprocess path. Feature-gated (only reachable when in-process exists).
+        #[cfg(feature = "rammap-inprocess")]
+        if !inprocess && !config.rammap_subprocess {
+            if config.multicore > 1 {
+                eprintln!(
+                    "Note: the in-process rammap backend is single-core in this build; \
+                     --multicore {} uses the subprocess rammap backend for this run.",
+                    config.multicore
+                );
+            } else if !matches!(config.format, ReadFormat::FastQ) {
+                eprintln!(
+                    "Note: the in-process rammap backend supports FastQ input only; this \
+                     FastA run uses the subprocess rammap backend."
+                );
+            }
+        }
     }
     eprintln!("{}", config.summary());
     pipeline(&config)?;
@@ -356,6 +385,31 @@ fn process_se_chunk(
             cr.count
         );
     }
+    // Phase 2 (epic 06152026): when the in-process rammap backend is compiled in and
+    // selected (single-core SE FastQ, `--rammap` not force-subprocessed), drive the
+    // merge over `Arc<rammap::Aligner>`-backed streams (each converted `.mmi` loaded
+    // ONCE, shared across the 2/4 instances) instead of spawning 2/4 rammap
+    // subprocesses. `drive_merge` is generic over `SamStream`; the merge / XM / output
+    // arm is byte-frozen. `--multicore N>1` and FastA fall through to the subprocess
+    // path (see `use_se_inprocess_rammap` + the never-silent notices in `run`).
+    #[cfg(feature = "rammap-inprocess")]
+    if use_se_inprocess_rammap(config) {
+        let pbat = matches!(config.library, LibraryType::Pbat);
+        let mut streams = build_se_inprocess_streams(config, &converted)?;
+        drive_merge(
+            input,
+            &mut streams,
+            config,
+            genome,
+            refid,
+            pbat,
+            sinks,
+            counters,
+        )?;
+        // In-process streams own no subprocess — nothing to `finish()`; they drop here.
+        return Ok(converted);
+    }
+
     // Phase 3/8: spawn the instances per the per-mode plan, in Bismark slot order
     // so the merge's `enumerate` index == the Perl `@fhs` index.
     let mut streams = Vec::with_capacity(2);
@@ -390,6 +444,130 @@ fn process_se_chunk(
         s.finish()?;
     }
     Ok(converted)
+}
+
+/// Whether the SE single-core in-process rammap path drives this chunk (epic
+/// 06152026 Phase 2).
+///
+/// Unconditional + `cfg!`-gated (NOT `#[cfg]`-gated) on purpose, so it (a) returns
+/// `false` on the feature-off build, (b) is callable from `run`'s backend notice on
+/// BOTH builds — reusing ONE predicate so the printed backend can never disagree with
+/// the path actually taken, and (c) reads `config.rammap_subprocess` in always-compiled
+/// code so the field is never a feature-off dead field (`-D warnings`).
+///
+/// `config.multicore <= 1` is the single-core discriminator: `parallel::run_se_multicore`'s
+/// worker clone deliberately leaves `cfg.multicore = N (> 1)` (it clears only skip/upto),
+/// so a parallel chunk worker never takes this branch. That gate is load-bearing — without
+/// it, `--rammap --multicore N` would route each of the N workers through two `from_index`
+/// loads (= N × ~27 GB co-resident, an OOM regression worse than the subprocess fork). The
+/// HISAT2 `--multicore → multicore = 1` remap cannot fool it: rammap is mutually exclusive
+/// with `--hisat2`. FastQ-only because the Phase-1 `InProcessAlignerStream` reads 4-line
+/// FastQ records (FastA falls back to the subprocess path).
+fn use_se_inprocess_rammap(config: &RunConfig) -> bool {
+    inprocess_rammap_selected(
+        config.aligner,
+        config.rammap_subprocess,
+        config.multicore,
+        config.format,
+    )
+}
+
+/// The pure selection logic behind [`use_se_inprocess_rammap`], over primitives so it
+/// is unit-testable without a full `RunConfig`. `cfg!(feature = "rammap-inprocess")` is
+/// the first conjunct → always `false` on the feature-off build.
+fn inprocess_rammap_selected(
+    aligner: Aligner,
+    force_subprocess: bool,
+    multicore: u32,
+    format: ReadFormat,
+) -> bool {
+    cfg!(feature = "rammap-inprocess")
+        && aligner == Aligner::Rammap
+        && !force_subprocess
+        && multicore <= 1
+        && matches!(format, ReadFormat::FastQ)
+}
+
+/// Build the SE in-process rammap streams (epic 06152026 Phase 2): load each converted
+/// `.mmi` the per-mode [`se_instance_plan`] references EXACTLY ONCE into an
+/// `Arc<rammap::Aligner>` and `Arc::clone` it into one [`InProcessAlignerStream`] per
+/// instance — in Bismark slot order, so the merge's `enumerate` index matches the
+/// subprocess path. Each stream reads the SAME converted temp bytes the subprocess CLI
+/// reads (with a `.gz` sniff). Orientation is ignored (rammap takes no `--norc`/`--nofw`;
+/// strand is classified by instance index in the merge).
+///
+/// All three library types reference BOTH indexes (directional: OT→CT + CTOB→GA; pbat:
+/// CTOT→CT + CTOB→GA; non-directional: all four), so this loads two indexes for every
+/// library — the EPIC's "construct 2 `Arc<Aligner>`". The per-`IndexChoice` gating below
+/// is future-proofing (load only what the plan references), NOT an RSS optimisation for
+/// any current library (PLAN rev 1, correcting the plan-review premise that directional
+/// needs only CT).
+#[cfg(feature = "rammap-inprocess")]
+fn build_se_inprocess_streams(
+    config: &RunConfig,
+    converted: &[convert::ConvertedReads],
+) -> Result<Vec<crate::inprocess::InProcessAlignerStream<Box<dyn BufRead>>>> {
+    use std::sync::Arc;
+
+    let plan = se_instance_plan(config.library);
+
+    // Load each `.mmi` the plan references, exactly once. `from_index` takes a `&str`
+    // path (cf. the Phase-1 cross-check); map non-UTF-8 / load failure to a validation
+    // error (fail-loud, never-silent).
+    let load = |basename: &Path| -> Result<Arc<::rammap::Aligner>> {
+        let mut mmi = basename.as_os_str().to_owned();
+        mmi.push(".mmi");
+        let mmi_str = mmi.to_str().ok_or_else(|| {
+            AlignerError::Validation(format!(
+                "rammap index path is not valid UTF-8: {}",
+                Path::new(&mmi).display()
+            ))
+        })?;
+        let aligner =
+            ::rammap::Aligner::from_index(mmi_str, ::rammap::Preset::MapOnt).map_err(|e| {
+                AlignerError::Validation(format!("failed to load rammap index {mmi_str}: {e}"))
+            })?;
+        Ok(Arc::new(aligner))
+    };
+
+    let needs_ct = plan.iter().any(|(_, ic, _)| matches!(ic, IndexChoice::Ct));
+    let needs_ga = plan.iter().any(|(_, ic, _)| matches!(ic, IndexChoice::Ga));
+    let ct = if needs_ct {
+        Some(load(&config.genome.ct_index_basename)?)
+    } else {
+        None
+    };
+    let ga = if needs_ga {
+        Some(load(&config.genome.ga_index_basename)?)
+    } else {
+        None
+    };
+
+    let mut streams = Vec::with_capacity(plan.len());
+    for (_orientation, index_choice, file_idx) in plan {
+        let aligner = match index_choice {
+            IndexChoice::Ct => Arc::clone(
+                ct.as_ref()
+                    .expect("CT index loaded because the plan references it"),
+            ),
+            IndexChoice::Ga => Arc::clone(
+                ga.as_ref()
+                    .expect("GA index loaded because the plan references it"),
+            ),
+        };
+        // The converted temp the subprocess CLI would have read (`.gz` when `--gzip`).
+        let path = &converted[file_idx].path;
+        let f = File::open(path)?;
+        let reader: Box<dyn BufRead> = if path.to_string_lossy().ends_with(".gz") {
+            Box::new(BufReader::new(MultiGzDecoder::new(f)))
+        } else {
+            Box::new(BufReader::new(f))
+        };
+        streams.push(crate::inprocess::InProcessAlignerStream::new(
+            aligner, reader,
+        )?);
+    }
+    Ok(streams)
 }
 
 /// SE pipeline (single-core / `--parallel 1`, all library types): load the genome
@@ -662,9 +840,9 @@ fn strip_fastq_suffix(name: &str) -> String {
 /// BAM record. `skip`/`upto` MUST match Phase 2's conversion so the driver and
 /// the streams see the same reads.
 #[allow(clippy::too_many_arguments)]
-fn drive_merge(
+fn drive_merge<S: SamStream>(
     read_file: &Path,
-    streams: &mut [AlignerStream],
+    streams: &mut [S],
     config: &RunConfig,
     genome: &Genome,
     refid: &HashMap<String, usize>,
@@ -4556,6 +4734,66 @@ mod tests {
         // fail-loud: an untagged qname is NEVER silently mis-partitioned.
         let err = strip_conv_tag("read1").unwrap_err();
         assert!(format!("{err}").contains("__CT/__GA conversion tag"));
+    }
+
+    /// Epic 06152026 Phase 2: the SE in-process rammap selection predicate (V4 + V5).
+    /// Runs on BOTH builds — the "selected" case is true iff the feature is compiled in
+    /// (`cfg!` first conjunct); every disqualifier forces the subprocess path regardless.
+    #[test]
+    fn inprocess_rammap_predicate_truth_table() {
+        use crate::config::{Aligner, ReadFormat};
+        // rammap + not-forced + single-core + FastQ selects in-process IFF the feature is on.
+        let selected = cfg!(feature = "rammap-inprocess");
+        assert_eq!(
+            inprocess_rammap_selected(Aligner::Rammap, false, 1, ReadFormat::FastQ),
+            selected
+        );
+        // Wrong aligner → subprocess (on both builds).
+        assert!(!inprocess_rammap_selected(
+            Aligner::Bowtie2,
+            false,
+            1,
+            ReadFormat::FastQ
+        ));
+        assert!(!inprocess_rammap_selected(
+            Aligner::Hisat2,
+            false,
+            1,
+            ReadFormat::FastQ
+        ));
+        assert!(!inprocess_rammap_selected(
+            Aligner::Minimap2,
+            false,
+            1,
+            ReadFormat::FastQ
+        ));
+        // `--rammap_subprocess` forces the subprocess path.
+        assert!(!inprocess_rammap_selected(
+            Aligner::Rammap,
+            true,
+            1,
+            ReadFormat::FastQ
+        ));
+        // Multicore worker (N>1) → subprocess — the gate that prevents N×27 GB (V5).
+        assert!(!inprocess_rammap_selected(
+            Aligner::Rammap,
+            false,
+            2,
+            ReadFormat::FastQ
+        ));
+        assert!(!inprocess_rammap_selected(
+            Aligner::Rammap,
+            false,
+            8,
+            ReadFormat::FastQ
+        ));
+        // FastA → subprocess (the in-process stream is 4-line FastQ-only).
+        assert!(!inprocess_rammap_selected(
+            Aligner::Rammap,
+            false,
+            1,
+            ReadFormat::FastA
+        ));
     }
 
     /// A canned [`SamStream`] over a fixed record list — for `spill_stream_to_file`.

--- a/rust/bismark-aligner/tests/cli.rs
+++ b/rust/bismark-aligner/tests/cli.rs
@@ -2643,6 +2643,14 @@ fn rammap_se_mapped_names_report_and_notice() {
         .arg("--genome")
         .arg(genome.path())
         .arg("--rammap")
+        // This test validates the SUBPROCESS rammap backend (the fake `rammap` binary,
+        // its positional `.mmi` invocation, naming, option string, supplementary
+        // handling). With the `rammap-inprocess` feature ON, `--rammap` defaults to the
+        // in-process backend, which would bypass the fake binary and try to load the
+        // fake `.mmi` via real rammap-core. Force the subprocess path so this test is
+        // backend-stable on both builds (epic 06152026 Phase 2). The in-process backend
+        // is exercised by the oxy byte-identity smoke (it needs a real `.mmi`).
+        .arg("--rammap_subprocess")
         .arg("--path_to_rammap")
         .arg(bins.path())
         .arg("--temp_dir")


### PR DESCRIPTION
## What

Phase 2 of the rammap in-process library integration epic (`plans/06152026_rammap-library-integration/`). When the default-OFF **`rammap-inprocess`** feature is on, `bismark_rs --rammap` (single-end, single-core, FastQ) now drives the merge over **in-process `rammap-core` `Arc<Aligner>` streams** — each converted `.mmi` loaded **once**, shared across the 2/4 strand instances — instead of spawning rammap subprocesses. The architectural payoff is the RSS regime a subprocess fork model can't reach (~27 GB vs the subprocess 67.6 GB).

## How (byte-frozen discipline)

- `drive_merge` generified `<S: SamStream>` (single-site; the only concrete `[AlignerStream]` consumer — body unchanged, subprocess path codegen-identical).
- New feature-gated `process_se_chunk` branch + `build_se_inprocess_streams` (loads each referenced index once, `Arc::clone` per instance in slot order, `.gz` sniff) + `use_se_inprocess_rammap` predicate.
- `--rammap_subprocess` flag forces the subprocess path (the gate oracle). `--multicore N>1` and FastA fall back to the subprocess path, **never-silent** (the `run()` notice names the active backend via the same predicate).
- Merge / XM / SAM-output and `parallel.rs` are **untouched**.

## Gate result — concordance, not byte-identity (accepted)

The oxy smoke (`phase2-driver-wiring/GATE_OXY.md`) found the in-process path is **not byte-identical** to the subprocess `--rammap`: rammap's `map_seq_with` **library API diverges from the rammap CLI** on ~1–2 borderline long-ONT reads per 10k. Thread count (`-t1`==`-t2`), `-K` batching (`250K`==`2G`), and the wiring were all **ruled out** with direct evidence. The divergence is one-directional + conservative (**0 reads gained**, 1–2 dropped unique→non-unique per cell, **~99.95% unique-call agreement**). Per the epic's documented fallback (and consistent with the whole concordance-gated rammap track), the gate is **concordance-to-subprocess + divergence ledger**. Phase 3 = the formal concordance gate at 1M + ~27 GB co-resident RSS.

## Tests / CI

- Feature-OFF: rammap-core absent (`cargo tree`), clippy `-D warnings` + fmt clean, 419 lib + 100 integ green.
- Feature-ON: builds on stable, clippy `-D` + fmt clean, 423 lib + 100 integ + 3 conformance green.
- New `rammap-inprocess` CI job builds + clippy + tests the feature (the default jobs build feature-OFF).
- Dual code-review APPROVE×2 (0 Critical/High) + plan-manager COMPLETE.

Default behaviour is unchanged (feature default-OFF; `--rammap` without the feature spawns the subprocess as before).