### PR TITLE
perf(aligner): BGZF-compress the --combined_index_sequential pass-1 spill (#1019)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "flate2",
  "mimalloc",
  "noodles-bam",
+ "noodles-bgzf 0.47.0",
  "noodles-core 0.20.0",
  "noodles-sam",
  "predicates",

--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -53,7 +53,8 @@ noodles-bam = "=0.89.0"
 # Issue #1019: BGZF-compress the `--combined_index_sequential` pass-1 spill (~7x less
 # scratch, wall-neutral — parallel encode hides behind pass-1 alignment). MultithreadedWriter
 # (write) + io::Reader (read). Pinned to the workspace's shared noodles-bgzf (bismark-io + 3
-# others declare =0.47.0; also transitive via noodles-bam) so one shared noodles-bgzf links.
+# others declare =0.47.0; also transitive via noodles-bam) — the spill resolves to this direct
+# =0.47.0. (A separate noodles-bgzf 0.42.0 reachable via noodles-csi is pre-existing, not added here.)
 noodles-bgzf = "=0.47.0"
 bstr = "=1.10.0"
 # Phase 1 (epic 06152026): the in-process rammap backend (`inprocess::InProcessAlignerStream`).

--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -50,6 +50,11 @@ noodles-core = "=0.20.0"
 # (no Bismark-tag validation — the --ambig_bam holds bare aligner records, no XR/XG/XM).
 # Pinned to bismark-io's transitive choice so the workspace links one shared noodles-bam.
 noodles-bam = "=0.89.0"
+# Issue #1019: BGZF-compress the `--combined_index_sequential` pass-1 spill (~7x less
+# scratch, wall-neutral — parallel encode hides behind pass-1 alignment). MultithreadedWriter
+# (write) + io::Reader (read). Pinned to the workspace's shared noodles-bgzf (bismark-io + 3
+# others declare =0.47.0; also transitive via noodles-bam) so one shared noodles-bgzf links.
+noodles-bgzf = "=0.47.0"
 bstr = "=1.10.0"
 # Phase 1 (epic 06152026): the in-process rammap backend (`inprocess::InProcessAlignerStream`).
 # OPTIONAL + gated behind the default-OFF `rammap-inprocess` feature (Rev 2.1, Felix

--- a/rust/bismark-aligner/src/align.rs
+++ b/rust/bismark-aligner/src/align.rs
@@ -409,7 +409,7 @@ impl Drop for AlignerStream {
 /// with [`AlignerStream`] (the spill writes only records, so in practice there are
 /// none, but a header would be tolerated).
 pub struct FileSamStream {
-    reader: BufReader<File>,
+    reader: BufReader<noodles_bgzf::io::Reader<File>>,
     current: Option<SamRecord>,
     line_buf: String,
 }
@@ -425,7 +425,7 @@ impl FileSamStream {
                 path.display()
             ))
         })?;
-        let mut reader = BufReader::new(file);
+        let mut reader = BufReader::new(noodles_bgzf::io::Reader::new(file)); // BGZF spill (issue #1019)
         let mut line = String::new();
         let current = loop {
             line.clear();
@@ -695,7 +695,7 @@ impl Drop for PairedAlignerStream {
 /// **lone trailing line** (odd line count → no second mate) yields `None`, mirroring
 /// [`PairedAlignerStream::advance_pair`] (Perl 6491), NOT an error.
 pub struct PairedFileSamStream {
-    reader: BufReader<File>,
+    reader: BufReader<noodles_bgzf::io::Reader<File>>,
     current: Option<SamPair>,
 }
 
@@ -710,7 +710,7 @@ impl PairedFileSamStream {
                 path.display()
             ))
         })?;
-        let mut reader = BufReader::new(file);
+        let mut reader = BufReader::new(noodles_bgzf::io::Reader::new(file)); // BGZF spill (issue #1019)
         // Skip `@` header lines; the first non-`@` line is the first record of the
         // first pair (cf. `PairedAlignerStream::spawn`).
         let mut line1 = String::new();
@@ -933,7 +933,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let p = dir.path().join("ct_pass.sam");
         let miss = "r2\t4\t*\t0\t0\t*\t*\t0\t0\tACGTAC\tFFFFFF";
-        std::fs::write(&p, format!("{MAPPED}\n{miss}\n")).unwrap();
+        write_bgzf(&p, format!("{MAPPED}\n{miss}\n").as_bytes());
 
         let mut s = FileSamStream::open(&p).unwrap();
         assert_eq!(s.current().unwrap().qname, "r1");
@@ -952,15 +952,15 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
 
         let empty = dir.path().join("empty.sam");
