### PR TITLE
refactor(release): rename _rs binaries → canonical names (GA epic Ph3a)

### DIFF
--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "bismark_rs"
+name = "bismark"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-aligner/tests/byte_identity_real_data.rs
+++ b/rust/bismark-aligner/tests/byte_identity_real_data.rs
@@ -180,7 +180,7 @@ fn run_oracle(ds: &AlignerDataset) {
         ds.label,
         base.display()
     );
-    Command::cargo_bin("bismark_rs")
+    Command::cargo_bin("bismark")
         .unwrap()
         .arg("--genome")
         .arg(&genome)

--- a/rust/bismark-aligner/tests/cli.rs
+++ b/rust/bismark-aligner/tests/cli.rs
@@ -13,7 +13,7 @@ use predicates::prelude::*;
 use tempfile::TempDir;
 
 fn bin() -> Command {
-    Command::cargo_bin("bismark_rs").unwrap()
+    Command::cargo_bin("bismark").unwrap()
 }
 
 #[cfg(unix)]

--- a/rust/bismark-aligner/tests/five_base_groundtruth.rs
+++ b/rust/bismark-aligner/tests/five_base_groundtruth.rs
@@ -56,7 +56,7 @@ fn load_first_contig_gz(path: &Path) -> Vec<u8> {
 type Truth = HashMap<String, Vec<(usize, bool)>>;
 
 fn bin() -> Command {
-    Command::cargo_bin("bismark_rs").unwrap()
+    Command::cargo_bin("bismark").unwrap()
 }
 
 fn have_minimap2() -> bool {

--- a/rust/bismark-bam2nuc/Cargo.toml
+++ b/rust/bismark-bam2nuc/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "bam2nuc_rs"
+name = "bam2nuc"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-bam2nuc/tests/byte_identity_real_data.rs
+++ b/rust/bismark-bam2nuc/tests/byte_identity_real_data.rs
@@ -28,7 +28,7 @@ fn real_bam_produces_nonempty_stats() {
     let out = tempfile::tempdir().unwrap();
     let dir_arg = format!("{}/", out.path().display());
 
-    Command::cargo_bin("bam2nuc_rs")
+    Command::cargo_bin("bam2nuc")
         .unwrap()
         .arg("-g")
         .arg(&genome)

--- a/rust/bismark-bam2nuc/tests/golden.rs
+++ b/rust/bismark-bam2nuc/tests/golden.rs
@@ -47,7 +47,7 @@ fn assert_bytes_eq(actual: &[u8], expected: &[u8], label: &str) {
 }
 
 fn bin() -> Command {
-    Command::cargo_bin("bam2nuc_rs").unwrap()
+    Command::cargo_bin("bam2nuc").unwrap()
 }
 
 /// Run `--genomic_composition_only` against a genome fixture; return the cache.

--- a/rust/bismark-bedgraph/Cargo.toml
+++ b/rust/bismark-bedgraph/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "bismark2bedGraph_rs"
+name = "bismark2bedGraph"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-bedgraph/tests/byte_identity_fixtures.rs
+++ b/rust/bismark-bedgraph/tests/byte_identity_fixtures.rs
@@ -83,7 +83,7 @@ fn run_cell_with_files(cell: &str, flags: &[&str], files: &[&str], outputs: &[Ou
         fs::copy(fx.join(f), tmp.path().join(f)).unwrap();
     }
 
-    let mut cmd = Command::cargo_bin("bismark2bedGraph_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark2bedGraph").unwrap();
     cmd.current_dir(tmp.path());
     cmd.args(flags);
     cmd.args(["-o", "out.bedGraph"]);

--- a/rust/bismark-bedgraph/tests/byte_identity_real_data.rs
+++ b/rust/bismark-bedgraph/tests/byte_identity_real_data.rs
@@ -26,7 +26,7 @@ use std::process::Command;
 use flate2::read::GzDecoder;
 use tempfile::TempDir;
 
-const RUST_BIN: &str = env!("CARGO_BIN_EXE_bismark2bedGraph_rs");
+const RUST_BIN: &str = env!("CARGO_BIN_EXE_bismark2bedGraph");
 
 fn gunzip(path: &Path) -> Vec<u8> {
     let bytes = fs::read(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));

--- a/rust/bismark-bedgraph/tests/cli_behavior.rs
+++ b/rust/bismark-bedgraph/tests/cli_behavior.rs
@@ -38,7 +38,7 @@ fn run_and_read(workdir: &Path, out_dir: &Path, extra: &[&str]) -> (Vec<u8>, Vec
     for f in CPG {
         fs::copy(fx.join(f), workdir.join(f)).unwrap();
     }
-    let mut cmd = Command::cargo_bin("bismark2bedGraph_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark2bedGraph").unwrap();
     cmd.current_dir(workdir);
     cmd.args(extra);
     cmd.args(["-o", "out.bedGraph"]);
@@ -120,7 +120,7 @@ fn accepted_but_ignored_flags_do_not_change_output() {
 
 #[test]
 fn version_flag_prints_provenance_and_exits_zero() {
-    Command::cargo_bin("bismark2bedGraph_rs")
+    Command::cargo_bin("bismark2bedGraph")
         .unwrap()
         .arg("--version")
         .assert()
@@ -130,7 +130,7 @@ fn version_flag_prints_provenance_and_exits_zero() {
 
 #[test]
 fn man_flag_prints_long_help_and_exits_zero() {
-    Command::cargo_bin("bismark2bedGraph_rs")
+    Command::cargo_bin("bismark2bedGraph")
         .unwrap()
         .arg("--man")
         .assert()
@@ -140,7 +140,7 @@ fn man_flag_prints_long_help_and_exits_zero() {
 
 #[test]
 fn help_flag_smoke() {
-    Command::cargo_bin("bismark2bedGraph_rs")
+    Command::cargo_bin("bismark2bedGraph")
         .unwrap()
         .arg("--help")
         .assert()

--- a/rust/bismark-bedgraph/tests/many_scaffolds.rs
+++ b/rust/bismark-bedgraph/tests/many_scaffolds.rs
@@ -37,7 +37,7 @@ fn handles_thousands_of_scaffolds_in_bytewise_order() {
         }
     }
 
-    Command::cargo_bin("bismark2bedGraph_rs")
+    Command::cargo_bin("bismark2bedGraph")
         .unwrap()
         .current_dir(tmp.path())
         .args(["-o", "out.bedGraph", "CpG_OT_scaffolds.txt"])

--- a/rust/bismark-coverage2cytosine/Cargo.toml
+++ b/rust/bismark-coverage2cytosine/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "coverage2cytosine_rs"
+name = "coverage2cytosine"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-coverage2cytosine/tests/golden_phase1.rs
+++ b/rust/bismark-coverage2cytosine/tests/golden_phase1.rs
@@ -44,7 +44,7 @@ fn list_sorted(dir: &Path) -> Vec<String> {
 /// Run `coverage2cytosine_rs` into a fresh tempdir; assert success; return it.
 fn run_rust(genome: &str, cov: &str, oname: &str, flags: &[&str]) -> tempfile::TempDir {
     let tmp = tempfile::tempdir().unwrap();
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg(oname)

--- a/rust/bismark-coverage2cytosine/tests/golden_phase2.rs
+++ b/rust/bismark-coverage2cytosine/tests/golden_phase2.rs
@@ -43,7 +43,7 @@ fn list_sorted(dir: &Path) -> Vec<String> {
 /// Run `coverage2cytosine_rs` into a fresh tempdir; assert success; return it.
 fn run_rust(genome: &str, cov: &str, oname: &str, flags: &[&str]) -> tempfile::TempDir {
     let tmp = tempfile::tempdir().unwrap();
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg(oname)

--- a/rust/bismark-coverage2cytosine/tests/golden_phase3.rs
+++ b/rust/bismark-coverage2cytosine/tests/golden_phase3.rs
@@ -41,7 +41,7 @@ fn list_sorted(dir: &Path) -> Vec<String> {
 
 fn run_rust(genome: &str, cov: &str, oname: &str, flags: &[&str]) -> tempfile::TempDir {
     let tmp = tempfile::tempdir().unwrap();
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg(oname)

--- a/rust/bismark-coverage2cytosine/tests/golden_phase_b.rs
+++ b/rust/bismark-coverage2cytosine/tests/golden_phase_b.rs
@@ -19,7 +19,7 @@ fn assert_mode_matches_golden(mode: &str, report_suffix: &str, extra: &[&str]) {
     let d = data_dir();
     let tmp = tempfile::tempdir().unwrap();
 
-    let mut cmd = Command::cargo_bin("coverage2cytosine_rs").unwrap();
+    let mut cmd = Command::cargo_bin("coverage2cytosine").unwrap();
     cmd.arg("-o")
         .arg(mode)
         .arg("-g")
@@ -93,7 +93,7 @@ fn run_with(genome_fa: &str, cov: &str, extra: &[&str]) -> String {
     let out = tmp.path().join("out");
     std::fs::create_dir(&out).unwrap();
 
-    let mut cmd = Command::cargo_bin("coverage2cytosine_rs").unwrap();
+    let mut cmd = Command::cargo_bin("coverage2cytosine").unwrap();
     cmd.arg("-o")
         .arg("s")
         .arg("-g")
@@ -140,7 +140,7 @@ fn empty_coverage_input_standard_path_emits_all_zero_report() {
     let cov = tmp.path().join("empty.cov");
     std::fs::write(&cov, "").unwrap();
 
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg("s")
@@ -187,7 +187,7 @@ fn empty_coverage_gzipped_standard_path_emits_gzipped_all_zero_report() {
     enc.write_all(b"").unwrap();
     enc.finish().unwrap();
 
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg("s")
@@ -234,7 +234,7 @@ fn empty_coverage_missing_file_errors() {
     std::fs::write(gdir.join("g.fa"), ">chrA\nACGT\n").unwrap();
     let missing = tmp.path().join("does_not_exist.cov");
 
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg("s")
@@ -262,7 +262,7 @@ fn empty_coverage_corrupt_gzip_with_gz_name_errors() {
     // decompress, which fails.
     std::fs::write(&cov, b"this is not gzip data at all\n").unwrap();
 
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg("s")
@@ -305,7 +305,7 @@ fn empty_coverage_threshold_emits_empty_report() {
     let cov = tmp.path().join("empty.cov");
     std::fs::write(&cov, "").unwrap();
 
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg("s")
@@ -335,7 +335,7 @@ fn empty_coverage_nome_emits_empty_report() {
     let cov = tmp.path().join("empty.cov");
     std::fs::write(&cov, "").unwrap();
 
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg("s")
@@ -364,7 +364,7 @@ fn empty_coverage_gc_emits_empty_report() {
     let cov = tmp.path().join("empty.cov");
     std::fs::write(&cov, "").unwrap();
 
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg("s")

--- a/rust/bismark-coverage2cytosine/tests/golden_phase_c.rs
+++ b/rust/bismark-coverage2cytosine/tests/golden_phase_c.rs
@@ -33,7 +33,7 @@ fn file_set(dir: &Path) -> BTreeSet<String> {
 fn run(stem: &str, flags: &[&str]) -> tempfile::TempDir {
     let d = data_dir();
     let tmp = tempfile::tempdir().unwrap();
-    let mut cmd = Command::cargo_bin("coverage2cytosine_rs").unwrap();
+    let mut cmd = Command::cargo_bin("coverage2cytosine").unwrap();
     cmd.arg("-o")
         .arg(stem)
         .arg("-g")
@@ -187,7 +187,7 @@ fn split_reappearance_truncates_and_summary_in_last_chr() {
     .unwrap();
     let out = tmp.path().join("out");
     std::fs::create_dir(&out).unwrap();
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg("s")

--- a/rust/bismark-coverage2cytosine/tests/golden_phase_d.rs
+++ b/rust/bismark-coverage2cytosine/tests/golden_phase_d.rs
@@ -25,7 +25,7 @@ fn gunzip(path: &Path) -> Vec<u8> {
 /// Run `--merge_CpGs …` into a tempdir; assert success; return the tempdir.
 fn run_merge(genome: &Path, cov: &Path, flags: &[&str]) -> tempfile::TempDir {
     let tmp = tempfile::tempdir().unwrap();
-    let mut cmd = Command::cargo_bin("coverage2cytosine_rs").unwrap();
+    let mut cmd = Command::cargo_bin("coverage2cytosine").unwrap();
     cmd.arg("-o")
         .arg("m")
         .arg("-g")
@@ -131,7 +131,7 @@ fn eof_mid_resync_errors_with_partial_merged_file() {
     // hits EOF; Perl dies (255) leaving chrM's merged line. Rust errors (exit 1,
     // no panic) and leaves the SAME partial merged file.
     let tmp = tempfile::tempdir().unwrap();
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-o")
         .arg("m")

--- a/rust/bismark-coverage2cytosine/tests/methylseq_conformance.rs
+++ b/rust/bismark-coverage2cytosine/tests/methylseq_conformance.rs
@@ -84,7 +84,7 @@ fn methylseq_coverage2cytosine_empty_runtime_emits_required_outputs() {
     enc.write_all(b"").unwrap();
     enc.finish().unwrap();
 
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg(&cov)
         .arg("--genome")

--- a/rust/bismark-coverage2cytosine/tests/sanity.rs
+++ b/rust/bismark-coverage2cytosine/tests/sanity.rs
@@ -10,7 +10,7 @@ use predicates::str::is_match;
 
 #[test]
 fn version_output_matches_provenance_regex() {
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("--version")
         .assert()
@@ -20,7 +20,7 @@ fn version_output_matches_provenance_regex() {
 
 #[test]
 fn short_version_flag_works_too() {
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-V")
         .assert()
@@ -30,7 +30,7 @@ fn short_version_flag_works_too() {
 
 #[test]
 fn help_lists_v1_flags() {
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("--help")
         .assert()
@@ -45,7 +45,7 @@ fn help_lists_v1_flags() {
 #[test]
 fn missing_output_fails_with_clear_message() {
     // validate() returns MissingOutput before any I/O.
-    Command::cargo_bin("coverage2cytosine_rs")
+    Command::cargo_bin("coverage2cytosine")
         .unwrap()
         .arg("-g")
         .arg("genome_dir")

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "deduplicate_bismark_rs"
+name = "deduplicate_bismark"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-dedup/tests/byte_identity_real_data.rs
+++ b/rust/bismark-dedup/tests/byte_identity_real_data.rs
@@ -235,7 +235,7 @@ fn run_byte_identity_at_parallel_for(parallel: Option<u32>, spec: &DatasetSpec) 
 
     // Run from the dataset dir with the basename so the report includes
     // exactly the same `file_label` as the Perl baseline.
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.current_dir(&dataset_dir)
         .arg("--paired")
         .arg("--output_dir")

--- a/rust/bismark-dedup/tests/integration_dedup.rs
+++ b/rust/bismark-dedup/tests/integration_dedup.rs
@@ -304,7 +304,7 @@ fn pe_dedup_retains_first_occurrence_and_removes_subsequent_duplicates() {
 
     write_bam(&input, &records);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--paired")
         .arg("--output_dir")
         .arg(dir.path())
@@ -348,7 +348,7 @@ fn pe_dedup_output_preserves_r1_followed_by_r2_adjacency() {
     }
     write_bam(&input, &records);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--paired")
         .arg("--output_dir")
         .arg(dir.path())
@@ -396,7 +396,7 @@ fn se_dedup_retains_first_occurrence_and_removes_subsequent_duplicates() {
 
     write_bam(&input, &records);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--single")
         .arg("--output_dir")
         .arg(dir.path())
@@ -433,7 +433,7 @@ fn ctot_pair_non_directional_dedup_works_end_to_end() {
 
     write_bam(&input, &records);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--paired")
         .arg("--output_dir")
         .arg(dir.path())
@@ -463,7 +463,7 @@ fn ctob_pair_non_directional_dedup_works_end_to_end() {
 
     write_bam(&input, &records);
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--output_dir")
@@ -495,7 +495,7 @@ fn mixed_four_strand_single_file_all_pairs_coexist() {
     records.push(build_record("ob1", b"GA", b"GA", 163, 0, 4100, 50));
     write_bam(&input, &records);
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--output_dir")
@@ -536,7 +536,7 @@ fn nondir_pe_repro_1030_dedups_without_crash() {
         vec!["--barcode", "--parallel", "4"],
     ] {
         let dir = TempDir::new().unwrap();
-        let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+        let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
         cmd.arg("--paired").arg("--output_dir").arg(dir.path());
         for a in &extra_args {
             cmd.arg(a);
@@ -573,7 +573,7 @@ fn pe_dedup_report_bytes_match_perl_format() {
     records.extend(ot_pair("dup", 1000, 1100));
     write_bam(&input, &records);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--paired")
         .arg("--output_dir")
         .arg(dir.path())
@@ -605,7 +605,7 @@ fn outfile_with_directory_prefix_strips_path_per_perl_regex() {
     let input = dir.path().join("input.bam");
     write_bam(&input, &ot_pair("u0", 1000, 1100));
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--paired")
         .arg("--output_dir")
         .arg(dir.path())
@@ -671,7 +671,7 @@ fn multiple_mode_accumulates_dedup_state_across_inputs() {
     f2.extend(ot_pair("f2_dup_of_f1_u0", 1000, 1100));
     write_bam(&input2, &f2);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--multiple")
         .arg("--paired")
         .arg("--output_dir")
@@ -759,7 +759,7 @@ fn empty_input_se_is_graceful() {
     let input = dir.path().join("empty.bam");
     write_bam(&input, &[]); // header only, no records
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--single")
         .arg("--output_dir")
         .arg(dir.path())
@@ -780,7 +780,7 @@ fn empty_input_pe_is_graceful() {
     let input = dir.path().join("empty.bam");
     write_bam(&input, &[]);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--paired")
         .arg("--output_dir")
         .arg(dir.path())
@@ -799,7 +799,7 @@ fn empty_input_parallel_is_graceful() {
     let input = dir.path().join("empty.bam");
     write_bam(&input, &[]);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--single")
         .arg("--parallel")
         .arg("2")
@@ -821,7 +821,7 @@ fn empty_input_umi_is_graceful() {
     let input = dir.path().join("empty.bam");
     write_bam(&input, &[]);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--single")
         .arg("--barcode")
         .arg("--output_dir")
@@ -846,7 +846,7 @@ fn all_unmapped_input_is_graceful() {
     let rec = build_record("r1", b"CT", b"CT", 0x4, 0, 1, 50);
     write_bam(&input, &[rec]);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--single")
         .arg("--output_dir")
         .arg(dir.path())
@@ -886,7 +886,7 @@ fn multiple_mode_rejects_different_sq_name_sets_across_inputs() {
         .unwrap();
     writer.finish().unwrap();
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--multiple")
         .arg("--paired")
         .arg("--output_dir")
@@ -920,7 +920,7 @@ fn multiple_mode_empty_file1_still_processes_file2() {
     write_bam(&input1, &[]); // file1: header only
     write_bam(&input2, &ot_pair("u0", 1000, 1100)); // file2: one PE pair
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--multiple")
         .arg("--paired")
         .arg("--output_dir")
@@ -971,7 +971,7 @@ fn multiple_mode_all_files_empty_is_graceful() {
     write_bam(&input1, &[]);
     write_bam(&input2, &[]);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--multiple")
         .arg("--single")
         .arg("--output_dir")
@@ -1015,7 +1015,7 @@ fn multiple_mode_sq_mismatch_fires_when_file1_is_empty() {
         .unwrap();
     writer.finish().unwrap();
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--multiple")
         .arg("--paired")
         .arg("--output_dir")
@@ -1055,7 +1055,7 @@ fn multiple_mode_rejects_mixed_input_formats() {
         writer.finish().unwrap();
     }
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--multiple")
         .arg("--paired")
         .arg("--output_dir")
@@ -1086,7 +1086,7 @@ fn pe_dedup_report_with_no_duplicates_renders_zero_percent() {
     }
     write_bam(&input, &records);
 
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--paired")
         .arg("--output_dir")
         .arg(dir.path())
@@ -1152,7 +1152,7 @@ fn pe_parallel_4_produces_same_qname_set_as_single_threaded() {
     // Run with --parallel 1 (single-threaded path).
     let out1 = dir.path().join("single");
     std::fs::create_dir_all(&out1).unwrap();
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--parallel")
@@ -1166,7 +1166,7 @@ fn pe_parallel_4_produces_same_qname_set_as_single_threaded() {
     // Run with --parallel 4 (threaded path).
     let out4 = dir.path().join("threaded");
     std::fs::create_dir_all(&out4).unwrap();
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--parallel")
@@ -1222,7 +1222,7 @@ fn se_parallel_4_produces_same_qname_set_as_single_threaded() {
 
     let out1 = dir.path().join("single");
     std::fs::create_dir_all(&out1).unwrap();
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--single")
         .arg("--parallel")
@@ -1235,7 +1235,7 @@ fn se_parallel_4_produces_same_qname_set_as_single_threaded() {
 
     let out4 = dir.path().join("threaded");
     std::fs::create_dir_all(&out4).unwrap();
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--single")
         .arg("--parallel")
@@ -1302,7 +1302,7 @@ fn multiple_parallel_4_produces_same_qname_set_as_single_threaded() {
 
     let out1 = dir.path().join("single");
     std::fs::create_dir_all(&out1).unwrap();
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--multiple")
         .arg("--paired")
@@ -1317,7 +1317,7 @@ fn multiple_parallel_4_produces_same_qname_set_as_single_threaded() {
 
     let out4 = dir.path().join("threaded");
     std::fs::create_dir_all(&out4).unwrap();
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--multiple")
         .arg("--paired")
@@ -1377,7 +1377,7 @@ fn pe_parallel_4_preserves_r1_followed_by_r2_adjacency() {
         "PE adjacency fixture too small to span multiple BGZF blocks ({bam_size} bytes)"
     );
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--parallel")
@@ -1416,7 +1416,7 @@ fn parallel_above_four_emits_diminishing_returns_warning() {
     let input = dir.path().join("input.bam");
     write_bam(&input, &ot_pair("u0", 1000, 1100));
 
-    let output = Command::cargo_bin("deduplicate_bismark_rs")
+    let output = Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--parallel")
@@ -1455,7 +1455,7 @@ fn parallel_equal_to_four_does_not_emit_diminishing_returns_warning() {
     let input = dir.path().join("input.bam");
     write_bam(&input, &ot_pair("u0", 1000, 1100));
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--parallel")
@@ -1475,7 +1475,7 @@ fn parallel_zero_is_rejected_at_validate() {
     let input = dir.path().join("input.bam");
     write_bam(&input, &ot_pair("u0", 1000, 1100));
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--parallel")
@@ -1540,7 +1540,7 @@ fn cram_with_parallel_n_logs_warning_and_runs_single_threaded() {
         writer.finish().unwrap();
     }
 
-    let output = Command::cargo_bin("deduplicate_bismark_rs")
+    let output = Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--parallel")
@@ -1641,7 +1641,7 @@ fn parallel_4_multiple_mode_output_ends_with_bgzf_eof_marker() {
         "fixture combined size ({combined} B) too small to span multiple BGZF blocks"
     );
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--multiple")
         .arg("--paired")
@@ -1710,7 +1710,7 @@ fn umi_barcode_dedup_matches_perl_baseline_byte_for_byte() {
     let dir = TempDir::new().unwrap();
     let input = umi_fixtures_dir().join(format!("{BARCODE_STEM}.bam"));
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--barcode")
@@ -1797,7 +1797,7 @@ fn umi_bclconvert_dedup_matches_perl_baseline_byte_for_byte() {
     let dir = TempDir::new().unwrap();
     let input = umi_fixtures_dir().join(format!("{BCLCONVERT_STEM}.bam"));
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--bclconvert")
@@ -1835,7 +1835,7 @@ fn umi_barcode_engages_mode_retains_more_reads_than_position_only() {
     std::fs::create_dir_all(&dir_umi).unwrap();
     std::fs::create_dir_all(&dir_pos).unwrap();
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--barcode")
@@ -1845,7 +1845,7 @@ fn umi_barcode_engages_mode_retains_more_reads_than_position_only() {
         .assert()
         .success();
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--output_dir")
@@ -1895,7 +1895,7 @@ fn umi_mode_with_parallel_4_produces_same_qname_set_as_parallel_1() {
     std::fs::create_dir_all(&dir4).unwrap();
 
     for (parallel, out_dir) in [(1, &dir1), (4, &dir4)] {
-        Command::cargo_bin("deduplicate_bismark_rs")
+        Command::cargo_bin("deduplicate_bismark")
             .unwrap()
             .arg("--paired")
             .arg("--barcode")
@@ -1936,7 +1936,7 @@ fn umi_bclconvert_and_barcode_together_bclconvert_wins() {
     std::fs::create_dir_all(&dir_bclonly).unwrap();
     std::fs::create_dir_all(&dir_both).unwrap();
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--bclconvert")
@@ -1946,7 +1946,7 @@ fn umi_bclconvert_and_barcode_together_bclconvert_wins() {
         .assert()
         .success();
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--bclconvert")
@@ -1992,7 +1992,7 @@ fn umi_barcode_with_multiple_input_files_accumulates_state() {
     std::fs::create_dir_all(&dir_double).unwrap();
 
     // Single input via --multiple (degenerate; should match the single-file path).
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--multiple")
         .arg("--paired")
@@ -2005,7 +2005,7 @@ fn umi_barcode_with_multiple_input_files_accumulates_state() {
 
     // Same input passed twice — cross-file UMI dedup state should
     // collapse all duplicates from the second file against the first.
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--multiple")
         .arg("--paired")
@@ -2052,7 +2052,7 @@ fn umi_barcode_on_record_without_umi_errors_with_extraction_failed() {
     }
     write_bam(&input, &pairs);
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--barcode")
@@ -2090,7 +2090,7 @@ fn autodetect_barcode_against_bclconvert_input_errors_with_helpful_hint() {
     let dir = TempDir::new().unwrap();
     let input = umi_fixtures_dir().join(format!("{BCLCONVERT_STEM}.bam"));
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--barcode") // WRONG flag for bcl-convert format input
@@ -2119,7 +2119,7 @@ fn autodetect_bclconvert_on_bclconvert_input_proceeds_without_conflict() {
     let dir = TempDir::new().unwrap();
     let input = umi_fixtures_dir().join(format!("{BCLCONVERT_STEM}.bam"));
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--bclconvert") // CORRECT flag
@@ -2138,7 +2138,7 @@ fn autodetect_barcode_on_barcode_input_proceeds_without_conflict() {
     let dir = TempDir::new().unwrap();
     let input = umi_fixtures_dir().join(format!("{BARCODE_STEM}.bam"));
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--barcode") // CORRECT flag for barcode-format input
@@ -2160,7 +2160,7 @@ fn autodetect_bclconvert_on_barcode_input_skips_autodetect_fails_at_extraction()
     let dir = TempDir::new().unwrap();
     let input = umi_fixtures_dir().join(format!("{BARCODE_STEM}.bam"));
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--bclconvert") // WRONG flag for barcode-format input
@@ -2184,7 +2184,7 @@ fn autodetect_skipped_when_no_umi_flag_even_on_bclconvert_input() {
     let dir = TempDir::new().unwrap();
     let input = umi_fixtures_dir().join(format!("{BCLCONVERT_STEM}.bam"));
 
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         // no --barcode, no --bclconvert — position-only dedup
@@ -2300,7 +2300,7 @@ fn perl_vs_rust_nondirectional_pe_dedup() {
     );
 
     // Rust.
-    Command::cargo_bin("deduplicate_bismark_rs")
+    Command::cargo_bin("deduplicate_bismark")
         .unwrap()
         .arg("--paired")
         .arg("--bam")

--- a/rust/bismark-dedup/tests/methylseq_conformance.rs
+++ b/rust/bismark-dedup/tests/methylseq_conformance.rs
@@ -80,7 +80,7 @@ fn methylseq_deduplicate_empty_input_does_not_crash_pipeline() {
         let input = dir.path().join("aligned.bam");
         write_header_only_bam(&input);
 
-        Command::cargo_bin("deduplicate_bismark_rs")
+        Command::cargo_bin("deduplicate_bismark")
             .unwrap()
             .arg(mode)
             .arg("--bam")

--- a/rust/bismark-dedup/tests/sanity.rs
+++ b/rust/bismark-dedup/tests/sanity.rs
@@ -10,7 +10,7 @@ use predicates::str::is_match;
 
 #[test]
 fn version_output_matches_provenance_regex() {
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--version")
         .assert()
         .success()
@@ -23,7 +23,7 @@ fn version_output_matches_provenance_regex() {
 
 #[test]
 fn short_version_flag_works_too() {
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("-V")
         .assert()
         .success()
@@ -32,7 +32,7 @@ fn short_version_flag_works_too() {
 
 #[test]
 fn invocation_with_no_input_files_errors_with_clear_message() {
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.assert()
         .failure()
         .stderr(predicates::str::contains("no input file"));
@@ -40,7 +40,7 @@ fn invocation_with_no_input_files_errors_with_clear_message() {
 
 #[test]
 fn representative_flag_errors_with_perl_verbatim_joke() {
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--representative")
         .arg("dummy.bam")
         .assert()
@@ -59,7 +59,7 @@ fn barcode_flag_emits_perl_line_167_startup_banner() {
     let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/data/synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam");
     let tmp = tempfile::tempdir().unwrap();
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--paired")
         .arg("--barcode")
         .arg("--output_dir")
@@ -78,7 +78,7 @@ fn bclconvert_flag_emits_perl_line_172_startup_banner() {
     let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/data/synth_bclconvert_10k_R1_val_1_bismark_bt2_pe.bam");
     let tmp = tempfile::tempdir().unwrap();
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--paired")
         .arg("--bclconvert")
         .arg("--output_dir")
@@ -98,7 +98,7 @@ fn non_umi_invocation_does_not_emit_umi_startup_banner() {
     let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/data/synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam");
     let tmp = tempfile::tempdir().unwrap();
-    let mut cmd = Command::cargo_bin("deduplicate_bismark_rs").unwrap();
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
     cmd.arg("--paired")
         .arg("--output_dir")
         .arg(tmp.path())

--- a/rust/bismark-extractor/Cargo.toml
+++ b/rust/bismark-extractor/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "bismark_methylation_extractor_rs"
+name = "bismark_methylation_extractor"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-extractor/tests/mbias_writer_phase_d_smoke.rs
+++ b/rust/bismark-extractor/tests/mbias_writer_phase_d_smoke.rs
@@ -115,7 +115,7 @@ fn smoke_mbias_se_directional_produces_se_format_mbias_txt() {
     writer.finish().unwrap();
 
     let output_dir = workdir.path().join("out");
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(&bam_path)
         .arg("--single-end")
         .arg("--output_dir")
@@ -179,7 +179,7 @@ fn smoke_mbias_pe_auto_detect_produces_pe_format_mbias_txt() {
     writer.finish().unwrap();
 
     let output_dir = workdir.path().join("out");
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     // No --paired-end / --single-end — let AutoDetect dispatch.
     cmd.arg(&bam_path)
         .arg("--output_dir")
@@ -242,7 +242,7 @@ fn smoke_mbias_txt_absent_with_mbias_off() {
     writer.finish().unwrap();
 
     let output_dir = workdir.path().join("out");
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(&bam_path)
         .arg("--single-end")
         .arg("--mbias_off")

--- a/rust/bismark-extractor/tests/methylseq_conformance.rs
+++ b/rust/bismark-extractor/tests/methylseq_conformance.rs
@@ -260,7 +260,7 @@ fn methylseq_extractor_no_alignment_runtime_emits_required_outputs() {
     write_header_only_bam(&bam);
     let out_dir = work.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam)
         .args(["--bedGraph", "--counts", "--gzip", "--report", "-s", "--CX"])

--- a/rust/bismark-extractor/tests/multifile_coordsorted.rs
+++ b/rust/bismark-extractor/tests/multifile_coordsorted.rs
@@ -129,7 +129,7 @@ fn write_bam(path: &Path, header: Header, records: &[BismarkRecord]) {
 }
 
 fn extractor() -> Command {
-    Command::cargo_bin("bismark_methylation_extractor_rs").unwrap()
+    Command::cargo_bin("bismark_methylation_extractor").unwrap()
 }
 
 fn read_gz(path: &Path) -> Vec<u8> {

--- a/rust/bismark-extractor/tests/nondir_swapped_flags_1030.rs
+++ b/rust/bismark-extractor/tests/nondir_swapped_flags_1030.rs
@@ -80,7 +80,7 @@ fn write_bam(path: &Path, records: &[BismarkRecord]) {
 
 fn run_extractor(bam: &Path, outdir: &Path, extra: &[&str]) -> assert_cmd::assert::Assert {
     fs::create_dir_all(outdir).unwrap();
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam)
         .arg("--paired-end")
         .arg("--output_dir")

--- a/rust/bismark-extractor/tests/output_modes_phase_e_smoke.rs
+++ b/rust/bismark-extractor/tests/output_modes_phase_e_smoke.rs
@@ -193,7 +193,7 @@ fn smoke_comprehensive_emits_3_files_with_context_infix() {
     write_se_directional_bam(&bam_path);
     let out = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -234,7 +234,7 @@ fn smoke_merge_non_cpg_emits_8_files_with_chg_chh_in_non_cpg() {
     write_se_directional_bam(&bam_path);
     let out = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -278,7 +278,7 @@ fn smoke_comprehensive_merge_non_cpg_emits_2_files() {
     write_se_directional_bam(&bam_path);
     let out = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -306,7 +306,7 @@ fn smoke_yacht_emits_1_file_with_8_col_rows_and_reverse_strand_swap() {
     write_se_directional_bam(&bam_path);
     let out = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -356,7 +356,7 @@ fn smoke_mbias_only_emits_no_split_files() {
     write_se_directional_bam(&bam_path);
     let out = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -390,7 +390,7 @@ fn smoke_mbias_only_invalid_xm_byte_silently_skipped() {
     write_bam_with_invalid_xm_byte(&bam_path);
     let out = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -421,7 +421,7 @@ fn smoke_mbias_only_counters_match_default_mode() {
     let default_out = workdir.path().join("default_out");
     let mbias_out = workdir.path().join("mbias_out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -429,7 +429,7 @@ fn smoke_mbias_only_counters_match_default_mode() {
         .arg(&default_out)
         .assert()
         .success();
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -471,7 +471,7 @@ fn smoke_gzip_default_emits_12_gz_files_with_byte_identical_decompression() {
 
     let plain_out = workdir.path().join("plain");
     let gz_out = workdir.path().join("gz");
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -479,7 +479,7 @@ fn smoke_gzip_default_emits_12_gz_files_with_byte_identical_decompression() {
         .arg(&plain_out)
         .assert()
         .success();
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -534,7 +534,7 @@ fn smoke_gzip_comprehensive_emits_3_gz_files() {
     write_se_directional_bam(&bam_path);
     let out = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -561,7 +561,7 @@ fn smoke_gzip_mbias_only_emits_no_gz_files() {
     write_se_directional_bam(&bam_path);
     let out = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -590,7 +590,7 @@ fn smoke_yacht_gzip_emits_1_gz_file_with_reverse_strand_swap_after_decode() {
     write_se_directional_bam(&bam_path);
     let out = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -631,7 +631,7 @@ fn smoke_yacht_empty_bam_emits_header_only_file() {
     write_empty_bam(&bam_path);
     let out = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")

--- a/rust/bismark-extractor/tests/output_phase_c2.rs
+++ b/rust/bismark-extractor/tests/output_phase_c2.rs
@@ -87,7 +87,7 @@ fn empty_file_sweep_emits_perl_format_log_lines_on_stderr() {
     write_se_directional_one_cpg_record(&bam_path);
     let outdir = workdir.path().join("out");
 
-    let output = Command::cargo_bin("bismark_methylation_extractor_rs")
+    let output = Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -161,7 +161,7 @@ fn splitting_report_byte_shape_matches_perl_format() {
     write_se_directional_one_cpg_record(&bam_path);
     let outdir = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -256,7 +256,7 @@ fn splitting_report_yacht_mode_matches_perl_comprehensive_merge() {
     write_se_directional_one_cpg_record(&bam_path);
     let outdir = workdir.path().join("out");
 
-    Command::cargo_bin("bismark_methylation_extractor_rs")
+    Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")
@@ -350,7 +350,7 @@ fn mbias_only_mode_does_not_call_sweep_no_trailing_blank_lines() {
     write_se_directional_one_cpg_record(&bam_path);
     let outdir = workdir.path().join("out");
 
-    let output = Command::cargo_bin("bismark_methylation_extractor_rs")
+    let output = Command::cargo_bin("bismark_methylation_extractor")
         .unwrap()
         .arg(&bam_path)
         .arg("--single-end")

--- a/rust/bismark-extractor/tests/pe_phase_c.rs
+++ b/rust/bismark-extractor/tests/pe_phase_c.rs
@@ -766,7 +766,7 @@ mod pe_e2e {
     }
 
     fn run_binary(bam: &std::path::Path, outdir: &std::path::Path, extra_args: &[&str]) {
-        let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+        let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
         cmd.arg(bam)
             .arg("--paired-end")
             .arg("--output_dir")
@@ -998,7 +998,7 @@ mod pe_e2e {
         writer.finish().unwrap();
 
         let outdir = work.path().join("out");
-        let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+        let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
         cmd.arg(&bam_path)
             .arg("--paired-end")
             .arg("--output_dir")
@@ -1036,7 +1036,7 @@ mod pe_e2e {
             vec![pair.r1().clone(), pair.r2().clone(), orphan_r1],
         );
         let outdir = work.path().join("out");
-        let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+        let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
         cmd.arg(&bam_path)
             .arg("--paired-end")
             .arg("--output_dir")
@@ -1417,7 +1417,7 @@ mod auto_detect {
 
         let outdir = work.path().join("out");
         // No --single-end / --paired-end — AutoDetect must dispatch to PE.
-        let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+        let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
         cmd.arg(&bam_path)
             .arg("--output_dir")
             .arg(&outdir)
@@ -1451,7 +1451,7 @@ mod auto_detect {
         writer.finish().unwrap();
 
         let outdir = work.path().join("out");
-        let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+        let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
         cmd.arg(&bam_path)
             .arg("--output_dir")
             .arg(&outdir)
@@ -1474,7 +1474,7 @@ mod auto_detect {
         writer.finish().unwrap();
 
         let outdir = work.path().join("out");
-        let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+        let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
         cmd.arg(&bam_path)
             .arg("--output_dir")
             .arg(&outdir)

--- a/rust/bismark-extractor/tests/pe_phase_c_smoke.rs
+++ b/rust/bismark-extractor/tests/pe_phase_c_smoke.rs
@@ -144,7 +144,7 @@ fn smoke_pe_auto_detect_produces_all_12_files_and_report() {
     let output_dir = workdir.path().join("out");
 
     // No --single-end / --paired-end → AutoDetect via @PG ID:Bismark.
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(&bam_path)
         .arg("--output_dir")
         .arg(&output_dir)
@@ -217,7 +217,7 @@ fn smoke_pe_explicit_paired_end_flag_works() {
     write_pe_directional_bam(&bam_path);
 
     let output_dir = workdir.path().join("out");
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(&bam_path)
         .arg("--paired-end")
         .arg("--output_dir")

--- a/rust/bismark-extractor/tests/phase2_inline.rs
+++ b/rust/bismark-extractor/tests/phase2_inline.rs
@@ -163,7 +163,7 @@ fn write_non_cpg_only_bam(path: &Path) {
 
 /// Run the extractor binary on `bam` into `out_dir` with the given extra args.
 fn run_extractor(bam: &Path, out_dir: &Path, extra: &[&str]) -> assert_cmd::assert::Assert {
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam)
         .arg("--single-end")
         .arg("--output_dir")

--- a/rust/bismark-extractor/tests/phase3a_streaming.rs
+++ b/rust/bismark-extractor/tests/phase3a_streaming.rs
@@ -179,7 +179,7 @@ fn write_non_cpg_only_bam(path: &Path) {
 // ─────────────────────────────────────────────────────────────────────────
 
 fn run_extractor(bam: &Path, out_dir: &Path, extra: &[&str]) -> assert_cmd::assert::Assert {
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam)
         .arg("--single-end")
         .arg("--output_dir")
@@ -949,7 +949,7 @@ fn streaming_pe_matches_standalone() {
 
     // Extract-only (PE) → per-context files.
     let extract_dir = work.path().join("extract");
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(&bam)
         .arg("--paired-end")
         .arg("--output_dir")
@@ -973,7 +973,7 @@ fn streaming_pe_matches_standalone() {
     );
 
     let inline_dir = work.path().join("inline");
-    let mut cmd2 = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd2 = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd2.arg(&bam)
         .arg("--paired-end")
         .arg("--bedGraph")

--- a/rust/bismark-extractor/tests/sanity.rs
+++ b/rust/bismark-extractor/tests/sanity.rs
@@ -9,7 +9,7 @@ use predicates::str::is_match;
 
 #[test]
 fn version_output_matches_provenance_regex() {
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg("--version").assert().success().stdout(
         is_match(r"^bismark_methylation_extractor_rs \d+\.\d+\.\d+(-[\w.]+)? \(\S+/\S+\)\n$")
             .unwrap(),
@@ -18,7 +18,7 @@ fn version_output_matches_provenance_regex() {
 
 #[test]
 fn short_version_flag_works_too() {
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg("-V")
         .assert()
         .success()
@@ -27,7 +27,7 @@ fn short_version_flag_works_too() {
 
 #[test]
 fn invocation_with_no_input_files_errors_with_clear_message() {
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.assert()
         .failure()
         .stderr(predicates::str::contains("no input file"));
@@ -38,7 +38,7 @@ fn invocation_with_no_input_files_errors_with_clear_message() {
 /// is present so Phase A doesn't silently drop one.
 #[test]
 fn help_text_lists_all_35_flags() {
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     let output = cmd.arg("--help").assert().success();
 
     let stdout = String::from_utf8_lossy(&output.get_output().stdout).into_owned();

--- a/rust/bismark-extractor/tests/se_phase_b.rs
+++ b/rust/bismark-extractor/tests/se_phase_b.rs
@@ -1079,7 +1079,7 @@ fn main_paired_end_no_longer_rejected_phase_c() {
     // the call fails at the bismark-io reader stage (NOT at the phase-gate).
     // We assert the error message does NOT contain Phase B's old gate text.
     let bam = tempbam();
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam.path())
         .arg("--paired-end")
         .assert()
@@ -1101,7 +1101,7 @@ fn main_paired_end_no_longer_rejected_phase_c() {
 #[test]
 fn main_accepts_multicore_no_longer_rejected() {
     let bam = tempbam();
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam.path())
         .arg("--parallel")
         .arg("4")
@@ -1117,7 +1117,7 @@ fn main_accepts_multicore_no_longer_rejected() {
 #[test]
 fn main_accepts_gzip_no_longer_rejected() {
     let bam = tempbam();
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam.path())
         .arg("--gzip")
         .assert()
@@ -1131,7 +1131,7 @@ fn main_accepts_gzip_no_longer_rejected() {
 #[test]
 fn main_accepts_comprehensive_no_longer_rejected() {
     let bam = tempbam();
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam.path())
         .arg("--comprehensive")
         .assert()
@@ -1143,7 +1143,7 @@ fn main_accepts_comprehensive_no_longer_rejected() {
 #[test]
 fn main_accepts_merge_non_cpg_no_longer_rejected() {
     let bam = tempbam();
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam.path())
         .arg("--merge_non_CpG")
         .assert()
@@ -1156,7 +1156,7 @@ fn main_accepts_merge_non_cpg_no_longer_rejected() {
 #[test]
 fn main_accepts_yacht_no_longer_rejected() {
     let bam = tempbam();
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam.path())
         .arg("--yacht")
         .assert()
@@ -1168,7 +1168,7 @@ fn main_accepts_yacht_no_longer_rejected() {
 #[test]
 fn main_accepts_mbias_only_no_longer_rejected() {
     let bam = tempbam();
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam.path())
         .arg("--mbias_only")
         .assert()
@@ -1184,7 +1184,7 @@ fn main_accepts_mbias_only_no_longer_rejected() {
 #[test]
 fn main_bedgraph_no_longer_rejected_phase_g() {
     let bam = tempbam();
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(bam.path())
         .arg("--bedGraph")
         .assert()

--- a/rust/bismark-extractor/tests/se_phase_b_smoke.rs
+++ b/rust/bismark-extractor/tests/se_phase_b_smoke.rs
@@ -170,7 +170,7 @@ fn smoke_se_directional_produces_all_12_files_and_report() {
 
     let output_dir = workdir.path().join("out");
 
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(&bam_path)
         .arg("--single-end")
         .arg("--output_dir")
@@ -251,7 +251,7 @@ fn smoke_se_rejects_record_with_paired_flag_set() {
 
     let output_dir = workdir.path().join("out");
 
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(&bam_path)
         .arg("--single-end")
         .arg("--output_dir")
@@ -289,7 +289,7 @@ fn smoke_se_empty_bam_writes_only_header_files() {
 
     let output_dir = workdir.path().join("out");
 
-    let mut cmd = Command::cargo_bin("bismark_methylation_extractor_rs").unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg(&bam_path)
         .arg("--single-end")
         .arg("--output_dir")

--- a/rust/bismark-filter-nonconversion/Cargo.toml
+++ b/rust/bismark-filter-nonconversion/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "filter_non_conversion_rs"
+name = "filter_non_conversion"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-filter-nonconversion/tests/byte_identity.rs
+++ b/rust/bismark-filter-nonconversion/tests/byte_identity.rs
@@ -101,7 +101,7 @@ fn run_case(data: &Path, case: &Case) {
     std::fs::copy(case_dir.join(&case.inbase), tmp.path().join(&case.inbase))
         .expect("copy input bam");
 
-    let mut cmd = AssertCommand::cargo_bin("filter_non_conversion_rs").unwrap();
+    let mut cmd = AssertCommand::cargo_bin("filter_non_conversion").unwrap();
     cmd.current_dir(tmp.path());
     for f in &case.flags {
         cmd.arg(f);

--- a/rust/bismark-filter-nonconversion/tests/byte_identity_real_data.rs
+++ b/rust/bismark-filter-nonconversion/tests/byte_identity_real_data.rs
@@ -82,7 +82,7 @@ fn compare_cell(perl: &Path, real_bam: &Path, mode_flag: &str, extra: &[&str], l
     assert!(perl_status.success(), "[{label}] Perl run failed");
 
     // Rust.
-    let mut rust_cmd = AssertCommand::cargo_bin("filter_non_conversion_rs").unwrap();
+    let mut rust_cmd = AssertCommand::cargo_bin("filter_non_conversion").unwrap();
     rust_cmd.current_dir(rust_dir.path()).arg(mode_flag);
     for f in extra {
         rust_cmd.arg(f);

--- a/rust/bismark-filter-nonconversion/tests/edge_cases.rs
+++ b/rust/bismark-filter-nonconversion/tests/edge_cases.rs
@@ -115,7 +115,7 @@ fn count_records(path: &Path) -> usize {
 }
 
 fn bin() -> Command {
-    Command::cargo_bin("filter_non_conversion_rs").unwrap()
+    Command::cargo_bin("filter_non_conversion").unwrap()
 }
 
 // ─────────────────────────────── tests ─────────────────────────────────

--- a/rust/bismark-genome-preparation/Cargo.toml
+++ b/rust/bismark-genome-preparation/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "bismark_genome_preparation_rs"
+name = "bismark_genome_preparation"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-genome-preparation/tests/byte_identity_real_data.rs
+++ b/rust/bismark-genome-preparation/tests/byte_identity_real_data.rs
@@ -29,7 +29,7 @@ use std::process::Command;
 
 use tempfile::TempDir;
 
-const RUST_BIN: &str = env!("CARGO_BIN_EXE_bismark_genome_preparation_rs");
+const RUST_BIN: &str = env!("CARGO_BIN_EXE_bismark_genome_preparation");
 
 /// Create a fake `bowtie2-build` that exits 0, so Step III completes without a
 /// real indexer (the gate is the converted FASTA, not the index). Returns the

--- a/rust/bismark-genome-preparation/tests/integration.rs
+++ b/rust/bismark-genome-preparation/tests/integration.rs
@@ -74,7 +74,7 @@ fn binary_end_to_end_mfa_bytes() {
     .unwrap();
     let bin = fake_indexer_dir(tmp.path());
 
-    Command::cargo_bin("bismark_genome_preparation_rs")
+    Command::cargo_bin("bismark_genome_preparation")
         .unwrap()
         .env("BISMARK_BIN", &bin)
         .arg(&genome)
@@ -108,7 +108,7 @@ fn binary_combined_genome_is_ct_concat_ga() {
     fs::write(genome.join("b.fa"), b">chr2\nGGCC\n").unwrap();
     let bin = fake_indexer_dir(tmp.path());
 
-    Command::cargo_bin("bismark_genome_preparation_rs")
+    Command::cargo_bin("bismark_genome_preparation")
         .unwrap()
         .env("BISMARK_BIN", &bin)
         .arg("--combined_genome")
@@ -131,7 +131,7 @@ fn binary_genomic_composition_freq_table_bytes() {
     fs::write(genome.join("g.fa"), b">chr1\nACGT\n").unwrap();
     let bin = fake_indexer_dir(tmp.path());
 
-    Command::cargo_bin("bismark_genome_preparation_rs")
+    Command::cargo_bin("bismark_genome_preparation")
         .unwrap()
         .env("BISMARK_BIN", &bin)
         .arg("--genomic_composition")
@@ -156,7 +156,7 @@ fn binary_no_genomic_composition_flag_writes_no_table() {
     fs::write(genome.join("g.fa"), b">chr1\nACGT\n").unwrap();
     let bin = fake_indexer_dir(tmp.path());
 
-    Command::cargo_bin("bismark_genome_preparation_rs")
+    Command::cargo_bin("bismark_genome_preparation")
         .unwrap()
         .env("BISMARK_BIN", &bin)
         .arg(&genome)
@@ -175,7 +175,7 @@ fn binary_no_fasta_dir_errors() {
     let genome = tmp.path().join("empty_genome");
     fs::create_dir_all(&genome).unwrap();
     let bin = fake_indexer_dir(tmp.path());
-    Command::cargo_bin("bismark_genome_preparation_rs")
+    Command::cargo_bin("bismark_genome_preparation")
         .unwrap()
         .env("BISMARK_BIN", &bin)
         .arg(&genome)
@@ -229,7 +229,7 @@ fn perl_vs_rust_byte_identical_mfa() {
     assert!(perl_status.success(), "perl genome prep failed");
 
     // Rust: fake indexer via BISMARK_BIN.
-    Command::cargo_bin("bismark_genome_preparation_rs")
+    Command::cargo_bin("bismark_genome_preparation")
         .unwrap()
         .env("BISMARK_BIN", &bin)
         .arg(&rust_dir)
@@ -287,7 +287,7 @@ fn perl_vs_rust_byte_identical_single_fasta() {
         .expect("failed to run perl");
     assert!(perl_status.success(), "perl genome prep failed");
 
-    Command::cargo_bin("bismark_genome_preparation_rs")
+    Command::cargo_bin("bismark_genome_preparation")
         .unwrap()
         .env("BISMARK_BIN", &bin)
         .arg("--single_fasta")
@@ -326,7 +326,7 @@ fn bad_path_to_aligner_fails_before_conversion() {
     fs::write(genome.join("g.fa"), b">chr1\nACGT\n").unwrap();
     let badpath = tmp.path().join("no_such_aligner_dir");
 
-    Command::cargo_bin("bismark_genome_preparation_rs")
+    Command::cargo_bin("bismark_genome_preparation")
         .unwrap()
         .arg("--path_to_aligner")
         .arg(&badpath)
@@ -372,7 +372,7 @@ fn oracle_compare(setup: impl Fn(&Path), extra_args: &[&str], rel_files: &[&str]
     pcmd.arg(&perl_dir).env("PATH", &path_env);
     assert!(pcmd.status().expect("run perl").success(), "perl failed");
 
-    let mut rcmd = Command::cargo_bin("bismark_genome_preparation_rs").unwrap();
+    let mut rcmd = Command::cargo_bin("bismark_genome_preparation").unwrap();
     rcmd.env("BISMARK_BIN", &bin);
     for a in extra_args {
         rcmd.arg(a);

--- a/rust/bismark-methylation-consistency/Cargo.toml
+++ b/rust/bismark-methylation-consistency/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "methylation_consistency_rs"
+name = "methylation_consistency"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-methylation-consistency/tests/integration.rs
+++ b/rust/bismark-methylation-consistency/tests/integration.rs
@@ -119,7 +119,7 @@ fn sep() -> String {
 }
 
 fn run(dir: &TempDir, args: &[&str]) -> assert_cmd::assert::Assert {
-    let mut cmd = Command::cargo_bin("methylation_consistency_rs").unwrap();
+    let mut cmd = Command::cargo_bin("methylation_consistency").unwrap();
     cmd.current_dir(dir.path());
     cmd.args(args);
     cmd.assert()
@@ -545,7 +545,7 @@ fn assert_perl_rust_identical(records: &[RecordBuf], so: Option<&str>, extra_arg
     );
 
     // Rust run.
-    let mut rust = Command::cargo_bin("methylation_consistency_rs").unwrap();
+    let mut rust = Command::cargo_bin("methylation_consistency").unwrap();
     rust.args(extra_args).arg(rust_dir.join("in.bam"));
     rust.assert().success();
 

--- a/rust/bismark-nome-filtering/Cargo.toml
+++ b/rust/bismark-nome-filtering/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "NOMe_filtering_rs"
+name = "NOMe_filtering"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-nome-filtering/tests/cli_phase_a.rs
+++ b/rust/bismark-nome-filtering/tests/cli_phase_a.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use assert_cmd::Command;
 
 fn bin() -> Command {
-    Command::cargo_bin("NOMe_filtering_rs").unwrap()
+    Command::cargo_bin("NOMe_filtering").unwrap()
 }
 
 #[test]

--- a/rust/bismark-nome-filtering/tests/golden_phase_b.rs
+++ b/rust/bismark-nome-filtering/tests/golden_phase_b.rs
@@ -32,7 +32,7 @@ fn run_case(yacht: &str) -> Vec<u8> {
     let d = data();
     let tmp = tempfile::tempdir().unwrap();
     std::fs::copy(d.join(yacht), tmp.path().join(yacht)).unwrap();
-    Command::cargo_bin("NOMe_filtering_rs")
+    Command::cargo_bin("NOMe_filtering")
         .unwrap()
         .arg("-g")
         .arg(d.join("genome"))
@@ -88,7 +88,7 @@ fn vs_empty_leaves_header_only_gz_and_exits_nonzero() {
     let d = data();
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("empty.yacht.txt"), "").unwrap();
-    Command::cargo_bin("NOMe_filtering_rs")
+    Command::cargo_bin("NOMe_filtering")
         .unwrap()
         .arg("-g")
         .arg(d.join("genome"))
@@ -112,7 +112,7 @@ fn vs_crlf_input_matches_lf_golden() {
     let crlf = lf.replace('\n', "\r\n");
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("crlf.yacht.txt"), crlf).unwrap();
-    Command::cargo_bin("NOMe_filtering_rs")
+    Command::cargo_bin("NOMe_filtering")
         .unwrap()
         .arg("-g")
         .arg(d.join("genome"))
@@ -137,7 +137,7 @@ fn unknown_chromosome_read_yields_header_only_no_data_line() {
         "rZ\t+\tchrZ\t6\tz\t4\t12\t+\n",
     )
     .unwrap();
-    Command::cargo_bin("NOMe_filtering_rs")
+    Command::cargo_bin("NOMe_filtering")
         .unwrap()
         .arg("-g")
         .arg(d.join("genome"))

--- a/rust/bismark-report/Cargo.toml
+++ b/rust/bismark-report/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "bismark2report_rs"
+name = "bismark2report"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-report/tests/cli.rs
+++ b/rust/bismark-report/tests/cli.rs
@@ -7,7 +7,7 @@ use assert_cmd::Command;
 use tempfile::tempdir;
 
 fn bin() -> Command {
-    Command::cargo_bin("bismark2report_rs").unwrap()
+    Command::cargo_bin("bismark2report").unwrap()
 }
 
 fn minimal_pe_report() -> Vec<u8> {

--- a/rust/bismark-report/tests/perl_vs_rust.rs
+++ b/rust/bismark-report/tests/perl_vs_rust.rs
@@ -73,7 +73,7 @@ fn run_both_and_compare(work: &Path, label: &str) {
         "perl bismark2report failed for `{label}`"
     );
 
-    let rust_status = Command::new(env!("CARGO_BIN_EXE_bismark2report_rs"))
+    let rust_status = Command::new(env!("CARGO_BIN_EXE_bismark2report"))
         .args(["--dir", "rust/", "--__test_timestamp", "0"])
         .current_dir(work)
         .output()

--- a/rust/bismark-summary/Cargo.toml
+++ b/rust/bismark-summary/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["science::bioinformatics", "command-line-utilities"]
 path = "src/lib.rs"
 
 [[bin]]
-name = "bismark2summary_rs"
+name = "bismark2summary"
 path = "src/main.rs"
 
 [dependencies]

--- a/rust/bismark-summary/tests/perl_oracle.rs
+++ b/rust/bismark-summary/tests/perl_oracle.rs
@@ -60,7 +60,7 @@ fn run_perl(dir: &Path, script: &Path, basename: &str) -> std::process::ExitStat
 }
 
 fn run_rust(dir: &Path, basename: &str) -> std::process::ExitStatus {
-    Command::new(env!("CARGO_BIN_EXE_bismark2summary_rs"))
+    Command::new(env!("CARGO_BIN_EXE_bismark2summary"))
         .args([
             "-o",
             basename,
@@ -468,7 +468,7 @@ fn oracle_explicit_argv_order() {
         .status()
         .unwrap()
         .success();
-    let rust_ok = Command::new(env!("CARGO_BIN_EXE_bismark2summary_rs"))
+    let rust_ok = Command::new(env!("CARGO_BIN_EXE_bismark2summary"))
         .args([
             "-o",
             "rust_out",
@@ -519,7 +519,7 @@ fn oracle_basename_zero_truthiness() {
         .current_dir(pdir.path())
         .status()
         .unwrap();
-    Command::new(env!("CARGO_BIN_EXE_bismark2summary_rs"))
+    Command::new(env!("CARGO_BIN_EXE_bismark2summary"))
         .args(["-o", "0", "--__test_timestamp", "1780272000"])
         .current_dir(rdir.path())
         .status()

--- a/rust/bismark-summary/tests/txt_golden.rs
+++ b/rust/bismark-summary/tests/txt_golden.rs
@@ -11,7 +11,7 @@ fn wgbs_two_sample_txt_is_byte_exact() {
     let dir = tempfile::tempdir().unwrap();
     common::build_wgbs_two_sample(dir.path());
 
-    let status = Command::new(env!("CARGO_BIN_EXE_bismark2summary_rs"))
+    let status = Command::new(env!("CARGO_BIN_EXE_bismark2summary"))
         .current_dir(dir.path())
         .args(["-o", "out", "--title", "Gate Test"])
         .status()
@@ -35,7 +35,7 @@ s1_bismark_bt2_pe.bam\t10000\t8000\t1500\t500\t0\t2000\t6000\t400000\t9000\t8000
 #[test]
 fn no_bams_exits_nonzero() {
     let dir = tempfile::tempdir().unwrap();
-    let status = Command::new(env!("CARGO_BIN_EXE_bismark2summary_rs"))
+    let status = Command::new(env!("CARGO_BIN_EXE_bismark2summary"))
         .current_dir(dir.path())
         .args(["-o", "out"])
         .status()


### PR DESCRIPTION
**GA epic Phase 3a — Rust canonical binary rename.** Part of the Bismark Rust **GA (2.0.0)** transition (`plans/06252026_rust-ga-release/`). Drops the transitional `_rs` suffix from all 12 binary crates so the suite ships under canonical Bismark names (`bismark`, `deduplicate_bismark`, `bismark_methylation_extractor`, …). **Binary-naming only — no behavior change.**

## Changes
- **12 `[[bin]]` renames** `<tool>_rs` → `<tool>`.
- **169 test/bench references swept** in lockstep across 46 files — `cargo_bin("<tool>_rs")` → `cargo_bin("<tool>")` and `CARGO_BIN_EXE_<tool>_rs` → `CARGO_BIN_EXE_<tool>`. Without this the suite tests fail loudly (`binary <tool>_rs not found`).

## Verification
- `cargo build --workspace` clean.
- **Full `cargo test --workspace` green** — the real gate: a `CARGO_BIN_EXE_*` miss fails at compile, a `cargo_bin` miss fails at runtime, so a clean run proves all 169 refs + 12 renames are consistent.
- `clippy -D warnings` + `fmt --check` clean.

## Why this is "3a" (scope split)
Investigation found Phase 3 was ~3× the epic's implied scope (the 169 test-harness refs), and that moving the Perl scripts to `legacy/` would break the **BismarkCI** (`ci_tests.yml`) gate (it runs `./bismark` etc. from root). So Phase 3 was split:
- **This PR (3a):** the self-contained, CI-verifiable Rust rename.
- **Deferred — 3b:** Perl scripts → `legacy/` + the BismarkCI repoint/retire decision + the 7 perl-oracle test-path repoints.
- **Deferred — Ph4** (release pipeline, dry-run-tested): `release.yml` `_rs` binary lists + Dockerfile canonical-name logic + the OD-7 version-probe graduation (`v0.25.1`→`v2.0.0`).
- **Deferred — Ph6** (GA docs): `docs/` + `rust/README.md` `_rs` references.
