### PR TITLE
chore(release): GA 2.0.0 release-pipeline rework + crates.io publish job (GA epic Ph4a)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,9 @@ name: Docs site (Astro + Starlight)
 
 on:
   push:
-    branches: [rust/iron-chancellor]
+    # `master` keeps docs deploying after the GA master-takeover; iron-chancellor
+    # stays so docs still build from the integration branch pre-takeover.
+    branches: [rust/iron-chancellor, master]
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,11 @@ jobs:
             diff <(echo "$members") <(echo "$order_sorted") || true
             exit 1
           fi
-          echo "✓ ORDER covers all $(echo "$members" | wc -l | xargs) workspace members"
+          # ORDER must list each crate exactly once (a duplicate would re-publish).
+          n_order=$(printf '%s\n' $ORDER | wc -l | xargs)
+          n_uniq=$(printf '%s\n' $ORDER | sort -u | wc -l | xargs)
+          [ "$n_order" = "$n_uniq" ] || { echo "::error::ORDER has a duplicate crate ($n_order entries, $n_uniq unique)"; exit 1; }
+          echo "✓ ORDER covers all $(echo "$members" | wc -l | xargs) workspace members, no duplicates"
           echo "::endgroup::"
 
           # --- Invariant 1: every intra-workspace dep carries a `version =`
@@ -263,6 +267,20 @@ jobs:
             exit 1
           fi
           echo "✓ all intra-workspace deps carry a version"
+          echo "::endgroup::"
+
+          # --- Invariant 1b: NO dependency uses a git source without a `version =`.
+          # crates.io rejects ANY git dep — even an optional, feature-gated one
+          # (e.g. bismark-aligner's optional rammap-core git rev). Invariant 1's
+          # bismark-* scan can't see third-party git deps, so guard them here.
+          echo "::group::git-deps carry a version"
+          git_unversioned=$(for c in $ORDER; do grep -HnE '(^|[,{[:space:]])git[[:space:]]*=' "$c/Cargo.toml"; done | grep -v 'version' || true)
+          if [ -n "$git_unversioned" ]; then
+            echo "::error::these git deps have no 'version =' (crates.io will reject the publish):"
+            echo "$git_unversioned"
+            exit 1
+          fi
+          echo "✓ all git deps carry a version"
           echo "::endgroup::"
 
           # --- Invariant 2: ORDER is a valid topological sort (each crate's

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Build the whole suite
         env:
           BISMARK_SUITE_VERSION: ${{ needs.check-release.outputs.version }}
-        # Compile bismark_rs with the in-process rammap backend ON so the shipped
+        # Compile the `bismark` aligner with the in-process rammap backend ON so the shipped
         # binary's `--rammap_inprocess` opt-in is functional (default `--rammap`
         # stays subprocess), AND with `binseq-input` ON so the shipped binary can read
         # BINSEQ `.vbq` files (#1025 Phase 2 — a default `cargo build` rejects `.vbq`
@@ -123,10 +123,10 @@ jobs:
           ARCHIVE="bismark-rust-${{ needs.check-release.outputs.version }}-${{ matrix.name }}"
           BINDIR="rust/target/${{ matrix.target }}/release"
           mkdir -p "staging/${ARCHIVE}"
-          for b in bismark_rs deduplicate_bismark_rs bismark_methylation_extractor_rs \
-                   bismark2bedGraph_rs coverage2cytosine_rs bismark_genome_preparation_rs \
-                   bam2nuc_rs NOMe_filtering_rs filter_non_conversion_rs \
-                   methylation_consistency_rs bismark2report_rs bismark2summary_rs; do
+          for b in bismark deduplicate_bismark bismark_methylation_extractor \
+                   bismark2bedGraph coverage2cytosine bismark_genome_preparation \
+                   bam2nuc NOMe_filtering filter_non_conversion \
+                   methylation_consistency bismark2report bismark2summary; do
             cp "${BINDIR}/${b}" "staging/${ARCHIVE}/"
           done
           cp license.txt "staging/${ARCHIVE}/LICENSE"
@@ -157,15 +157,154 @@ jobs:
           cd /tmp/binaries
           tar xzf bismark-rust-${{ needs.check-release.outputs.version }}-linux-x86_64.tar.gz
           DIR="bismark-rust-${{ needs.check-release.outputs.version }}-linux-x86_64"
-          for b in bismark_rs deduplicate_bismark_rs bismark_methylation_extractor_rs \
-                   bismark2bedGraph_rs coverage2cytosine_rs bismark_genome_preparation_rs \
-                   bam2nuc_rs NOMe_filtering_rs filter_non_conversion_rs \
-                   methylation_consistency_rs bismark2report_rs bismark2summary_rs; do
+          for b in bismark deduplicate_bismark bismark_methylation_extractor \
+                   bismark2bedGraph coverage2cytosine bismark_genome_preparation \
+                   bam2nuc NOMe_filtering filter_non_conversion \
+                   methylation_consistency bismark2report bismark2summary; do
             echo "--- $b ---"
             "$DIR/$b" --version
             "$DIR/$b" --help > /dev/null
           done
           echo "✓ all 12 binaries smoke-tested"
