### PR TITLE
docs: announce Perl maintenance freeze; redirect new work to the Rust suite

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Thank you for contributing to Bismark! -->
+
+> [!IMPORTANT]
+> **The Perl version of Bismark is in maintenance freeze** (this is the default branch). It accepts
+> **critical bug and security fixes only**. New features and performance changes should target the
+> **Bismark Rust suite** (`rust/iron-chancellor`) — please see [CONTRIBUTING.md](../CONTRIBUTING.md).
+> Thank you for understanding!
+
+## What does this PR do?
+
+
+## Type of change
+
+- [ ] Critical bug fix (allowed during the Perl maintenance freeze)
+- [ ] Security fix (allowed)
+- [ ] Documentation / typo
+- [ ] New feature or performance change — **please retarget to the Rust suite** (`rust/iron-chancellor`); see [CONTRIBUTING.md](../CONTRIBUTING.md)
+
+## Checklist
+
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and understand the Perl maintenance freeze.
+- [ ] For a bug or security fix: I opened an issue describing it first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to Bismark
+
+Thank you for your interest in contributing to Bismark.
+
+## Bismark (Perl) is in maintenance freeze
+
+The Perl version of Bismark (`v0.25.x`, this repository's default branch) is in **maintenance freeze**.
+It now receives **critical correctness and security fixes only** — no new features and no performance
+changes.
+
+Bismark is being reimplemented in Rust. The
+**[Bismark Rust suite](https://felixkrueger.github.io/Bismark/rust/overview/)** reimplements every tool
+and is byte-identical to Perl `v0.25.1` on the faithful default path (the opt-in combined-index and
+`rammap` modes are concordance-gated rather than byte-identical). It is faster, lower-memory,
+worker-invariant, and actively developed, and it adds capabilities the Perl architecture cannot reach.
+It is currently in beta. At the Rust general release the Perl code will be archived as tagged legacy,
+following the model of [Salmon's `cpp` branch](https://github.com/COMBINE-lab/salmon).
+
+This is a freeze, not a judgement on the quality of contributions. It lets development effort go where
+it now compounds.
+
+## What is still welcome on the Perl version
+
+- **Critical bug fixes** — a correctness regression or a crash.
+- **Security fixes.**
+
+For either, please **open an issue first** describing the problem, so we can confirm it belongs on the
+frozen branch before you invest time in a pull request.
+
+## What should go to the Rust suite instead
+
+Everything else: **new features, performance work, new aligners or modes, and refactors.** The Rust
+suite is developed on the **`rust/iron-chancellor`** branch. Good starting points:
+
+- [Rust rewrite: scope and motivation](https://felixkrueger.github.io/Bismark/rust/overview/)
+- [Benchmarks](https://felixkrueger.github.io/Bismark/rust/benchmarks/)
+
+## A note on performance contributions
+
+Performance contributions are genuinely appreciated. The reason they now belong in the Rust suite
+rather than the Perl code is **end-to-end**: the Rust tools are faster *and* lower-memory *and*
+worker-invariant, and they keep their gains as cores are added, where the Perl wrapper's single-threaded
+design saturates. That combination is not reachable by a Perl patch, however well its hot loops are
+optimised (see the [benchmarks](https://felixkrueger.github.io/Bismark/rust/benchmarks/)). Performance
+changes to the Perl version will not be merged during the freeze; we would much rather see the same
+effort directed at the Rust suite, where it carries forward instead of into a frozen codebase.
+
+## Getting in touch
+
+Please [open an issue](https://github.com/FelixKrueger/Bismark/issues) — the pinned freeze announcement
+has more detail and is a good place to ask where a contribution best fits. Thank you again for
+contributing to Bismark.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/bismark/README.html)
 
+> [!IMPORTANT]
+> **The Perl version of Bismark is in maintenance freeze.** Bismark `v0.25.x` (this codebase) now
+> receives **critical correctness and security fixes only** — no new features or performance changes.
+> It is being succeeded by the **[Bismark Rust suite](https://felixkrueger.github.io/Bismark/rust/overview/)**,
+> which is byte-identical to `v0.25.1` on the faithful default path, faster, lower-memory, and actively
+> developed (currently in beta); the Perl code will be archived as tagged legacy at the Rust general
+> release. **New contributions, including performance work, should target the Rust suite** — please read
+> [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Thank you!
+
 > **See the documentation**: <https://felixkrueger.github.io/Bismark>
 
 Bismark is a program to map bisulfite treated sequencing reads to a genome of interest and perform methylation calls in a single step. The output can be easily imported into a genome viewer, such as [SeqMonk](http://www.bioinformatics.babraham.ac.uk/projects/seqmonk/), and enables a researcher to analyse the methylation levels of their samples straight away. Its main features are:


### PR DESCRIPTION
## Summary

Declares the **Perl version of Bismark (`v0.25.x`) in maintenance freeze** and redirects new contributions — features and performance included — to the Bismark Rust suite. Two-phase: maintenance freeze **now** (critical bug + security fixes only) → archived as tagged legacy at the Rust general release (following Salmon's `cpp`-branch precedent).

Motivated in part by recent high-quality Perl performance PRs (#1006, #1007): genuinely good work, but the Rust suite already realises these gains end-to-end and retains them under multi-core scaling and at lower memory.

## Changes (all on `master`, the default branch)

- **README.md** — a `> [!IMPORTANT]` maintenance-freeze banner below the bioconda badge.
- **CONTRIBUTING.md** (new) — the freeze policy: what's still accepted on Perl (critical bug + security fixes, issue-first), what should go to Rust (features / performance / new modes), and an end-to-end note on *why* performance work belongs in the Rust suite.
- **.github/PULL_REQUEST_TEMPLATE.md** (new) — a short freeze notice + a type-of-change checklist that routes feature/perf PRs to the Rust suite. Prefills on every new PR against `master`.

## Notes

- The Rust suite is described as "currently in beta"; "byte-identical to v0.25.1" is qualified to the faithful default path (combined-index / `rammap` are concordance-gated), with the full caveat in CONTRIBUTING.
- A companion docs PR reconciles the Rust "Scope of the rewrite" page to the same two-phase wording.
- A pinned announcement Issue will follow once this merges.
