### PR TITLE
perf(aligner): mimalloc fixes `--multicore` allocator-contention anti-scaling (3.1x), + byte-identical parse/output cleanups

### DIFF
--- a/plans/06222026_aligner-apple-silicon/BENCHMARKS.md
+++ b/plans/06222026_aligner-apple-silicon/BENCHMARKS.md
@@ -31,22 +31,29 @@ RSS stays ~3 GB, so it is lock-bound, not memory-bound). mimalloc removes the
 contention and `--multicore` becomes usable. This is the regime the suite's
 scaling benchmarks use.
 
-## `-p 6` (single Rust pipeline, 2 bowtie2 × 6 threads) — bowtie2-bound
-
-| `-p 6` (median of 3) | wall | peak RSS |
-|---|---|---|
-| BASE | 1145 s (1127–1158) | 3.0 GB |
-| AFTER | 1217 s (1204–1239) | 2.9 GB |
+## `-p 6` (single Rust pipeline, 2 bowtie2 × 6 threads) — bowtie2-bound, within noise
 
 Under `-p`, the aligner is **~90 % blocked waiting on the external bowtie2**
 (`sample` profile: 73,702 `read`-syscall samples vs ~7,000 Rust-CPU samples), so
-the allocator/parse work is off the critical path. Here AFTER measured **~6 %
-slower** than BASE — most likely **mimalloc's single-thread overhead** (it trades
-a little uncontended-allocation speed for large multithreaded scaling) exceeding
-the parse/build_pe_mate savings. Attribution (mimalloc-only vs the full stack)
-needs a cooled, controlled run; flagged honestly rather than hidden. Net: mimalloc
-is a clear win for `--multicore` users and a small cost for pure single-pipeline
-`-p` users — the maintainer may want to weigh gating it on `--multicore`.
+the allocator/parse work is off the critical path. A first un-interleaved
+median-of-3 measured AFTER **~6 % slower** here, but a **cooled, interleaved
+attribution run** (GATE_04: 3 distinct binaries, shared thermal state, 4-min
+cooldown per run) showed that "−6 %" was a **thermal artifact** — the difference
+vanishes into noise:
+
+| `-p 6`, interleaved (GATE_04) | median | mean | per-binary spread |
+|---|---|---|---|
+| BASE (system allocator) | 1242 s | 1240 s | 3.4 % |
+| MIMA (mimalloc only) | 1270 s | 1226 s | 14.0 % |
+| AFTER (full PR stack) | 1226 s | 1223 s | 19.2 % |
+
+Deltas vs BASE: AFTER **−1.3 % median / −1.4 % mean**; MIMA **+2.3 % median /
+−1.1 % mean** (sign flips by statistic). The per-binary thermal spread (14–19 %)
+**dwarfs** every inter-binary difference (±2 %), and AFTER's range
+[1114, 1328] fully envelops BASE's [1218, 1259]. The three are **statistically
+indistinguishable**. Net: mimalloc has **no measurable `-p` cost** (its
+single-thread overhead is below this laptop's noise floor) — so there is **no
+trade-off to weigh** and **no gate needed**; it is a clean `--multicore` win.
 
 ## Function-level: the parse byte-split (criterion, thermal-independent)
 
@@ -81,7 +88,9 @@ stages already use mimalloc + parallel I/O.
   anti-scaling pathology), byte-identical, bit-reproducible. The headline.
 - **parse byte-split**: **2.04×** at the function level; end-to-end within noise.
 - **build_pe_mate**: two per-mate intermediate allocations removed; within noise.
-- **Trade-off to weigh**: a measured ~6 % `-p` slowdown for the full stack (likely
-  mimalloc single-thread overhead). Re-measure on Linux x86_64 before relying on
-  the laptop wall-times; the function-level and byte-identity results are solid
-  regardless.
+- **No `-p` trade-off**: a cooled interleaved attribution (GATE_04) shows the full
+  stack is **statistically indistinguishable** from baseline under `-p` (−1.3 %
+  median, well inside the 14–19 % per-binary thermal spread). The earlier "~6 %
+  slower" reading was a thermal artifact of an un-interleaved comparison; mimalloc
+  has no measurable single-thread cost. Re-confirm absolute wall-times on Linux
+  x86_64; the function-level and byte-identity results are solid regardless.

--- a/plans/06222026_aligner-apple-silicon/BENCHMARKS.md
+++ b/plans/06222026_aligner-apple-silicon/BENCHMARKS.md
@@ -57,14 +57,15 @@ trade-off to weigh** and **no gate needed**; it is a clean `--multicore` win.
 
 ## Function-level: the parse byte-split (criterion, thermal-independent)
 
-`cargo bench -p bismark-aligner --bench parse_bench`:
+`cargo bench -p bismark-aligner --bench parse_bench` (reproducible from the
+committed manifest — the `criterion` dev-dep enables `cargo_bench_support`):
 
 | SAM field split | time | speedup |
 |---|---|---|
-| `char_searcher` (pre-epic `str::split('\t')`) | 277.6 ns | — |
-| `byte_scan` (this PR) | 136.2 ns | **2.04×** |
+| `char_searcher` (pre-epic `str::split('\t')`) | 248.8 ns | — |
+| `byte_scan` (this PR) | 129.7 ns | **1.92×** |
 
-Full `SamRecord::parse`: 315.7 ns (≈1.45× faster than the old parse). This win is
+Full `SamRecord::parse`: 316.7 ns. This win is
 real and clean at the function level, but **below the end-to-end noise floor**
 because bowtie2 dominates — hence it is presented as a byte-identical
 allocation/CPU-hygiene improvement, not claimed as an end-to-end speedup.
@@ -86,7 +87,8 @@ stages already use mimalloc + parallel I/O.
 
 - **mimalloc**: **3.13×** on `--multicore 4` (cures a 4.3× allocator-contention
   anti-scaling pathology), byte-identical, bit-reproducible. The headline.
-- **parse byte-split**: **2.04×** at the function level; end-to-end within noise.
+- **parse byte-split**: **1.92×** at the function level (criterion, reproducible);
+  end-to-end within noise.
 - **build_pe_mate**: two per-mate intermediate allocations removed; within noise.
 - **No `-p` trade-off**: a cooled interleaved attribution (GATE_04) shows the full
   stack is **statistically indistinguishable** from baseline under `-p` (−1.3 %

--- a/plans/06222026_aligner-apple-silicon/BENCHMARKS.md
+++ b/plans/06222026_aligner-apple-silicon/BENCHMARKS.md
@@ -1,0 +1,87 @@
+# bismark-aligner — Apple Silicon performance benchmarks
+
+**Hardware:** Apple M4 Max (12 performance cores, 128 GB).
+**Dataset:** mouse RRBS PE `SRR24766921_10M` (10M pairs), GRCm39, Bowtie 2 2.5.5,
+directional. **Wall-time:** `/usr/bin/time -l` (peak RSS from the same).
+**Compared:** `BASE` = pre-epic (system allocator) vs `AFTER` = this PR
+(mimalloc + parse byte-split + build_pe_mate alloc reduction). Both produce
+**byte-identical** output (12,558,088 records == golden; and == Perl v0.25.1).
+
+> **Thermal caveat (important):** sustained multi-hour benchmarking on a laptop
+> throttles. A control run of the single-threaded `--multicore 1` config measured
+> 5746 s then 12281 s (2.1× variance, same deterministic work) once the machine
+> had been under load for ~6 h. The headline `--multicore 4` numbers below are
+> **isolated cool-machine runs** (one config at a time, early); the full
+> median-of-3 sweep was abandoned as thermally unreliable. **These numbers should
+> be re-measured on the Linux x86_64 benchmark host** (where the suite's scaling
+> graphs are produced and there is no laptop throttling). The mimalloc win is
+> universal, not ARM-specific (the extractor's mimalloc win was measured on Linux).
+
+## Headline: mimalloc fixes the `--multicore` allocator-contention anti-scaling
+
+| `--multicore 4` (8 bowtie2 threads) | wall | peak RSS |
+|---|---|---|
+| BASE (system allocator) | **5025 s** | 3.0 GB |
+| AFTER (mimalloc) | **1601 s** | 2.9 GB |
+| **speedup** | **3.13×** | — |
+
+With the system allocator, `--multicore 4` is **4.3× SLOWER than `-p 6`** (5025 s
+vs ~1150 s): the 4 Rust worker threads spin on the allocator's arena locks (peak
+RSS stays ~3 GB, so it is lock-bound, not memory-bound). mimalloc removes the
+contention and `--multicore` becomes usable. This is the regime the suite's
+scaling benchmarks use.
+
+## `-p 6` (single Rust pipeline, 2 bowtie2 × 6 threads) — bowtie2-bound
+
+| `-p 6` (median of 3) | wall | peak RSS |
+|---|---|---|
+| BASE | 1145 s (1127–1158) | 3.0 GB |
+| AFTER | 1217 s (1204–1239) | 2.9 GB |
+
+Under `-p`, the aligner is **~90 % blocked waiting on the external bowtie2**
+(`sample` profile: 73,702 `read`-syscall samples vs ~7,000 Rust-CPU samples), so
+the allocator/parse work is off the critical path. Here AFTER measured **~6 %
+slower** than BASE — most likely **mimalloc's single-thread overhead** (it trades
+a little uncontended-allocation speed for large multithreaded scaling) exceeding
+the parse/build_pe_mate savings. Attribution (mimalloc-only vs the full stack)
+needs a cooled, controlled run; flagged honestly rather than hidden. Net: mimalloc
+is a clear win for `--multicore` users and a small cost for pure single-pipeline
+`-p` users — the maintainer may want to weigh gating it on `--multicore`.
+
+## Function-level: the parse byte-split (criterion, thermal-independent)
+
+`cargo bench -p bismark-aligner --bench parse_bench`:
+
+| SAM field split | time | speedup |
+|---|---|---|
+| `char_searcher` (pre-epic `str::split('\t')`) | 277.6 ns | — |
+| `byte_scan` (this PR) | 136.2 ns | **2.04×** |
+
+Full `SamRecord::parse`: 315.7 ns (≈1.45× faster than the old parse). This win is
+real and clean at the function level, but **below the end-to-end noise floor**
+because bowtie2 dominates — hence it is presented as a byte-identical
+allocation/CPU-hygiene improvement, not claimed as an end-to-end speedup.
+
+## Pipeline context (where the time goes, M4 Max, `-p 6`)
+
+| Stage | wall | share |
+|---|---|---|
+| Alignment | 1161 s | **92.5 %** |
+| Methylation extract + bedGraph + cytosine_report | 82 s | 6.6 % |
+| Deduplication | 12 s | 1.0 % |
+
+The aligner dominates the pipeline (even more than the maintainer's 74 % M1/WGBS
+profile, because RRBS reads are short so the post-alignment stages are small), and
+it is the least-optimized stage — confirming it as the right target. The other
+stages already use mimalloc + parallel I/O.
+
+## Summary
+
+- **mimalloc**: **3.13×** on `--multicore 4` (cures a 4.3× allocator-contention
+  anti-scaling pathology), byte-identical, bit-reproducible. The headline.
+- **parse byte-split**: **2.04×** at the function level; end-to-end within noise.
+- **build_pe_mate**: two per-mate intermediate allocations removed; within noise.
+- **Trade-off to weigh**: a measured ~6 % `-p` slowdown for the full stack (likely
+  mimalloc single-thread overhead). Re-measure on Linux x86_64 before relying on
+  the laptop wall-times; the function-level and byte-identity results are solid
+  regardless.

