### PR TITLE
docs(rust): reconcile Scope-page freeze wording to two-phase

### DIFF
--- a/docs/src/content/docs/rust/overview.md
+++ b/docs/src/content/docs/rust/overview.md
@@ -34,8 +34,9 @@ The goals of the rewrite follow from this profile: faster and lower-memory post-
 on a maintainable modern codebase, while producing output that is **byte-identical to Perl `v0.25.1`**.
 Byte-identity is the correctness contract that lets the Rust suite stand in for the Perl one without
 revalidating an established pipeline. The measured speed-ups for each tool are on the
-[benchmarks page](/Bismark/rust/benchmarks/). The Perl version is being frozen as tagged legacy at the
-Rust general release, following the precedent of Salmon's `cpp` branch.
+[benchmarks page](/Bismark/rust/benchmarks/). The Perl version is in maintenance
+freeze (critical correctness and security fixes only) and will be archived as tagged legacy at the Rust
+general release, following the precedent of Salmon's `cpp` branch.
 
 ## What stays the same
 


### PR DESCRIPTION
## Summary

Reconciles the freeze wording on the Rust "Scope of the rewrite" page with the new Perl maintenance-freeze notice on `master`. The page previously said the Perl version is frozen "at the Rust general release" (future tense); it now states the **two-phase** policy used everywhere else: in maintenance freeze **now** (critical correctness and security fixes only) → archived as tagged legacy at the Rust general release.

Companion to the `master` freeze-notice PR. One sentence changed; docs build green (25 pages), zero em-dashes, route unchanged.
