### PR TITLE
feat(aligner): paired-end unaligned-BAM (uBAM) input (#1025 Phase 1)

### DIFF
--- a/rust/bismark-aligner/src/config.rs
+++ b/rust/bismark-aligner/src/config.rs
@@ -279,6 +279,33 @@ fn hisat2_multicore_threads(aligner: Aligner, cli_multicore: Option<u32>) -> Opt
 }
 
 /// Resolve a parsed [`Cli`] + the verbatim command line into a [`RunConfig`].
+/// Reject a paired-end layout with an aligner that has no PE support / no
+/// byte-identity oracle (minimap2, rammap — minimap-like, SE-only).
+///
+/// PE-minimap2 is NOT byte-identity-reachable and is deferred out of v1.x
+/// (Felix decision 2026-06-05): the Perl minimap2 paired-end path
+/// (`paired_end_…_minimap2` 6697-6708) is unfinished WIP (`# TODO` +
+/// `warn`+`sleep(1)` twice per read pair) AND the PE report writer (1845-1850)
+/// has no `$mm2` branch, so it mislabels minimap2 PE as "HISAT2" — there is no
+/// trustworthy oracle to byte-match. minimap2 AND rammap are SE-only. The error
+/// names the actual engine (`aligner.name()`) so a `--rammap` run reads "--rammap".
+///
+/// Shared by [`resolve`] (native `-1/-2`) AND the uBAM SingleEnd→PairedEnd switch
+/// (`lib::resolve_ubam_inputs`), so this layout-dependent guard cannot drift
+/// between the two entry points — a positional paired uBAM is rejected for
+/// minimap2/rammap exactly as `-1/-2` would be.
+pub fn reject_unsupported_paired_aligner(aligner: Aligner, layout: &ReadLayout) -> Result<()> {
+    if matches!(aligner, Aligner::Minimap2 | Aligner::Rammap) && layout.is_paired() {
+        return Err(AlignerError::Unsupported(format!(
+            "paired-end alignment with --{0} is not supported: the Perl Bismark minimap2 \
+             paired-end path is unfinished/experimental and has no trustworthy byte-identity \
+             reference. Use --{0} for single-end reads, or --bowtie2/--hisat2 for paired-end.",
+            aligner.name()
+        )));
+    }
+    Ok(())
+}
+
 pub fn resolve(cli: &Cli, command_line: String) -> Result<RunConfig> {
     let aligner = resolve_aligner(cli)?;
     // `--rammap_inprocess` (opt into the in-process rammap backend) is meaningful only
@@ -354,22 +381,7 @@ pub fn resolve(cli: &Cli, command_line: String) -> Result<RunConfig> {
     let (genome_arg, reads_positional) = resolve_genome_and_positional(cli)?;
     let layout = resolve_layout(cli, &reads_positional)?;
 
-    // PE-minimap2 is NOT byte-identity-reachable and is deferred out of v1.x
-    // (Felix decision 2026-06-05): the Perl minimap2 paired-end path
-    // (`paired_end_…_minimap2` 6697-6708) is unfinished WIP (`# TODO` +
-    // `warn`+`sleep(1)` twice per read pair) AND the PE report writer (1845-1850)
-    // has no `$mm2` branch, so it mislabels minimap2 PE as "HISAT2" — there is no
-    // trustworthy oracle to byte-match. Fail loudly (Bowtie 2 + HISAT2 cover PE).
-    // minimap2 AND rammap (minimap-like) are SE-only. The error names the actual
-    // engine (`aligner.name()`) so a `--rammap` run reads "--rammap".
-    if matches!(aligner, Aligner::Minimap2 | Aligner::Rammap) && layout.is_paired() {
-        return Err(AlignerError::Unsupported(format!(
-            "paired-end alignment with --{0} is not supported: the Perl Bismark minimap2 \
-             paired-end path is unfinished/experimental and has no trustworthy byte-identity \
-             reference. Use --{0} for single-end reads, or --bowtie2/--hisat2 for paired-end.",
-            aligner.name()
-        )));
-    }
+    reject_unsupported_paired_aligner(aligner, &layout)?;
 
     // --combined_index (v2) scope guard: SE (directional OR non-directional)
     // Bowtie 2 only. Reject every not-yet-supported combination loudly (never
@@ -1143,6 +1155,30 @@ mod tests {
         assert!(resolve_aligner(&cli_from(&["--hisat2", "--bowtie2"])).is_err());
         assert!(resolve_aligner(&cli_from(&["--hisat2", "--minimap2"])).is_err());
         assert!(resolve_aligner(&cli_from(&["--minimap2", "--bowtie2"])).is_err());
+    }
+
+    /// #1025: the shared paired-aligner guard — minimap2/rammap PE rejected,
+    /// Bowtie 2/HISAT2 PE allowed, and minimap2/rammap SE allowed. This is the
+    /// guard `lib::resolve_ubam_inputs` re-runs after the uBAM SE→PE switch so a
+    /// positional `--minimap2 <pe.bam>` fails loud exactly like `--minimap2 -1/-2`.
+    #[test]
+    fn reject_unsupported_paired_aligner_guard() {
+        let pe = ReadLayout::PairedEnd {
+            mates1: vec!["a_1.fq".into()],
+            mates2: vec!["a_2.fq".into()],
+        };
+        let se = ReadLayout::SingleEnd {
+            reads: vec!["a.fq".into()],
+        };
+        // minimap2/rammap + PE → rejected.
+        assert!(reject_unsupported_paired_aligner(Aligner::Minimap2, &pe).is_err());
+        assert!(reject_unsupported_paired_aligner(Aligner::Rammap, &pe).is_err());
+        // Bowtie 2/HISAT2 + PE → allowed.
+        assert!(reject_unsupported_paired_aligner(Aligner::Bowtie2, &pe).is_ok());
+        assert!(reject_unsupported_paired_aligner(Aligner::Hisat2, &pe).is_ok());
+        // minimap2/rammap + SE → allowed (SE is their supported mode).
+        assert!(reject_unsupported_paired_aligner(Aligner::Minimap2, &se).is_ok());
+        assert!(reject_unsupported_paired_aligner(Aligner::Rammap, &se).is_ok());
     }
 
     /// Phase 3 (T2): `--rammap` selects [`Aligner::Rammap`].

--- a/rust/bismark-aligner/src/lib.rs
+++ b/rust/bismark-aligner/src/lib.rs
@@ -279,6 +279,13 @@ fn resolve_ubam_inputs(config: &mut RunConfig, cli: &cli::Cli) -> Result<Vec<Pat
         }
         config.layout = ReadLayout::PairedEnd { mates1, mates2 };
         config.format = ReadFormat::FastQ;
+        // The positional uBAM resolved as SINGLE-END, so `resolve()`'s layout-dependent
+        // guards ran against the SE layout. Re-run the paired-aligner reject now that the
+        // layout is PE, via the SAME shared validator `resolve()` uses — so e.g.
+        // `--minimap2 <collated-pe.bam>` (a long-read uBAM) fails loud exactly as
+        // `--minimap2 -1 .. -2 ..` does, instead of silently entering the deferred
+        // minimap2-PE path.
+        config::reject_unsupported_paired_aligner(config.aligner, &config.layout)?;
         // The positional uBAM resolved as SINGLE-END, so `resolve()` built single-end
         // aligner options. A paired-end run needs the PE Bowtie 2 flags
         // (`--no-mixed --no-discordant --dovetail --maxins …`); recompute via the SAME

--- a/rust/bismark-aligner/src/lib.rs
+++ b/rust/bismark-aligner/src/lib.rs
@@ -191,43 +191,31 @@ pub fn run(cli: &cli::Cli, command_line: String) -> Result<()> {
 /// methylation-call re-read consume it — R2), and switch the format to FASTQ.
 /// Emits a never-silent notice per transcoded input.
 ///
-/// Paired-end uBAM (a single file split into mates) is not yet wired and fails
-/// loud. uBAM + `--fasta` is rejected (BAM carries qualities → FASTQ).
+/// A uBAM read input is **auto-detected** (magic byte) and, from its FLAGs,
+/// classified single- vs paired-end:
+/// - **Single-end uBAM** → transcoded to one temp FASTQ; the reads list entry is
+///   substituted in place (SingleEnd layout preserved).
+/// - **Paired-end uBAM** (a single collated file, `0x1`) → split into R1/R2 temp
+///   FASTQs and the layout is **switched SingleEnd → PairedEnd** (the user passes
+///   one positional file; we recover the mates, equivalent to `samtools fastq -1/-2`).
+///
+/// Mixing a paired uBAM with other inputs fails loud; a uBAM supplied via `-1`/`-2`
+/// fails loud (pass the collated PE uBAM positionally instead); uBAM + `--fasta`
+/// is rejected (BAM carries qualities → FASTQ).
 ///
 /// Each transcode goes into its OWN subdir `<temp_dir>/.bismark_ubam/<i>/` so the
-/// temp is named `<stem>.fastq` (preserving the output stem, R3) yet two
-/// same-basename uBAMs can't collide on the temp and a pre-existing
-/// `<stem>.fastq` in `temp_dir`/CWD is never clobbered. Returns the created
-/// subdirs for the caller to clean up after the pipeline.
+/// temp keeps the `<stem>` basename (preserving the output stem, R3) yet two
+/// same-basename uBAMs can't collide and a pre-existing temp is never clobbered.
+/// Returns the created subdirs for the caller to clean up after the pipeline.
 fn resolve_ubam_inputs(config: &mut RunConfig) -> Result<Vec<PathBuf>> {
     let temp_dir = config.output.temp_dir.clone();
     let is_fasta = matches!(config.format, ReadFormat::FastA);
-    let mut transcoded_any = false;
     let mut temp_dirs: Vec<PathBuf> = Vec::new();
-    match &mut config.layout {
-        ReadLayout::SingleEnd { reads } => {
-            for (i, read) in reads.iter_mut().enumerate() {
-                if !ubam::is_bam_input(Path::new(read)) {
-                    continue;
-                }
-                if is_fasta {
-                    return Err(AlignerError::Validation(
-                        "unaligned BAM input is incompatible with --fasta/-f (BAM carries \
-                         base qualities, so it transcodes to FASTQ, not FASTA)"
-                            .into(),
-                    ));
-                }
-                eprintln!(
-                    "Note: input '{read}' detected as an unaligned BAM — transcoding reads to \
-                     FASTQ (equivalent to `samtools fastq`) before alignment."
-                );
-                let sub = temp_dir.join(".bismark_ubam").join(i.to_string());
-                let temp = ubam::transcode_ubam_to_fastq_se(Path::new(read), &sub)?;
-                *read = temp.to_string_lossy().into_owned();
-                temp_dirs.push(sub);
-                transcoded_any = true;
-            }
-        }
+
+    // A positional PE uBAM arrives as a SingleEnd layout (one file). A uBAM passed
+    // via -1/-2 is not the supported shape — fail loud (design: single collated file).
+    let reads = match &config.layout {
+        ReadLayout::SingleEnd { reads } => reads.clone(),
         ReadLayout::PairedEnd { mates1, mates2 } => {
             if mates1
                 .iter()
@@ -235,14 +223,79 @@ fn resolve_ubam_inputs(config: &mut RunConfig) -> Result<Vec<PathBuf>> {
                 .any(|f| ubam::is_bam_input(Path::new(f)))
             {
                 return Err(AlignerError::Validation(
-                    "paired-end unaligned BAM input is not yet supported (single-end uBAM is). \
-                     Convert with `samtools fastq -1 r1.fq.gz -2 r2.fq.gz <in.bam>` for now."
+                    "unaligned BAM via -1/-2 is not supported; pass a single collated paired-end \
+                     uBAM as a positional argument (it is auto-detected and split into mates), or \
+                     run `samtools fastq -1 r1.fq.gz -2 r2.fq.gz <in.bam>` first"
                         .into(),
                 ));
             }
+            return Ok(temp_dirs);
         }
+    };
+
+    // Classify each SE input: (is_uBAM, is_paired_uBAM).
+    let mut classes = Vec::with_capacity(reads.len());
+    let mut any_ubam = false;
+    let mut any_pe = false;
+    for r in &reads {
+        let is_bam = ubam::is_bam_input(Path::new(r));
+        let is_pe = is_bam && ubam::is_paired(Path::new(r))?;
+        any_ubam |= is_bam;
+        any_pe |= is_pe;
+        classes.push((is_bam, is_pe));
     }
-    if transcoded_any {
+    if !any_ubam {
+        return Ok(temp_dirs); // plain FASTQ/FASTA single-end — nothing to do.
+    }
+    if is_fasta {
+        return Err(AlignerError::Validation(
+            "unaligned BAM input is incompatible with --fasta/-f (BAM carries base qualities, so \
+             it transcodes to FASTQ, not FASTA)"
+                .into(),
+        ));
+    }
+
+    if any_pe {
+        // Paired-end uBAM(s): every input must be a paired uBAM (no mixing).
+        if !classes.iter().all(|(is_bam, is_pe)| *is_bam && *is_pe) {
+            return Err(AlignerError::Validation(
+                "a paired-end unaligned BAM cannot be mixed with single-end or FASTQ inputs in \
+                 the same run"
+                    .into(),
+            ));
+        }
+        let mut mates1 = Vec::with_capacity(reads.len());
+        let mut mates2 = Vec::with_capacity(reads.len());
+        for (i, r) in reads.iter().enumerate() {
+            eprintln!(
+                "Note: input '{r}' detected as a paired-end unaligned BAM — splitting mates and \
+                 transcoding to FASTQ (equivalent to `samtools fastq -1/-2`) before alignment."
+            );
+            let sub = temp_dir.join(".bismark_ubam").join(i.to_string());
+            let (r1, r2) = ubam::transcode_ubam_to_fastq_pe(Path::new(r), &sub)?;
+            mates1.push(r1.to_string_lossy().into_owned());
+            mates2.push(r2.to_string_lossy().into_owned());
+            temp_dirs.push(sub);
+        }
+        config.layout = ReadLayout::PairedEnd { mates1, mates2 };
+        config.format = ReadFormat::FastQ;
+    } else {
+        // Single-end uBAM(s): transcode each; leave any plain FASTQ entries as-is.
+        let mut new_reads = reads.clone();
+        for (i, read) in new_reads.iter_mut().enumerate() {
+            if !classes[i].0 {
+                continue;
+            }
+            eprintln!(
+                "Note: input '{read}' detected as an unaligned BAM — transcoding reads to FASTQ \
+                 (equivalent to `samtools fastq`) before alignment."
+            );
+            let sub = temp_dir.join(".bismark_ubam").join(i.to_string());
+            let temp = ubam::transcode_ubam_to_fastq_se(Path::new(read), &sub)?;
+            *read = temp.to_string_lossy().into_owned();
+            temp_dirs.push(sub);
+        }
+        config.layout = ReadLayout::SingleEnd { reads: new_reads };
         config.format = ReadFormat::FastQ;
     }
     Ok(temp_dirs)

--- a/rust/bismark-aligner/src/lib.rs
+++ b/rust/bismark-aligner/src/lib.rs
@@ -120,7 +120,7 @@ pub fn run(cli: &cli::Cli, command_line: String) -> Result<()> {
     // convert→align→merge path runs unchanged. Returns the per-input temp dirs to
     // clean up after the run (the transcode FASTQ is consumed by BOTH the convert
     // step and the methylation-call re-read, so cleanup must follow the pipeline).
-    let ubam_temp_dirs = resolve_ubam_inputs(&mut config)?;
+    let ubam_temp_dirs = resolve_ubam_inputs(&mut config, cli)?;
     let deferred = config::deferred_flags(cli);
     if !deferred.is_empty() {
         eprintln!(
@@ -207,7 +207,7 @@ pub fn run(cli: &cli::Cli, command_line: String) -> Result<()> {
 /// temp keeps the `<stem>` basename (preserving the output stem, R3) yet two
 /// same-basename uBAMs can't collide and a pre-existing temp is never clobbered.
 /// Returns the created subdirs for the caller to clean up after the pipeline.
-fn resolve_ubam_inputs(config: &mut RunConfig) -> Result<Vec<PathBuf>> {
+fn resolve_ubam_inputs(config: &mut RunConfig, cli: &cli::Cli) -> Result<Vec<PathBuf>> {
     let temp_dir = config.output.temp_dir.clone();
     let is_fasta = matches!(config.format, ReadFormat::FastA);
     let mut temp_dirs: Vec<PathBuf> = Vec::new();
@@ -279,6 +279,21 @@ fn resolve_ubam_inputs(config: &mut RunConfig) -> Result<Vec<PathBuf>> {
         }
         config.layout = ReadLayout::PairedEnd { mates1, mates2 };
         config.format = ReadFormat::FastQ;
+        // The positional uBAM resolved as SINGLE-END, so `resolve()` built single-end
+        // aligner options. A paired-end run needs the PE Bowtie 2 flags
+        // (`--no-mixed --no-discordant --dovetail --maxins …`); recompute via the SAME
+        // builder with is_paired=true so the options exactly match a native `-1/-2` run.
+        // (Without `--no-mixed`/`--no-discordant`, Bowtie 2 emits half-mapped pairs the
+        // PE merge can't score.)
+        let (opts, gaps) = options::build_aligner_options(
+            cli,
+            config.aligner,
+            config.format,
+            true,
+            config.hisat2_multicore_remap,
+        )?;
+        config.aligner_options = opts;
+        config.gap_penalties = gaps;
     } else {
         // Single-end uBAM(s): transcode each; leave any plain FASTQ entries as-is.
         let mut new_reads = reads.clone();

--- a/rust/bismark-aligner/src/ubam.rs
+++ b/rust/bismark-aligner/src/ubam.rs
@@ -35,6 +35,7 @@ use noodles_sam::alignment::RecordBuf;
 use crate::error::{AlignerError, Result};
 
 // SAM FLAG bits we consult.
+const FLAG_PAIRED: u16 = 0x1;
 const FLAG_REVERSE: u16 = 0x10;
 const FLAG_READ1: u16 = 0x40;
 const FLAG_READ2: u16 = 0x80;
@@ -54,6 +55,24 @@ pub fn is_bam_input(path: &Path) -> bool {
         bismark_io::AlignmentKind::from_path(path),
         Ok(bismark_io::AlignmentKind::Bam)
     )
+}
+
+/// Peek a uBAM to classify single- vs paired-end: `true` iff the first **primary**
+/// record (secondary/supplementary skipped) carries the paired flag (`0x1`).
+/// A header-only / no-primary BAM returns `false` (→ the single-end path, which
+/// produces an empty FASTQ → the existing graceful-empty handling).
+pub fn is_paired(bam: &Path) -> Result<bool> {
+    let mut reader = noodles_bam::io::Reader::new(BufReader::new(File::open(bam)?));
+    let header = reader.read_header()?;
+    for result in reader.record_bufs(&header) {
+        let rec = result?;
+        let flags = u16::from(rec.flags());
+        if flags & (FLAG_SECONDARY | FLAG_SUPPLEMENTARY) != 0 {
+            continue;
+        }
+        return Ok(flags & FLAG_PAIRED != 0);
+    }
+    Ok(false)
 }
 
 /// Full-IUPAC complement, matching `samtools fastq`'s reverse-complement table.

--- a/rust/bismark-aligner/tests/ubam_transcode.rs
+++ b/rust/bismark-aligner/tests/ubam_transcode.rs
@@ -174,3 +174,52 @@ fn se_ubam_header_only_yields_empty_fastq() {
     let out = ubam::transcode_ubam_to_fastq_se(&bam, dir.path()).unwrap();
     assert_eq!(read_to_string(&out), "", "header-only uBAM → empty FASTQ");
 }
+
+#[test]
+fn is_paired_classifies_from_first_primary_record() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Paired uBAM: first primary record carries 0x1.
+    let pe = dir.path().join("pe.bam");
+    write_ubam(
+        &pe,
+        &Header::default(),
+        &[
+            record("p", 0x1 | 0x40, b"ACGT", vec![30, 30, 30, 30]),
+            record("p", 0x1 | 0x80, b"TTGG", vec![30, 30, 30, 30]),
+        ],
+    );
+    assert!(ubam::is_paired(&pe).unwrap(), "0x1 records → paired");
+
+    // Single-end uBAM: no 0x1.
+    let se = dir.path().join("se.bam");
+    write_ubam(
+        &se,
+        &Header::default(),
+        &[record("s", 0, b"ACGT", vec![30, 30, 30, 30])],
+    );
+    assert!(!ubam::is_paired(&se).unwrap(), "no 0x1 → single-end");
+
+    // A leading secondary (0x100) record is skipped; the first PRIMARY decides.
+    let lead_sec = dir.path().join("lead_sec.bam");
+    write_ubam(
+        &lead_sec,
+        &Header::default(),
+        &[
+            record("x", 0x100, b"GGGG", vec![20, 20, 20, 20]), // secondary, skipped
+            record("x", 0, b"ACGT", vec![30, 30, 30, 30]),     // first primary: SE
+        ],
+    );
+    assert!(
+        !ubam::is_paired(&lead_sec).unwrap(),
+        "secondary skipped → first primary (SE) decides"
+    );
+
+    // Header-only → false (→ SE path → empty → graceful).
+    let empty = dir.path().join("empty.bam");
+    write_ubam(&empty, &Header::default(), &[]);
+    assert!(
+        !ubam::is_paired(&empty).unwrap(),
+        "header-only → not paired"
+    );
+}


### PR DESCRIPTION
## What

Adds **paired-end unaligned-BAM (uBAM) input** to the Rust `bismark` aligner, completing the uBAM backend of the pluggable-input front-end (#1025). Builds on the merged single-end uBAM support (#1026).

A **single collated PE uBAM passed positionally** (e.g. `bismark_rs --genome G sample.bam`) is auto-detected and split into mates — equivalent to `samtools fastq -1/-2` then a normal paired-end run.

## How

- **Auto-detect.** `ubam::is_paired` peeks the first **primary** record's `0x1` flag (secondary/supplementary skipped; header-only → single-end → graceful-empty). A single-end uBAM (no `0x1`) stays on the SE path, so existing SE behavior is unchanged.
- **Split + switch.** A paired uBAM is split into R1/R2 temp FASTQs via the `_pe` transcoder (samtools-fastq parity, name-collation required + fail-loud on desync), and the layout is switched **SingleEnd → PairedEnd**.
- **Layout-consistent config.** Because the positional uBAM first resolves as single-end, the SE→PE switch re-derives the two layout-dependent things `resolve()` would have set for native `-1/-2`:
  - the **PE aligner options** (`--no-mixed --no-discordant --dovetail --maxins …`), recomputed via the same `options::build_aligner_options(.., is_paired=true, ..)`; and
  - the **paired-aligner reject**, re-run via a new shared `config::reject_unsupported_paired_aligner` (used by both `resolve()` and the switch) so `--minimap2`/`--rammap` + a PE uBAM fails loud exactly as `-1/-2` does.
- **Fail-loud guards:** mixing a PE uBAM with other inputs; a uBAM via `-1/-2` (pass the collated file positionally); uBAM + `--fasta`.

## Validation

- **Real-data PE equivalence gate (oxy, GRCh38, Bowtie 2 2.5.5, 100k pairs):** `bismark_rs <collated pe.bam>` (auto-detect→split) records **byte-identical** to `bismark_rs -1 <samtools fastq -1> -2 <samtools fastq -2>`, **3/3 cells** (directional / non-directional / pbat). See `plans/06252026_ubam-input/GATE_PE.md`.
- **Dual independent code-review** + **plan-manager** (COMPLETE). The review caught a never-silent gap — the SE→PE switch hadn't re-run the minimap2/rammap-PE reject — fixed via the shared validator above (the gate had already caught and driven the fix for the aligner-options half).
- **Tests:** 437 lib (incl. the new `is_paired` + paired-aligner-guard tests) + 7 integration (real uBAM fixtures via the noodles writer). `cargo fmt --check` + `clippy -D warnings` clean.

## Scope

SE uBAM (#1026) + PE uBAM (this PR) complete the uBAM input backend. **CLI/README docs** (and the `rust/README.md` Milestones line for the uBAM work) are a tracked follow-up. Refs #1025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