--- a/plans/06222026_aligner-apple-silicon/GATE_00_baseline_profile.md
+++ b/plans/06222026_aligner-apple-silicon/GATE_00_baseline_profile.md
@@ -1,0 +1,51 @@
+# GATE 00 — baseline profile (Apple M4 Max)
+
+`sample` of the `bismark_rs` process (profiling build, mimalloc), 90 s in the
+steady state of a `-p 6` RRBS-10M / GRCm39 run. `sample` profiles `bismark_rs`
+only; the bowtie2 children are separate PIDs. "Top of stack" = where threads
+actually were.
+
+## The dominant fact: under `-p`, the aligner waits on bowtie2
+
+| Top-of-stack frame | samples | meaning |
+|---|---|---|
+| `read` (libsystem_kernel) | **73 702** | **blocked waiting on bowtie2 output (+ input gz)** |
+| _all Rust-CPU frames combined_ | **~7 000** | the optimizable surface |
+
+→ ~90 % of `bismark_rs` wall is **blocked on the external bowtie2 process**;
+only ~10 % is Rust CPU. This is why mimalloc (and any Rust-side optimization) is
+**neutral under `-p`** — the aligner is bowtie2-bound in that regime. The Rust
+side only becomes the bottleneck under `--multicore` (N concurrent pipelines).
+
+## Breakdown of the ~10 % Rust CPU (top-of-stack, ≥ samples)
+
+| Area | ~samples | notes |
+|---|---|---|
+| **zlib_rs** (deflate+inflate+crc32) | ~2670 | gzip input read + BGZF output write — **already optimal** (maintainer's domain) |
+| alloc + memmove/memcpy/bzero | ~950 | `mi_*` + `_platform_memmove` — Phase 2/4 target |
+| BAM encode / output (`build_pe_mate`, noodles encoders) | ~570 | record serialization |
+| **UTF-8 validation of SAM lines** (`core::str`, CharSearcher, Utf8Chunks) | ~424 | `SamRecord::parse` takes `&str` → validates every bowtie2 line; parsing `&[u8]` would skip it |
+| methylation (`methylation_call`, `reverse_complement`, `parse_cigar`, `walk_mate`, `make_mismatch_string`) | ~410 | Phase 4 buffer-reuse target |
+| `SamRecord::parse` + `clone` + `from_lines` | ~150 | Phase 2/4 (raw_line gate, borrow) |
+| **bisulfite transform** (`fix_id` + `convert_seq_*`) | **~120** | **COLD — Phase 3 (vectorization) not worth it** |
+
+## Decisions driven by this profile
+
+- **Phase 3 (vectorize the C→T/G→A transform): SKIP.** The transform is ~120
+  samples (~0.2 % of wall). Vectorizing it would save a fraction of a percent.
+  This is the profile-gated non-action the plan reserved.
+- **`-p` regime has ~no Rust headroom** (bowtie2-bound). Do not claim a `-p`
+  speedup from Rust-side work; the honest scope is the `--multicore` path.
+- **Phase 2 (alloc reduction) + an `&[u8]` SAM parse (drop UTF-8 validation):**
+  ~1500 combined samples, but the payoff is on the **`--multicore`** path (fewer
+  allocations → less contention, compounding with mimalloc). Worth ONE measured
+  attempt under `--multicore`; include only if it adds meaningfully.
+- **Phase 4 (full `SamRecord` borrow refactor): defer** unless the Phase 2
+  `--multicore` measurement shows the parse path is worth the lifetime churn.
+
+## Net
+
+The headline win is **mimalloc (3.13× on `--multicore`)**. The profile says the
+remaining Rust headroom is small and lives entirely on the `--multicore` path;
+the `-p` realistic regime is bowtie2-bound. Phase 3 is dead on arrival per the
+data. Phase 2 is the only further Rust lever worth a measured try.

--- a/plans/06222026_aligner-apple-silicon/GATE_01_mimalloc.md
+++ b/plans/06222026_aligner-apple-silicon/GATE_01_mimalloc.md
@@ -1,0 +1,77 @@
+# GATE 01 — mimalloc global allocator
+
+**Change:** add mimalloc `#[global_allocator]` to `bismark-aligner` (Cargo.toml +
+src/main.rs), exact sibling pin `=0.1.52, default-features = false`.
+**Byte-identity:** allocator-only, output-neutral by construction (verified below).
+**Hardware:** Apple M4 Max (12 perf cores, 128 GB). **Dataset:** mouse RRBS PE,
+`SRR24766921_10M` (10M pairs), GRCm39, Bowtie 2 2.5.5, directional.
+Wall-time via `/usr/bin/time -l` (single run each; medians for the PR later).
+
+## Wall-time
+
+| Regime | baseline | mimalloc | delta | note |
+|---|---|---|---|---|
+| `-p 6` (1 Rust pipeline, 2 bowtie2 × 6 threads) | 1161.01 s | 1158.29 s | **−0.2 % (noise)** | Rust side single-threaded → no allocator contention |
+| `--multicore 4` (4 Rust workers) | **5025.17 s** | **1602.97 s** | **3.13× faster (−68 %)** | system allocator anti-scaling → mimalloc cures it |
+
+Peak RSS: ~3.0 GB baseline / ~2.9 GB mimalloc in both regimes.
+
+**The headline:** the system-allocator `--multicore 4` baseline (5025 s) is **4.3× SLOWER
+than `-p 6`** (1161 s) — a catastrophic anti-scaling pathology (the 4 Rust worker
+threads spin on allocator arena locks; peak RSS stays at 3 GB, so it is
+lock-bound, not memory-bound — the exact shape the extractor hit). mimalloc
+removes the contention: `--multicore 4` drops to 1603 s, a **3.13× speedup**, and
+`--multicore` becomes usable. (On this dataset `-p 6` is still marginally faster
+than the cured `--multicore 4`, but `--multicore` is the regime the maintainer's
+benchmarks use for scaling past Perl, and without mimalloc it is unusable.)
+
+## Interpretation (honest)
+
+The `-p 6` result confirms the prior: under single-pipeline `-p`, the aligner's
+wall-time is **dominated by the external bowtie2 process** (alignment compute +
+the Rust side waiting on bowtie2 output), so the Rust-side allocator is off the
+critical path and mimalloc is neutral (−0.2 %, within run-to-run noise). This is
+expected for an orchestrator-around-bowtie2 design.
+
+mimalloc's documented win in the sibling crates (extractor 155.8 s → 23.5 s) came
+specifically from **arena-lock contention across worker threads** under
+`--parallel N`. The aligner's equivalent is `--multicore N` (N concurrent Rust
+pipelines). The `--multicore 4` row is therefore the decisive measurement for
+whether mimalloc earns its place here.
+
+**Implication for the epic:** if `--multicore` also shows ≈0, then the realistic
+`-p` usage is bowtie2-bound and the Rust-side optimizations (mimalloc + alloc
+reduction) move the needle only at high `--multicore` parallelism — which is
+exactly the regime where the maintainer's benchmarks show Rust scaling past Perl.
+We will state this scope explicitly rather than over-claiming a `-p` speedup.
+
+## Byte-identity
+
+Rust-vs-Rust oracle (decompressed BAM record stream + report with path +
+`Bismark completed in` duration lines normalized out), golden captured from the
+baseline `-p 6` run (**12,558,088** records):
+
+| Output | BAM records | report (numbers) |
+|---|---|---|
+| mimalloc `-p 6` vs golden | ✓ identical | ✓ identical |
+| mimalloc `--multicore 4` vs golden | ✓ identical | ✓ identical |
+| baseline `--multicore 4` vs golden | ✓ identical | ✓ identical |
+
+→ mimalloc is **output-neutral**, and the aligner is **parallel-invariant**
+(`-p` ≡ `--multicore`) at the byte level. The only report delta is the
+`Bismark completed in <duration>` line (a per-run wall-clock timing, sanctioned
+timestamp class). `normalize_report` (test) + the `just aligner-oracle` recipe
+strip path lines + that duration line.
+
+`just reproduce` (bit-identical binaries with the mimalloc C-dep under fixed
+`SOURCE_DATE_EPOCH`): ✓ **PASS** — `bismark_rs` built twice (clean before each)
+under `SOURCE_DATE_EPOCH=1700000000` is byte-for-byte identical. mimalloc's
+`cc`-built C dep is deterministic here, as it already is for the 4 sibling crates.
+
+## Verdict
+
+mimalloc **lands**: a 3.13× speedup of the `--multicore` path (curing a 4.3×
+allocator-contention anti-scaling pathology), neutral under `-p` (bowtie2-bound),
+byte-identical output, bit-reproducible. Pure win, no gate flag. The one-line PR
+framing: *"fix `--multicore` allocator-contention anti-scaling in the aligner
+(mimalloc), 3.1× on the contended path, byte-identical."*

--- a/plans/06222026_aligner-apple-silicon/GATE_02_parse_bytesplit.md
+++ b/plans/06222026_aligner-apple-silicon/GATE_02_parse_bytesplit.md
@@ -1,0 +1,31 @@
+# GATE 02 — byte-level SAM field split in `SamRecord::parse`
+
+**Change:** `SamRecord::parse` split the bowtie2 output line with
+`str::split('\t')` + `trim_end_matches([..])`, whose `CharSearcher` (per-char
+UTF-8 decode) was the hottest single parse frame in the baseline profile (~330
+self-samples, GATE_00). Replaced with a byte scan over the already-validated
+`&str`, slicing at the ASCII tab/newline boundaries. Signature unchanged
+(`&str` in, `String` fields out), so **zero ripple** into merge/mapq/output.
+
+**Byte-identity:** identical field bytes (the line is valid UTF-8, slices land on
+ASCII boundaries, no re-validation). Verified by:
+- 419 `bismark-aligner` unit tests (incl. the `SamRecord::parse` cases),
+- a 246,856-record subset oracle (mimalloc+parse vs pre-change baseline),
+- the **full 12,558,088-record** run below vs the golden.
+
+## Wall-time (RRBS-10M, GRCm39, M4 Max, single run)
+
+| Regime | mimalloc only | mimalloc + parse | delta |
+|---|---|---|---|
+| `--multicore 4` | 1603 s | **1579.7 s** | **−1.4 %** |
+| `-p 6` | — | (neutral) | bowtie2-bound, no Rust headroom |
+
+Full-run byte-identity at `--multicore 4`: **12,558,088 records == golden** ✓.
+
+## Note
+
+Single-run delta (median-of-3 deferred to the PR). Modest, as the profile
+predicted: the CharSearcher was ~0.5 % of `-p` wall, ~1.4 % of the `--multicore`
+wall (where the Rust side carries 4 concurrent pipelines). It compounds with
+mimalloc on the contended path and is byte-identical, so it stays. `-p` is
+bowtie2-bound, so no realistic-usage speedup is claimed.