-        std::fs::write(&empty, b"").unwrap();
+        write_bgzf(&empty, b"");
         assert!(FileSamStream::open(&empty).unwrap().current().is_none());
 
         let hdr = dir.path().join("hdronly.sam");
-        std::fs::write(&hdr, b"@HD\tVN:1.0\n").unwrap();
+        write_bgzf(&hdr, b"@HD\tVN:1.0\n");
         assert!(FileSamStream::open(&hdr).unwrap().current().is_none());
 
         let mix = dir.path().join("mix.sam");
-        std::fs::write(&mix, format!("@HD\tVN:1.0\n{MAPPED}\n")).unwrap();
+        write_bgzf(&mix, format!("@HD\tVN:1.0\n{MAPPED}\n").as_bytes());
         assert_eq!(
             FileSamStream::open(&mix).unwrap().current().unwrap().qname,
             "r1"
@@ -1523,17 +1523,31 @@ mod tests {
 
     // ---- PairedFileSamStream (Phase 6 — the spilled PE pass replay) ---------
 
-    /// Write SAM `lines` (each newline-terminated) to a fresh temp file and return
-    /// it (the TempDir keeps the file alive for the test's lifetime).
+    /// Write `content` to `path` as a BGZF stream — the spill is BGZF since issue #1019,
+    /// so reader fixtures must be BGZF too. Mirrors the production writer
+    /// (`MultithreadedWriter` + `finish()`; 1 worker is plenty for tests).
+    fn write_bgzf(path: &std::path::Path, content: &[u8]) {
+        use std::io::Write as _;
+        let workers = std::num::NonZeroUsize::new(1).unwrap();
+        let mut w = noodles_bgzf::io::MultithreadedWriter::with_worker_count(
+            workers,
+            std::fs::File::create(path).unwrap(),
+        );
+        w.write_all(content).unwrap();
+        w.finish().unwrap();
+    }
+
+    /// Write SAM `lines` (each newline-terminated) to a fresh temp file as a BGZF spill
+    /// and return it (the TempDir keeps the file alive for the test's lifetime).
     fn write_spill(lines: &[&str]) -> (tempfile::TempDir, std::path::PathBuf) {
         let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("ct_pass.sam");
+        let path = dir.path().join("ct_pass.sam.gz");
         let mut body = String::new();
         for l in lines {
             body.push_str(l);
             body.push('\n');
         }
-        std::fs::write(&path, body).unwrap();
+        write_bgzf(&path, body.as_bytes());
         (dir, path)
     }
 

--- a/rust/bismark-aligner/src/lib.rs
+++ b/rust/bismark-aligner/src/lib.rs
@@ -1897,14 +1897,24 @@ fn select_and_route_se_nondir(
 /// live stream would, preserving the per-read lockstep `drive_merge_combined_nondir`
 /// relies on. Generic over [`SamStream`] so it is unit-testable with a canned stream.
 fn spill_stream_to_file<S: SamStream>(stream: &mut S, path: &Path) -> Result<u64> {
-    let mut w = BufWriter::new(File::create(path)?);
+    // BGZF-compressed spill (issue #1019): ~7x less scratch than raw SAM at ~0 wall cost
+    // (parallel encode hides behind pass-1 alignment; the decompressed line stream is
+    // byte-identical to the prior raw spill, so the FileSamStream replay + output are
+    // unchanged). 4 encoder workers far exceed the pass-1 SAM production rate (measured),
+    // so they never lag or contend with Bowtie 2.
+    let workers = std::num::NonZeroUsize::new(4).expect("nonzero BGZF worker count");
+    let mut w =
+        noodles_bgzf::io::MultithreadedWriter::with_worker_count(workers, File::create(path)?);
     let mut n: u64 = 0;
     while let Some(r) = stream.current() {
+        // writeln! => write_fmt => write_all (writes the whole line; NOT a bare partial .write()).
         writeln!(w, "{}", r.raw_line)?;
         n += 1;
         stream.advance()?;
     }
-    w.flush()?;
+    // finish() writes the BGZF EOF block + flushes; state then transitions to `Done`, so the
+    // subsequent Drop is a no-op (noodles-bgzf, unlike gzp, never panics in Drop).
+    w.finish()?;
     Ok(n)
 }
 
@@ -1918,15 +1928,19 @@ fn spill_stream_to_file<S: SamStream>(stream: &mut S, path: &Path) -> Result<u64
 /// on-disk line order, preserving the per-pair lockstep `drive_merge_combined_pe_nondir`
 /// relies on. Generic over [`PairedSamStream`] so it is unit-testable with a canned stream.
 fn spill_pe_stream_to_file<S: PairedSamStream>(stream: &mut S, path: &Path) -> Result<u64> {
-    let mut w = BufWriter::new(File::create(path)?);
+    // BGZF-compressed spill (issue #1019) — see `spill_stream_to_file` for the rationale.
+    let workers = std::num::NonZeroUsize::new(4).expect("nonzero BGZF worker count");
+    let mut w =
+        noodles_bgzf::io::MultithreadedWriter::with_worker_count(workers, File::create(path)?);
     let mut n: u64 = 0;
     while let Some(p) = stream.current_pair() {
+        // writeln! => write_fmt => write_all (NOT a bare partial .write()).
         writeln!(w, "{}", p.read1.raw_line)?;
         writeln!(w, "{}", p.read2.raw_line)?;
         n += 1;
         stream.advance_pair()?;
     }
-    w.flush()?;
+    w.finish()?;
     Ok(n)
 }
 
@@ -2077,7 +2091,7 @@ fn process_se_chunk_combined_nondir_sequential(
     // temp_dir — reusing its path sidesteps the empty default `temp_dir`).
     let mut spill_path = converted[0].path.clone();
     let mut spill_name = spill_path.file_name().unwrap_or_default().to_os_string();
-    spill_name.push(".ct_pass.sam");
+    spill_name.push(".ct_pass.sam.gz"); // BGZF-compressed (issue #1019)
     spill_path.set_file_name(spill_name);
 
     // ---- PASS 1 (C→T → OT/OB) ------------------------------------------------
@@ -4341,7 +4355,7 @@ fn process_pe_chunk_combined_nondir_sequential(
     // temp_dir — reusing its path sidesteps the empty default `temp_dir`).
     let mut spill_path = r1_ct.path.clone();
     let mut spill_name = spill_path.file_name().unwrap_or_default().to_os_string();
-    spill_name.push(".ct_pass.sam");
+    spill_name.push(".ct_pass.sam.gz"); // BGZF-compressed (issue #1019)
     spill_path.set_file_name(spill_name);
 
     // ---- PASS 1 (C→T reads → OT/OB) -----------------------------------------
@@ -4982,6 +4996,70 @@ mod tests {
             replay.advance_pair().unwrap();
         }
         assert!(replay.current_pair().is_none());
+    }
+
+    #[test]
+    fn spill_stream_to_file_crosses_bgzf_blocks() {
+        // A BGZF block holds <= 64 KiB; a spill larger than one block exercises the
+        // cross-block `read_line` reassembly path the small fixtures above never reach
+        // (the one BGZF-specific risk on the read side, issue #1019).
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = dir.path().join("ct_pass.sam.gz");
+        // ~2000 records × ~80 B ≈ 160 KB >> 64 KiB → several BGZF blocks.
+        let lines: Vec<String> = (0..2000u32)
+            .map(|i| {
+                format!(
+                    "r{i}\t0\tchr1_CT_converted\t{}\t255\t6M\t*\t0\t0\tACGTAC\tFFFFFF\tAS:i:0\tMD:Z:6",
+                    i + 1
+                )
+            })
+            .collect();
+        let recs: Vec<_> = lines
+            .iter()
+            .map(|l| crate::align::SamRecord::parse(l).unwrap())
+            .collect();
+        let mut stream = VecStream {
+            recs: recs.clone(),
+            idx: 0,
+        };
+        let n = spill_stream_to_file(&mut stream, &p).unwrap();
+        assert_eq!(n, 2000);
+        assert!(std::fs::metadata(&p).unwrap().len() > 0);
+
+        let mut replay = crate::align::FileSamStream::open(&p).unwrap();
+        for orig in &recs {
+            assert_eq!(
+                replay.current().unwrap(),
+                orig,
+                "record mismatch across BGZF block boundary"
+            );
+            replay.advance().unwrap();
+        }
+        assert!(replay.current().is_none());
+    }
+
+    #[test]
+    fn spill_pe_stream_to_file_empty_stream() {
+        // PE analog of `spill_stream_to_file_empty_stream`: a 0-pair spill must still write a
+        // valid (EOF-block) BGZF file that replays as zero pairs.
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = dir.path().join("ct_pass.sam.gz");
+        let mut stream = VecPairStream {
+            pairs: Vec::new(),
+            idx: 0,
+        };
+        assert_eq!(spill_pe_stream_to_file(&mut stream, &p).unwrap(), 0);
+        // Non-empty (the BGZF EOF block was written) yet zero pairs on replay.
+        assert!(
+            std::fs::metadata(&p).unwrap().len() > 0,
+            "empty spill should still write a BGZF EOF block"
+        );
+        assert!(
+            PairedFileSamStream::open(&p)
+                .unwrap()
+                .current_pair()
+                .is_none()
+        );
     }
 
     /// The non-directional PE desync guard: in-sync (head `seq_id` == identifier) and a

--- a/rust/bismark-aligner/tests/cli.rs
+++ b/rust/bismark-aligner/tests/cli.rs
@@ -4378,7 +4378,7 @@ fn run_combined_nondir_records(
         let leftover = fs::read_dir(temp.path())
             .unwrap()
             .filter_map(|e| e.ok())
-            .any(|e| e.file_name().to_string_lossy().ends_with(".ct_pass.sam"));
+            .any(|e| e.file_name().to_string_lossy().ends_with(".ct_pass.sam.gz"));
         assert!(!leftover, "sequential spill temp file must be cleaned up");
     }
 
@@ -4700,7 +4700,7 @@ fn run_combined_pe_nondir_records(
         let leftover = fs::read_dir(temp.path())
             .unwrap()
             .filter_map(|e| e.ok())
-            .any(|e| e.file_name().to_string_lossy().ends_with(".ct_pass.sam"));
+            .any(|e| e.file_name().to_string_lossy().ends_with(".ct_pass.sam.gz"));
         assert!(
             !leftover,
             "sequential PE spill temp file must be cleaned up"
@@ -5085,7 +5085,7 @@ fn run_combined_pe_hisat2_records(
         let leftover = fs::read_dir(temp.path())
             .unwrap()
             .filter_map(|e| e.ok())
-            .any(|e| e.file_name().to_string_lossy().ends_with(".ct_pass.sam"));
+            .any(|e| e.file_name().to_string_lossy().ends_with(".ct_pass.sam.gz"));
         assert!(!leftover, "sequential HISAT2 PE spill must be cleaned up");
     }
 
@@ -5135,7 +5135,7 @@ fn run_combined_se_hisat2_records(
         let leftover = fs::read_dir(temp.path())
             .unwrap()
             .filter_map(|e| e.ok())
-            .any(|e| e.file_name().to_string_lossy().ends_with(".ct_pass.sam"));
+            .any(|e| e.file_name().to_string_lossy().ends_with(".ct_pass.sam.gz"));
         assert!(!leftover, "sequential HISAT2 SE spill must be cleaned up");
     }
 


### PR DESCRIPTION
Closes #1019.

BGZF-compress the `--combined_index_sequential` pass-1 spill. The non-directional sequential mode spills its pass-1 (C→T) stream to disk and replays it against pass 2; that spill was **raw, uncompressed SAM** (~0.67 KB/pair — hundreds of GB to ~1 TB scratch for large PE). This switches it to **BGZF** via `noodles-bgzf`.

## Result (measured)
- **~7.4× less scratch** (6.26 GB → 913 MB for 10M PE) → the ~0.7 TB worst case becomes ~95 GB.
- **Wall-neutral**: parallel BGZF encode (~800 MB/s) hides behind pass-1 alignment; BGZF block-parallel decode reads back near-raw, and on a cold/slow `--temp_dir` it reads ~7× fewer bytes.
- This is the **basis for #1018** (making sequential the non-dir default — a ~95 GB worst case is defensible where ~0.7 TB is not).

## Change (framing-only → byte-identical)
- Writers (`spill_stream_to_file` / `spill_pe_stream_to_file`): `MultithreadedWriter::with_worker_count(NonZero(4), …)` + `finish()`; `writeln!` kept (write-all, not a partial `.write()`).
- Readers (`FileSamStream` / `PairedFileSamStream`): wrap the file in `noodles_bgzf::io::Reader` behind `BufReader`; `read_line`/`parse`/merge loop unchanged.
- Spill suffix `.ct_pass.sam` → `.ct_pass.sam.gz`. `noodles-bgzf = "=0.47.0"` (workspace pin).

The decompressed line stream is identical to the prior raw spill, so output is **byte-identical**.

## Validation
- **Before/after byte-identity gate (oxy, real GRCh38)**: combined-nondir-sequential, pre (`ec118c9`, raw spill) vs post (BGZF) — **SE 2,544,374 + PE 1,728,832 records IDENTICAL**, reports + strand counts match.
- **428 lib tests** (the 3 spill round-trip tests now exercise BGZF; +2 new: cross-block >64 KiB reassembly, PE empty-stream; the 6 reader-unit-test fixtures converted to BGZF) + **18 sequential CLI tests** (incl. `*_byte_identical_to_model_a`) green. `fmt --check` + `clippy -D warnings` clean.
- Dual code-review (both APPROVE, verified against noodles-bgzf 0.47.0 source: `finish()`→`Done`→Drop-noop, no gzp-style panic; ENOSPC propagates as `Err`) + plan-manager (COMPLETE). The one Medium they caught — `tests/cli.rs` cleanup assertions left matching the old `.ct_pass.sam` suffix — is fixed in `ff25fd6`.

Provenance + plan/reviews: `plans/06242026_bgzf-spill/`.