+
+  # ── crates.io publish (GA only) ───────────────────────────────────────────
+  # Publishes the 14-member workspace to crates.io in dependency (DAG) order.
+  # Runs on every REAL release, but the work is branch-gated INSIDE the script:
+  #   - dry-run (any version): validate only — per-crate `cargo publish
+  #     --dry-run` + a version-presence assert on every intra-workspace dep + a
+  #     topological-order assert. No registry contact, no OIDC. (`--dry-run`
+  #     resolves path-deps LOCALLY and never hits the registry, so it CANNOT
+  #     catch a wrong publish order — the topo assert is what covers that.)
+  #   - prerelease real (beta): NO-OP. Betas are never published (the immutable-
+  #     publish / exact-pin-cascade trap). Exiting 0 lets the downstream tag/
+  #     `:latest` jobs proceed unchanged on the beta track.
+  #   - GA real (non-prerelease, from master): OIDC trusted-publishing token →
+  #     ordered `cargo publish` L0 → L1 → L2, each verified-available before the
+  #     next (cargo's built-in index-propagation wait).
+  #
+  # Publish DAG (verified GA-epic Phase 1 against the live Cargo.tomls):
+  #   L0 (independent roots):  bismark-io, bismark-meta
+  #   L1 (depend only on L0):  bismark-aligner bismark-dedup bismark-bedgraph
+  #                            bismark-coverage2cytosine bismark-bam2nuc
+  #                            bismark-filter-nonconversion bismark-nome-filtering
+  #                            bismark-methylation-consistency
+  #                            bismark-genome-preparation bismark-report bismark-summary
+  #   L2 (publish LAST):       bismark-extractor (→ bedgraph + coverage2cytosine)
+  #
+  # SAFETY: docker-merge (moves `:latest`) and create-release (pushes the GA tag)
+  # `needs:` this job, so on a GA publish FAILURE they are skipped — a partial
+  # publish never strands a moved `:latest` or a pushed tag.
+  #
+  # PARTIAL-PUBLISH RUNBOOK (crates.io is yank-only — NO delete): a mid-cascade
+  # failure leaves earlier crates permanently published. Do NOT retry the SAME
+  # versions (republishing an existing version is rejected). Fix forward: patch
+  # the failing crate(s), BUMP the affected crate version(s) (+ the dependent
+  # exact-pins), and re-run from the first unpublished crate. The bare-`bismark`
+  # reserve crate (OD-3) is published separately at the Ph5 cut.
+  #
+  # OIDC PREREQ (real GA only): each crate needs a crates.io-side Trusted
+  # Publisher entry for this repo + `release.yml`. Confirm before the live Ph5
+  # cut — the dry-run skips the OIDC handshake, so it does NOT validate this.
+  publish-crates:
+    name: Publish to crates.io (GA only)
+    needs: [check-release, build-binaries, smoke-test-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # OIDC trusted-publishing token exchange
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      # OIDC trusted-publishing token — ONLY on a real GA publish (betas no-op;
+      # dry-run never contacts the registry, so neither needs a token).
+      - name: Authenticate to crates.io (OIDC)
+        id: auth
+        if: needs.check-release.outputs.is_dry_run != 'true' && needs.check-release.outputs.is_prerelease != 'true'
+        uses: rust-lang/crates-io-auth-action@v1
+      - name: Publish (or validate) the workspace in DAG order
+        working-directory: rust
+        env:
+          DRY_RUN: ${{ needs.check-release.outputs.is_dry_run }}
+          IS_PRERELEASE: ${{ needs.check-release.outputs.is_prerelease }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          set -euo pipefail
+          L0="bismark-io bismark-meta"
+          L1="bismark-aligner bismark-dedup bismark-bedgraph bismark-coverage2cytosine bismark-bam2nuc bismark-filter-nonconversion bismark-nome-filtering bismark-methylation-consistency bismark-genome-preparation bismark-report bismark-summary"
+          L2="bismark-extractor"
+          ORDER="$L0 $L1 $L2"
+
+          if [ "$DRY_RUN" != "true" ] && [ "$IS_PRERELEASE" = "true" ]; then
+            echo "Prerelease ($IS_PRERELEASE) — crates.io publish is deferred to the GA cut. No-op."
+            exit 0
+          fi
+
+          # --- Invariant 0: ORDER covers EVERY workspace member exactly once. A
+          # crate added to the workspace but forgotten here would silently never
+          # publish; assert set-equality against the [workspace] members list.
+          echo "::group::ORDER covers all workspace members"
+          members=$(grep -E '^members' Cargo.toml | grep -oE 'bismark-[a-z0-9-]+' | sort -u)
+          order_sorted=$(printf '%s\n' $ORDER | sort -u)
+          if [ "$members" != "$order_sorted" ]; then
+            echo "::error::publish ORDER does not match the [workspace] members:"
+            diff <(echo "$members") <(echo "$order_sorted") || true
+            exit 1
+          fi
+          echo "✓ ORDER covers all $(echo "$members" | wc -l | xargs) workspace members"
+          echo "::endgroup::"
+
+          # --- Invariant 1: every intra-workspace dep carries a `version =`
+          # (crates.io rejects a published crate whose path-dep has no version).
+          echo "::group::version-presence on intra-workspace deps"
+          bad_deps=$(for c in $ORDER; do grep -HE '^bismark-[a-z0-9-]+ *=' "$c/Cargo.toml"; done | grep -v 'version' || true)
+          if [ -n "$bad_deps" ]; then
+            echo "::error::these bismark-* path-deps lack a 'version =' (crates.io will reject the publish):"
+            echo "$bad_deps"
+            exit 1
+          fi
+          echo "✓ all intra-workspace deps carry a version"
+          echo "::endgroup::"
+
+          # --- Invariant 2: ORDER is a valid topological sort (each crate's
+          # bismark-* deps appear EARLIER). Catches a wrong publish order, which
+          # `cargo publish --dry-run` cannot (it resolves deps via local path).
+          echo "::group::topological-order check"
+          done_list=" "
+          bad=0
+          for c in $ORDER; do
+            for dep in $(grep -oE '^bismark-[a-z0-9-]+' "$c/Cargo.toml" | sort -u); do
+              case "$done_list" in
+                *" $dep "*) : ;;
+                *) echo "ORDER BUG: $c depends on $dep, which is not published earlier in ORDER"; bad=1 ;;
+              esac
+            done
+            done_list="$done_list$c "
+          done
+          [ "$bad" = 0 ] || { echo "::error::publish ORDER is not a valid topological sort"; exit 1; }
+          echo "✓ publish order is a valid topological sort"
+          echo "::endgroup::"
+
+          # --- Publish (real GA) or validate (dry-run) each crate IN ORDER.
+          for c in $ORDER; do
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::group::validate $c (dry-run)"
+              # `--dry-run` packages + verify-builds the crate and asserts deps
+              # carry versions; it subsumes `cargo package`. The ordering gap is
+              # covered by Invariant 2 above.
+              cargo publish -p "$c" --locked --dry-run --allow-dirty
+              echo "::endgroup::"
+            else
+              echo "::group::publish $c"
+              cargo publish -p "$c" --locked
+              echo "::endgroup::"
+            fi
+          done
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "✓ DRY-RUN: 14 crates packaged + dry-published; deps versioned; order valid"
+          else
+            echo "✓ PUBLISHED all 14 crates to crates.io in DAG order"
+          fi
 
   docker-build:
     name: Docker ${{ matrix.platform }}