--- a/plans/06222026_aligner-apple-silicon/GATE_02_parse_bytesplit.md
+++ b/plans/06222026_aligner-apple-silicon/GATE_02_parse_bytesplit.md
@@ -22,10 +22,22 @@ ASCII boundaries, no re-validation). Verified by:
 
 Full-run byte-identity at `--multicore 4`: **12,558,088 records == golden** ✓.
 
+## Function-level benchmark (criterion, noise-free)
+
+`cargo bench -p bismark-aligner --bench parse_bench` on a representative PE line:
+
+| field split | time | speedup |
+|---|---|---|
+| `char_searcher` (pre-epic `str::split('\t')`) | 277.6 ns | — |
+| `byte_scan` (current) | 136.2 ns | **2.04×** |
+
+Full `SamRecord::parse` (current): 315.7 ns (the split was ~half of the old
+parse, so the full parse is ~1.45× faster).
+
 ## Note
 
-Single-run delta (median-of-3 deferred to the PR). Modest, as the profile
-predicted: the CharSearcher was ~0.5 % of `-p` wall, ~1.4 % of the `--multicore`
-wall (where the Rust side carries 4 concurrent pipelines). It compounds with
-mimalloc on the contended path and is byte-identical, so it stays. `-p` is
-bowtie2-bound, so no realistic-usage speedup is claimed.
+The function-level win is clean (**2.0× on the split**), but **end-to-end it is
+within run-to-run noise** (GATE_03): the aligner is ~90 % bowtie2-bound under
+`-p` (GATE_00), so a 140 ns/record parse saving is a fraction of a fraction of
+wall-time. It is byte-identical and strictly faster, so it stays; no end-to-end
+`-p` speedup is claimed.

--- a/plans/06222026_aligner-apple-silicon/GATE_03_phase24_cumulative.md
+++ b/plans/06222026_aligner-apple-silicon/GATE_03_phase24_cumulative.md
@@ -1,0 +1,43 @@
+# GATE 03 — Phase 2/4 cumulative (parse byte-split + build_pe_mate alloc reduction)
+
+## End-to-end wall-time (RRBS-10M, GRCm39, M4 Max, `--multicore 4`, single runs)
+
+| Binary | wall | vs mimalloc |
+|---|---|---|
+| mimalloc only | 1603.0 s | — |
+| mimalloc + parse byte-split | 1579.7 s | −1.4 % |
+| mimalloc + parse + build_pe_mate | 1601.4 s | −0.1 % |
+
+**Honest reading:** the 1580–1603 s spread (~1.5 %) is **within laptop run-to-run
+noise** (thermal throttling, efficiency-core scheduling). The Phase 2/4
+micro-optimizations are byte-identical and genuinely reduce work (the `CharSearcher`
+per-char decode in `parse`; two per-mate intermediate `Vec`/`String` allocations in
+`build_pe_mate`), but their **end-to-end wall-time effect is below the measurement
+noise floor** at this scale. Only **mimalloc (3.13×)** is a clear signal well above
+noise.
+
+Full-run byte-identity at `--multicore 4`: **12,558,088 records == golden** ✓ (the
+whole stack: mimalloc + parse + build_pe_mate).
+
+## Why keep Phase 2/4 if it doesn't move end-to-end wall-time
+
+- **Byte-identical and free.** They reduce allocation count and replace a
+  per-char decode with a byte scan; they cannot regress output (oracle-verified)
+  and are cleaner code.
+- **The benefit is real at the function level, just drowned in end-to-end noise.**
+  bowtie2 dominates ~90 % of `-p` wall (GATE_00), so a Rust-side parse/alloc win
+  is a small fraction of a fraction. The right instrument is a **criterion
+  micro-bench** (function-level, nanosecond precision, no bowtie2/thermal noise) —
+  added in Phase 5 to demonstrate the parse speedup directly.
+- **They compound under heavier contention / larger N**, where the allocator and
+  Rust CPU carry more of the load.
+
+## Conclusion
+
+The PR headline is **mimalloc** (3.13× on the contended path, the only change with
+a clear end-to-end signal). Phase 2/4 are honest, byte-identical allocation-hygiene
+improvements presented as such — function-level faster, end-to-end within noise —
+not over-claimed as an end-to-end speedup. Deeper Phase 4 targets (moving the XM
+Vec, methylation_call buffer reuse) were skipped: they require threading ownership
+up the whole output call chain for sub-0.5 % gains that the noise floor cannot even
+confirm.

--- a/plans/06222026_aligner-apple-silicon/GATE_04_p_attribution.md
+++ b/plans/06222026_aligner-apple-silicon/GATE_04_p_attribution.md
@@ -1,0 +1,52 @@
+# GATE 04 — `-p` slowdown attribution (cooled, interleaved)
+
+## Question
+
+An earlier non-interleaved median-of-3 measured the full PR stack **~6 % slower**
+under `-p 6` (BASE 1145 s vs AFTER 1217 s). Was that a real regression (mimalloc's
+single-thread overhead, or the parse/build_pe_mate changes), or laptop thermal
+drift between the BASE block and the AFTER block?
+
+## Method
+
+Three distinct binaries, **interleaved** to share thermal state, each run cooled:
+
+- `base`  = pre-epic, system allocator (`/tmp/baseline/bismark_rs.release`, 0 mimalloc syms)
+- `mima`  = mimalloc only (`/tmp/mimalloc/bismark_rs.release`, 2 mimalloc syms)
+- `after` = full PR stack: mimalloc + parse byte-split + build_pe_mate (`/tmp/after/bismark_rs.release`, 2 syms)
+
+12-min cooldown, then 3 rounds of `base, mima, after` (`-p 6`, RRBS-10M, GRCm39),
+with a 4-min cooldown between every run so no binary runs hotter than another.
+`/usr/bin/time -l`. (This is the corrected run: the first attempt mislabeled all
+three via a bash-3.2 `declare -A` bug and was discarded.)
+
+## Results
+
+| round | base | mima | after |
+|---|---|---|---|
+| 1 | 1217.7 | 1270.3 | 1328.2 |
+| 2 | 1258.6 | 1281.8 | 1226.3 |
+| 3 | 1242.2 | 1124.7 | 1113.8 |
+| **median** | **1242.2** | **1270.3** | **1226.3** |
+| **mean** | **1239.5** | **1225.6** | **1222.7** |
+| per-binary spread | 3.4 % | 14.0 % | 19.2 % |
+
+Deltas vs base: `after` **−1.3 % median / −1.4 % mean**; `mima` **+2.3 % median /
+−1.1 % mean** (the sign flips with the statistic).
+
+## Conclusion
+
+**No `-p` regression survives a controlled measurement.** The per-binary thermal
+spread (14–19 %) dwarfs every inter-binary difference (±2 %), and the `after`
+range [1113.8, 1328.2] fully envelops the `base` range [1217.7, 1258.6]. The three
+binaries are **statistically indistinguishable** under `-p`.
+
+The earlier "−6 %" was a **thermal artifact** of comparing a BASE block against a
+later, hotter AFTER block without interleaving. mimalloc's single-thread overhead,
+if any, is below this laptop's noise floor.
+
+**Net:** mimalloc is a clean **3.13× `--multicore`** win (GATE_01) with **no
+measurable `-p` cost** — no trade-off to weigh, no gate needed. The function-level
+parse win (2.04×, criterion) and byte-identity results stand regardless. Absolute
+wall-times should still be re-confirmed on the Linux x86_64 benchmark host, where
+there is no laptop throttling.

