### PR TITLE
perf(bismark): speed up the four hottest per-read loops (~40% faster alignment, bit-identical)

### DIFF
--- a/bismark
+++ b/bismark
@@ -9270,40 +9270,42 @@ sub make_mismatch_string{
 	my $ref_base;
 	my $actual_base;
 	
-	foreach my $pos ( 0..(length$actual_seq) - 1 ){
-
-		$actual_base = substr($actual_seq,$pos,1);
-		$ref_base    = substr($ref_seq,$pos,1);
-		# if ($verbose){ warn "reference: $ref_base\tseen base: $actual_base\n";}
-
-		if ( $actual_base eq $ref_base ){
-			++$prev_matching;
+	### Build the MD:Z string. The genomic mismatches (non-'X') are exactly the positions where the read and
+	### reference bytes differ, which we locate in a single C-level pass via the XOR of the two strings rather than
+	### an explicit per-base substr loop. 'X' positions (artificial padding for insertions/soft-clipping) are skipped,
+	### exactly as before. Produces a byte-identical MD tag (verified on the full pipeline and >300k fuzzed reads).
+	if (length($actual_seq) == length($ref_seq)){
+		my $xor = $actual_seq ^ $ref_seq;
+		my $prev = -1;
+		while ($xor =~ /[^\0]/g){
+			my $mpos = pos($xor) - 1;
+			$prev_matching += ($mpos - $prev - 1);   # matching bases in the gap since the last emitted mismatch
+			$ref_base = substr($ref_seq,$mpos,1);
+			unless ($ref_base eq 'X'){               # 'X' padding (insertion/soft-clipping) is ignored for the MD tag
+				$MD_tag .= $prev_matching;
+				$MD_tag .= $ref_base;
+				$prev_matching = 0;
+			}
+			$prev = $mpos;
 		}
-		else{
-			# If the mismatch is due to an insertion or soft-clipping we simply move on, else we print the previously matching bases
-			# as well as the mismatching genomic base
-			if ($ref_base eq 'X'){
-				if ($verbose){ warn "The genome base was an artificially padded '$ref_base' due to an insertion or soft-clipping in the read at this position. Just ignoring it for the MD tag\n";}
+		$prev_matching += (length($actual_seq) - 1 - $prev);   # trailing matches after the last mismatch
+	}
+	else{
+		### Fallback preserving the exact original behaviour should the two strings ever differ in length.
+		foreach my $pos ( 0..(length$actual_seq) - 1 ){
+			$actual_base = substr($actual_seq,$pos,1);
+			$ref_base    = substr($ref_seq,$pos,1);
+			if ( $actual_base eq $ref_base ){
+				++$prev_matching;
 			}
 			else{
-				if ($verbose){ warn "previous matching bases: $prev_matching\n";}
-
-				### There is a mismatch between the sequence and the genome. First we need to write out how may bases matched until now
-				if ($prev_matching == 0){
-					if ($verbose){ warn "Got a mismatch either at the very start or next to another mismatch. Need to add a padding 0 as well as the mismatch\n";}
-					if ($verbose){ warn "${prev_matching}$ref_base\n";}
+				unless ($ref_base eq 'X'){
 					$MD_tag .= $prev_matching;
 					$MD_tag .= $ref_base;
+					$prev_matching = 0;
 				}
-				else{
-					if ($verbose){ warn "${prev_matching}$ref_base\n";}
-					$MD_tag .= $prev_matching;
-					$MD_tag .= $ref_base;
-				}
-
-				$prev_matching = 0; # resetting $prev_matching
 			}
-		}	
+		}
 	}
 	### appending the number of matches one last time
 	$MD_tag .= $prev_matching;

--- a/bismark
+++ b/bismark
@@ -9233,12 +9233,22 @@ sub revcomp{
 }
 
 sub hemming_dist{
-	my $matches = 0;
-	my @actual_seq = split //,(shift @_);
-	my @ref_seq = split //,(shift @_);
+	my ($actual_seq,$ref_seq) = @_;
 
+	### Fast path: for equal-length strings (the normal case, since callers pad insertions/soft-clips
+	### with 'X' so the read and genomic strings are the same length) the number of differing positions
+	### is the count of non-null bytes in the XOR of the two strings. Bit-identical to the base-by-base
+	### comparison below, but ~30x faster as it avoids splitting both strings into per-character arrays.
+	if (length($actual_seq) == length($ref_seq)){
+		return ($actual_seq ^ $ref_seq) =~ tr/\0//c;
+	}
+
+	### Fallback preserving the exact original semantics if the lengths ever differ.
+	my $matches = 0;
+	my @actual_seq = split //,$actual_seq;
+	my @ref_seq = split //,$ref_seq;
 	foreach (0..$#actual_seq){
-		++$matches if ($actual_seq[$_] eq $ref_seq[$_]);
+		++$matches if (defined $ref_seq[$_] and $actual_seq[$_] eq $ref_seq[$_]);
 	}
 	return my $hd = scalar @actual_seq - $matches;
 }

--- a/bismark
+++ b/bismark
@@ -2734,7 +2734,8 @@ sub check_results_single_end{
 
 		if ($fhs[$index]->{last_seq_id} eq $identifier) {
 		
-			my ($id,$flag,$mapped_chromosome,$position,$mapping_quality,$cigar,$bowtie_sequence,$qual) = (split (/\t/,$fhs[$index]->{last_line}))[0,1,2,3,4,5,9,10];
+			my @fields = split (/\t/,$fhs[$index]->{last_line});
+			my ($id,$flag,$mapped_chromosome,$position,$mapping_quality,$cigar,$bowtie_sequence,$qual) = @fields[0,1,2,3,4,5,9,10];
 			## If a sequence has no reported alignments there will be a single output line with a bit-wise flag value of 4. We can store the next alignment and move on to the next Bowtie 2 instance
 			if ($flag == 4){
 				## reading in the next alignment, which must be the next sequence
@@ -2770,7 +2771,6 @@ sub check_results_single_end{
 
 			### We will use the optional field to determine the best alignment. Later on we extract the number of mismatches and/or indels from the CIGAR string
 			my ($alignment_score,$second_best,$MD_tag);
-			my @fields = split (/\t/,$fhs[$index]->{last_line});
 
 			foreach (11..$#fields){
 				#warn "$fields[$_]";
@@ -3303,8 +3303,10 @@ sub check_results_paired_end{
 
 		### if the sequence pair we are currently looking at produced an alignment we are doing various things with it
 		if ($fhs[$index]->{last_seq_id} eq $identifier) {
-			my ($id_1,$flag_1,$mapped_chromosome_1,$position_1,$mapping_quality_1,$cigar_1,$bowtie_sequence_1,$qual_1) = (split (/\t/,$fhs[$index]->{last_line_1}))[0,1,2,3,4,5,9,10];
-			my ($id_2,$flag_2,$mapped_chromosome_2,$position_2,$mapping_quality_2,$cigar_2,$bowtie_sequence_2,$qual_2) = (split (/\t/,$fhs[$index]->{last_line_2}))[0,1,2,3,4,5,9,10];
+			my @fields_1 = split (/\t/,$fhs[$index]->{last_line_1});
+			my @fields_2 = split (/\t/,$fhs[$index]->{last_line_2});
+			my ($id_1,$flag_1,$mapped_chromosome_1,$position_1,$mapping_quality_1,$cigar_1,$bowtie_sequence_1,$qual_1) = @fields_1[0,1,2,3,4,5,9,10];
+			my ($id_2,$flag_2,$mapped_chromosome_2,$position_2,$mapping_quality_2,$cigar_2,$bowtie_sequence_2,$qual_2) = @fields_2[0,1,2,3,4,5,9,10];
 			# print "Index: $index\t$fhs[$index]->{last_line_1}\n";
 			# print "Index: $index\t$fhs[$index]->{last_line_2}\n";
 			# print join ("\t",$id_1,$flag_1,$mapped_chromosome_1,$position_1,$mapping_quality_1,$cigar_1,$bowtie_sequence_1,$qual_1),"\n";
@@ -3365,9 +3367,6 @@ sub check_results_paired_end{
 
 			### We will use the optional fields to determine the best alignments. Later on we extract the number of mismatches and/or indels from the CIGAR string
 			my ($alignment_score_1,$alignment_score_2,$second_best_1,$second_best_2,$MD_tag_1,$MD_tag_2);
-
-			my @fields_1 = split (/\t/,$fhs[$index]->{last_line_1});
-			my @fields_2 = split (/\t/,$fhs[$index]->{last_line_2});
 
 			foreach (11..$#fields_1){
 				if ($fields_1[$_] =~ /AS:i:(.*)/){

--- a/bismark
+++ b/bismark
@@ -4798,13 +4798,10 @@ sub extract_corresponding_genomic_sequence_paired_end{
 ### METHYLATION CALL
 
 sub methylation_call{
-	my ($identifier,$sequence_actually_observed,$genomic_sequence,$read_conversion) = @_;
-	### splitting both the actually observed sequence and the genomic sequence up into single bases so we can compare them one by one
-	my @seq = split(//,$sequence_actually_observed);
-	my @genomic = split(//,$genomic_sequence);
-	#  print join ("\n",$identifier,$sequence_actually_observed,$genomic_sequence,$read_conversion),"\n";
-	### Creating a match-string with different characters for non-cytosine bases (disregarding mismatches here), methyl-Cs or non-methyl Cs in either
-	### CpG, CHH or CHG context
+  my ($identifier,$sequence_actually_observed,$genomic_sequence,$read_conversion) = @_;
+
+  ### Creating a match-string with different characters for non-cytosine bases (disregarding mismatches here), methyl-Cs or non-methyl Cs in either
+  ### CpG, CHH or CHG context
 
   #################################################################
   ### . for bases not involving cytosines                       ###
@@ -4818,8 +4815,17 @@ sub methylation_call{
   ### u for not methylated C in unknwon context (was converted) ###
   #################################################################
 
-  my @match =();
-  warn "length of \@seq: ",scalar @seq,"\tlength of \@genomic: ",scalar @genomic,"\n" unless (scalar @seq eq (scalar@genomic-2)); ## CHH changed to -2
+  ### PERFORMANCE NOTE (bit-identical refactor):
+  ### The only positions that ever receive a non-'.' call are those where the genomic base is a 'C' (CT read) or a 'G'
+  ### (GA read); every other position is '.'. Instead of splitting both strings into per-character arrays and branching
+  ### at every base, we start from an all-'.' string and only visit the relevant genomic bases, located cheaply with
+  ### index(). The branch logic, the emitted characters and all eight context counters are exactly as before. This was
+  ### verified bit-identical against the original on the full pipeline and on >200k fuzzed CT/GA reads.
+
+  my $len = length($sequence_actually_observed);
+  warn "length of seq: $len\tlength of genomic: ",length($genomic_sequence),"\n" unless ($len == (length($genomic_sequence)-2)); ## CHH changed to -2
+
+  my $methylation_call = '.' x $len;
   my $methyl_CHH_count = 0;
   my $methyl_CHG_count = 0;
   my $methyl_CpG_count = 0;
@@ -4830,178 +4836,155 @@ sub methylation_call{
   my $unmethylated_C_unknown_count = 0;
 
   if ($read_conversion eq 'CT'){
-    for my $index (0..$#seq) {
-      if ($seq[$index] eq $genomic[$index]) {
-	### The residue can only be a C if it was not converted to T, i.e. protected my methylation
-	if ($genomic[$index] eq 'C') {
-	  ### If the residue is a C we want to know if it was in CpG context or in any other context
-	  my $downstream_base = $genomic[$index+1];
+    ### genomic[$index] aligns with seq[$index]; context is read from the two downstream genomic bases
+    my $start = 0;
+    while ( (my $index = index($genomic_sequence,'C',$start)) >= 0 ){
+      $start = $index + 1;
+      last if ($index >= $len); ### remaining 'C's are context-only bases beyond the read
 
-	  if ($downstream_base eq 'G'){
-	    ++$methyl_CpG_count;
-	    push @match,'Z'; # protected C, methylated, in CpG context
-	  }
-	  elsif ($downstream_base eq 'N' or $downstream_base eq 'X'){ # if the downstream base was an N we cannot really be sure about the sequence context (as it might have been a CG)
-	    ++$methyl_C_unknown_count;
-	    push @match,'U'; # protected C, methylated, in Unknown context
-	  }
-	  else {
-	    ### C in not in CpG-context, determining the second downstream base context
-	    my $second_downstream_base = $genomic[$index+2];
+      my $seq_base = substr($sequence_actually_observed,$index,1);
+      my $call;
 
-	    if ($second_downstream_base eq 'G'){
-	      ++$methyl_CHG_count;
-	      push @match,'X'; # protected C, methylated, in CHG context
-	    }
-	    elsif ($second_downstream_base eq 'N' or $second_downstream_base eq 'X'){
-	      ++$methyl_C_unknown_count; # if the second downstream base was an N we cannot really be sure about the sequence context (as it might have been a CHH or CHG)
-	      push @match,'U'; # protected C, methylated, in Unknown context
-	    }
-	    else{
-	      ++$methyl_CHH_count;
-	      push @match,'H'; # protected C, methylated, in CHH context
-	    }
-	  }
+      if ($seq_base eq 'C') {
+	### The residue can only be a C if it was not converted to T, i.e. protected by methylation
+	my $downstream_base = substr($genomic_sequence,$index+1,1);
+	if ($downstream_base eq 'G'){
+	  ++$methyl_CpG_count;
+	  $call = 'Z'; # protected C, methylated, in CpG context
+	}
+	elsif ($downstream_base eq 'N' or $downstream_base eq 'X'){ # if the downstream base was an N we cannot really be sure about the sequence context (as it might have been a CG)
+	  ++$methyl_C_unknown_count;
+	  $call = 'U'; # protected C, methylated, in Unknown context
 	}
 	else {
-	  push @match, '.';
-	}
-      }
-      elsif ($seq[$index] ne $genomic[$index]) {
-	### for the methylation call we are only interested in mismatches involving cytosines (in the genomic sequence) which were converted into Ts
-	### in the actually observed sequence
-	if ($genomic[$index] eq 'C' and $seq[$index] eq 'T') {
-	  ### If the residue was converted to T we want to know if it was in CpG, CHG or CHH  context
-	  my $downstream_base = $genomic[$index+1];
-
-	  if ($downstream_base eq 'G'){
-	    ++$unmethylated_CpG_count;
-	    push @match,'z'; # converted C, not methylated, in CpG context
+	  ### C in not in CpG-context, determining the second downstream base context
+	  my $second_downstream_base = substr($genomic_sequence,$index+2,1);
+	  if ($second_downstream_base eq 'G'){
+	    ++$methyl_CHG_count;
+	    $call = 'X'; # protected C, methylated, in CHG context
 	  }
-	  elsif ($downstream_base eq 'N' or $downstream_base eq 'X'){ # if the downstream base was an N we cannot really be sure about the sequence context (as it might have been a CG)
-	    ++$unmethylated_C_unknown_count;
-	    push @match,'u'; # converted C, not methylated, in Unknown context
+	  elsif ($second_downstream_base eq 'N' or $second_downstream_base eq 'X'){
+	    ++$methyl_C_unknown_count; # if the second downstream base was an N we cannot really be sure about the sequence context (as it might have been a CHH or CHG)
+	    $call = 'U'; # protected C, methylated, in Unknown context
 	  }
 	  else{
-	    ### C in not in CpG-context, determining the second downstream base context
-	    my $second_downstream_base = $genomic[$index+2];
-
-	    if ($second_downstream_base eq 'G'){
-	      ++$unmethylated_CHG_count;
-	      push @match,'x'; # converted C, not methylated, in CHG context
-	    }
-	    elsif ($second_downstream_base eq 'N' or $second_downstream_base eq 'X'){
-	      ++$unmethylated_C_unknown_count; # if the second downstream base was an N we cannot really be sure about the sequence context (as it might have been a CHH or CHG)
-	      push @match,'u'; # converted C, not methylated, in Unknown context
-	    }
-	    else{
-	      ++$unmethylated_CHH_count;
-	      push @match,'h'; # converted C, not methylated, in CHH context
-	    }
+	    ++$methyl_CHH_count;
+	    $call = 'H'; # protected C, methylated, in CHH context
 	  }
 	}
-	### all other mismatches are not of interest for a methylation call
-	else {
-	  push @match,'.';
+      }
+      elsif ($seq_base eq 'T') {
+	### genomic C converted to T in the observed sequence: not methylated
+	my $downstream_base = substr($genomic_sequence,$index+1,1);
+	if ($downstream_base eq 'G'){
+	  ++$unmethylated_CpG_count;
+	  $call = 'z'; # converted C, not methylated, in CpG context
+	}
+	elsif ($downstream_base eq 'N' or $downstream_base eq 'X'){ # if the downstream base was an N we cannot really be sure about the sequence context (as it might have been a CG)
+	  ++$unmethylated_C_unknown_count;
+	  $call = 'u'; # converted C, not methylated, in Unknown context
+	}
+	else{
+	  ### C in not in CpG-context, determining the second downstream base context
+	  my $second_downstream_base = substr($genomic_sequence,$index+2,1);
+	  if ($second_downstream_base eq 'G'){
+	    ++$unmethylated_CHG_count;
+	    $call = 'x'; # converted C, not methylated, in CHG context
+	  }
+	  elsif ($second_downstream_base eq 'N' or $second_downstream_base eq 'X'){
+	    ++$unmethylated_C_unknown_count; # if the second downstream base was an N we cannot really be sure about the sequence context (as it might have been a CHH or CHG)
+	    $call = 'u'; # converted C, not methylated, in Unknown context
+	  }
+	  else{
+	    ++$unmethylated_CHH_count;
+	    $call = 'h'; # converted C, not methylated, in CHH context
+	  }
 	}
       }
-      else{
-	die "There can be only 2 possibilities\n";
+      ### all other mismatches at a genomic C are not of interest for a methylation call and stay '.'
+      else {
+	next;
       }
+      substr($methylation_call,$index,1) = $call;
     }
   }
   elsif ($read_conversion eq 'GA'){
-    # print join ("\n",'***',$identifier,$sequence_actually_observed,$genomic_sequence,$read_conversion,'***'),"\n";
+    ### seq[$index] aligns with genomic[$index+2]; context is read from the upstream genomic bases (genomic[$index+1] and genomic[$index])
+    my $start = 2;
+    while ( (my $gpos = index($genomic_sequence,'G',$start)) >= 0 ){
+      $start = $gpos + 1;
+      my $index = $gpos - 2;
+      last if ($index >= $len); ### remaining 'G's are beyond the read
 
-    for my $index (0..$#seq) {
-      if ($seq[$index] eq $genomic[$index+2]) {
-	### The residue can only be a G if the C on the other strand was not converted to T, i.e. protected my methylation
-	if ($genomic[$index+2] eq 'G') {
-	  ### If the residue is a G we want to know if the C on the other strand was in CpG, CHG or CHH context, therefore we need
-	  ### to look if the base upstream is a C
+      my $seq_base = substr($sequence_actually_observed,$index,1);
+      my $call;
 
-	  my $upstream_base = $genomic[$index+1];
-
-	  if ($upstream_base eq 'C'){
-	    ++$methyl_CpG_count;
-	    push @match,'Z'; # protected C on opposing strand, methylated, in CpG context
-	  }
-	  elsif ($upstream_base eq 'N' or $upstream_base eq 'X'){ # if the upstream base was an N we cannot really be sure about the sequence context (as it might have been a CG)
-	    ++$methyl_C_unknown_count;
-	    push @match,'U'; # protected C on opposing strand, methylated, in Unknown context
-	  }
-	  else{
-	    ### C in not in CpG-context, determining the second upstream base context
-	    my $second_upstream_base = $genomic[$index];
-
-	    if ($second_upstream_base eq 'C'){
-	      ++$methyl_CHG_count;
-	      push @match,'X'; # protected C on opposing strand, methylated, in CHG context
-	    }
-	    elsif ($second_upstream_base eq 'N' or $second_upstream_base eq 'X'){
-	      ++$methyl_C_unknown_count; # if the second upstream base was an N we cannot really be sure about the sequence context (as it might have been a CHH or CHG)
-	      push @match,'U'; # protected C, methylated, in Unknown context
-	    }
-	    else{
-	      ++$methyl_CHH_count;
-	      push @match,'H'; # protected C on opposing strand, methylated, in CHH context
-	    }
-	  }
+      if ($seq_base eq 'G') {
+	### The residue can only be a G if the C on the other strand was not converted to T, i.e. protected by methylation
+	my $upstream_base = substr($genomic_sequence,$index+1,1);
+	if ($upstream_base eq 'C'){
+	  ++$methyl_CpG_count;
+	  $call = 'Z'; # protected C on opposing strand, methylated, in CpG context
+	}
+	elsif ($upstream_base eq 'N' or $upstream_base eq 'X'){ # if the upstream base was an N we cannot really be sure about the sequence context (as it might have been a CG)
+	  ++$methyl_C_unknown_count;
+	  $call = 'U'; # protected C on opposing strand, methylated, in Unknown context
 	}
 	else{
-	  push @match, '.';
-	}
-      }
-      elsif ($seq[$index] ne $genomic[$index+2]) {
-	### for the methylation call we are only interested in mismatches involving cytosines (in the genomic sequence) which were converted to Ts
-	### on the opposing strand, so G to A conversions in the actually observed sequence
-	if ($genomic[$index+2] eq 'G' and $seq[$index] eq 'A') {
-	  ### If the C residue on the opposing strand was converted to T then we will see an A in the currently observed sequence. We want to know if
-	  ### the C on the opposing strand was it was in CpG, CHG or CHH context, therefore we need to look one (or two) bases upstream!
-
-	  my $upstream_base = $genomic[$index+1];
-
-	  if ($upstream_base eq 'C'){
-	    ++$unmethylated_CpG_count;
-	    push @match,'z'; # converted C on opposing strand, not methylated, in CpG context
+	  ### C in not in CpG-context, determining the second upstream base context
+	  my $second_upstream_base = substr($genomic_sequence,$index,1);
+	  if ($second_upstream_base eq 'C'){
+	    ++$methyl_CHG_count;
+	    $call = 'X'; # protected C on opposing strand, methylated, in CHG context
 	  }
-	  elsif ($upstream_base eq 'N' or $upstream_base eq 'X'){ # if the upstream base was an N we cannot really be sure about the sequence context (as it might have been a CG)
-	    ++$unmethylated_C_unknown_count;
-	    push @match,'u'; # converted C on opposing strand, not methylated, in Unknown context
+	  elsif ($second_upstream_base eq 'N' or $second_upstream_base eq 'X'){
+	    ++$methyl_C_unknown_count; # if the second upstream base was an N we cannot really be sure about the sequence context (as it might have been a CHH or CHG)
+	    $call = 'U'; # protected C, methylated, in Unknown context
 	  }
 	  else{
-	    ### C in not in CpG-context, determining the second upstream base context
-	    my $second_upstream_base = $genomic[$index];
-
-	    if ($second_upstream_base eq 'C'){
-	      ++$unmethylated_CHG_count;
-	      push @match,'x'; # converted C on opposing strand, not methylated, in CHG context
-	    }
-	    elsif ($second_upstream_base eq 'N' or $second_upstream_base eq 'X'){
-	      ++$unmethylated_C_unknown_count; # if the second upstream base was an N we cannot really be sure about the sequence context (as it might have been a CHH or CHG)
-	      push @match,'u'; # converted C on opposing strand, not methylated, in Unknown context
-	    }
-	    else{
-	      ++$unmethylated_CHH_count;
-	      push @match,'h'; # converted C on opposing strand, not methylated, in CHH context
-	    }
+	    ++$methyl_CHH_count;
+	    $call = 'H'; # protected C on opposing strand, methylated, in CHH context
 	  }
 	}
-	### all other mismatches are not of interest for a methylation call
-	else {
-	  push @match,'.';
+      }
+      elsif ($seq_base eq 'A') {
+	### C on the opposing strand converted to T -> observed as A: not methylated
+	my $upstream_base = substr($genomic_sequence,$index+1,1);
+	if ($upstream_base eq 'C'){
+	  ++$unmethylated_CpG_count;
+	  $call = 'z'; # converted C on opposing strand, not methylated, in CpG context
+	}
+	elsif ($upstream_base eq 'N' or $upstream_base eq 'X'){ # if the upstream base was an N we cannot really be sure about the sequence context (as it might have been a CG)
+	  ++$unmethylated_C_unknown_count;
+	  $call = 'u'; # converted C on opposing strand, not methylated, in Unknown context
+	}
+	else{
+	  ### C in not in CpG-context, determining the second upstream base context
+	  my $second_upstream_base = substr($genomic_sequence,$index,1);
+	  if ($second_upstream_base eq 'C'){
+	    ++$unmethylated_CHG_count;
+	    $call = 'x'; # converted C on opposing strand, not methylated, in CHG context
+	  }
+	  elsif ($second_upstream_base eq 'N' or $second_upstream_base eq 'X'){
+	    ++$unmethylated_C_unknown_count; # if the second upstream base was an N we cannot really be sure about the sequence context (as it might have been a CHH or CHG)
+	    $call = 'u'; # converted C on opposing strand, not methylated, in Unknown context
+	  }
+	  else{
+	    ++$unmethylated_CHH_count;
+	    $call = 'h'; # converted C on opposing strand, not methylated, in CHH context
+	  }
 	}
       }
-      else{
-	die "There can be only 2 possibilities\n";
+      ### all other mismatches at a genomic G are not of interest for a methylation call and stay '.'
+      else {
+	next;
       }
+      substr($methylation_call,$index,1) = $call;
     }
   }
   else{
     die "Strand conversion info is required to perform a methylation call\n";
   }
-
-  my $methylation_call = join ("",@match);
 
   $counting{total_meCHH_count} += $methyl_CHH_count;
   $counting{total_meCHG_count} += $methyl_CHG_count;
@@ -5011,8 +4994,6 @@ sub methylation_call{
   $counting{total_unmethylated_CHG_count} += $unmethylated_CHG_count;
   $counting{total_unmethylated_CpG_count} += $unmethylated_CpG_count;
   $counting{total_unmethylated_C_unknown_count} += $unmethylated_C_unknown_count;
-
-  # print "\n$sequence_actually_observed\n$genomic_sequence\n",@match,"\n$read_conversion\n\n";
 
   return $methylation_call;
 }


### PR DESCRIPTION
## Summary

Speeds up the `bismark` aligner by rewriting the four hottest per-read Perl subroutines, with **byte-identical output** (alignments and methylation calls are unchanged). This is purely CPU/algorithmic and is independent of the I/O-threading work in #1004.

## Motivation

Profiling a single-instance run (Devel::NYTProf, 100k reads) showed ~90% of Bismark's own Perl time (i.e. excluding the aligner subprocess) concentrated in four per-read subs. On a small genome where Bowtie2 is fast, this Perl overhead is a large share of wall-clock; it scales with read count, so it matters most for WGBS.

## Changes (each bit-identical, with a fallback)

- **`hemming_dist`** — count mismatches with `($a ^ $b) =~ tr/\0//c` instead of splitting both strings into per-character arrays. ~30× faster in isolation. Falls back to the original loop if the two strings ever differ in length.
- **`methylation_call`** — start from an all-`.` call string and visit only the genomic `C` (CT read) / `G` (GA read) positions via `index()`, instead of splitting both strings and branching at every base. Identical call string and all eight context counters. ~3× faster in isolation.
- **`make_mismatch_string`** (MD:Z tag) — locate genomic mismatches in one C-level pass with `($a ^ $b) =~ /[^\0]/g` instead of a per-base `substr` loop; `X` padding handling and deletion processing unchanged. ~10× faster in isolation. Length-guarded fallback to the original loop.
- **`check_results_single_end` / `check_results_paired_end`** — split each Bowtie2/HISAT2 output line once and reuse the fields, instead of splitting the same line twice.

Each rewrite was fuzz-tested for identity against the original (200k–300k randomized reads per sub, including `N`/`X` padding and random mismatches) in addition to the full-pipeline check below.

## End-to-end effect

`bismark` alignment of 1,000,000 single-end reads, single instance, best of 3:

| | wall-clock |
|---|---|
| `master` | 61.7 s |
| this branch | **36.7 s** |

≈ **40% faster** alignment (1.7×). The same per-read savings apply per instance under `--parallel`.

## Correctness verification

Full SE + PE pipeline (align → deduplicate → methylation-extract) run with `master` and with this branch on the bundled `test_files/` data; all output BAMs are byte-identical after `samtools view | sort`. Methylation extraction and downstream files are unaffected because the SAM records (including the `XM`/`MD`/`NM` tags) are unchanged.

## Notes

- `deduplicate_bismark` (~2.4 µs/record) and `bismark_methylation_extractor` (sort/IO-bound, with an existing linear-CIGAR fast path) are not per-read-Perl-bound to the same degree, so no rewrites were applied there.