@@ -218,7 +357,11 @@ jobs:
 
   docker-merge:
     name: Docker merge + tag
-    needs: [check-release, docker-build]
+    # publish-crates is in needs so a GA crates.io publish FAILURE skips this job
+    # (default skip-propagation) — `:latest` is never moved onto an image whose
+    # crates didn't publish. On the beta track publish-crates no-ops (succeeds),
+    # so this still runs and moves `:beta`/`:<version>` as before.
+    needs: [check-release, docker-build, publish-crates]
     if: needs.check-release.outputs.is_dry_run != 'true'
     runs-on: ubuntu-latest
     steps:
@@ -256,22 +399,29 @@ jobs:
       - name: Pull + test
         run: |
           IMG="ghcr.io/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}"
-          docker run --rm "$IMG" bismark_rs --version
-          docker run --rm "$IMG" bismark_methylation_extractor_rs --version
+          # `bismark` is the version-probe WRAPPER (execs the real aligner for
+          # everything else); the real aligner binary is `bismark.bin`.
+          docker run --rm "$IMG" bismark --version
+          docker run --rm "$IMG" bismark.bin --version
+          docker run --rm "$IMG" bismark_methylation_extractor --version
           docker run --rm "$IMG" bowtie2 --version
           docker run --rm "$IMG" samtools --version | head -1