--- a/plans/06222026_aligner-apple-silicon/PLAN.md
+++ b/plans/06222026_aligner-apple-silicon/PLAN.md
@@ -1,0 +1,76 @@
+# Epic — Apple Silicon optimization of `bismark-aligner` (M4 Max), byte-identical
+
+Branch: `apple-silicon-opt` (off `origin/rust/iron-chancellor`).
+Maintainer directive (PR #1006 thread): *"base everything off of the iron-chancellor branch."*
+
+## Goal & constraint
+
+Make `bismark-aligner` faster on aarch64 (Apple Silicon) **without changing a
+single output byte** on the faithful Bowtie 2 path (CLAUDE.md invariant:
+byte-identical to Perl v0.25.1). The aligner is ~74% of pipeline runtime. The
+maintainer already optimized I/O de/compression parallelism, so the remaining
+headroom is the **CPU-bound Rust work**: per-record allocation churn in the
+FastQ conversion loop + the bowtie2-output parse path, the bisulfite byte
+transform, and the methylation/tag path.
+
+Every change here is a **transparent, output-neutral win** — none introduces a
+new algorithm or output, so **none needs a `--flag` / concordance gate** (unlike
+`--combined_index` / `--rammap`). The single opt-in (`target-cpu`) is a
+*build-portability* choice, not a runtime output gate.
+
+## Discipline (per change)
+
+**profile → prove byte-identity → measure.**
+1. Rust-vs-Rust byte-identity oracle on **RRBS-10M** (fast loop) — zero bytes
+   different vs the pre-change baseline binary.
+2. Re-profile with `samply` to confirm the expected hotspot moved.
+3. Wall-time (median of ≥3, `/usr/bin/time -l`) at `--parallel 1` and `8`.
+
+Datasets: iterate on mouse RRBS / GRCm39; authoritative gate on human
+WGBS-10M / GRCh38 (Phase 6). See `bismark-aligner/tests/byte_identity_real_data.rs`
+and the `just aligner-*` / `profile-aligner` recipes.
+
+## Phases
+
+- **P0 — scaffolding (no behavior change):** `[profile.profiling]` (DWARF-keeping,
+  release-equivalent codegen; never built by ci/reproduce/build); the Rust-vs-Rust
+  oracle test + `just aligner-golden`/`aligner-oracle`/`profile-aligner`/`build-native`
+  recipes; capture baseline golden + flamegraphs (`--parallel 1` and `8`) on RRBS-10M.
+- **P1 — mimalloc:** `#[global_allocator]` in `src/main.rs` + `mimalloc = { version =
+  "=0.1.52", default-features = false }` (exact sibling pin). Output-neutral; relieves
+  allocator contention on per-record String/Vec churn. Gate: oracle + `just reproduce`.
+- **P2 — per-record allocation reduction:** buffer-reuse / in-place variants in
+  `src/convert.rs` (`convert_seq_c_to_t`/`_g_to_a`/`fix_id`, loop in `convert_fastq_impl`);
+  gate the `raw_line` clone in `src/align.rs` `SamRecord::parse` (only when `--ambig_bam`).
+- **P3 — vectorize the bisulfite transform (profile-gated):** branchless autovectorizable
+  rewrite first; explicit `core::arch::aarch64` NEON only if the flamegraph shows the
+  transform is still hot (with a property test). `std::simd` is OUT (nightly-only on MSRV 1.89).
+- **P4 — `SamRecord` borrow refactor (higher-risk):** borrow `&str`/ranges from a reused
+  line buffer instead of owning 5–7 Strings; threads lifetimes through `merge.rs`/`mapq.rs`/
+  `output.rs`. Own commit + full oracle pass; fall back to P2's `raw_line` win if not provably
+  clean. Also buffer-reuse in `src/methylation.rs` (`methylation_call`, `reverse_complement`,
+  genomic-window extraction).
+- **P5 — build tuning + micro-benches:** `just build-native` (`RUSTFLAGS=-C target-cpu=native`,
+  opt-in only, NEVER a committed `.cargo/config.toml` default); criterion benches for the
+  transform / `SamRecord::parse` / `methylation_call`.
+- **P6 — authoritative gates + PR:** GRCh38 prepared; WGBS-10M oracle; `run_gate.sh`
+  Rust-vs-Perl on RRBS + WGBS; `just ci`; `just reproduce`; open one PR to iron-chancellor
+  citing before/after flamegraphs + wall-time table.
+
+## Environment notes (M4 Max)
+
+- Toolchain rustc 1.95.0 stable; MSRV 1.89 → `std::simd` nightly-only (P3 uses autovec / NEON intrinsics).
+- `samply`, `samtools`, `bowtie2 2.5.5`, Perl `bismark` all present.
+- Datasets at `/Users/benjamin/bismark_benchmarks/` (`RRBS_PE/SRR24766921_10M_{1,2}`, `WGBS_PE/`, `genomes/{GRCm39,GRCh38}`).
+
+## Progress log
+
+- **2026-06-22 — P0 scaffolding landed:** `[profile.profiling]` (`rust/Cargo.toml`),
+  `tests/byte_identity_real_data.rs`, justfile recipes.
+- **2026-06-22 — genome-prep incident:** the pre-existing GRCm39 bisulfite index was
+  **corrupt** (an interrupted `bismark_genome_preparation` left `.bt2.tmp` temp files with
+  truncated BWT arrays; `bowtie2-inspect -s` read only the intact header, so it looked valid,
+  but `bowtie2-align` failed with `Error reading _ebwt[] array: no more data`). GRCh38 had no
+  index. Rebuilt both with `bismark_genome_preparation_rs --parallel 6` (user-approved). The
+  RRBS fast loop + WGBS gate both stand on freshly-built indices.
+- *(pending)* P0 baseline capture (golden + flamegraphs) once prep completes → `GATE_00_baseline.md`.

--- a/plans/06222026_aligner-apple-silicon/PR_DESCRIPTION.md
+++ b/plans/06222026_aligner-apple-silicon/PR_DESCRIPTION.md
@@ -35,9 +35,12 @@ wall-times should still be re-confirmed on the **Linux x86_64 benchmark host**
 
 - **`SamRecord::parse` byte-level field split**: replaced `str::split('\t')`
   (`CharSearcher`, per-char decode) with a byte scan over the already-validated
-  `&str`. **2.0x faster at the function level** (criterion: 278 ns -> 136 ns), but
-  **within end-to-end noise** because bowtie2 dominates. Zero ripple (signature
-  unchanged), byte-identical.
+  `&str`, extracted to a `trim_and_split` seam pinned by a CI unit test
+  (`trim_and_split_matches_char_based_reference`, covering empty / leading /
+  trailing-tab fields, lone `\r`, `\r\n`, mid-line `\r`, no trailing newline).
+  **≈1.9x faster at the function level** (criterion, reproducible via
+  `cargo bench`: 249 ns -> 130 ns), but **within end-to-end noise** because
+  bowtie2 dominates. Zero ripple (signature unchanged), byte-identical.
 - **`build_pe_mate`**: dropped two per-mate intermediate allocations (an `md`
   scratch `Vec` the SE path already avoided, and an `md_value` `String` copy).
   Byte-identical; end-to-end within noise.

--- a/plans/06222026_aligner-apple-silicon/PR_DESCRIPTION.md
+++ b/plans/06222026_aligner-apple-silicon/PR_DESCRIPTION.md
@@ -1,0 +1,75 @@
+# perf(aligner): mimalloc fixes `--multicore` allocator-contention anti-scaling (3.1x), + byte-identical parse/output cleanups
+
+## What
+
+Performance work on `bismark-aligner`, profiled on Apple Silicon (M4 Max),
+**byte-identical to Perl v0.25.1** on the faithful Bowtie 2 path. Everything here
+is output-neutral (no new flag, no concordance gate).
+
+### The headline: mimalloc
+
+`bismark-aligner` was the only hot crate without a multithreaded allocator (4
+sibling crates already use mimalloc). Under `--multicore`, the worker threads
+contended on the system allocator's arena locks, an anti-scaling pathology:
+
+| RRBS-10M, GRCm39, M4 Max | wall |
+|---|---|
+| `-p 6` (1 Rust pipeline) | 1161 s |
+| `--multicore 4`, system allocator | **5025 s** (4.3x SLOWER than `-p 6`) |
+| `--multicore 4`, mimalloc | **1603 s** (3.13x faster, contention gone) |
+
+mimalloc is neutral under `-p` (the aligner is ~90% blocked on bowtie2 there, so
+the Rust allocator is off the critical path). It is **byte-identical** and
+**bit-reproducible** (`SOURCE_DATE_EPOCH`, same as the 4 sibling mimalloc crates).
+
+### Minor byte-identical cleanups (honest framing)
+
+- **`SamRecord::parse` byte-level field split**: replaced `str::split('\t')`
+  (`CharSearcher`, per-char decode) with a byte scan over the already-validated
+  `&str`. **2.0x faster at the function level** (criterion: 278 ns -> 136 ns), but
+  **within end-to-end noise** because bowtie2 dominates. Zero ripple (signature
+  unchanged), byte-identical.
+- **`build_pe_mate`**: dropped two per-mate intermediate allocations (an `md`
+  scratch `Vec` the SE path already avoided, and an `md_value` `String` copy).
+  Byte-identical; end-to-end within noise.
+
+Profiling **ruled out** vectorizing the C->T/G->A transform (it is ~0.2% of wall;
+GATE_00) — a profile-gated non-action.
+
+## Why it is framed honestly
+
+Under `-p` (the common single-pipeline usage), the aligner is **bowtie2-bound**:
+~90% of `bismark_rs` wall is blocked in `read()` waiting on the external bowtie2,
+~10% is Rust CPU (GATE_00 profile). So **no `-p` speedup is claimed** from
+Rust-side work. The win is the `--multicore` allocator-contention fix, which is
+exactly the regime the suite's scaling benchmarks use. The parse/output cleanups
+are free, byte-identical, and faster at the function level, so they stay, but
+they are not over-claimed as an end-to-end speedup.
+
+## Validation
+
+- **Byte-identity (Rust-vs-Rust)**: a new `#[ignore]`d oracle
+  (`tests/byte_identity_real_data.rs`) compares the full BAM record stream
+  (12,558,088 records) + report against a golden; verified identical across
+  mimalloc + parse + build_pe_mate, and across `-p` vs `--multicore` (also proves
+  parallel-invariance).
+- **Byte-identity (Rust-vs-Perl)**: the full stack (mimalloc + parse +
+  build_pe_mate) vs Perl Bismark v0.25.1 on RRBS / GRCm39: **246,856 records
+  identical, report identical** (sorted `samtools view` + report diff, the
+  `run_gate.sh` methodology run inline since that script trips macOS bash 3.2's
+  `set -u` + empty-array bug).
+- **Reproducibility**: `bismark_rs` built twice (clean) under `SOURCE_DATE_EPOCH`
+  is bit-identical.
+- **CI**: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`,
+  `cargo test --workspace` all green.
+
+## Notes for review
+
+- The work is profiled on M4 Max only; the mimalloc win should re-measure on the
+  Linux x86_64 benchmark host (it is universal, not ARM-specific — the extractor's
+  mimalloc win was on Linux).
+- Adds a `profiling` cargo profile (symbols for samply; never built by CI), a few
+  `just` perf recipes, a `criterion` dev-dependency + one bench, and a documented
+  **opt-in** `just build-native` (`RUSTFLAGS=-C target-cpu=native`; never the
+  committed/CI default, to keep release binaries portable/reproducible).
+- Provenance + per-change measurements live in `plans/06222026_aligner-apple-silicon/`.

--- a/plans/06222026_aligner-apple-silicon/PR_DESCRIPTION.md
+++ b/plans/06222026_aligner-apple-silicon/PR_DESCRIPTION.md
@@ -18,9 +18,16 @@ contended on the system allocator's arena locks, an anti-scaling pathology:
 | `--multicore 4`, system allocator | **5025 s** (4.3x SLOWER than `-p 6`) |
 | `--multicore 4`, mimalloc | **1603 s** (3.13x faster, contention gone) |
 
-mimalloc is neutral under `-p` (the aligner is ~90% blocked on bowtie2 there, so
-the Rust allocator is off the critical path). It is **byte-identical** and
+Under `-p` the aligner is ~90% blocked on bowtie2, so the Rust allocator is off
+the critical path. A median-of-3 here measured the full PR stack **~6% slower**
+under `-p 6` (BASE 1145 s vs AFTER 1217 s) — likely mimalloc's single-thread
+overhead (or uncontrolled laptop thermal drift; the same session showed 2.1×
+thermal variance on long runs). This needs a **clean re-measurement on the Linux
+x86_64 benchmark host** before relying on it; flagged honestly rather than hidden.
+Net: a clear `--multicore` win, possibly a small `-p` cost — you may want to weigh
+gating mimalloc on `--multicore`. The change is **byte-identical** and
 **bit-reproducible** (`SOURCE_DATE_EPOCH`, same as the 4 sibling mimalloc crates).
+See `BENCHMARKS.md` for the full table + thermal caveat.
 
 ### Minor byte-identical cleanups (honest framing)
 

--- a/plans/06222026_aligner-apple-silicon/PR_DESCRIPTION.md
+++ b/plans/06222026_aligner-apple-silicon/PR_DESCRIPTION.md
@@ -19,15 +19,17 @@ contended on the system allocator's arena locks, an anti-scaling pathology:
 | `--multicore 4`, mimalloc | **1603 s** (3.13x faster, contention gone) |
 
 Under `-p` the aligner is ~90% blocked on bowtie2, so the Rust allocator is off
-the critical path. A median-of-3 here measured the full PR stack **~6% slower**
-under `-p 6` (BASE 1145 s vs AFTER 1217 s) — likely mimalloc's single-thread
-overhead (or uncontrolled laptop thermal drift; the same session showed 2.1×
-thermal variance on long runs). This needs a **clean re-measurement on the Linux
-x86_64 benchmark host** before relying on it; flagged honestly rather than hidden.
-Net: a clear `--multicore` win, possibly a small `-p` cost — you may want to weigh
-gating mimalloc on `--multicore`. The change is **byte-identical** and
-**bit-reproducible** (`SOURCE_DATE_EPOCH`, same as the 4 sibling mimalloc crates).
-See `BENCHMARKS.md` for the full table + thermal caveat.
+the critical path. A first un-interleaved median-of-3 *looked* ~6% slower under
+`-p 6`, but a **cooled, interleaved attribution run** (GATE_04: base vs
+mimalloc-only vs full-stack, shared thermal state, 4-min cooldown per run) shows
+that was a **thermal artifact**: the full stack is **statistically
+indistinguishable** from baseline under `-p` (−1.3% median, inside a 14–19%
+per-binary thermal spread). So there is **no `-p` trade-off** — mimalloc has no
+measurable single-thread cost, just the large `--multicore` win. Absolute
+wall-times should still be re-confirmed on the **Linux x86_64 benchmark host**
+(no laptop throttling). The change is **byte-identical** and **bit-reproducible**
+(`SOURCE_DATE_EPOCH`, same as the 4 sibling mimalloc crates). See `BENCHMARKS.md`
++ `GATE_04_p_attribution.md` for the full tables.
 
 ### Minor byte-identical cleanups (honest framing)
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +126,7 @@ dependencies = [
  "bismark-meta",
  "bstr",
  "clap",
+ "criterion",
  "flate2",
  "mimalloc",
  "noodles-bam",
@@ -417,6 +424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +444,33 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -514,6 +554,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +620,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -735,6 +815,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,10 +875,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -1127,6 +1244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1524,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1566,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1556,6 +1701,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1741,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1706,6 +1871,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1847,3 +2021,9 @@ name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "bstr",
  "clap",
  "flate2",
+ "mimalloc",
  "noodles-bam",
  "noodles-core 0.20.0",
  "noodles-sam",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,3 +14,12 @@ opt-level = 3
 lto = true
 codegen-units = 1
 strip = "debuginfo"
+
+# Measurement-only profile for `samply`/Instruments on Apple Silicon (and perf
+# elsewhere): identical codegen to `release` but keeps DWARF so the sampler can
+# symbolicate. NEVER built by `just ci` / `just reproduce` / `just build`
+# (those use `release`), so the reproducibility + CI gates are untouched.
+[profile.profiling]
+inherits = "release"
+debug = "line-tables-only"
+strip = false

--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -29,6 +29,17 @@ which = "=7.0.3"
 flate2 = "=1.1.9"
 thiserror = "=2.0.0"
 anyhow = "=1.0.86"
+# Multithreaded global allocator (Apple Silicon perf epic, 06222026). The
+# aligner allocates heavily per record on the Rust side — bowtie2-output parse
+# (`SamRecord::parse`: ~7 owned String/Vec per line × 2-4 records/read), the
+# C->T / G->A conversion loop, and the methylation/tag path — and `--multicore`
+# chunk workers contend on the system allocator's arena locks (the same
+# anti-scaling that made the extractor's `--parallel N>1` slower than N=1 until
+# mimalloc: 155.8s -> 23.5s). Allocator choice does NOT affect computed output —
+# byte-identity holds (guarded by tests/byte_identity_real_data.rs + `just
+# reproduce`). Exact-pinned to the sibling crates' choice so the workspace links
+# one shared mimalloc.
+mimalloc = { version = "=0.1.52", default-features = false }
 # Phase 5: BAM output via the shared noodles writer layer. Pins MUST match
 # bismark-io's transitive choice (same as bismark-dedup declares) so the
 # workspace links one shared noodles.

--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -77,3 +77,11 @@ rammap-inprocess = ["dep:rammap-core", "dep:rayon"]
 assert_cmd = "=2.0.16"
 predicates = "=3.1.2"
 tempfile = "=3.10.1"
+# Function-level micro-benchmarks (06222026 perf epic). Dev-only: never compiled
+# into the shipped binary. Demonstrates the SamRecord::parse byte-split speedup
+# that is real at the function level but below end-to-end (bowtie2-dominated) noise.
+criterion = { version = "=0.5.1", default-features = false }
+
+[[bench]]
+name = "parse_bench"
+harness = false

--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -80,7 +80,11 @@ tempfile = "=3.10.1"
 # Function-level micro-benchmarks (06222026 perf epic). Dev-only: never compiled
 # into the shipped binary. Demonstrates the SamRecord::parse byte-split speedup
 # that is real at the function level but below end-to-end (bowtie2-dominated) noise.
-criterion = { version = "=0.5.1", default-features = false }
+# `cargo_bench_support` is REQUIRED for `cargo bench` to actually measure (the
+# criterion harness's arg parsing + timing live behind it); `default-features =
+# false` otherwise drops the heavy `plotters`/`rayon` HTML-report machinery we do
+# not need for a CI-reproducible number.
+criterion = { version = "=0.5.1", default-features = false, features = ["cargo_bench_support"] }
 
 [[bench]]
 name = "parse_bench"

--- a/rust/bismark-aligner/benches/parse_bench.rs
+++ b/rust/bismark-aligner/benches/parse_bench.rs
@@ -1,0 +1,67 @@
+//! Function-level micro-benchmark for `SamRecord::parse` (06222026 perf epic).
+//!
+//! The parse byte-split's win is real but below the end-to-end noise floor
+//! (the aligner is ~90% bowtie2-bound under `-p`; GATE_00). This bench isolates
+//! it: it compares the current byte-scan field split against the pre-epic
+//! `str::split('\t')` (`CharSearcher`, per-char decode), and times the full
+//! `SamRecord::parse`, on a representative bismark/bowtie2 PE output line.
+//!
+//! Run: `cargo bench -p bismark-aligner --bench parse_bench`.
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+use bismark_aligner::align::SamRecord;
+
+/// A representative directional PE mate-1 line: qname with `/1`, FLAG 99,
+/// CT-converted RNAME, 50M CIGAR, 50bp SEQ/QUAL, and the AS/XS/MD/… tag tail.
+const SAM_LINE: &str = "SRR24766921.1_1/1\t99\t1_CT_converted\t3010512\t40\t50M\t=\t3010700\t238\t\
+TGGTTGATTTGGTAGTAGTAGTTGGAGTTGGTTTAGTAGTTGGAGTAGTT\t\
+IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII\t\
+AS:i:0\tXS:i:-12\tXN:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tNM:i:0\tMD:Z:50\tYS:i:-6\tYT:Z:CP";
+
+/// Current byte-scan field split (what `SamRecord::parse` now does internally).
+fn split_byte_scan(line: &str) -> usize {
+    let lb = line.as_bytes();
+    let mut end = lb.len();
+    while end > 0 && (lb[end - 1] == b'\n' || lb[end - 1] == b'\r') {
+        end -= 1;
+    }
+    let trimmed = &line[..end];
+    let mut f: Vec<&str> = Vec::with_capacity(16);
+    let mut start = 0usize;
+    for (i, &b) in trimmed.as_bytes().iter().enumerate() {
+        if b == b'\t' {
+            f.push(&trimmed[start..i]);
+            start = i + 1;
+        }
+    }
+    f.push(&trimmed[start..]);
+    black_box(&f);
+    f.len()
+}
+
+/// Pre-epic char-based field split (`CharSearcher`), for comparison only.
+fn split_char_searcher(line: &str) -> usize {
+    let trimmed = line.trim_end_matches(['\n', '\r']);
+    let f: Vec<&str> = trimmed.split('\t').collect();
+    black_box(&f);
+    f.len()
+}
+
+fn bench_parse(c: &mut Criterion) {
+    let mut g = c.benchmark_group("sam_field_split");
+    g.bench_function("byte_scan (current)", |b| {
+        b.iter(|| split_byte_scan(black_box(SAM_LINE)))
+    });
+    g.bench_function("char_searcher (pre-epic)", |b| {
+        b.iter(|| split_char_searcher(black_box(SAM_LINE)))
+    });
+    g.finish();
+
+    c.bench_function("SamRecord::parse (full, current)", |b| {
+        b.iter(|| SamRecord::parse(black_box(SAM_LINE)).unwrap())
+    });
+}
+
+criterion_group!(benches, bench_parse);
+criterion_main!(benches);

--- a/rust/bismark-aligner/src/align.rs
+++ b/rust/bismark-aligner/src/align.rs
@@ -75,34 +75,46 @@ pub struct SamRecord {
     pub raw_line: String,
 }
 
+/// Strip the trailing CR/LF terminator then split on TAB, operating on the
+/// already-validated `&str`'s bytes. This avoids
+/// `line.trim_end_matches(['\n', '\r']).split('\t')`, whose `CharSearcher`
+/// (per-char UTF-8 decode) was the aligner's hottest parse cost (06222026 perf
+/// epic; ~330 self-samples). The line is valid UTF-8 (read_line validated it)
+/// and `\t`/`\n`/`\r` are all < 0x80, so a byte slice at those boundaries never
+/// lands mid-codepoint and yields valid `&str` fields with no re-validation.
+///
+/// **Byte-identical to the char-based reference** by construction (only trailing
+/// `\n`/`\r` are trimmed; field bytes are untouched; an empty input yields a
+/// single empty field, like `"".split('\t')`). Returned as a seam so the
+/// equivalence is pinned by a CI unit test (`trim_and_split_*`), not just the
+/// `#[ignore]`d real-data oracle. The returned `trimmed` slice backs both the
+/// fields and `raw_line`.
+fn trim_and_split(line: &str) -> (&str, Vec<&str>) {
+    let lb = line.as_bytes();
+    let mut end = lb.len();
+    while end > 0 && (lb[end - 1] == b'\n' || lb[end - 1] == b'\r') {
+        end -= 1;
+    }
+    let trimmed = &line[..end];
+    let mut f: Vec<&str> = Vec::with_capacity(16);
+    let mut start = 0usize;
+    for (i, &b) in trimmed.as_bytes().iter().enumerate() {
+        if b == b'\t' {
+            f.push(&trimmed[start..i]);
+            start = i + 1;
+        }
+    }
+    f.push(&trimmed[start..]);
+    (trimmed, f)
+}
+
 impl SamRecord {
     /// Parse one SAM line (`split('\t')`). The line may carry a trailing
     /// terminator, which is stripped. Errors on `< 11` fields or unparseable
     /// FLAG/POS/MAPQ; unparseable tag values are left `None` (lenient — Phase 4
     /// enforces `AS`/`MD` presence, Perl `die` 2838).
     pub fn parse(line: &str) -> Result<SamRecord> {
-        // Byte-level trim + tab split. Operating on the already-validated &str's
-        // bytes avoids `str::split('\t')` / `trim_end_matches([..])`, whose
-        // `CharSearcher` (per-char decode) was the aligner's hottest parse cost
-        // (06222026 perf epic; ~330 self-samples). The line is valid UTF-8
-        // (read_line validated it), so slicing at the ASCII '\t'/'\n'/'\r'
-        // boundaries yields valid &str fields with no re-validation. Field bytes
-        // are unchanged, so this is byte-identical to the char-based split.
-        let lb = line.as_bytes();
-        let mut end = lb.len();
-        while end > 0 && (lb[end - 1] == b'\n' || lb[end - 1] == b'\r') {
-            end -= 1;
-        }
-        let trimmed = &line[..end];
-        let mut f: Vec<&str> = Vec::with_capacity(16);
-        let mut start = 0usize;
-        for (i, &b) in trimmed.as_bytes().iter().enumerate() {
-            if b == b'\t' {
-                f.push(&trimmed[start..i]);
-                start = i + 1;
-            }
-        }
-        f.push(&trimmed[start..]);
+        let (trimmed, f) = trim_and_split(line);
         if f.len() < 11 {
             return Err(AlignerError::Validation(format!(
                 "malformed SAM line ({} fields, expected >= 11): {trimmed}",
@@ -869,6 +881,47 @@ mod tests {
         assert_eq!(r.qual, "IIIIIIIIII"); // no trailing \r on QUAL
         assert!(!r.raw_line.ends_with('\r') && !r.raw_line.ends_with('\n'));
         assert_eq!(r.raw_line, MAPPED);
+    }
+
+    #[test]
+    fn trim_and_split_matches_char_based_reference() {
+        // The byte-scan field split (06222026 perf epic) MUST be byte-identical to
+        // the original `line.trim_end_matches(['\n', '\r']).split('\t')`. This pins
+        // the edge cases reviewed by hand on PR #1013 so CI guards them (the
+        // real-data oracle that also covers them is `#[ignore]`d): empty / leading /
+        // trailing-tab fields, lone `\r`, `\r\n`, mid-line `\r` (NOT trailing, so it
+        // stays inside the field), no trailing newline, and empty input (→ `[""]`).
+        for line in [
+            "",            // empty → one empty field
+            "\n",          // bare LF → one empty field
+            "\r",          // bare CR → one empty field
+            "\r\n",        // CRLF → one empty field
+            "\n\r",        // both terminators trimmed
+            "a",           // single field, no terminator
+            "a\n",         // single field + LF
+            "a\r\n",       // single field + CRLF
+            "\ta",         // leading tab → empty first field
+            "a\t",         // trailing tab → empty last field
+            "\t",          // lone tab → two empty fields
+            "a\t\tb",      // empty middle field
+            "a\tb\tc",     // ordinary three fields
+            "a\tb\tc\r\n", // three fields + CRLF
+            "a\rb",        // mid-line CR is content, not trimmed
+            "a\tb\rc\n",   // mid-line CR inside field 2, trailing LF trimmed
+        ] {
+            let reference: Vec<&str> = line.trim_end_matches(['\n', '\r']).split('\t').collect();
+            let (trimmed, got) = trim_and_split(line);
+            assert_eq!(got, reference, "field split mismatch for {line:?}");
+            assert_eq!(
+                trimmed,
+                line.trim_end_matches(['\n', '\r']),
+                "trim mismatch"
+            );
+            assert!(
+                !got.is_empty(),
+                "split always yields >= 1 field (even empty input)"
+            );
+        }
     }
 
     // ---- FileSamStream (v2 phase 9 — sequential combined-index spill replay) ----

--- a/rust/bismark-aligner/src/align.rs
+++ b/rust/bismark-aligner/src/align.rs
@@ -81,8 +81,28 @@ impl SamRecord {
     /// FLAG/POS/MAPQ; unparseable tag values are left `None` (lenient — Phase 4
     /// enforces `AS`/`MD` presence, Perl `die` 2838).
     pub fn parse(line: &str) -> Result<SamRecord> {
-        let trimmed = line.trim_end_matches(['\n', '\r']);
-        let f: Vec<&str> = trimmed.split('\t').collect();
+        // Byte-level trim + tab split. Operating on the already-validated &str's
+        // bytes avoids `str::split('\t')` / `trim_end_matches([..])`, whose
+        // `CharSearcher` (per-char decode) was the aligner's hottest parse cost
+        // (06222026 perf epic; ~330 self-samples). The line is valid UTF-8
+        // (read_line validated it), so slicing at the ASCII '\t'/'\n'/'\r'
+        // boundaries yields valid &str fields with no re-validation. Field bytes
+        // are unchanged, so this is byte-identical to the char-based split.
+        let lb = line.as_bytes();
+        let mut end = lb.len();
+        while end > 0 && (lb[end - 1] == b'\n' || lb[end - 1] == b'\r') {
+            end -= 1;
+        }
+        let trimmed = &line[..end];
+        let mut f: Vec<&str> = Vec::with_capacity(16);
+        let mut start = 0usize;
+        for (i, &b) in trimmed.as_bytes().iter().enumerate() {
+            if b == b'\t' {
+                f.push(&trimmed[start..i]);
+                start = i + 1;
+            }
+        }
+        f.push(&trimmed[start..]);
         if f.len() < 11 {
             return Err(AlignerError::Validation(format!(
                 "malformed SAM line ({} fields, expected >= 11): {trimmed}",

--- a/rust/bismark-aligner/src/main.rs
+++ b/rust/bismark-aligner/src/main.rs
@@ -10,6 +10,14 @@ use clap::Parser;
 use bismark_aligner::cli::Cli;
 use bismark_aligner::{run, version_string};
 
+// Multithreaded global allocator (Apple Silicon perf epic, 06222026). Relieves
+// system-allocator arena-lock contention on the aligner's per-record String/Vec
+// churn (bowtie2-output parse, conversion loop, methylation/tag path) — the same
+// win the extractor + 3 other crates already take. Allocator-only: output is
+// byte-identical (guarded by tests/byte_identity_real_data.rs + `just reproduce`).
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() -> ExitCode {
     // Capture the verbatim argv (program name excluded) BEFORE parsing — this is
     // the `@PG` `CL:` string (Perl captures `join(" ",@ARGV)` at startup, line 32).

--- a/rust/bismark-aligner/src/output.rs
+++ b/rust/bismark-aligner/src/output.rs
@@ -603,25 +603,32 @@ fn build_pe_mate(
 ) -> Result<BismarkRecord> {
     let mut actual_seq = original_seq.to_vec();
     let mut ref_seq = ref_seq_trimmed;
-    let mut md = md_seq.to_vec();
     let offset: u8 = if phred64 { 64 } else { 33 };
     let mut scores: Vec<u8> = qual.iter().map(|&q| q.wrapping_sub(offset)).collect();
 
     if strand == b'-' {
         actual_seq = revcomp(&actual_seq);
         ref_seq = revcomp(&ref_seq);
-        if cigar.contains('D') {
-            md = revcomp(&md); // second revcomp (extraction did the first)
-        }
         scores.reverse();
     }
 
+    // `md` is only read by make_mismatch_string (never stored in the record),
+    // and only differs from `md_seq` when reverse-complemented — strand '-' AND
+    // a deletion (the SE path already borrows md_seq directly). Allocate only
+    // in that case; borrow otherwise. The second revcomp matches Perl (the
+    // extraction did the first). Byte-identical to the prior `md_seq.to_vec()`.
+    let md_owned: Vec<u8>;
+    let md: &[u8] = if strand == b'-' && cigar.contains('D') {
+        md_owned = revcomp(md_seq);
+        &md_owned
+    } else {
+        md_seq
+    };
+
     let nm = hemming_dist(&actual_seq, &ref_seq) as i64 + indels as i64;
-    let md_full = make_mismatch_string(&actual_seq, &ref_seq, cigar, &md);
-    let md_value = md_full
-        .strip_prefix("MD:Z:")
-        .unwrap_or(&md_full)
-        .to_string();
+    let md_full = make_mismatch_string(&actual_seq, &ref_seq, cigar, md);
+    // Slice off the `MD:Z:` prefix in place (no intermediate String copy).
+    let md_value = md_full.strip_prefix("MD:Z:").unwrap_or(&md_full).as_bytes();
     let xm: Vec<u8> = if strand == b'-' {
         methylation_call.iter().rev().copied().collect()
     } else {

--- a/rust/bismark-aligner/tests/byte_identity_real_data.rs
+++ b/rust/bismark-aligner/tests/byte_identity_real_data.rs
@@ -115,13 +115,15 @@ fn find_one(dir: &Path, suffix: &str) -> PathBuf {
 
 /// Drop the report lines that legitimately vary between two runs of the same
 /// code and are NOT output content:
+///
 /// - absolute filesystem paths (output dir / temp dir differ by design between
 ///   the golden capture and this run),
 /// - the `Bismark completed in 0d 0h 19m 20s` wall-clock DURATION line (a
 ///   per-run timing, the same class of sanctioned timestamp exception as
-///   `localtime` in bismark2report — it differs run-to-run and across
+///   `localtime` in bismark2report; it differs run-to-run and across
 ///   `-p`/`--multicore`, but is not part of the byte-identity contract).
-/// The remaining report content — the numbers — must be byte-identical.
+///
+/// The remaining report content (the numbers) must be byte-identical.
 fn normalize_report(s: &str) -> String {
     s.lines()
         .filter(|l| {

--- a/rust/bismark-aligner/tests/byte_identity_real_data.rs
+++ b/rust/bismark-aligner/tests/byte_identity_real_data.rs
@@ -213,8 +213,10 @@ fn run_oracle(ds: &AlignerDataset) {
     eprintln!("✓ {idx} BAM records byte-identical");
 
     // 2) Report numbers (path lines normalized out).
-    let golden = normalize_report(&std::fs::read_to_string(&golden_report).expect("read golden report"));
-    let current = normalize_report(&std::fs::read_to_string(&cur_report).expect("read current report"));
+    let golden =
+        normalize_report(&std::fs::read_to_string(&golden_report).expect("read golden report"));
+    let current =
+        normalize_report(&std::fs::read_to_string(&cur_report).expect("read current report"));
     assert_eq!(current, golden, "report numbers differ (current vs golden)");
     eprintln!("✓ report numbers byte-identical");
 

--- a/rust/bismark-aligner/tests/byte_identity_real_data.rs
+++ b/rust/bismark-aligner/tests/byte_identity_real_data.rs
@@ -94,8 +94,16 @@ const DATASET_WGBS_10M: AlignerDataset = AlignerDataset {
     golden_report_rel: "aligner_golden/wgbs_10m/golden.report.txt",
 };
 
+/// Resolve the dataset root, most specific first:
+/// 1. the per-dataset env var (`BISMARK_ALIGNER_REAL_DATA_DIR_RRBS` / `…_WGBS`),
+/// 2. the shared `BISMARK_ALIGNER_REAL_DATA_DIR` (one root for both datasets),
+/// 3. the hardcoded `default_base` (the maintainer's host layout).
+///
+/// So a reviewer on a different host can point the whole oracle at one directory
+/// with a single env var instead of editing the source.
 fn base_dir(ds: &AlignerDataset) -> PathBuf {
     std::env::var(ds.env_var)
+        .or_else(|_| std::env::var("BISMARK_ALIGNER_REAL_DATA_DIR"))
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from(ds.default_base))
 }

--- a/rust/bismark-aligner/tests/byte_identity_real_data.rs
+++ b/rust/bismark-aligner/tests/byte_identity_real_data.rs
@@ -1,0 +1,234 @@
+//! Rust-vs-Rust byte-identity oracle for `bismark_rs` (the aligner).
+//!
+//! This is the regression gate for the Apple Silicon performance epic
+//! (`plans/06222026_aligner-apple-silicon/`): every optimization on the
+//! faithful Bowtie 2 path must change **zero output bytes**. Unlike the
+//! sibling crates' real-data gates (which compare against a Perl v0.25.1
+//! baseline), this one compares the **current** binary against a *golden*
+//! captured from the pre-optimization binary — a pure Rust-vs-Rust diff,
+//! which is faster to reason about (no Perl in the loop, no sanctioned
+//! timestamp/version exceptions) and is **order-preserving** (the BAM
+//! record stream is compared in file order, so a record-order regression
+//! is caught — the shell `run_gate.sh` sorts and cannot catch that).
+//!
+//! ## Why `#[ignore]`?
+//!
+//! Running the gate aligns the 10M-read dataset with Bowtie 2 (minutes),
+//! needs an aligner + a prepared genome on the host, and needs the golden
+//! captured first. It is not part of the `cargo test` unit loop.
+//!
+//! ## Setup + invocation
+//!
+//! 1. Capture the golden ONCE from a known byte-identical commit:
+//!    ```sh
+//!    cd rust && just aligner-golden          # writes aligner_golden/rrbs_10m/golden.{bam,report.txt}
+//!    ```
+//! 2. Run the oracle (RRBS fast loop):
+//!    ```sh
+//!    cd rust && cargo test -p bismark-aligner --release \
+//!      -- --ignored --exact byte_identity_real_data_rrbs_10m
+//!    ```
+//!
+//! The dataset root defaults to `/Users/benjamin/bismark_benchmarks` and is
+//! overridable per dataset (`BISMARK_ALIGNER_REAL_DATA_DIR_RRBS` /
+//! `…_WGBS`). If any input or the golden is missing, the test prints a clear
+//! SKIP and returns success — a host without the dataset sees no false
+//! failure.
+//!
+//! ## What is compared
+//!
+//! - **BAM record stream**, record-by-record in order, including every tag
+//!   (`XM`/`XR`/`XG`/`NM`/`MD`). The BAM header is intentionally *not*
+//!   compared: its `@PG CL:` line embeds the `-o` output dir, which differs
+//!   by design between the golden capture and the test's temp dir. The
+//!   record bodies carry no paths, so they must match exactly.
+//! - **Alignment report**, with absolute-path lines filtered out (the
+//!   output dir / temp dir differ by design; the numbers must match).
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+/// A dataset the aligner oracle can run against. The choice of physical
+/// root directory is overridable via the per-dataset env var.
+struct AlignerDataset {
+    /// Short label for skip/diagnostic messages.
+    label: &'static str,
+    /// Env var that overrides the default root directory.
+    env_var: &'static str,
+    /// Default root if the env var is unset.
+    default_base: &'static str,
+    /// Prepared genome directory, relative to the root.
+    genome_rel: &'static str,
+    /// Mate 1 / mate 2 FastQ, relative to the root.
+    r1_rel: &'static str,
+    r2_rel: &'static str,
+    /// Golden BAM + report (captured by `just aligner-golden`), relative to the root.
+    golden_bam_rel: &'static str,
+    golden_report_rel: &'static str,
+}
+
+/// Fast iteration loop: Olecka 2024 mouse RRBS PE (GRCm39).
+const DATASET_RRBS_10M: AlignerDataset = AlignerDataset {
+    label: "rrbs_10m",
+    env_var: "BISMARK_ALIGNER_REAL_DATA_DIR_RRBS",
+    default_base: "/Users/benjamin/bismark_benchmarks",
+    genome_rel: "genomes/GRCm39",
+    r1_rel: "RRBS_PE/SRR24766921_10M_1.fastq.gz",
+    r2_rel: "RRBS_PE/SRR24766921_10M_2.fastq.gz",
+    golden_bam_rel: "aligner_golden/rrbs_10m/golden.bam",
+    golden_report_rel: "aligner_golden/rrbs_10m/golden.report.txt",
+};
+
+/// Authoritative gate (Phase 6): Buckberry 2023 human WGBS PE (GRCh38).
+/// Requires GRCh38 to be `bismark_genome_preparation`-ed first.
+const DATASET_WGBS_10M: AlignerDataset = AlignerDataset {
+    label: "wgbs_10m",
+    env_var: "BISMARK_ALIGNER_REAL_DATA_DIR_WGBS",
+    default_base: "/Users/benjamin/bismark_benchmarks",
+    genome_rel: "genomes/GRCh38",
+    r1_rel: "WGBS_PE/SRR24827378_10M_1.fastq.gz",
+    r2_rel: "WGBS_PE/SRR24827378_10M_2.fastq.gz",
+    golden_bam_rel: "aligner_golden/wgbs_10m/golden.bam",
+    golden_report_rel: "aligner_golden/wgbs_10m/golden.report.txt",
+};
+
+fn base_dir(ds: &AlignerDataset) -> PathBuf {
+    std::env::var(ds.env_var)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(ds.default_base))
+}
+
+/// Find the single file in `dir` whose name ends with `suffix`.
+fn find_one(dir: &Path, suffix: &str) -> PathBuf {
+    std::fs::read_dir(dir)
+        .expect("read output dir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(suffix))
+        })
+        .unwrap_or_else(|| panic!("no file ending {suffix:?} in {}", dir.display()))
+}
+
+/// Drop the report lines that legitimately vary between two runs of the same
+/// code and are NOT output content:
+/// - absolute filesystem paths (output dir / temp dir differ by design between
+///   the golden capture and this run),
+/// - the `Bismark completed in 0d 0h 19m 20s` wall-clock DURATION line (a
+///   per-run timing, the same class of sanctioned timestamp exception as
+///   `localtime` in bismark2report — it differs run-to-run and across
+///   `-p`/`--multicore`, but is not part of the byte-identity contract).
+/// The remaining report content — the numbers — must be byte-identical.
+fn normalize_report(s: &str) -> String {
+    s.lines()
+        .filter(|l| {
+            !l.contains("/Users/")
+                && !l.contains("/tmp/")
+                && !l.contains("/var/folders/")
+                && !l.contains("/private/")
+                && !l.contains("Bismark completed in")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn run_oracle(ds: &AlignerDataset) {
+    let base = base_dir(ds);
+    let genome = base.join(ds.genome_rel);
+    let r1 = base.join(ds.r1_rel);
+    let r2 = base.join(ds.r2_rel);
+    let golden_bam = base.join(ds.golden_bam_rel);
+    let golden_report = base.join(ds.golden_report_rel);
+
+    for (name, p) in [
+        ("genome", &genome),
+        ("R1", &r1),
+        ("R2", &r2),
+        ("golden BAM", &golden_bam),
+        ("golden report", &golden_report),
+    ] {
+        if !p.exists() {
+            eprintln!(
+                "SKIP: aligner byte-identity oracle ({}) — missing {} at {}.\n\
+                 Set {} to override the root, and run `just aligner-golden` to \
+                 capture the golden from a known byte-identical binary.",
+                ds.label,
+                name,
+                p.display(),
+                ds.env_var,
+            );
+            return;
+        }
+    }
+
+    let out = TempDir::new().expect("create temp output dir");
+    eprintln!(
+        "running bismark_rs on {} (root {})...",
+        ds.label,
+        base.display()
+    );
+    Command::cargo_bin("bismark_rs")
+        .unwrap()
+        .arg("--genome")
+        .arg(&genome)
+        .arg("-1")
+        .arg(&r1)
+        .arg("-2")
+        .arg(&r2)
+        .arg("-o")
+        .arg(out.path())
+        .assert()
+        .success();
+
+    let cur_bam = find_one(out.path(), "_bismark_bt2_pe.bam");
+    let cur_report = find_one(out.path(), "_PE_report.txt");
+
+    // 1) BAM record stream — streamed lockstep (bounded memory), order-preserving.
+    let mut g_reader = bismark_io::open_reader(&golden_bam, None).expect("open golden BAM");
+    let mut c_reader = bismark_io::open_reader(&cur_bam, None).expect("open current BAM");
+    let mut g_it = g_reader.records();
+    let mut c_it = c_reader.records();
+    let mut idx: u64 = 0;
+    loop {
+        match (g_it.next(), c_it.next()) {
+            (Some(g), Some(c)) => {
+                let g = format!("{:?}", g.expect("decode golden record").inner());
+                let c = format!("{:?}", c.expect("decode current record").inner());
+                assert_eq!(c, g, "BAM record {idx} differs (current vs golden)");
+                idx += 1;
+            }
+            (None, None) => break,
+            (g, c) => panic!(
+                "BAM record count differs at index {idx}: golden has more = {}, current has more = {}",
+                g.is_some(),
+                c.is_some()
+            ),
+        }
+    }
+    eprintln!("✓ {idx} BAM records byte-identical");
+
+    // 2) Report numbers (path lines normalized out).
+    let golden = normalize_report(&std::fs::read_to_string(&golden_report).expect("read golden report"));
+    let current = normalize_report(&std::fs::read_to_string(&cur_report).expect("read current report"));
+    assert_eq!(current, golden, "report numbers differ (current vs golden)");
+    eprintln!("✓ report numbers byte-identical");
+
+    eprintln!("byte-identity oracle PASSED ({}): {idx} records", ds.label);
+}
+
+/// RRBS fast-loop oracle — run after every optimization.
+#[test]
+#[ignore]
+fn byte_identity_real_data_rrbs_10m() {
+    run_oracle(&DATASET_RRBS_10M);
+}
+
+/// WGBS authoritative oracle (Phase 6; needs GRCh38 prepared + golden captured).
+#[test]
+#[ignore]
+fn byte_identity_real_data_wgbs_10m() {
+    run_oracle(&DATASET_WGBS_10M);
+}

--- a/rust/justfile
+++ b/rust/justfile
@@ -9,6 +9,14 @@ repo := "https://github.com/FelixKrueger/Bismark"
 suite_tag := "bismark-rust-v2.0.0-beta.11"
 suite_crates := "bismark-genome-preparation bismark-aligner bismark-dedup bismark-extractor bismark-bedgraph bismark-coverage2cytosine bismark-methylation-consistency bismark-nome-filtering bismark-filter-nonconversion bismark-bam2nuc bismark-report bismark-summary"
 
+# Local benchmark dataset root for the aligner Apple Silicon perf work
+# (`genomes/`, `RRBS_PE/`, `aligner_golden/`). Override on the command line.
+bench_dir := "/Users/benjamin/bismark_benchmarks"
+rrbs_genome := bench_dir / "genomes/GRCm39"
+rrbs_r1 := bench_dir / "RRBS_PE/SRR24766921_10M_1.fastq.gz"
+rrbs_r2 := bench_dir / "RRBS_PE/SRR24766921_10M_2.fastq.gz"
+rrbs_gold := bench_dir / "aligner_golden/rrbs_10m"
+
 # Default: the portable CI check suite (lint + tests, both profiles).
 default: ci
 
@@ -77,6 +85,56 @@ reproduce:
         if cmp -s /tmp/bismark_repro1/$b /tmp/bismark_repro2/$b; then echo "✓ $b bit-identical"; \
         else echo "✗ $b DIFFERS"; fi; \
     done
+
+# ── Apple Silicon perf helpers (bismark-aligner) ────────────────────────────
+# Discipline: profile -> prove byte-identity -> measure. See
+# plans/06222026_aligner-apple-silicon/PLAN.md.
+
+# Symbol-keeping build for samply/Instruments (the `profiling` profile keeps
+# DWARF; it is NEVER built by ci/reproduce/build, so the gates are untouched).
+build-profiling:
+    cargo build --profile profiling -p bismark-aligner
+
+# Non-portable build tuned for the host CPU. OPT-IN ONLY — never the CI/release
+# default (would break portable + bit-reproducible binaries).
+build-native:
+    RUSTFLAGS="-C target-cpu=native" cargo build --release -p bismark-aligner
+
+# Capture the golden aligner output from the CURRENT (baseline) binary so the
+# Rust-vs-Rust byte-identity oracle has a reference. Run ONCE from a known
+# byte-identical commit BEFORE optimizing; re-capture only when output
+# legitimately changes (never during pure perf work).
+aligner-golden genome=rrbs_genome r1=rrbs_r1 r2=rrbs_r2 out=rrbs_gold:
+    cargo build --release -p bismark-aligner
+    rm -rf {{out}} && mkdir -p {{out}}
+    ./target/release/bismark_rs --genome {{genome}} -1 {{r1}} -2 {{r2}} -o {{out}}
+    cp {{out}}/*_bismark_bt2_pe.bam {{out}}/golden.bam
+    cp {{out}}/*_PE_report.txt {{out}}/golden.report.txt
+    @echo "✓ golden captured in {{out}}"
+
+# Rust-vs-Rust byte-identity oracle (fast iteration loop). Runs the CURRENT
+# binary and asserts decompressed BAM + report bytes equal the captured golden.
+# Uses samtools only as a local decompressor (not shipped logic); the committed
+# in-repo equivalent is bismark-aligner/tests/byte_identity_real_data.rs.
+aligner-oracle genome=rrbs_genome r1=rrbs_r1 r2=rrbs_r2 gold=rrbs_gold:
+    cargo build --release -p bismark-aligner
+    rm -rf /tmp/aligner_oracle && mkdir -p /tmp/aligner_oracle
+    ./target/release/bismark_rs --genome {{genome}} -1 {{r1}} -2 {{r2}} -o /tmp/aligner_oracle
+    # Records only (no -h): the @PG CL header line embeds the -o path and so
+    # differs by design; the record stream carries no paths and must match.
+    samtools view /tmp/aligner_oracle/*_bismark_bt2_pe.bam > /tmp/aligner_oracle/cur.sam
+    samtools view {{gold}}/golden.bam > /tmp/aligner_oracle/gold.sam
+    @cmp -s /tmp/aligner_oracle/gold.sam /tmp/aligner_oracle/cur.sam && echo "✓ BAM records byte-identical" || { echo "✗ BAM records DIFFER"; diff /tmp/aligner_oracle/gold.sam /tmp/aligner_oracle/cur.sam | head; exit 1; }
+    # Report: ignore absolute-path lines (output dir / tmp differ by design).
+    grep -vE '/Users/|/tmp/|/var/folders/|/private/|Bismark completed in' {{gold}}/golden.report.txt > /tmp/aligner_oracle/gold.report
+    grep -vE '/Users/|/tmp/|/var/folders/|/private/|Bismark completed in' /tmp/aligner_oracle/*_PE_report.txt > /tmp/aligner_oracle/cur.report
+    @cmp -s /tmp/aligner_oracle/gold.report /tmp/aligner_oracle/cur.report && echo "✓ report numbers byte-identical" || { echo "✗ report DIFFERS"; diff /tmp/aligner_oracle/gold.report /tmp/aligner_oracle/cur.report | head; exit 1; }
+
+# Record a samply CPU profile of the aligner process (Apple Silicon). bismark_rs
+# is profiled; bowtie2 is a separate PID. `parallel=1` = clean hot path;
+# `parallel=8` surfaces allocator contention.
+profile-aligner parallel="1" genome=rrbs_genome r1=rrbs_r1 r2=rrbs_r2: build-profiling
+    samply record --rate 1000 -- ./target/profiling/bismark_rs --genome {{genome}} -1 {{r1}} -2 {{r2}} -o /tmp/aligner_prof --parallel {{parallel}}
 
 # Show all recipes.
 help:


### PR DESCRIPTION
# perf(aligner): mimalloc fixes `--multicore` allocator-contention anti-scaling (3.1x), + byte-identical parse/output cleanups

## What

Performance work on `bismark-aligner`, profiled on Apple Silicon (M4 Max),
**byte-identical to Perl v0.25.1** on the faithful Bowtie 2 path. Everything here
is output-neutral (no new flag, no concordance gate).

### The headline: mimalloc

`bismark-aligner` was the only hot crate without a multithreaded allocator (4
sibling crates already use mimalloc). Under `--multicore`, the worker threads
contended on the system allocator's arena locks, an anti-scaling pathology:

| RRBS-10M, GRCm39, M4 Max | wall |
|---|---|
| `-p 6` (1 Rust pipeline) | 1161 s |
| `--multicore 4`, system allocator | **5025 s** (4.3x SLOWER than `-p 6`) |
| `--multicore 4`, mimalloc | **1603 s** (3.13x faster, contention gone) |

Under `-p` the aligner is ~90% blocked on bowtie2, so the Rust allocator is off
the critical path. A first un-interleaved median-of-3 *looked* ~6% slower under
`-p 6`, but a **cooled, interleaved attribution run** (GATE_04: base vs
mimalloc-only vs full-stack, shared thermal state, 4-min cooldown per run) shows
that was a **thermal artifact**: the full stack is **statistically
indistinguishable** from baseline under `-p` (−1.3% median, inside a 14–19%
per-binary thermal spread). So there is **no `-p` trade-off** — mimalloc has no
measurable single-thread cost, just the large `--multicore` win. Absolute
wall-times should still be re-confirmed on the **Linux x86_64 benchmark host**
(no laptop throttling). The change is **byte-identical** and **bit-reproducible**
(`SOURCE_DATE_EPOCH`, same as the 4 sibling mimalloc crates). See `BENCHMARKS.md`
+ `GATE_04_p_attribution.md` for the full tables.

### Minor byte-identical cleanups (honest framing)

- **`SamRecord::parse` byte-level field split**: replaced `str::split('\t')`
  (`CharSearcher`, per-char decode) with a byte scan over the already-validated
  `&str`. **2.0x faster at the function level** (criterion: 278 ns -> 136 ns), but
  **within end-to-end noise** because bowtie2 dominates. Zero ripple (signature
  unchanged), byte-identical.
- **`build_pe_mate`**: dropped two per-mate intermediate allocations (an `md`
  scratch `Vec` the SE path already avoided, and an `md_value` `String` copy).
  Byte-identical; end-to-end within noise.

Profiling **ruled out** vectorizing the C->T/G->A transform (it is ~0.2% of wall;
GATE_00) — a profile-gated non-action.

## Why it is framed honestly

Under `-p` (the common single-pipeline usage), the aligner is **bowtie2-bound**:
~90% of `bismark_rs` wall is blocked in `read()` waiting on the external bowtie2,
~10% is Rust CPU (GATE_00 profile). So **no `-p` speedup is claimed** from
Rust-side work. The win is the `--multicore` allocator-contention fix, which is
exactly the regime the suite's scaling benchmarks use. The parse/output cleanups
are free, byte-identical, and faster at the function level, so they stay, but
they are not over-claimed as an end-to-end speedup.

## Validation

- **Byte-identity (Rust-vs-Rust)**: a new `#[ignore]`d oracle
  (`tests/byte_identity_real_data.rs`) compares the full BAM record stream
  (12,558,088 records) + report against a golden; verified identical across
  mimalloc + parse + build_pe_mate, and across `-p` vs `--multicore` (also proves
  parallel-invariance).
- **Byte-identity (Rust-vs-Perl)**: the full stack (mimalloc + parse +
  build_pe_mate) vs Perl Bismark v0.25.1 on RRBS / GRCm39: **246,856 records
  identical, report identical** (sorted `samtools view` + report diff, the
  `run_gate.sh` methodology run inline since that script trips macOS bash 3.2's
  `set -u` + empty-array bug).
- **Reproducibility**: `bismark_rs` built twice (clean) under `SOURCE_DATE_EPOCH`
  is bit-identical.
- **CI**: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`,
  `cargo test --workspace` all green.

## Notes for review

- The work is profiled on M4 Max only; the mimalloc win should re-measure on the
  Linux x86_64 benchmark host (it is universal, not ARM-specific — the extractor's
  mimalloc win was on Linux).
- Adds a `profiling` cargo profile (symbols for samply; never built by CI), a few
  `just` perf recipes, a `criterion` dev-dependency + one bench, and a documented
  **opt-in** `just build-native` (`RUSTFLAGS=-C target-cpu=native`; never the
  committed/CI default, to keep release binaries portable/reproducible).
- Provenance + per-change measurements live in `plans/06222026_aligner-apple-silicon/`.
