### PR TITLE
feat(aligner): opt-in paraseq + mim FastQ readers for the convert step (#1025 Phase 3b/3c)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,13 +110,15 @@ jobs:
           BISMARK_SUITE_VERSION: ${{ needs.check-release.outputs.version }}
         # Compile the `bismark` aligner with the in-process rammap backend ON so the shipped
         # binary's `--rammap_inprocess` opt-in is functional (default `--rammap`
-        # stays subprocess), AND with `binseq-input` ON so the shipped binary can read
-        # BINSEQ `.vbq` files (#1025 Phase 2 — a default `cargo build` rejects `.vbq`
-        # fail-loud; release binaries decode it). `pkg/feature` syntax: both features
-        # live only on bismark-aligner; this still builds all 14 workspace members, and
-        # the other 11 binaries are byte-unaffected. The rammap-core git dep + the
-        # binseq crates.io dep are fetched at build (network available on the runner).
-        run: cargo build --release --locked --manifest-path rust/Cargo.toml --target ${{ matrix.target }} --features bismark-aligner/rammap-inprocess,bismark-aligner/binseq-input
+        # stays subprocess), with `binseq-input` ON so the shipped binary can read
+        # BINSEQ `.vbq`/`.cbq` files (#1025 Phase 2/3: a default `cargo build` rejects
+        # them fail-loud; release binaries decode them), AND with `paraseq-convert` ON so
+        # the shipped binary honours `--paraseq` (#1025 Phase 3c, opt-in fast FastQ parse,
+        # byte-identical; the default convert path is unchanged). `pkg/feature` syntax: all
+        # three features live only on bismark-aligner; this still builds all 14 workspace
+        # members, and the other 11 binaries are byte-unaffected. The rammap-core git dep +
+        # the binseq/paraseq crates.io deps are fetched at build (network available on the runner).
+        run: cargo build --release --locked --manifest-path rust/Cargo.toml --target ${{ matrix.target }} --features bismark-aligner/rammap-inprocess,bismark-aligner/binseq-input,bismark-aligner/paraseq-convert
       - name: Package the suite tarball
         id: package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,13 +112,17 @@ jobs:
         # binary's `--rammap_inprocess` opt-in is functional (default `--rammap`
         # stays subprocess), with `binseq-input` ON so the shipped binary can read
         # BINSEQ `.vbq`/`.cbq` files (#1025 Phase 2/3: a default `cargo build` rejects
-        # them fail-loud; release binaries decode them), AND with `paraseq-convert` ON so
-        # the shipped binary honours `--paraseq` (#1025 Phase 3c, opt-in fast FastQ parse,
-        # byte-identical; the default convert path is unchanged). `pkg/feature` syntax: all
-        # three features live only on bismark-aligner; this still builds all 14 workspace
-        # members, and the other 11 binaries are byte-unaffected. The rammap-core git dep +
-        # the binseq/paraseq crates.io deps are fetched at build (network available on the runner).
-        run: cargo build --release --locked --manifest-path rust/Cargo.toml --target ${{ matrix.target }} --features bismark-aligner/rammap-inprocess,bismark-aligner/binseq-input,bismark-aligner/paraseq-convert
+        # them fail-loud; release binaries decode them), with `paraseq-convert` ON so the
+        # shipped binary honours `--paraseq` (#1025 Phase 3c, opt-in fast FastQ parse), AND
+        # with `mim-input` ON so it honours `--mim` (#1025 Phase 3b, opt-in opportunistic
+        # gzip-index parallel decode). Both are opt-in + byte-identical; the default convert
+        # path is unchanged. The release toolchain is `@stable` (>= 1.91), which satisfies
+        # mim-index's edition-2024 MSRV (the default/MSRV-1.89 CI builds never compile mim).
+        # `pkg/feature` syntax: all four features live only on bismark-aligner; this still
+        # builds all 14 workspace members, and the other 11 binaries are byte-unaffected. The
+        # rammap-core git dep + the binseq/paraseq/mim-index crates.io deps are fetched at
+        # build (network available on the runner).
+        run: cargo build --release --locked --manifest-path rust/Cargo.toml --target ${{ matrix.target }} --features bismark-aligner/rammap-inprocess,bismark-aligner/binseq-input,bismark-aligner/paraseq-convert,bismark-aligner/mim-input
       - name: Package the suite tarball
         id: package
         run: |

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -165,6 +165,14 @@ jobs:
         run: cargo build -p bismark-aligner --all-targets --features paraseq-convert
       - name: cargo clippy -p bismark-aligner --features paraseq-convert -D warnings
         run: cargo clippy -p bismark-aligner --all-targets --features paraseq-convert -- -D warnings
+      - name: Install minimap2 (5-Base #787 ground-truth gates)
+        # `cargo test -p bismark-aligner` runs the 5-Base real-aligner gates, which panic
+        # when $CI is set and minimap2 is missing (they must not pass vacuously). This
+        # feature job runs them too, so it needs minimap2 like the main `cargo test` job.
+        run: |
+          sudo apt-get update || sudo apt-get update
+          sudo apt-get install -y --no-install-recommends minimap2
+          minimap2 --version
       - name: cargo test -p bismark-aligner --features paraseq-convert
         run: cargo test -p bismark-aligner --features paraseq-convert
 
@@ -195,6 +203,14 @@ jobs:
         run: cargo build -p bismark-aligner --all-targets --features mim-input
       - name: cargo clippy -p bismark-aligner --features mim-input -D warnings
         run: cargo clippy -p bismark-aligner --all-targets --features mim-input -- -D warnings
+      - name: Install minimap2 (5-Base #787 ground-truth gates)
+        # `cargo test -p bismark-aligner` runs the 5-Base real-aligner gates, which panic
+        # when $CI is set and minimap2 is missing (they must not pass vacuously). This
+        # feature job runs them too, so it needs minimap2 like the main `cargo test` job.
+        run: |
+          sudo apt-get update || sudo apt-get update
+          sudo apt-get install -y --no-install-recommends minimap2
+          minimap2 --version
       - name: cargo test -p bismark-aligner --features mim-input
         run: cargo test -p bismark-aligner --features mim-input
 

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -139,6 +139,35 @@ jobs:
       - name: cargo test -p bismark-aligner --features binseq-input
         run: cargo test -p bismark-aligner --features binseq-input
 
+  paraseq-convert:
+    name: cargo build/test (paraseq-convert feature)
+    # The default `test`/`clippy` jobs build FEATURE-OFF, so the paraseq fast-parse convert
+    # path (`convert::convert_fastq_impl_paraseq` + the `paraseq_byte_identity` concordance
+    # tests, all `#[cfg(feature = "paraseq-convert")]`) is otherwise NEVER compiled in CI
+    # (#1025 Phase 3c). This job compiles + tests it. `paraseq` is an OPTIONAL crates.io dep
+    # (edition 2021, MSRV ≤ 1.89); it forced the workspace `smallvec` pin up to =1.15.2
+    # (byte-output-neutral). The hermetic byte-identity tests assert serial == paraseq output.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.89"
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+      - name: cargo build -p bismark-aligner --features paraseq-convert
+        run: cargo build -p bismark-aligner --all-targets --features paraseq-convert
+      - name: cargo clippy -p bismark-aligner --features paraseq-convert -D warnings
+        run: cargo clippy -p bismark-aligner --all-targets --features paraseq-convert -- -D warnings
+      - name: cargo test -p bismark-aligner --features paraseq-convert
+        run: cargo test -p bismark-aligner --features paraseq-convert
+
   fmt:
     name: cargo fmt --check
     runs-on: ubuntu-latest

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -168,6 +168,36 @@ jobs:
       - name: cargo test -p bismark-aligner --features paraseq-convert
         run: cargo test -p bismark-aligner --features paraseq-convert
 
+  mim-input:
+    name: cargo build/test (mim-input feature)
+    # The mim opportunistic gzip-index convert path (`convert::convert_fastq_impl_mim` + the
+    # `mim_byte_identity` concordance tests, all `#[cfg(feature = "mim-input")]`) is otherwise
+    # NEVER compiled in CI (#1025 Phase 3b). UNLIKE the other feature jobs this runs on Rust
+    # **1.91** (not the workspace MSRV 1.89): `mim-index` is edition 2024 / MSRV 1.91. The
+    # default build + all other features stay 1.89-valid (mim is default-OFF), so only this
+    # opt-in feature needs the newer toolchain. The hermetic tests build a real `.fq.gz` +
+    # `.mim` sidecar and assert serial == mim output at 1/2/4 workers.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.91"
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+      - name: cargo build -p bismark-aligner --features mim-input
+        run: cargo build -p bismark-aligner --all-targets --features mim-input
+      - name: cargo clippy -p bismark-aligner --features mim-input -D warnings
+        run: cargo clippy -p bismark-aligner --all-targets --features mim-input -- -D warnings
+      - name: cargo test -p bismark-aligner --features mim-input
+        run: cargo test -p bismark-aligner --features mim-input
+
   fmt:
     name: cargo fmt --check
     runs-on: ubuntu-latest

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,27 +37,12 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -64,15 +55,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -110,6 +92,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,12 +137,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -185,6 +211,7 @@ dependencies = [
  "clap",
  "criterion",
  "flate2",
+ "mim-index",
  "mimalloc",
  "noodles-bam",
  "noodles-bgzf 0.47.0",
@@ -448,12 +475,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7871516cbb4e097e220623917e1491c995ee58c8018d929d4b1e76c378002bf"
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -468,10 +518,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "buffer-redux"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -507,11 +572,31 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -539,6 +624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,14 +653,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 2.7.1",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "52fa72306bb30daf11bc97773431628e5b4916e97aaa74b7d3f625d4d495da02"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -577,11 +668,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "2071365c5c56eae7d77414029dde2f4f4ba151cf68d5a3261c9a40de428ace93"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -589,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "dec5be1eea072311774b7b84ded287adbd9f293f9d23456817605c6042f4f5e0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -601,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -616,6 +707,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core_affinity"
@@ -730,6 +827,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "defmt"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +887,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,7 +932,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -834,6 +954,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -961,6 +1087,12 @@ dependencies = [
  "num_cpus",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -1111,6 +1243,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lender"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeed4888de4544bf3ba2e111326978dbcc37f57bf2c7d6a6a78ed6c01f77ef93"
+dependencies = [
+ "aliasable",
+ "fallible-iterator",
+ "lender-derive",
+ "maybe-dangling",
+ "stable_try_trait_v2",
+]
+
+[[package]]
+name = "lender-derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d074a297c82222d442171bad4f392fef93d35fb31e24a115f605a0c907ce0af9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "lexical-core"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,12 +1342,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "liblzma"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a631d2b24be269775ba8f7789a6afa1ac228346a20c9e87dbbbe4975a79fd764"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdadf1a99aceff34553de1461674ab6ac7e7f0843ae9875e339f4a14eb43475"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1116a951fd9d5110720bb2ae66f72ce5d7b10bd8aa8744924677157089ce13f"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1225,6 +1416,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "maybe-dangling"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59dbb09ed53f8e4f314e353dc6c1853ae5b4c480a668a422657804a544ea9f65"
+
+[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1453,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mim-index"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ff38c9682bbdaf8f8013954a8e7feeefb457ffcbc7b9fa11463b5b9e4a0874"
+dependencies = [
+ "anyhow",
+ "base16",
+ "base64",
+ "bincode 2.0.1",
+ "blake3",
+ "clap",
+ "ctrlc",
+ "flate2",
+ "lender",
+ "libc",
+ "libz-rs-sys",
+ "memchr",
+ "needletail",
+ "num_cpus",
+ "parking_lot",
+ "path-tools",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1275,6 +1510,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "needletail"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa22e1ae8bce4ecf257e2475ef2046026caea08d66b1848d073fe7bc77e4351"
+dependencies = [
+ "buffer-redux",
+ "bytecount",
+ "bzip2 0.4.4",
+ "flate2",
+ "liblzma",
+ "memchr",
+ "zstd",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1340,7 +1602,7 @@ checksum = "bae197edf3fbf530f6cbd4cf22dc36dba94b1a14d6ed1a925bd17e0eaecc40e8"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
- "bzip2",
+ "bzip2 0.6.1",
  "flate2",
  "indexmap",
  "lexical-core",
@@ -1414,6 +1676,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1702,21 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1490,6 +1776,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "path-tools"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cbc2d27ab7424ba124b691f0abb77ff27474c3eaa7478baf50600fa67c3677c"
 
 [[package]]
 name = "pin-project"
@@ -1654,7 +1946,7 @@ version = "1.1.1"
 source = "git+https://github.com/jwanglab/rammap?rev=5ea62cd5e2f7875fef5234d57ada12ac5a30dbba#5ea62cd5e2f7875fef5234d57ada12ac5a30dbba"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "bitflags 2.11.1",
  "byteorder",
  "flate2",
@@ -1843,6 +2135,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +2170,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -1884,6 +2187,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1918,6 +2230,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "stable_try_trait_v2"
+version = "1.75.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4e48411f4db8ccca0470bfb67e3bb821af4227d455aa147917d8d109be0d13"
 
 [[package]]
 name = "strsim"
@@ -2005,6 +2323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2339,67 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2033,10 +2421,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -36,7 +36,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -55,6 +70,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -166,6 +190,7 @@ dependencies = [
  "noodles-bgzf 0.47.0",
  "noodles-core 0.20.0",
  "noodles-sam",
+ "paraseq",
  "predicates",
  "rammap-core",
  "rayon",
@@ -406,6 +431,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -550,7 +581,7 @@ version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -627,7 +658,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -646,7 +677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -699,6 +730,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,10 +791,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream 1.0.0",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -963,10 +1049,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1218,7 +1338,7 @@ version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae197edf3fbf530f6cbd4cf22dc36dba94b1a14d6ed1a925bd17e0eaecc40e8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bstr",
  "bzip2",
  "flate2",
@@ -1277,7 +1397,7 @@ version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbaf538bea4f886de8b3fb611784a13f82c9f8e08e942849e88ec44234674512"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bstr",
  "indexmap",
  "lexical-core",
@@ -1331,6 +1451,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "paraseq"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4145fc3ea04f7fcb950dcddea404a3351879a6ec9a0b01f46c939488e824abd6"
+dependencies = [
+ "crossbeam-channel",
+ "either",
+ "env_logger",
+ "itertools 0.14.0",
+ "log",
+ "memchr",
+ "num_cpus",
+ "parking_lot",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1522,21 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1402,6 +1578,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,7 +1616,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec 0.8.0",
- "bitflags",
+ "bitflags 2.11.1",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1457,7 +1655,7 @@ source = "git+https://github.com/jwanglab/rammap?rev=5ea62cd5e2f7875fef5234d57ad
 dependencies = [
  "anyhow",
  "bincode",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "flate2",
  "hashbrown 0.15.5",
@@ -1532,6 +1730,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,7 +1779,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1585,7 +1792,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -1699,9 +1906,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spin"

--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -95,6 +95,18 @@ rayon = { version = "1", optional = true }
 # default build. Two workspace pin bumps are forced: `thiserror` (binseq's unconditional
 # `^2.0.17` dep) and `anyhow` (the feature above needs `^1.0.100`). Exact-pinned per convention.
 binseq = { version = "=0.9.2", default-features = false, features = ["anyhow"], optional = true }
+# #1025 Phase 3c: paraseq fast FASTQ parser for the bisulfite-convert prelude (the
+# `convert::paraseq_convert` path). OPTIONAL + behind the default-OFF `paraseq-convert`
+# feature, mirroring `binseq-input` so the default/local/Mac `cargo build` NEVER compiles
+# paraseq. Opt-in at runtime via `--paraseq` (never-silent; a default build rejects the flag
+# loudly). The serial `fastq::Reader` is used (NOT the parallel `process_parallel`, which
+# exposes no record-set index → cannot guarantee byte-identical file-order output); reads are
+# converted + written inline (no owned-record channel hand-off), so paraseq's zero-copy parse
+# win is captured while the converted temp FASTQ stays byte-identical to the serial loop.
+# `default-features = false` drops paraseq's `niffler` (compression auto-detect) + `anyhow`
+# defaults; we feed it an already-decompressed stream (flate2 `MultiGzDecoder`), so no
+# compression backend is needed. Exact-pinned per convention.
+paraseq = { version = "=0.4.13", default-features = false, optional = true }
 
 [features]
 # Default-OFF: compiles the in-process rammap backend (`inprocess.rs`) + its rammap-typed
@@ -105,6 +117,11 @@ rammap-inprocess = ["dep:rammap-core", "dep:rayon"]
 # tests. The extension-detection + the CBQ/BQ/feature-off fail-loud rejects compile on ANY
 # toolchain (feature-independent); only the actual `binseq`-crate decode is gated here.
 binseq-input = ["dep:binseq"]
+# Default-OFF: compiles the paraseq fast-parse convert path (`convert::paraseq_convert`). The
+# `--paraseq` flag parses + is rejected never-silently on ANY build (feature-independent);
+# only the actual paraseq decode is gated here. Opt-in at runtime so the byte-frozen serial
+# convert loop stays the default.
+paraseq-convert = ["dep:paraseq"]
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"

--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 # PATH-based discovery of the external aligner (bowtie2). Same crate + pin the
 # genome-preparation port uses for subprocess discovery.
 which = "=7.0.3"
@@ -107,6 +107,20 @@ binseq = { version = "=0.9.2", default-features = false, features = ["anyhow"], 
 # defaults; we feed it an already-decompressed stream (flate2 `MultiGzDecoder`), so no
 # compression backend is needed. Exact-pinned per convention.
 paraseq = { version = "=0.4.13", default-features = false, optional = true }
+# #1025 Phase 3b: mim opportunistic gzip index. OPTIONAL + behind the default-OFF
+# `mim-input` feature. Opt-in `--mim`: when the input `.fq.gz` has a pre-built `.mim`
+# sidecar, decode it in parallel (record-aligned chunk ranges) via mim's `GzipStreamReader`,
+# driving our OWN `paraseq::fastq::Reader` over each worker's stream for byte-identical
+# reconstruction (so the converted temp FastQ is byte-identical to the serial path; workers
+# write contiguous chunk ranges, concatenated in worker order = file order). NB: mim-index is
+# **edition 2024 / MSRV 1.91** (feature therefore requires Rust >= 1.91; the default
+# build + all other features stay on the workspace MSRV 1.89); a dedicated 1.91 CI job covers
+# it (rust_ci.yml). We drive our OWN `paraseq::fastq::Reader` over mim's unconditional
+# `get_reader` (not mim's `get_paraseq_reader`/`get_needletail_iter`), so mim's `paraseq`
+# feature is dropped. `needletail` is enabled ONLY because mim 0.1.1's `lib.rs` re-exports
+# needletail-gated types (`MultiMimReader`/`ReadIter`) unconditionally, so the lib does not
+# compile without it (an upstream quirk, not something we use).
+mim-index = { version = "=0.1.1", default-features = false, features = ["needletail"], optional = true }
 
 [features]
 # Default-OFF: compiles the in-process rammap backend (`inprocess.rs`) + its rammap-typed
@@ -122,6 +136,11 @@ binseq-input = ["dep:binseq"]
 # only the actual paraseq decode is gated here. Opt-in at runtime so the byte-frozen serial
 # convert loop stays the default.
 paraseq-convert = ["dep:paraseq"]
+# Default-OFF: compiles the mim opportunistic gzip-index convert path
+# (`convert::convert_fastq_impl_mim`). Requires Rust >= 1.91 (mim-index is edition 2024). The
+# `--mim` flag parses + is rejected never-silently on ANY build (feature-independent); only
+# the actual mim decode is gated here. Pulls `paraseq` too (the reconstruction is shared).
+mim-input = ["dep:mim-index", "dep:paraseq"]
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"

--- a/rust/bismark-aligner/README.md
+++ b/rust/bismark-aligner/README.md
@@ -12,6 +12,8 @@ the `XM`/`XR`/`XG` methylation call, and writes the Bismark BAM + reports.
 
 **Input formats:** FastQ, FastA, and **unaligned BAM (uBAM)** — a uBAM is auto-detected by its BAM magic bytes (single-end, or a single name-collated paired-end uBAM that is auto-split into mates) and transcoded to a temp FASTQ matching `samtools fastq`, so output is byte-identical to the equivalent FASTQ run. See the [Alignment usage docs](https://felixkrueger.github.io/Bismark/usage/alignment/) for details.
 
+**Fast FastQ parsing (`--paraseq`):** opt-in flag (#1025) that parses the input FastQ with the [`paraseq`](https://github.com/noamteyssier/paraseq) reader in the bisulfite-convert step instead of the built-in line reader. Output is **byte-identical** to the default path (verified by a serial-vs-paraseq concordance gate); the win is faster raw-read parsing, most relevant on the in-process backend where parsing is a larger share of wall time than on the gzip-output / alignment-dominated Bowtie2 / HISAT2 path. Behind the default-OFF / release-ON `paraseq-convert` feature; a default build rejects `--paraseq` fail-loud.
+
 ## Status — built phase by phase
 
 This crate is implemented incrementally against a phased epic

--- a/rust/bismark-aligner/README.md
+++ b/rust/bismark-aligner/README.md
@@ -14,6 +14,8 @@ the `XM`/`XR`/`XG` methylation call, and writes the Bismark BAM + reports.
 
 **Fast FastQ parsing (`--paraseq`):** opt-in flag (#1025) that parses the input FastQ with the [`paraseq`](https://github.com/noamteyssier/paraseq) reader in the bisulfite-convert step instead of the built-in line reader. Output is **byte-identical** to the default path (verified by a serial-vs-paraseq concordance gate); the win is faster raw-read parsing, most relevant on the in-process backend where parsing is a larger share of wall time than on the gzip-output / alignment-dominated Bowtie2 / HISAT2 path. Behind the default-OFF / release-ON `paraseq-convert` feature; a default build rejects `--paraseq` fail-loud.
 
+**Opportunistic gzip index (`--mim`):** opt-in flag (#1025) that, when an input `.fq.gz` has a pre-built `<file>.mim` sidecar (from the [`mim`](https://crates.io/crates/mim-index) indexer), decodes it in parallel (record-aligned chunk ranges, one per worker) in the bisulfite-convert step; otherwise it emits a note and falls back to the standard parser. Output is **byte-identical** to the default path and **worker-count-invariant** (verified by a serial-vs-mim concordance gate at 1/2/4 workers); with `--gzip` the temp is decompression-identical (the decompressed reads, and thus the alignment and final output, are byte-identical). Behind the default-OFF / release-ON `mim-input` feature, which (unlike the others) requires **Rust >= 1.91** because `mim-index` is edition 2024; a default build rejects `--mim` fail-loud. Mutually exclusive with `--paraseq`.
+
 ## Status — built phase by phase
 
 This crate is implemented incrementally against a phased epic

--- a/rust/bismark-aligner/src/cli.rs
+++ b/rust/bismark-aligner/src/cli.rs
@@ -377,6 +377,14 @@ pub struct Cli {
     /// whitespace with underscores (Bismark issue #236; affects `fix_IDs`).
     #[arg(long)]
     pub icpc: bool,
+    /// Parse the input FastQ with the `paraseq` fast parser for the bisulfite-convert
+    /// step instead of the built-in line reader (#1025). Opt-in; requires a build with
+    /// the `paraseq-convert` feature (rejected never-silently otherwise). Output is
+    /// byte-identical to the default path; the win is faster raw-read parsing (most
+    /// relevant on the in-process backend, where parsing is a larger share of wall time
+    /// than on the gzip-output/alignment-dominated Bowtie2/HISAT2 path).
+    #[arg(long = "paraseq")]
+    pub paraseq: bool,
     /// minimap2 short-read preset (`-x sr`; minimap2 mode only).
     #[arg(long = "mm2_short_reads")]
     pub mm2_short_read: bool,

--- a/rust/bismark-aligner/src/cli.rs
+++ b/rust/bismark-aligner/src/cli.rs
@@ -385,6 +385,14 @@ pub struct Cli {
     /// than on the gzip-output/alignment-dominated Bowtie2/HISAT2 path).
     #[arg(long = "paraseq")]
     pub paraseq: bool,
+    /// Opportunistically use a `mim` gzip index (#1025): when an input `.fq.gz` has a
+    /// pre-built `<file>.mim` sidecar, decode it in parallel (record-aligned chunk ranges)
+    /// in the bisulfite-convert step; otherwise fall back to the standard parser (never
+    /// silent). Opt-in; requires a build with the `mim-input` feature (Rust >= 1.91),
+    /// rejected fail-loud otherwise. Output is byte-identical to the default path. Mutually
+    /// exclusive with `--paraseq`.
+    #[arg(long = "mim")]
+    pub mim: bool,
     /// minimap2 short-read preset (`-x sr`; minimap2 mode only).
     #[arg(long = "mm2_short_reads")]
     pub mm2_short_read: bool,

--- a/rust/bismark-aligner/src/config.rs
+++ b/rust/bismark-aligner/src/config.rs
@@ -163,6 +163,9 @@ pub struct ReadProcessing {
     /// `--paraseq`: parse the input FastQ with the paraseq fast parser in the convert
     /// step (#1025; opt-in, byte-identical, requires the `paraseq-convert` feature).
     pub paraseq: bool,
+    /// `--mim`: opportunistic mim gzip-index parallel decode in the convert step (#1025;
+    /// opt-in, byte-identical, requires the `mim-input` feature; falls back if no sidecar).
+    pub mim: bool,
 }
 
 /// The fully-resolved configuration (the seam consumed by later phases).
@@ -552,6 +555,15 @@ pub fn resolve(cli: &Cli, command_line: String) -> Result<RunConfig> {
     let (score_min_intercept, score_min_slope) = options::score_min_params(cli, aligner)?;
     let score_min_local = cli.local; // --local: ln() scMin + the local MAPQ ladder
     reject_unsupported_output_flags(cli)?;
+    // #1025: --paraseq and --mim both replace the FastQ reader in the convert step; allowing
+    // both is ambiguous, so reject the combination never-silently.
+    if cli.paraseq && cli.mim {
+        return Err(AlignerError::Validation(
+            "--paraseq and --mim are mutually exclusive (both replace the FastQ reader in the \
+             bisulfite-convert step); pick one."
+                .into(),
+        ));
+    }
     let output = resolve_output(cli)?;
     let read_processing = ReadProcessing {
         skip: cli.skip,
@@ -560,6 +572,7 @@ pub fn resolve(cli: &Cli, command_line: String) -> Result<RunConfig> {
         // Resolved above (minimap2: Some(value-or-default-10000); else None).
         maximum_length_cutoff,
         paraseq: cli.paraseq,
+        mim: cli.mim,
     };
 
     Ok(RunConfig {

--- a/rust/bismark-aligner/src/config.rs
+++ b/rust/bismark-aligner/src/config.rs
@@ -160,6 +160,9 @@ pub struct ReadProcessing {
     pub icpc: bool,
     /// minimap2-only maximum read length (`--mm2_maximum_length`); inert for Bowtie 2.
     pub maximum_length_cutoff: Option<u32>,
+    /// `--paraseq`: parse the input FastQ with the paraseq fast parser in the convert
+    /// step (#1025; opt-in, byte-identical, requires the `paraseq-convert` feature).
+    pub paraseq: bool,
 }
 
 /// The fully-resolved configuration (the seam consumed by later phases).
@@ -556,6 +559,7 @@ pub fn resolve(cli: &Cli, command_line: String) -> Result<RunConfig> {
         icpc: cli.icpc,
         // Resolved above (minimap2: Some(value-or-default-10000); else None).
         maximum_length_cutoff,
+        paraseq: cli.paraseq,
     };
 
     Ok(RunConfig {

--- a/rust/bismark-aligner/src/convert.rs
+++ b/rust/bismark-aligner/src/convert.rs
@@ -39,6 +39,9 @@ pub struct ConvertOptions {
     pub maximum_length_cutoff: Option<u32>,
     /// `--paraseq`: use the paraseq fast parser (#1025; opt-in, byte-identical).
     pub paraseq: bool,
+    /// `--mim`: opportunistic mim gzip-index parallel decode when a `.mim` sidecar is
+    /// present (#1025; opt-in, byte-identical, falls back to the serial parser otherwise).
+    pub mim: bool,
 }
 
 impl ConvertOptions {
@@ -53,6 +56,7 @@ impl ConvertOptions {
             icpc: cfg.read_processing.icpc,
             maximum_length_cutoff: cfg.read_processing.maximum_length_cutoff,
             paraseq: cfg.read_processing.paraseq,
+            mim: cfg.read_processing.mim,
         }
     }
 }
@@ -266,6 +270,36 @@ fn convert_fastq_impl(
     if opts.paraseq {
         return convert_fastq_impl_paraseq(input, temp_dir, opts, kind, id_suffix, file_base);
     }
+    // #1025 Phase 3b: opt-in mim opportunistic gzip-index path. Engages ONLY when the input
+    // is gzipped AND a `<input>.mim` sidecar exists; otherwise a never-silent note + fall
+    // through to the serial loop ("use the .mim if it's there, else normal parsing").
+    #[cfg(feature = "mim-input")]
+    if opts.mim {
+        let is_gz = input.to_string_lossy().ends_with(".gz");
+        let sidecar = mim_index::default_index_path(input, None);
+        if is_gz && sidecar.exists() {
+            return convert_fastq_impl_mim(input, temp_dir, opts, kind, id_suffix, file_base);
+        }
+        eprintln!(
+            "Note: --mim set but {} for '{}'; using the standard FastQ parser.",
+            if is_gz {
+                "no .mim sidecar was found"
+            } else {
+                "the input is not gzipped"
+            },
+            input.display()
+        );
+        // fall through to the serial loop below.
+    }
+    #[cfg(not(feature = "mim-input"))]
+    if opts.mim {
+        return Err(AlignerError::Validation(
+            "this bismark_rs build was compiled without `--mim` support; rebuild with \
+             `--features mim-input` (requires Rust >= 1.91), or drop --mim to use the built-in \
+             FastQ parser."
+                .into(),
+        ));
+    }
 
     // ---- output name + path (raw concat, Perl ${temp_dir}${name}) -----------
     let basename = input.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
@@ -376,6 +410,43 @@ fn convert_fastq_impl(
     })
 }
 
+/// Shared per-record emit for the paraseq (#1025 Phase 3c) and mim (Phase 3b) convert
+/// paths: reconstruct the 4 FastQ lines from a parsed record's raw fields and write the
+/// converted record, byte-for-byte identical to the serial [`convert_fastq_impl`] loop.
+/// `id` is the header WITHOUT the leading `@` (paraseq `id()`); `sep` is the separator line
+/// WITH its leading `+` (paraseq `sep()`); `seq`/`qual` are the raw line bodies (a CRLF
+/// `\r` is carried through unchanged). `fix_id` runs here (only for records that are
+/// actually written) so a skipped record costs nothing, matching the serial path where a
+/// skipped record produced no output. The dead tab counter is omitted (it is always 0).
+#[cfg(any(feature = "paraseq-convert", feature = "mim-input"))]
+#[allow(clippy::too_many_arguments)]
+fn emit_converted<W: Write>(
+    w: &mut W,
+    kind: ConvKind,
+    id_suffix: &[u8],
+    icpc: bool,
+    id: &[u8],
+    seq: &[u8],
+    sep: &[u8],
+    qual: &[u8],
+    id_scratch: &mut Vec<u8>,
+) -> Result<()> {
+    id_scratch.clear();
+    id_scratch.push(b'@');
+    id_scratch.extend_from_slice(id);
+    let mut fixed_id = fix_id(id_scratch, icpc);
+    fixed_id.extend_from_slice(id_suffix);
+    fixed_id.push(b'\n');
+    w.write_all(&fixed_id)?;
+    w.write_all(&convert_one(seq, kind))?;
+    w.write_all(b"\n")?;
+    w.write_all(sep)?;
+    w.write_all(b"\n")?;
+    w.write_all(qual)?;
+    w.write_all(b"\n")?;
+    Ok(())
+}
+
 /// #1025 Phase 3c, paraseq fast-parse variant of [`convert_fastq_impl`]. Reads the input
 /// FastQ with paraseq's serial reader (zero-copy borrowed record views) instead of the
 /// `read_until`×4 loop, reconstructs the chomped ID line (`@`+`id()`; `id()` omits the
@@ -432,8 +503,7 @@ fn convert_fastq_impl_paraseq(
     });
 
     let mut count: u64 = 0;
-    let mut seqid_tab_count: u64 = 0;
-    let mut id_line: Vec<u8> = Vec::new(); // reused scratch: "@" + id()
+    let mut id_scratch: Vec<u8> = Vec::new();
     let mut rset = reader.new_record_set();
 
     'outer: while rset
@@ -445,19 +515,10 @@ fn convert_fastq_impl_paraseq(
                 AlignerError::Validation(format!("failed to parse FastQ '{input:?}': {e}"))
             })?;
             count += 1;
-
-            // ID: "@" + raw header (paraseq id() is after '@', before '\n', spaces + a CRLF
-            // '\r' preserved) -> fix_id -> (PE: /1/1 or /2/2) -> '\n'. Matches the serial
-            // path's fix_id(chomp_newline(&id)) exactly.
-            id_line.clear();
-            id_line.push(b'@');
-            id_line.extend_from_slice(rec.id());
-            let mut fixed_id = fix_id(&id_line, opts.icpc);
-            fixed_id.extend_from_slice(id_suffix);
-            fixed_id.push(b'\n');
-
             // skip/upto (Perl falsy-0). count is already incremented (matches serial: the
-            // upto-triggering record is counted, then the loop stops).
+            // upto-triggering record is counted, then the loop stops). fix_id runs inside
+            // emit_converted (only for written records); a skipped record produced no output
+            // in the serial path either, so deferring it is byte-identical.
             if let Some(s) = opts.skip
                 && s > 0
                 && count <= s
@@ -470,7 +531,6 @@ fn convert_fastq_impl_paraseq(
             {
                 break 'outer;
             }
-
             let seq = rec.seq_raw();
             // max-length guard (mm2-only, inert on the Bowtie 2 spine). The serial path
             // measures the raw seq line length INCLUDING its terminator, so add 1 for the
@@ -480,25 +540,17 @@ fn convert_fastq_impl_paraseq(
             {
                 continue;
             }
-
-            // tab-in-ID counter (dead: fix_id removed tabs above, a faithful replica of
-            // Perl's likewise-dead check, kept so ConvertedReads.seqid_tab_count matches).
-            if fixed_id.contains(&b'\t') {
-                seqid_tab_count += 1;
-            }
-            // (The serial path's record-1 FastQ sanity is omitted: fixed_id always starts
-            // with '@' and the separator with '+' on this path, and paraseq has already
-            // fail-loud-rejected any non-FastQ input above, so the check can never fire.)
-
-            // uc + C→T/G→A + write; separator (paraseq sep() already includes the leading
-            // '+', unlike id() which omits '@') and qual verbatim, each + '\n'.
-            writer.write_all(&fixed_id)?;
-            writer.write_all(&convert_one(seq, kind))?;
-            writer.write_all(b"\n")?;
-            writer.write_all(rec.sep())?;
-            writer.write_all(b"\n")?;
-            writer.write_all(rec.qual().unwrap_or(b""))?;
-            writer.write_all(b"\n")?;
+            emit_converted(
+                &mut writer,
+                kind,
+                id_suffix,
+                opts.icpc,
+                rec.id(),
+                seq,
+                rec.sep(),
+                rec.qual().unwrap_or(b""),
+                &mut id_scratch,
+            )?;
         }
     }
 
@@ -507,8 +559,10 @@ fn convert_fastq_impl_paraseq(
     Ok(ConvertedReads {
         name,
         path: full_path,
+        // seqid_tab_count is always 0 (fix_id strips tabs before the dead Perl check); the
+        // serial path returns the same 0.
         count,
-        seqid_tab_count,
+        seqid_tab_count: 0,
     })
 }
 
@@ -529,6 +583,210 @@ fn convert_fastq_impl_paraseq(
          to use the built-in FastQ parser."
             .into(),
     ))
+}
+
+/// #1025 Phase 3b, mim opportunistic gzip-index variant of [`convert_fastq_impl`]. When the
+/// input `.fq.gz` has a pre-built `.mim` sidecar, mim assigns the file's record-aligned
+/// chunks to `num_workers` CONTIGUOUS, ascending ranges; each worker decodes its gzip range
+/// in parallel and converts its records into a private buffer, and the buffers are
+/// concatenated in worker order = file order. Each worker drives our own
+/// `paraseq::fastq::Reader` over mim's `GzipStreamReader` and reuses [`emit_converted`], so
+/// the converted temp FastQ is byte-identical to the serial path AND worker-count-invariant
+/// (the parallel split changes only speed). `--skip`/`--upto`/count stay exact because each
+/// worker derives its global 1-based record count from the chunk's `next_record_idx`. With
+/// `--gzip` the temp is **decompression-identical** rather than byte-identical: zlib's
+/// block-split decisions depend on write-chunk sizes, so the parallel assembly's deflate
+/// framing can differ, but the decompressed reads (and thus the alignment + final output)
+/// are byte-identical.
+#[cfg(feature = "mim-input")]
+fn convert_fastq_impl_mim(
+    input: &Path,
+    temp_dir: &Path,
+    opts: &ConvertOptions,
+    kind: ConvKind,
+    id_suffix: &[u8],
+    file_base: &str,
+) -> Result<ConvertedReads> {
+    let nw = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    convert_fastq_impl_mim_with_workers(input, temp_dir, opts, kind, id_suffix, file_base, nw)
+}
+
+/// The worker-count-parameterised core (so tests can prove worker-count invariance).
+#[cfg(feature = "mim-input")]
+fn convert_fastq_impl_mim_with_workers(
+    input: &Path,
+    temp_dir: &Path,
+    opts: &ConvertOptions,
+    kind: ConvKind,
+    id_suffix: &[u8],
+    file_base: &str,
+    num_workers: usize,
+) -> Result<ConvertedReads> {
+    use mim_index::MimReader;
+
+    // ---- output name + path (IDENTICAL to convert_fastq_impl) ----------------
+    let basename = input.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
+        AlignerError::Validation(format!("could not derive a file name from input {input:?}"))
+    })?;
+    let mut name = match &opts.prefix {
+        Some(p) => format!("{p}.{basename}"),
+        None => basename.to_string(),
+    };
+    name.push_str(file_base);
+    name.push_str(if opts.gzip { ".fastq.gz" } else { ".fastq" });
+    let full = format!("{}{name}", temp_dir_prefix(temp_dir)?);
+    let full_path = PathBuf::from(&full);
+
+    let mreader = MimReader::new(input, num_workers.max(1));
+    // Stale-sidecar guard: the `.mim` must match the `.gz` it indexes (blake3), else we would
+    // silently mis-decode against an outdated index. Fail loud.
+    if !mreader.index.verify_hash(input) {
+        return Err(AlignerError::Validation(format!(
+            "the mim sidecar for '{}' does not match the input file (stale or wrong index); \
+             rebuild it, or drop --mim.",
+            input.display()
+        )));
+    }
+    let nw = mreader.num_workers;
+    let total = mreader.index.total_num_records.max(0) as u64;
+
+    // Per-worker converted buffers (uncompressed), assembled in worker order = file order.
+    let mut buffers: Vec<Vec<u8>> = vec![Vec::new(); nw];
+    std::thread::scope(|scope| -> Result<()> {
+        let mut handles = Vec::with_capacity(nw);
+        for w in 0..nw {
+            let range = mreader.chunk_assignments[w].clone();
+            if range.is_empty() {
+                // Excess worker (num_workers > chunks): no records, empty buffer.
+                handles.push(None);
+                continue;
+            }
+            // Global 0-based rank of this worker's first record (chunks are contiguous).
+            let start_rank = mreader
+                .index
+                .checkpoints
+                .get(range.start)
+                .map(|c| c.next_record_idx)
+                .unwrap_or(total);
+            let mreader_ref = &mreader;
+            handles.push(Some(scope.spawn(move || {
+                convert_mim_worker(mreader_ref, w, start_rank, opts, kind, id_suffix, input)
+            })));
+        }
+        for (w, h) in handles.into_iter().enumerate() {
+            if let Some(h) = h {
+                buffers[w] = h
+                    .join()
+                    .map_err(|_| AlignerError::Validation(format!("mim worker {w} panicked")))??;
+            }
+        }
+        Ok(())
+    })?;
+
+    // ---- writer (gz or plain): concatenate the buffers in worker (= file) order ----
+    let out = File::create(&full_path)?;
+    let mut writer: BufWriter<Box<dyn Write>> = BufWriter::new(if opts.gzip {
+        Box::new(GzEncoder::new(out, Compression::default()))
+    } else {
+        Box::new(out)
+    });
+    for buf in &buffers {
+        writer.write_all(buf)?;
+    }
+    writer.flush()?;
+    drop(writer);
+
+    // count matches the serial loop: every record is counted; an active --upto stops after
+    // counting record upto+1. seqid_tab_count is always 0 (fix_id strips tabs).
+    let count = match opts.upto {
+        Some(u) if u > 0 && u < total => u + 1,
+        _ => total,
+    };
+    Ok(ConvertedReads {
+        name,
+        path: full_path,
+        count,
+        seqid_tab_count: 0,
+    })
+}
+
+/// One mim worker: decode + convert this worker's contiguous chunk range into a buffer.
+/// `start_rank` is the global 0-based record index of the worker's first record, so the
+/// 1-based global `count` used by `--skip`/`--upto` is `start_rank + local + 1`.
+#[cfg(feature = "mim-input")]
+#[allow(clippy::too_many_arguments)]
+fn convert_mim_worker(
+    mreader: &mim_index::MimReader,
+    worker_id: usize,
+    start_rank: u64,
+    opts: &ConvertOptions,
+    kind: ConvKind,
+    id_suffix: &[u8],
+    input: &Path,
+) -> Result<Vec<u8>> {
+    use paraseq::Record as _;
+    use paraseq::fastq::Reader;
+
+    let stream = mreader.get_reader(worker_id).map_err(|e| {
+        AlignerError::Validation(format!(
+            "mim worker {worker_id} on '{}': {e}",
+            input.display()
+        ))
+    })?;
+    let mut reader = Reader::new(stream);
+    let mut out: Vec<u8> = Vec::new();
+    let mut id_scratch: Vec<u8> = Vec::new();
+    let mut rset = reader.new_record_set();
+    let mut local: u64 = 0;
+    'outer: while rset.fill(&mut reader).map_err(|e| {
+        AlignerError::Validation(format!(
+            "mim worker {worker_id} parse '{}': {e}",
+            input.display()
+        ))
+    })? {
+        for rec in rset.iter() {
+            let rec = rec.map_err(|e| {
+                AlignerError::Validation(format!(
+                    "mim worker {worker_id} parse '{}': {e}",
+                    input.display()
+                ))
+            })?;
+            let count = start_rank + local + 1; // 1-based global record number
+            local += 1;
+            if let Some(s) = opts.skip
+                && s > 0
+                && count <= s
+            {
+                continue;
+            }
+            if let Some(u) = opts.upto
+                && u > 0
+                && count > u
+            {
+                break 'outer;
+            }
+            let seq = rec.seq_raw();
+            if let Some(cutoff) = opts.maximum_length_cutoff
+                && (seq.len() as u64 + 1) > cutoff as u64
+            {
+                continue;
+            }
+            emit_converted(
+                &mut out,
+                kind,
+                id_suffix,
+                opts.icpc,
+                rec.id(),
+                seq,
+                rec.sep(),
+                rec.qual().unwrap_or(b""),
+                &mut id_scratch,
+            )?;
+        }
+    }
+    Ok(out)
 }
 
 // ===========================================================================
@@ -1157,6 +1415,7 @@ mod tests {
             icpc,
             maximum_length_cutoff: None,
             paraseq: false,
+            mim: false,
         }
     }
 
@@ -1942,6 +2201,7 @@ mod paraseq_byte_identity {
             icpc: false,
             maximum_length_cutoff: None,
             paraseq: false,
+            mim: false,
         }
     }
 
@@ -2062,5 +2322,177 @@ GGGGCCCCAAAATTTT\n\
         let mut o = base_opts();
         o.gzip = true;
         assert_concordant(TRICKY, &o, bisulfite_convert_fastq_se);
+    }
+}
+
+// ===========================================================================
+// #1025 Phase 3b, mim gzip-index byte-identity gate.
+//
+// Concordance: the `--mim` parallel path must produce byte-identical converted FastQ to the
+// serial loop over the same `.fq.gz` (which is byte-identical to Perl v0.25.1), AND be
+// worker-count-invariant. Build a real `.fq.gz` + `.mim` sidecar, then assert serial == mim
+// at 1/2/4 workers (proving the contiguous-chunk parallel split + global-rank skip/upto
+// bookkeeping are exact).
+// ===========================================================================
+#[cfg(all(test, feature = "mim-input"))]
+mod mim_byte_identity {
+    use super::*;
+    use flate2::read::MultiGzDecoder;
+    use std::io::Read as _;
+
+    fn base_opts() -> ConvertOptions {
+        ConvertOptions {
+            prefix: None,
+            gzip: false,
+            skip: None,
+            upto: None,
+            icpc: false,
+            maximum_length_cutoff: None,
+            paraseq: false,
+            mim: false,
+        }
+    }
+
+    fn read_bytes(p: &Path) -> Vec<u8> {
+        let mut v = Vec::new();
+        File::open(p).unwrap().read_to_end(&mut v).unwrap();
+        v
+    }
+
+    fn gzip_to(path: &Path, data: &[u8]) {
+        // Flush every ~1 KiB so the deflate stream has MANY block boundaries; mim can only
+        // checkpoint at a block boundary, so a single giant block would yield one chunk and
+        // never exercise the worker split.
+        let mut enc = GzEncoder::new(File::create(path).unwrap(), Compression::default());
+        for chunk in data.chunks(1024) {
+            enc.write_all(chunk).unwrap();
+            enc.flush().unwrap();
+        }
+        enc.finish().unwrap();
+    }
+
+    /// A tricky FastQ: spaced + tabbed headers (fix_id), lowercase bases (uc), `+readname`
+    /// separators on every 3rd record (sep reconstruction), and varying lengths.
+    fn tricky_fastq(n: usize) -> Vec<u8> {
+        let mut v = Vec::new();
+        for i in 0..n {
+            let header = format!("read{i} some comment\tcol {i}");
+            v.push(b'@');
+            v.extend_from_slice(header.as_bytes());
+            v.push(b'\n');
+            let seq: &[u8] = if i % 2 == 0 {
+                b"acgtACGTnNCCGGAATT"
+            } else {
+                b"CCGGAATTCCGG"
+            };
+            v.extend_from_slice(seq);
+            v.push(b'\n');
+            if i % 3 == 0 {
+                v.push(b'+');
+                v.extend_from_slice(header.as_bytes());
+            } else {
+                v.push(b'+');
+            }
+            v.push(b'\n');
+            let qual: &[u8] = if i % 2 == 0 {
+                b"IIIIIIIIIIIIIIIIII"
+            } else {
+                b"############"
+            };
+            v.extend_from_slice(qual);
+            v.push(b'\n');
+        }
+        v
+    }
+
+    fn assert_concordant(opts: &ConvertOptions, kind: ConvKind, id_suffix: &[u8], file_base: &str) {
+        let dir = tempfile::tempdir().unwrap();
+        let gz = dir.path().join("reads.fastq.gz");
+        gzip_to(&gz, &tricky_fastq(300));
+        // Small chunk size forces MANY record-aligned chunks so the worker split is real.
+        mim_index::build_mim_index(&gz, 256, None, None).unwrap();
+        let sidecar = mim_index::default_index_path(&gz, None);
+        let idx = mim_index::types::MimIndex::read_path(&sidecar).unwrap();
+        assert!(
+            idx.checkpoints.len() > 3,
+            "fixture must span multiple chunks; got {}",
+            idx.checkpoints.len()
+        );
+
+        // For a gzipped temp, compare the DECOMPRESSED content: the deflate framing can
+        // differ (zlib's block-split decisions depend on write-chunk sizes, and the parallel
+        // assembly feeds the encoder differently than the per-record serial path), but the
+        // decompressed reads, hence the bowtie2 input and the final output, are byte-identical.
+        // A plain temp is compared byte-for-byte.
+        let read_content = |p: &Path| -> Vec<u8> {
+            let raw = read_bytes(p);
+            if opts.gzip {
+                let mut out = Vec::new();
+                MultiGzDecoder::new(&raw[..]).read_to_end(&mut out).unwrap();
+                out
+            } else {
+                raw
+            }
+        };
+
+        // serial baseline over the .gz (mim off).
+        let mut serial_opts = opts.clone();
+        serial_opts.mim = false;
+        let serial_dir = dir.path().join("serial");
+        std::fs::create_dir_all(&serial_dir).unwrap();
+        let a =
+            convert_fastq_impl(&gz, &serial_dir, &serial_opts, kind, id_suffix, file_base).unwrap();
+        let a_content = read_content(&a.path);
+
+        for nw in [1usize, 2, 4] {
+            let wdir = dir.path().join(format!("mim{nw}"));
+            std::fs::create_dir_all(&wdir).unwrap();
+            let b = convert_fastq_impl_mim_with_workers(
+                &gz, &wdir, opts, kind, id_suffix, file_base, nw,
+            )
+            .unwrap();
+            assert_eq!(
+                a_content,
+                read_content(&b.path),
+                "serial vs mim (workers={nw}) converted content differs"
+            );
+            assert_eq!(a.count, b.count, "record count differs (workers={nw})");
+        }
+    }
+
+    #[test]
+    fn se_ct_concordant() {
+        assert_concordant(&base_opts(), ConvKind::Ct, b"", "_C_to_T");
+    }
+
+    #[test]
+    fn se_ga_concordant() {
+        assert_concordant(&base_opts(), ConvKind::Ga, b"", "_G_to_A");
+    }
+
+    #[test]
+    fn pe_r1_concordant() {
+        assert_concordant(&base_opts(), ConvKind::Ct, b"/1/1", "_C_to_T");
+    }
+
+    #[test]
+    fn skip_concordant() {
+        let mut o = base_opts();
+        o.skip = Some(50);
+        assert_concordant(&o, ConvKind::Ct, b"", "_C_to_T");
+    }
+
+    #[test]
+    fn upto_concordant() {
+        let mut o = base_opts();
+        o.upto = Some(123);
+        assert_concordant(&o, ConvKind::Ct, b"", "_C_to_T");
+    }
+
+    #[test]
+    fn gzip_output_concordant() {
+        let mut o = base_opts();
+        o.gzip = true;
+        assert_concordant(&o, ConvKind::Ct, b"", "_C_to_T");
     }
 }

--- a/rust/bismark-aligner/src/convert.rs
+++ b/rust/bismark-aligner/src/convert.rs
@@ -37,6 +37,8 @@ pub struct ConvertOptions {
     pub icpc: bool,
     /// minimap2-only max read length; inert for Bowtie 2.
     pub maximum_length_cutoff: Option<u32>,
+    /// `--paraseq`: use the paraseq fast parser (#1025; opt-in, byte-identical).
+    pub paraseq: bool,
 }
 
 impl ConvertOptions {
@@ -50,6 +52,7 @@ impl ConvertOptions {
             upto: cfg.read_processing.upto,
             icpc: cfg.read_processing.icpc,
             maximum_length_cutoff: cfg.read_processing.maximum_length_cutoff,
+            paraseq: cfg.read_processing.paraseq,
         }
     }
 }
@@ -257,6 +260,13 @@ fn convert_fastq_impl(
     id_suffix: &[u8],
     file_base: &str,
 ) -> Result<ConvertedReads> {
+    // #1025 Phase 3c: opt-in paraseq fast-parse path. Gated so the default build never
+    // compiles paraseq; the serial loop below stays the byte-frozen default. Dispatched
+    // up front so the two paths share nothing but produce byte-identical output.
+    if opts.paraseq {
+        return convert_fastq_impl_paraseq(input, temp_dir, opts, kind, id_suffix, file_base);
+    }
+
     // ---- output name + path (raw concat, Perl ${temp_dir}${name}) -----------
     let basename = input.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
         AlignerError::Validation(format!("could not derive a file name from input {input:?}"))
@@ -364,6 +374,161 @@ fn convert_fastq_impl(
         count,
         seqid_tab_count,
     })
+}
+
+/// #1025 Phase 3c, paraseq fast-parse variant of [`convert_fastq_impl`]. Reads the input
+/// FastQ with paraseq's serial reader (zero-copy borrowed record views) instead of the
+/// `read_until`×4 loop, reconstructs the chomped ID line (`@`+`id()`; `id()` omits the
+/// `@`), takes the raw seq, the separator line `sep()` (which already includes the leading
+/// `+`) and the qual from the parsed fields, and runs the
+/// IDENTICAL per-record transform in the IDENTICAL order (count -> `fix_id` -> skip/upto ->
+/// max-len -> `C→T`/`G→A` -> write `id2`/`qual` verbatim). The output is byte-identical to
+/// the serial path for well-formed FastQ (paraseq's `id()`/`sep()`/`seq_raw()`/`qual()` are
+/// the raw line bodies, a CRLF `\r` included). Records are converted + written inline (no
+/// owned-record channel hand-off), so paraseq's parse win is captured without the regression
+/// the maintainer's spike found. Malformed input (a truncated final record) fails loud here
+/// where the serial loop silently drops it, an acceptable never-silent divergence on this
+/// opt-in path.
+#[cfg(feature = "paraseq-convert")]
+fn convert_fastq_impl_paraseq(
+    input: &Path,
+    temp_dir: &Path,
+    opts: &ConvertOptions,
+    kind: ConvKind,
+    id_suffix: &[u8],
+    file_base: &str,
+) -> Result<ConvertedReads> {
+    use paraseq::Record as _;
+    use paraseq::fastq::Reader;
+
+    // ---- output name + path (IDENTICAL to convert_fastq_impl) ----------------
+    let basename = input.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
+        AlignerError::Validation(format!("could not derive a file name from input {input:?}"))
+    })?;
+    let mut name = match &opts.prefix {
+        Some(p) => format!("{p}.{basename}"),
+        None => basename.to_string(),
+    };
+    name.push_str(file_base);
+    name.push_str(if opts.gzip { ".fastq.gz" } else { ".fastq" });
+    let full = format!("{}{name}", temp_dir_prefix(temp_dir)?);
+    let full_path = PathBuf::from(&full);
+
+    // ---- input reader (gz or plain), handed to paraseq already decompressed --
+    let file = File::open(input)?;
+    let inner: Box<dyn BufRead> = if input.to_string_lossy().ends_with(".gz") {
+        Box::new(BufReader::new(MultiGzDecoder::new(file)))
+    } else {
+        Box::new(BufReader::new(file))
+    };
+    let mut reader = Reader::new(inner);
+
+    // ---- writer (gz or plain), IDENTICAL ------------------------------------
+    let out = File::create(&full_path)?;
+    let mut writer: BufWriter<Box<dyn Write>> = BufWriter::new(if opts.gzip {
+        Box::new(GzEncoder::new(out, Compression::default()))
+    } else {
+        Box::new(out)
+    });
+
+    let mut count: u64 = 0;
+    let mut seqid_tab_count: u64 = 0;
+    let mut id_line: Vec<u8> = Vec::new(); // reused scratch: "@" + id()
+    let mut rset = reader.new_record_set();
+
+    'outer: while rset
+        .fill(&mut reader)
+        .map_err(|e| AlignerError::Validation(format!("failed to parse FastQ '{input:?}': {e}")))?
+    {
+        for rec in rset.iter() {
+            let rec = rec.map_err(|e| {
+                AlignerError::Validation(format!("failed to parse FastQ '{input:?}': {e}"))
+            })?;
+            count += 1;
+
+            // ID: "@" + raw header (paraseq id() is after '@', before '\n', spaces + a CRLF
+            // '\r' preserved) -> fix_id -> (PE: /1/1 or /2/2) -> '\n'. Matches the serial
+            // path's fix_id(chomp_newline(&id)) exactly.
+            id_line.clear();
+            id_line.push(b'@');
+            id_line.extend_from_slice(rec.id());
+            let mut fixed_id = fix_id(&id_line, opts.icpc);
+            fixed_id.extend_from_slice(id_suffix);
+            fixed_id.push(b'\n');
+
+            // skip/upto (Perl falsy-0). count is already incremented (matches serial: the
+            // upto-triggering record is counted, then the loop stops).
+            if let Some(s) = opts.skip
+                && s > 0
+                && count <= s
+            {
+                continue;
+            }
+            if let Some(u) = opts.upto
+                && u > 0
+                && count > u
+            {
+                break 'outer;
+            }
+
+            let seq = rec.seq_raw();
+            // max-length guard (mm2-only, inert on the Bowtie 2 spine). The serial path
+            // measures the raw seq line length INCLUDING its terminator, so add 1 for the
+            // stripped '\n' to match byte-for-byte.
+            if let Some(cutoff) = opts.maximum_length_cutoff
+                && (seq.len() as u64 + 1) > cutoff as u64
+            {
+                continue;
+            }
+
+            // tab-in-ID counter (dead: fix_id removed tabs above, a faithful replica of
+            // Perl's likewise-dead check, kept so ConvertedReads.seqid_tab_count matches).
+            if fixed_id.contains(&b'\t') {
+                seqid_tab_count += 1;
+            }
+            // (The serial path's record-1 FastQ sanity is omitted: fixed_id always starts
+            // with '@' and the separator with '+' on this path, and paraseq has already
+            // fail-loud-rejected any non-FastQ input above, so the check can never fire.)
+
+            // uc + C→T/G→A + write; separator (paraseq sep() already includes the leading
+            // '+', unlike id() which omits '@') and qual verbatim, each + '\n'.
+            writer.write_all(&fixed_id)?;
+            writer.write_all(&convert_one(seq, kind))?;
+            writer.write_all(b"\n")?;
+            writer.write_all(rec.sep())?;
+            writer.write_all(b"\n")?;
+            writer.write_all(rec.qual().unwrap_or(b""))?;
+            writer.write_all(b"\n")?;
+        }
+    }
+
+    writer.flush()?;
+    drop(writer);
+    Ok(ConvertedReads {
+        name,
+        path: full_path,
+        count,
+        seqid_tab_count,
+    })
+}
+
+/// Feature-OFF twin: `--paraseq` was passed to a build without the `paraseq-convert`
+/// feature. Reject never-silently rather than silently falling back to the serial parser.
+#[cfg(not(feature = "paraseq-convert"))]
+fn convert_fastq_impl_paraseq(
+    _input: &Path,
+    _temp_dir: &Path,
+    _opts: &ConvertOptions,
+    _kind: ConvKind,
+    _id_suffix: &[u8],
+    _file_base: &str,
+) -> Result<ConvertedReads> {
+    Err(AlignerError::Validation(
+        "this bismark_rs build was compiled without `--paraseq` support; rebuild with \
+         `--features paraseq-convert` (the released binaries include it), or drop --paraseq \
+         to use the built-in FastQ parser."
+            .into(),
+    ))
 }
 
 // ===========================================================================
@@ -991,6 +1156,7 @@ mod tests {
             upto,
             icpc,
             maximum_length_cutoff: None,
+            paraseq: false,
         }
     }
 
@@ -1751,5 +1917,150 @@ mod tests {
             .unwrap_err();
             assert!(format!("{err}").contains("reserved combined-index conversion tag"));
         }
+    }
+}
+
+// ===========================================================================
+// #1025 Phase 3c, paraseq fast-parse byte-identity gate.
+//
+// Concordance: the `--paraseq` path must produce byte-identical converted FastQ to the
+// frozen serial loop (which is itself byte-identical to Perl v0.25.1). So serial == paraseq
+// transitively proves the paraseq path is byte-identical to Perl. Runs both paths over the
+// SAME input with the SAME options and asserts the output bytes + count match.
+// ===========================================================================
+#[cfg(all(test, feature = "paraseq-convert"))]
+mod paraseq_byte_identity {
+    use super::*;
+    use std::io::Read as _;
+
+    fn base_opts() -> ConvertOptions {
+        ConvertOptions {
+            prefix: None,
+            gzip: false,
+            skip: None,
+            upto: None,
+            icpc: false,
+            maximum_length_cutoff: None,
+            paraseq: false,
+        }
+    }
+
+    fn read_bytes(p: &Path) -> Vec<u8> {
+        let mut v = Vec::new();
+        File::open(p).unwrap().read_to_end(&mut v).unwrap();
+        v
+    }
+
+    /// Run `convert` serially and via paraseq on the same `input_bytes`/`opts`; assert the
+    /// converted file bytes + record count are identical.
+    fn assert_concordant(
+        input_bytes: &[u8],
+        opts: &ConvertOptions,
+        convert: impl Fn(&Path, &Path, &ConvertOptions) -> Result<ConvertedReads>,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.fastq");
+        std::fs::write(&input, input_bytes).unwrap();
+
+        let serial_dir = dir.path().join("serial");
+        let paraseq_dir = dir.path().join("paraseq");
+        std::fs::create_dir_all(&serial_dir).unwrap();
+        std::fs::create_dir_all(&paraseq_dir).unwrap();
+
+        let mut o = opts.clone();
+        o.paraseq = false;
+        let a = convert(&input, &serial_dir, &o).unwrap();
+        o.paraseq = true;
+        let b = convert(&input, &paraseq_dir, &o).unwrap();
+
+        assert_eq!(
+            read_bytes(&a.path),
+            read_bytes(&b.path),
+            "serial vs paraseq converted bytes differ"
+        );
+        assert_eq!(a.count, b.count, "record count differs");
+        assert_eq!(a.seqid_tab_count, b.seqid_tab_count, "tab count differs");
+    }
+
+    /// A deliberately tricky FastQ: header with internal spaces (fix_id underscores them),
+    /// lowercase bases (uc), a non-bare `+read3` separator line (sep reconstruction), mixed
+    /// lengths, and CpG/CHG context so C->T actually fires.
+    const TRICKY: &[u8] = b"@read1 with spaces here\n\
+acgtACGTnN\n\
++\n\
+IIIIIIIIII\n\
+@read2\n\
+CCGGCCGGCCGG\n\
++\n\
+##########\x21\x21\n\
+@read3 desc\ttabbed\n\
+ACGTACGT\n\
++read3 desc tabbed\n\
+JJJJJJJJ\n\
+@read4\n\
+GGGGCCCCAAAATTTT\n\
++\n\
+0123456789:;<=>?\n";
+
+    #[test]
+    fn se_ct_concordant() {
+        assert_concordant(TRICKY, &base_opts(), bisulfite_convert_fastq_se);
+    }
+
+    #[test]
+    fn se_ga_concordant() {
+        assert_concordant(TRICKY, &base_opts(), bisulfite_convert_fastq_se_ga);
+    }
+
+    #[test]
+    fn pe_r1_concordant() {
+        assert_concordant(TRICKY, &base_opts(), |i, t, o| {
+            bisulfite_convert_fastq_pe(i, t, o, 1)
+        });
+    }
+
+    #[test]
+    fn pe_r2_concordant() {
+        assert_concordant(TRICKY, &base_opts(), |i, t, o| {
+            bisulfite_convert_fastq_pe(i, t, o, 2)
+        });
+    }
+
+    #[test]
+    fn icpc_concordant() {
+        let mut o = base_opts();
+        o.icpc = true; // truncate ID at first space/tab instead of underscoring
+        assert_concordant(TRICKY, &o, bisulfite_convert_fastq_se);
+    }
+
+    #[test]
+    fn skip_concordant() {
+        let mut o = base_opts();
+        o.skip = Some(2);
+        assert_concordant(TRICKY, &o, bisulfite_convert_fastq_se);
+    }
+
+    #[test]
+    fn upto_concordant() {
+        let mut o = base_opts();
+        o.upto = Some(3);
+        assert_concordant(TRICKY, &o, bisulfite_convert_fastq_se);
+    }
+
+    #[test]
+    fn crlf_concordant() {
+        // CRLF line endings: chomp_newline strips only '\n', leaving '\r' in every field;
+        // paraseq splits on '\n' too, so the '\r' is carried identically.
+        let crlf = b"@r1 a b\r\nACGTacgt\r\n+\r\nIIIIIIII\r\n@r2\r\nCCGG\r\n+\r\n!!!!\r\n";
+        assert_concordant(crlf, &base_opts(), bisulfite_convert_fastq_se);
+    }
+
+    #[test]
+    fn gzip_output_concordant() {
+        // gzip temp output: GzEncoder is deterministic, so identical decompressed content
+        // yields identical gz bytes.
+        let mut o = base_opts();
+        o.gzip = true;
+        assert_concordant(TRICKY, &o, bisulfite_convert_fastq_se);
     }
 }

--- a/rust/bismark-bam2nuc/Cargo.toml
+++ b/rust/bismark-bam2nuc/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 thiserror = "=2.0.18"
 # bismark-io supplies the magic-byte format sniff (AlignmentKind::from_path) for
 # the .bam accept gate + detect_paired_from_header for SE/PE detection. We do

--- a/rust/bismark-bedgraph/Cargo.toml
+++ b/rust/bismark-bedgraph/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 thiserror = "=2.0.18"
 # Multithreaded global allocator (see src/main.rs). The parallel per-file parse
 # (parallel.rs) is allocation-heavy (per-thread hashmap growth); under the

--- a/rust/bismark-coverage2cytosine/Cargo.toml
+++ b/rust/bismark-coverage2cytosine/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 thiserror = "=2.0.18"
 # Genome FASTA reading (mirrors bismark-io/src/cram_ref.rs pins).
 noodles-fasta = "=0.61.0"

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -25,7 +25,7 @@ bismark-io = { version = "=1.0.0", path = "../bismark-io" }
 # Needed directly for `Header` (returned by `bismark_io::open_reader`
 # via `AnyReader::header`) and for test-helper types.
 noodles-sam = "=0.85.0"
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 rustc-hash = "=2.1.0"
 thiserror = "=2.0.18"
 anyhow = "=1.0.103"

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -32,7 +32,10 @@ anyhow = "=1.0.103"
 bstr = "=1.10.0"
 # Phase B (v1.2 UMI epic): UmiDedupKey carries the per-record UMI as a
 # stack-allocated SmallVec for ≤16-byte UMIs. Matches bismark-io's pin.
-smallvec = "=1.13.2"
+# Pinned at =1.15.2 (bumped from =1.13.2 to satisfy paraseq's `^1.15.1`, #1025
+# Phase 3c, byte-output-neutral: SmallVec is an inline-or-heap Vec, contents
+# unchanged). bismark-io carries the same pin.
+smallvec = "=1.15.2"
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"

--- a/rust/bismark-extractor/Cargo.toml
+++ b/rust/bismark-extractor/Cargo.toml
@@ -25,7 +25,7 @@ bismark-io = { version = "=1.0.0", path = "../bismark-io" }
 # IN-PROCESS via these crates' `Cli`/`run()` (no fork/exec, no Perl subprocess).
 bismark-bedgraph = { version = "1.0.0", path = "../bismark-bedgraph" }
 bismark-coverage2cytosine = { version = "1.0.0", path = "../bismark-coverage2cytosine" }
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 # Multithreaded allocator (#884). The default system allocator's arena locks
 # were the dominant cost of the extractor's parallel pipeline: 4-8 worker
 # threads blocked in malloc/free on per-record allocations, causing N>1 to run

--- a/rust/bismark-filter-nonconversion/Cargo.toml
+++ b/rust/bismark-filter-nonconversion/Cargo.toml
@@ -31,7 +31,7 @@ bismark-io = { version = "=1.0.0", path = "../bismark-io" }
 noodles-bam = "=0.89.0"
 noodles-sam = "=0.85.0"
 noodles-bgzf = "=0.47.0"
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 thiserror = "=2.0.18"
 # Multithreaded global allocator (see src/main.rs). Free ~10% sequential win,
 # byte-neutral. Same pin as the extractor (#884) and bedgraph (#915).

--- a/rust/bismark-genome-preparation/Cargo.toml
+++ b/rust/bismark-genome-preparation/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 # gzip input (.fa.gz / .fasta.gz). MultiGzDecoder handles multi-member files
 # (some genome .gz are concatenated members); a plain GzDecoder would truncate.
 flate2 = "=1.1.9"

--- a/rust/bismark-io/Cargo.toml
+++ b/rust/bismark-io/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "2"
 # Phase B (v1.2 UMI epic): BismarkRecord carries an optional UMI as a
 # stack-allocated SmallVec for ≤16-byte UMIs (covers all known Bismark
 # workflows; longer UMIs heap-allocate without semantic change).
-smallvec = "=1.13.2"
+smallvec = "=1.15.2"
 # Plain-gzip `.fa.gz`/`.fasta.gz` support in `genome::` (Perl uses `gunzip -c`);
 # MultiGzDecoder also decodes gzip-framed BGZF. Added additively for the
 # promoted whole-genome reader; the crate version is unchanged (=1.0.0).

--- a/rust/bismark-methylation-consistency/Cargo.toml
+++ b/rust/bismark-methylation-consistency/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 bismark-io = { version = "=1.0.0", path = "../bismark-io" }
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 # noodles-sam pinned to match bismark-io's transitive choice (dedup/extractor
 # precedent). Needed directly for `Header` (returned by the reader's
 # `header()`) and for the @HD SO:coordinate PE sort guard.

--- a/rust/bismark-nome-filtering/Cargo.toml
+++ b/rust/bismark-nome-filtering/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 bismark-io = { version = "=1.0.0", path = "../bismark-io" }
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 thiserror = "=2.0.18"
 # Phase B: always-gzipped `.manOwar.txt.gz` output + gz-aware yacht input.
 flate2 = "=1.1.9"

--- a/rust/bismark-report/Cargo.toml
+++ b/rust/bismark-report/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 thiserror = "=2.0.18"
 # Local-time formatting for the default {{date}}/{{time}} (Perl `localtime`).
 # Already in the workspace Cargo.lock (transitive) — this adds NO new dependency

--- a/rust/bismark-summary/Cargo.toml
+++ b/rust/bismark-summary/Cargo.toml
@@ -23,7 +23,7 @@ bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 # bismark2summary opens NO BAM/SAM/CRAM (filename-only) and writes plain-text
 # outputs — so NO bismark-io, NO noodles, NO flate2. Pure CLI + text parsers +
 # string templating.
-clap = { version = "=4.5.30", features = ["derive"] }
+clap = { version = "=4.5.61", features = ["derive"] }
 thiserror = "=2.0.18"
 anyhow = "=1.0.103"
 


### PR DESCRIPTION
## What

Two opt-in fast/opportunistic FastQ readers for the bisulfite-convert step of #1025 ("Faster FastQ inputs + alternative input file formats"). Both are additive, opt-in, never-silent, feature-gated; the byte-frozen convert -> align -> merge core and its Perl v0.25.1 byte-identity are untouched on the default path.

> **CBQ dropped from this PR (was 73d8262).** Per Felix's review, CBQ decode hit a **blocking upstream defect**: binseq 0.9.2 (+ sucds 0.8.3, both latest) mis-decodes N-containing `.cbq` — silent `N`->`A` in release, panic in debug. Reproduced exactly (`NACGTACGT`->`AACGTACGT`, `NNNNNNNN`->`AAAAAAAA`). N support is CBQ's whole reason to exist over VBQ, there is no clean public API to detect Ns in binseq 0.9.2, and a silent `A` where a methylation caller expects a no-call `N` is unacceptable. CBQ is parked (the correct decode plumbing is preserved) pending an upstream binseq fix + an N round-trip re-verification, and will be re-proposed in its own PR. An upstream bug report against binseq/sucds is being filed.

### Phase 3c, paraseq fast FastQ parse (`--paraseq`)
Opt-in: parse the input FastQ with the `paraseq` reader in the bisulfite-convert step instead of the built-in `read_until` loop. Byte-identical to the default path; the win is faster raw-read parsing.
- Serial `fastq::Reader` (not the parallel `process_parallel`, which exposes no record-set index, so it cannot guarantee byte-identical file order; the maintainer's spike also found parallel convert value-negative on the wrapper path). Records are converted + written inline, capturing the parse win without the channel-handoff regression.
- Behind the default-OFF / release-ON `paraseq-convert` feature. Forced one workspace pin bump: `smallvec` =1.13.2 -> =1.15.2 (byte-output-neutral).
- A `paraseq_byte_identity` gate asserts serial == paraseq across SE C->T/G->A, PE R1/R2, --icpc/--skip/--upto, CRLF, and gzip output.

### Phase 3b, mim opportunistic gzip index (`--mim`)
Opt-in: when an input `.fq.gz` has a pre-built `<file>.mim` sidecar, decode it in parallel (record-aligned chunk ranges, one per worker) in the convert step; otherwise emit a note and fall back to the standard parser.
- Byte-identical AND worker-count-invariant: mim assigns CONTIGUOUS ascending chunk ranges per worker; each worker drives our own `paraseq::fastq::Reader` over mim's `GzipStreamReader` and reuses the shared `emit_converted`, and buffers are concatenated in worker order = file order. `--skip`/`--upto`/count stay exact via each chunk's `next_record_idx`. With `--gzip` the temp is decompression-identical (deflate framing may differ; the decompressed reads, alignment, and final output are byte-identical).
- Behind the default-OFF / release-ON `mim-input` feature. UNLIKE the others it requires **Rust >= 1.91** (`mim-index` is edition 2024), so it gets a dedicated 1.91 CI job; the default build + all other features stay 1.89-valid. Forced one workspace pin bump: `clap` =4.5.30 -> =4.5.61 (behavior + CLI-output neutral; the suite uses custom error strings, not clap auto-help). Mutually exclusive with `--paraseq`.
- A `mim_byte_identity` gate builds a real `.fq.gz` + `.mim` sidecar and asserts serial == mim at 1/2/4 workers across SE C->T/G->A, PE, --skip/--upto, and --gzip.

## Test plan
- `cargo test --workspace` (default): all crates green (validates the clap bump across all 12 binaries).
- `cargo test -p bismark-aligner --features paraseq-convert` (paraseq concordance), `--features mim-input` (mim concordance).
- `cargo clippy -p bismark-aligner --all-targets --release [--features ...] -- -D warnings` clean on default + both features.
- MSRV: default workspace builds on **1.89**; `mim-input` builds on **1.91**. New CI jobs cover paraseq-convert (1.89) and mim-input (1.91); release ships both features on `@stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)