-          # Canonical names (methylseq drop-in) resolve to the _rs binaries.
+          # Canonical names (methylseq drop-in) resolve; `bismark --help` also
+          # exercises the wrapper's exec of the real `bismark.bin`.
           docker run --rm "$IMG" bismark --help >/dev/null
           docker run --rm "$IMG" coverage2cytosine --help >/dev/null
           docker run --rm "$IMG" deduplicate_bismark --help >/dev/null
-          # Version probe: BOTH methylseq parser shapes must capture EXACTLY 0.25.1
-          # from `bismark` (the provenance line must NOT leak — the contract that
-          # keeps methylseq's versions.yml + nf-test snapshots unchanged).
+          # Version probe: BOTH methylseq parser shapes must capture EXACTLY the
+          # suite version from `bismark` (GA: the wrapper reports the TRUE suite
+          # version — at the 2.0.0 cut this is "2.0.0"; methylseq re-baselines its
+          # version snapshots, OD-7). Compared against the release version (not a
+          # hardcoded literal) so this stays correct for every later release/beta.
+          EXPECT="${{ needs.check-release.outputs.version }}"
           p1=$(docker run --rm "$IMG" bismark --version | grep Version | sed -e 's/Bismark Version: v//' | xargs)
           p2=$(echo $(docker run --rm "$IMG" bismark -v 2>&1) | sed 's/^.*Bismark Version: v//; s/Copyright.*$//' | xargs)
-          echo "version capture: parser1='$p1' parser2='$p2'"
-          [ "$p1" = "0.25.1" ] || { echo "FAIL: align-module parser captured '$p1'"; exit 1; }
-          [ "$p2" = "0.25.1" ] || { echo "FAIL: versions.yml parser captured '$p2' (provenance leak?)"; exit 1; }
+          echo "version capture: parser1='$p1' parser2='$p2' (expect '$EXPECT')"
+          [ "$p1" = "$EXPECT" ] || { echo "FAIL: align-module parser captured '$p1' (expected '$EXPECT')"; exit 1; }
+          [ "$p2" = "$EXPECT" ] || { echo "FAIL: versions.yml parser captured '$p2' (expected '$EXPECT')"; exit 1; }
           # Tools methylseq shells out to (genomeprep → *-build; extractor → gzip).
           # NB assert each individually — `command -v a b c` only resolves the FIRST
           # operand (POSIX), so a single multi-arg call would silently pass.
@@ -285,7 +435,10 @@ jobs:
   # (the check-release collision guard).
   create-release:
     name: Create tag + draft release
-    needs: [check-release, build-binaries, smoke-test-binaries, docker-build]
+    # publish-crates is in needs so a GA crates.io publish FAILURE skips the tag
+    # push + draft (nothing public is created on a partial publish). Betas no-op
+    # publish-crates (succeeds), so the tag/draft still happen on that track.
+    needs: [check-release, build-binaries, smoke-test-binaries, docker-build, publish-crates]
     if: needs.check-release.outputs.is_dry_run != 'true'
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV BISMARK_SUITE_VERSION=${BISMARK_SUITE_VERSION}
 # Copy the whole repo (context = repo root) and build the workspace --locked.
 # (A dep-only cache layer is omitted: the 14-crate workspace makes the dummy-src
 # trick brittle; a clean --locked build is correct and CI caches via the registry.)
-# `--features bismark-aligner/rammap-inprocess` compiles bismark_rs's in-process
+# `--features bismark-aligner/rammap-inprocess` compiles the `bismark` aligner's in-process
 # rammap backend ON so the shipped `--rammap_inprocess` opt-in is functional
 # (default `--rammap` stays subprocess). The feature is bismark-aligner-only, so
 # the other 11 binaries are byte-unaffected; the rammap-core git dep is fetched at
@@ -34,7 +34,7 @@ RUN cargo build --release --locked --manifest-path rust/Cargo.toml --features bi
 FROM mambaorg/micromamba:1.5.8-bookworm-slim
 
 LABEL org.opencontainers.image.source="https://github.com/FelixKrueger/Bismark"
-LABEL org.opencontainers.image.description="Bismark Rust suite (beta) — bisulfite aligner + methylation tools, byte-identical to Perl v0.25.1"
+LABEL org.opencontainers.image.description="Bismark Rust suite — bisulfite aligner + methylation tools; faithful core byte-identical to Perl v0.25.1"
 LABEL org.opencontainers.image.licenses="GPL-3.0-only"
 
 # The micromamba base ends on `USER mambauser` (an unprivileged user); installing into the
@@ -59,44 +59,45 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends procps \
     && rm -rf /var/lib/apt/lists/*
 
-# The 12 suite binaries (uniform `_rs` names during the beta/Perl-coexistence track).
+# The 12 suite binaries under their CANONICAL names (GA: the `_rs` suffix is
+# retired — Ph3a renamed every `[[bin]]`). The 11 non-aligner tools install
+# directly under their canonical names; the aligner lands as `bismark.bin` so
+# `/usr/local/bin/bismark` can be the version-probe wrapper (installed below).
 COPY --from=builder \
-    /build/rust/target/release/bismark_rs \
-    /build/rust/target/release/deduplicate_bismark_rs \
-    /build/rust/target/release/bismark_methylation_extractor_rs \
-    /build/rust/target/release/bismark2bedGraph_rs \
-    /build/rust/target/release/coverage2cytosine_rs \
-    /build/rust/target/release/bismark_genome_preparation_rs \
-    /build/rust/target/release/bam2nuc_rs \
-    /build/rust/target/release/NOMe_filtering_rs \
-    /build/rust/target/release/filter_non_conversion_rs \
-    /build/rust/target/release/methylation_consistency_rs \
-    /build/rust/target/release/bismark2report_rs \
-    /build/rust/target/release/bismark2summary_rs \
+    /build/rust/target/release/deduplicate_bismark \
+    /build/rust/target/release/bismark_methylation_extractor \
+    /build/rust/target/release/bismark2bedGraph \
+    /build/rust/target/release/coverage2cytosine \
+    /build/rust/target/release/bismark_genome_preparation \
+    /build/rust/target/release/bam2nuc \
+    /build/rust/target/release/NOMe_filtering \
+    /build/rust/target/release/filter_non_conversion \
+    /build/rust/target/release/methylation_consistency \
+    /build/rust/target/release/bismark2report \
+    /build/rust/target/release/bismark2summary \
     /usr/local/bin/
+# The aligner, renamed to `bismark.bin` (the wrapper installed below execs it).
+COPY --from=builder /build/rust/target/release/bismark /usr/local/bin/bismark.bin
 
-# ── Canonical tool names (nf-core/methylseq drop-in) ─────────
-# methylseq calls the Bismark tools by canonical name (no `_rs`) and captures the
-# suite version from the `bismark` binary via `bismark -v`/`--version`. Exposing
-# canonical names lets a methylseq container-swap PR use only a `withName` override
-# (no module script edits):
-#   - `bismark` is a version-probe WRAPPER — its `-v`/`--version` output is kept
-#     byte-identical to the Perl v0.25.1 oracle so methylseq's versions.yml + the
-#     bismark nf-test snapshots are unchanged (docker/bismark-canonical-wrapper.sh).
-#   - the other 11 are plain symlinks (methylseq scrapes ONLY `bismark`, so their
-#     `--version` stays the truthful Rust-suite banner).
+# ── Canonical `bismark` version-probe wrapper (nf-core/methylseq drop-in) ─────
+# methylseq calls the Bismark tools by canonical name and captures the suite
+# version from the `bismark` binary via `bismark -v`/`--version`. The 11 tools
+# above already carry their canonical names; only `bismark` needs special
+# handling, because methylseq scrapes its version banner in a shape the real
+# aligner binary does NOT emit (`Bismark Aligner (Rust port) Version: …`):
+#   - `/usr/local/bin/bismark` is the version-probe WRAPPER — its `-v`/`--version`
+#     prints the methylseq-parseable `Bismark Version: v<suite>` banner carrying
+#     the TRUE GA suite version; every other invocation execs the real aligner
+#     (`bismark.bin`). See docker/bismark-canonical-wrapper.sh.
+#   - the other 11 tools ARE the real binaries (methylseq scrapes ONLY `bismark`,
+#     so their `--version` stays the truthful Rust-suite banner).
 ARG BISMARK_SUITE_VERSION=unknown
 COPY docker/bismark-canonical-wrapper.sh /tmp/bismark-wrapper.sh
 RUN set -eu; \
     sed "s|__SUITE_VERSION__|${BISMARK_SUITE_VERSION}|" /tmp/bismark-wrapper.sh \
         > /usr/local/bin/bismark; \
     chmod +x /usr/local/bin/bismark; \
-    rm /tmp/bismark-wrapper.sh; \
-    for t in deduplicate_bismark bismark_methylation_extractor bismark2bedGraph \
-             coverage2cytosine bismark_genome_preparation bam2nuc NOMe_filtering \
-             filter_non_conversion methylation_consistency bismark2report bismark2summary; do \
-      ln -s "${t}_rs" "/usr/local/bin/${t}"; \
-    done
+    rm /tmp/bismark-wrapper.sh
 
 # License + third-party notices.
 COPY license.txt /usr/local/share/bismark/LICENSE

--- a/docker/bismark-canonical-wrapper.sh
+++ b/docker/bismark-canonical-wrapper.sh
@@ -1,29 +1,32 @@
 #!/bin/sh
-# Canonical-name `bismark` shim for the Rust-suite container (nf-core/methylseq drop-in).
+# Canonical-name `bismark` version-probe wrapper for the Rust-suite container
+# (nf-core/methylseq drop-in).
 #
 # methylseq's 7 Bismark modules ALL capture the suite version from the `bismark`
 # binary (verified against methylseq master), via two parser shapes:
 #   Parser-1 (align, topic: versions): `bismark --version | grep Version | sed -e 's/Bismark Version: v//' | xargs`
 #   Parser-2 (the other 6 modules):    `echo $(bismark -v 2>&1) | sed 's/^.*Bismark Version: v//; s/Copyright.*$//'`
 #
-# To keep the captured value BYTE-IDENTICAL to the Perl v0.25.1 oracle (so the
-# modules' versions.yml — and their nf-test snapshots — are unchanged), we
-# reproduce the Perl `bismark -v` banner shape: a `Bismark Version: v0.25.1`
-# line + a `Copyright`-prefixed line, then honest Rust-suite provenance on
-# line(s) AFTER `Copyright` containing NO "Version" token. Result:
-#   Parser-1 → "0.25.1"   Parser-2 → "0.25.1 "   (exactly the Perl oracle).
+# The REAL aligner binary's own `--version` is `Bismark Aligner (Rust port)
+# Version: <v>` — NOT the `Bismark Version: v<v>` shape methylseq greps for. So
+# we keep a thin wrapper that reproduces the Perl banner SHAPE (a `Bismark
+# Version: v<v>` line + a `Copyright`-prefixed line) but emits the TRUE suite
+# version. GA: honest provenance — this DROPS the beta-era impersonation of
+# v0.25.1 and reports the real suite version, so every run records `bismark
+# 2.0.0`. Result for suite version 2.0.0:
+#   Parser-1 → "2.0.0"   Parser-2 → "2.0.0"
 #
-# The `Bismark Version: v0.25.1` token is the FIXED byte-identity oracle version
-# (= the suite's behavioural target + methylseq's pinned container tag), NOT the
-# Rust suite version; only the provenance line carries the suite version
-# (__SUITE_VERSION__, injected from $BISMARK_SUITE_VERSION at image build).
+# __SUITE_VERSION__ is injected from $BISMARK_SUITE_VERSION at image build (=
+# rust/VERSION). methylseq re-baselines its nf-test version snapshots on this GA
+# bump (one-time, normal version-bump maintenance — see the GA epic OD-7).
 #
-# Every NON-version invocation execs the unchanged `bismark_rs` binary (argv,
-# stdin/stdout/stderr, exit code all preserved). methylseq always passes the
-# version flag as the sole argument, so matching `$1` is sufficient.
+# Every NON-version invocation execs the unchanged real aligner, installed in
+# the image as `bismark.bin` (argv, stdin/stdout/stderr, exit code all
+# preserved). methylseq always passes the version flag as the sole argument, so
+# matching `$1` is sufficient.
 case "$1" in
   --version|-v)
-    printf 'Bismark Version: v0.25.1\nCopyright 2010-25 Felix Krueger, Altos Bioinformatics\nhttps://github.com/FelixKrueger/Bismark\n(Bismark Rust suite __SUITE_VERSION__ — byte-identical reimplementation of Bismark v0.25.1)\n'
+    printf 'Bismark Version: v__SUITE_VERSION__\nCopyright 2010-25 Felix Krueger, Altos Bioinformatics\nhttps://github.com/FelixKrueger/Bismark\n'
     exit 0 ;;
 esac
-exec bismark_rs "$@"
+exec bismark.bin "$@"

--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -67,7 +67,11 @@ bstr = "=1.10.0"
 # Mapping}`. `default-features = false` drops rammap-core's own `parallel`/`wasm-threads`
 # defaults; we re-add `parallel` explicitly. rammap pulls NO noodles (the tight noodles
 # pins are safe); its `flate2 = "1"` is satisfied by our `=1.1.9` pin (one shared flate2).
-rammap-core = { git = "https://github.com/jwanglab/rammap", rev = "5ea62cd5e2f7875fef5234d57ada12ac5a30dbba", default-features = false, features = ["parallel"], optional = true }
+# `version = "=1.1.1"` is REQUIRED for the crates.io publish (GA): crates.io rejects a git
+# dependency that carries no version, even an optional/feature-gated one. The git `rev` is
+# the rammap v1.1.1 tagged commit, so local/release builds keep building from it; the
+# PUBLISHED manifest references rammap-core 1.1.1 from crates.io (same code, same version).
+rammap-core = { version = "=1.1.1", git = "https://github.com/jwanglab/rammap", rev = "5ea62cd5e2f7875fef5234d57ada12ac5a30dbba", default-features = false, features = ["parallel"], optional = true }
 # #995: rayon for the in-process parallel per-read map (the shared `ThreadPool`). OPTIONAL,
 # only under `rammap-inprocess` — already transitive via rammap-core's `parallel` feature, so
 # one shared rayon. `"1"` unifies with rammap-core's transitive pin (the default build never sees it).

--- a/rust/justfile
+++ b/rust/justfile
@@ -6,7 +6,7 @@
 
 # Install/update config for the `install-suite*` recipes (bump `suite_tag` on release).
 repo := "https://github.com/FelixKrueger/Bismark"
-suite_tag := "bismark-rust-v2.0.0-beta.13"
+suite_tag := "bismark-rust-v2.0.0"
 suite_crates := "bismark-genome-preparation bismark-aligner bismark-dedup bismark-extractor bismark-bedgraph bismark-coverage2cytosine bismark-methylation-consistency bismark-nome-filtering bismark-filter-nonconversion bismark-bam2nuc bismark-report bismark-summary"
 
 # Local benchmark dataset root for the aligner Apple Silicon perf work
@@ -46,11 +46,11 @@ test:
 test-release:
     cargo test --workspace --release
 
-# Build all 12 release binaries (target/release/*_rs).
+# Build all 12 release binaries (canonical names under target/release/).
 build:
     cargo build --workspace --release
 
-# Install all 12 `*_rs` binaries from the pinned release tag into ~/.cargo/bin.
+# Install all 12 canonical-named binaries from the pinned release tag into ~/.cargo/bin.
 install-suite:
     cargo install --git {{repo}} --tag {{suite_tag}} --locked {{suite_crates}}
 
@@ -60,10 +60,10 @@ install-suite-dev:
 
 # Print every suite binary's --version (provenance + suite-version check).
 version: build
-    @for b in bismark_rs deduplicate_bismark_rs bismark_methylation_extractor_rs \
-              bismark2bedGraph_rs coverage2cytosine_rs bismark_genome_preparation_rs \
-              bam2nuc_rs NOMe_filtering_rs filter_non_conversion_rs \
-              methylation_consistency_rs bismark2report_rs bismark2summary_rs; do \
+    @for b in bismark deduplicate_bismark bismark_methylation_extractor \
+              bismark2bedGraph coverage2cytosine bismark_genome_preparation \
+              bam2nuc NOMe_filtering filter_non_conversion \
+              methylation_consistency bismark2report bismark2summary; do \
         printf '%-34s ' "$b:"; ./target/release/$b --version 2>&1 | grep -iEm1 'version|/' || true; \
     done
 
@@ -78,10 +78,10 @@ reproduce:
     cargo clean
     SOURCE_DATE_EPOCH=1700000000 cargo build --workspace --release
     rm -rf /tmp/bismark_repro2 && cp -R target/release /tmp/bismark_repro2
-    @for b in bismark_rs deduplicate_bismark_rs bismark_methylation_extractor_rs \
-              bismark2bedGraph_rs coverage2cytosine_rs bismark_genome_preparation_rs \
-              bam2nuc_rs NOMe_filtering_rs filter_non_conversion_rs \
-              methylation_consistency_rs bismark2report_rs bismark2summary_rs; do \
+    @for b in bismark deduplicate_bismark bismark_methylation_extractor \
+              bismark2bedGraph coverage2cytosine bismark_genome_preparation \
+              bam2nuc NOMe_filtering filter_non_conversion \
+              methylation_consistency bismark2report bismark2summary; do \
         if cmp -s /tmp/bismark_repro1/$b /tmp/bismark_repro2/$b; then echo "✓ $b bit-identical"; \
         else echo "✗ $b DIFFERS"; fi; \
     done
@@ -107,7 +107,7 @@ build-native:
 aligner-golden genome=rrbs_genome r1=rrbs_r1 r2=rrbs_r2 out=rrbs_gold:
     cargo build --release -p bismark-aligner
     rm -rf {{out}} && mkdir -p {{out}}
-    ./target/release/bismark_rs --genome {{genome}} -1 {{r1}} -2 {{r2}} -o {{out}}
+    ./target/release/bismark --genome {{genome}} -1 {{r1}} -2 {{r2}} -o {{out}}
     cp {{out}}/*_bismark_bt2_pe.bam {{out}}/golden.bam
     cp {{out}}/*_PE_report.txt {{out}}/golden.report.txt
     @echo "✓ golden captured in {{out}}"
@@ -119,7 +119,7 @@ aligner-golden genome=rrbs_genome r1=rrbs_r1 r2=rrbs_r2 out=rrbs_gold:
 aligner-oracle genome=rrbs_genome r1=rrbs_r1 r2=rrbs_r2 gold=rrbs_gold:
     cargo build --release -p bismark-aligner
     rm -rf /tmp/aligner_oracle && mkdir -p /tmp/aligner_oracle
-    ./target/release/bismark_rs --genome {{genome}} -1 {{r1}} -2 {{r2}} -o /tmp/aligner_oracle
+    ./target/release/bismark --genome {{genome}} -1 {{r1}} -2 {{r2}} -o /tmp/aligner_oracle
     # Records only (no -h): the @PG CL header line embeds the -o path and so
     # differs by design; the record stream carries no paths and must match.
     samtools view /tmp/aligner_oracle/*_bismark_bt2_pe.bam > /tmp/aligner_oracle/cur.sam
@@ -130,11 +130,11 @@ aligner-oracle genome=rrbs_genome r1=rrbs_r1 r2=rrbs_r2 gold=rrbs_gold:
     grep -vE '/Users/|/tmp/|/var/folders/|/private/|Bismark completed in' /tmp/aligner_oracle/*_PE_report.txt > /tmp/aligner_oracle/cur.report
     @cmp -s /tmp/aligner_oracle/gold.report /tmp/aligner_oracle/cur.report && echo "✓ report numbers byte-identical" || { echo "✗ report DIFFERS"; diff /tmp/aligner_oracle/gold.report /tmp/aligner_oracle/cur.report | head; exit 1; }
 
-# Record a samply CPU profile of the aligner process (Apple Silicon). bismark_rs
+# Record a samply CPU profile of the aligner process (Apple Silicon). bismark
 # is profiled; bowtie2 is a separate PID. `parallel=1` = clean hot path;
 # `parallel=8` surfaces allocator contention.
 profile-aligner parallel="1" genome=rrbs_genome r1=rrbs_r1 r2=rrbs_r2: build-profiling
-    samply record --rate 1000 -- ./target/profiling/bismark_rs --genome {{genome}} -1 {{r1}} -2 {{r2}} -o /tmp/aligner_prof --parallel {{parallel}}
+    samply record --rate 1000 -- ./target/profiling/bismark --genome {{genome}} -1 {{r1}} -2 {{r2}} -o /tmp/aligner_prof --parallel {{parallel}}
 
 # Show all recipes.
 help:


### PR DESCRIPTION
## GA epic Phase 4a — release-pipeline rework

Reworks the release pipeline for the canonical-name GA takeover (Ph3a retired the `_rs` suffix) and adds the crates.io publish job. Part of the GA (2.0.0) epic (`plans/06252026_rust-ga-release/`); follows Ph2 (`b7baa30`) + Ph3a (`06c93f1`) + the legacy note (`e0db0d2`).

### Changes
- **OD-7 wrapper** (`docker/bismark-canonical-wrapper.sh`): emits the **true** suite version (`Bismark Version: v<suite>`, dropping the beta-era `v0.25.1` impersonation); execs the real aligner as `bismark.bin`. methylseq's two version parsers still capture cleanly.
- **Dockerfile**: install the 11 non-aligner tools under canonical names directly; aligner → `bismark.bin`; `bismark` = the wrapper. **Drop the broken `ln -s "${t}_rs"` loop.** LABEL no longer says "(beta)".
- **release.yml**: `_rs` → canonical in the package/smoke binary lists + the in-image docker smoke; version-probe assertion `0.25.1` → the **release version** (dynamic — correct for every later release/beta); **NEW `publish-crates` job** — OIDC trusted-publishing, DAG-ordered (`bismark-io`+`bismark-meta` → 11 L1 → `bismark-extractor`), **GA-only** (betas no-op), **dry-run validates** (`cargo publish --dry-run` per crate + workspace-member-coverage + version-presence + **topological-order** asserts). `docker-merge` (`:latest`) and `create-release` (GA tag) now `needs:` it, so a GA publish failure never strands a moved tag. Partial-publish/fix-forward runbook in-file.
- **docs.yml**: add `master` to the Pages-deploy trigger (docs stay live after the master takeover).
- **justfile**: `_rs` → canonical; `suite_tag` → `bismark-rust-v2.0.0`.

### Verification
⚠️ **`release.yml`/`Dockerfile` are NOT exercised by PR CI** — they run only on a release dispatch. The **4c dry-run from `master`** (gated, after the 4b master-merge) is the real gate. The publish-job validation logic (topo-sort, version-presence, member-coverage) was exercised locally against the live workspace **including a deliberately-broken negative case** (broken order + missing-version both correctly rejected). YAML + wrapper shell syntax validated.

### Gated next steps (NOT in this PR)
- **4b** merge `iron-chancellor` → `master` ⛔ explicit go.
- **4c** dry-run `release.yml` from `master` (THE gate).
- **Ph5** real GA cut + crates.io publish (IRREVERSIBLE) ⛔ explicit go. OIDC needs a crates.io-side Trusted Publisher entry per crate — confirm before Ph5.