### PR TITLE
refactor(suite): uniform --version + per-tool "Last modified" --help footer (pre-Ph5)

### DIFF
--- a/rust/bismark-aligner/Cargo.toml
+++ b/rust/bismark-aligner/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "bismark"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 clap = { version = "=4.5.30", features = ["derive"] }

--- a/rust/bismark-aligner/build.rs
+++ b/rust/bismark-aligner/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-aligner/src/binseq_decode.rs
+++ b/rust/bismark-aligner/src/binseq_decode.rs
@@ -83,7 +83,7 @@ pub fn is_binseq_input(path: &Path) -> bool {
 /// CBQ-not-yet-supported reject (v1 scope; documented fast-follow).
 fn reject_cbq() -> AlignerError {
     AlignerError::Validation(
-        "CBQ (.cbq) BINSEQ input is not yet supported by bismark_rs (only VBQ is). \
+        "CBQ (.cbq) BINSEQ input is not yet supported by bismark (only VBQ is). \
          Convert it to VBQ (`bqtools`) or to FASTQ, then re-run."
             .into(),
     )
@@ -343,7 +343,7 @@ mod vbq_impl {
     /// reject explicitly rather than mis-feed the FASTQ parser.
     fn unsupported() -> AlignerError {
         AlignerError::Validation(
-            "this bismark_rs build was compiled without BINSEQ (.vbq) support; rebuild with \
+            "this bismark build was compiled without BINSEQ (.vbq) support; rebuild with \
              `--features binseq-input` (the released Linux binaries include it), or convert the \
              input to FASTQ first."
                 .into(),

--- a/rust/bismark-aligner/src/cli.rs
+++ b/rust/bismark-aligner/src/cli.rs
@@ -14,12 +14,16 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
+/// `--help` footer: the per-tool last-modified date (embedded by build.rs).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 /// The Bismark aligner wrapper (Rust port): parse + discover + detect, then convert, align, and merge.
 #[derive(Parser, Debug)]
 #[command(
-    name = "bismark_rs",
+    name = "bismark",
     about = "Bisulfite read aligner — wraps Bowtie 2 against a bisulfite-converted genome.",
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     // ---- genome + reads ----------------------------------------------------
@@ -399,6 +403,10 @@ pub struct Cli {
     #[arg(long)]
     pub quiet: bool,
     /// Print version information and exit.
-    #[arg(long = "version")]
+    #[arg(
+        short = 'V',
+        long = "version",
+        help = "Print version information and exit"
+    )]
     pub version: bool,
 }

--- a/rust/bismark-aligner/src/config.rs
+++ b/rust/bismark-aligner/src/config.rs
@@ -1073,7 +1073,7 @@ fn resolve_genome_and_positional(cli: &Cli) -> Result<(PathBuf, Vec<String>)> {
             let mut it = cli.positional.iter();
             let genome = it.next().ok_or_else(|| {
                 AlignerError::Validation(
-                    "No genome folder specified! USAGE: bismark_rs [options] <genome_folder> \
+                    "No genome folder specified! USAGE: bismark [options] <genome_folder> \
                      {-1 <mates1> -2 <mates2> | <singles>}"
                         .into(),
                 )
@@ -1243,7 +1243,7 @@ mod tests {
     use clap::Parser;
 
     fn cli_from(args: &[&str]) -> Cli {
-        let mut v = vec!["bismark_rs"];
+        let mut v = vec!["bismark"];
         v.extend_from_slice(args);
         Cli::parse_from(v)
     }

--- a/rust/bismark-aligner/src/inprocess.rs
+++ b/rust/bismark-aligner/src/inprocess.rs
@@ -1,5 +1,5 @@
 //! In-process rammap [`SamStream`] — the load-bearing seam for byte-identical
-//! `bismark_rs --rammap` WITHOUT spawning the `rammap` subprocess (epic
+//! `bismark --rammap` WITHOUT spawning the `rammap` subprocess (epic
 //! `06152026_rammap-library-integration`, Phase 1).
 //!
 //! For each converted FastQ read, [`InProcessAlignerStream`] calls

--- a/rust/bismark-aligner/src/lib.rs
+++ b/rust/bismark-aligner/src/lib.rs
@@ -101,13 +101,7 @@ pub const BISMARK_VERSION: &str = "v0.25.1";
 
 /// `--version` banner (reports the SUITE version via `bismark_meta`; not byte-gated).
 pub fn version_string() -> String {
-    format!(
-        "\n          Bismark - Bisulfite Mapper and Methylation Caller.\n\n          \
-         Bismark Aligner (Rust port) Version: {}\n        \
-         Copyright 2010-25, Felix Krueger, Altos Bioinformatics\n\n               \
-         https://github.com/FelixKrueger/Bismark\n",
-        bismark_meta::SUITE_VERSION
-    )
+    bismark_meta::version_line("bismark")
 }
 
 /// Never-silent notice for the HISAT2 `--multicore N` → `-p N` semantic remap (Approach

--- a/rust/bismark-aligner/src/main.rs
+++ b/rust/bismark-aligner/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `bismark_rs` (Phase 1).
+//! Binary entry point for `bismark` (Phase 1).
 //!
 //! Exit codes: `0` success · `1` any [`bismark_aligner::AlignerError`] ·
 //! `2` clap parse error.

--- a/rust/bismark-aligner/src/options.rs
+++ b/rust/bismark-aligner/src/options.rs
@@ -431,7 +431,7 @@ mod tests {
     use clap::Parser;
 
     fn cli_from(args: &[&str]) -> Cli {
-        let mut v = vec!["bismark_rs"];
+        let mut v = vec!["bismark"];
         v.extend_from_slice(args);
         Cli::parse_from(v)
     }

--- a/rust/bismark-aligner/tests/cli.rs
+++ b/rust/bismark-aligner/tests/cli.rs
@@ -83,12 +83,13 @@ esac
 }
 
 #[test]
-fn version_flag_prints_banner() {
+fn version_flag_prints_uniform_suite_line() {
+    // Uniform suite one-liner: `bismark (Bismark Rust suite) v<version> (…)`.
     bin()
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Bismark Aligner (Rust port)"));
+        .stdout(predicate::str::contains("bismark (Bismark Rust suite) v"));
 }
 
 #[test]

--- a/rust/bismark-bam2nuc/Cargo.toml
+++ b/rust/bismark-bam2nuc/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "bam2nuc"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 clap = { version = "=4.5.30", features = ["derive"] }

--- a/rust/bismark-bam2nuc/build.rs
+++ b/rust/bismark-bam2nuc/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-bam2nuc/src/cli.rs
+++ b/rust/bismark-bam2nuc/src/cli.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for `bam2nuc_rs`.
+//! Command-line interface for `bam2nuc`.
 //!
 //! [`Cli`] is the clap-derived parser; [`Cli::validate`] resolves it into a
 //! [`ResolvedConfig`], reproducing Perl `bam2nuc`'s `process_commandline`
@@ -20,14 +20,19 @@ use clap::Parser;
 
 use crate::error::BismarkBam2nucError;
 
+/// `--help` footer: the per-tool last-modified date (git commit date of this
+/// crate, embedded by `build.rs` via `bismark_meta::last_modified_date`).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 /// Parsed command-line arguments. Use [`Cli::validate`] to convert to a
 /// [`ResolvedConfig`].
 #[derive(Parser, Debug)]
 #[command(
-    name = "bam2nuc_rs",
+    name = "bam2nuc",
     about = "Calculate mono- and di-nucleotide coverage of a Bismark alignment (genomic-sequence composition QC)",
     long_about = None,
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Input alignment file(s) in BAM format (`*.bam`). One stats file is
@@ -134,7 +139,7 @@ mod tests {
     use clap::CommandFactory;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
-        let mut full = vec!["bam2nuc_rs"];
+        let mut full = vec!["bam2nuc"];
         full.extend(args.iter().copied());
         Cli::try_parse_from(full)
     }

--- a/rust/bismark-bam2nuc/src/error.rs
+++ b/rust/bismark-bam2nuc/src/error.rs
@@ -28,7 +28,7 @@ pub enum BismarkBam2nucError {
     /// No input alignment file supplied AND not `--genomic_composition_only`
     /// (Perl prints help + exits; the Rust port surfaces a clear error).
     #[error(
-        "you need to provide one or more BAM files to continue — usage: bam2nuc_rs -g <genome_dir> <input.bam> [more.bam ...]"
+        "you need to provide one or more BAM files to continue — usage: bam2nuc -g <genome_dir> <input.bam> [more.bam ...]"
     )]
     MissingInput,
 

--- a/rust/bismark-bam2nuc/src/lib.rs
+++ b/rust/bismark-bam2nuc/src/lib.rs
@@ -6,7 +6,7 @@
 //! reverse-complementing for reverse-strand reads, then compares the read-
 //! derived composition against the whole-genome composition (cached in
 //! `genomic_nucleotide_frequencies.txt`). The binary is installed as
-//! `bam2nuc_rs`.
+//! `bam2nuc`.
 //!
 //! Acceptance gate: **byte-identity** of `*.nucleotide_stats.txt` and
 //! `genomic_nucleotide_frequencies.txt` vs Perl `bam2nuc` v0.25.1. See
@@ -89,15 +89,10 @@ pub fn run(config: &ResolvedConfig) -> Result<(), BismarkBam2nucError> {
     Ok(())
 }
 
-/// TG-style provenance string for the binary's `--version` output.
-///
-/// Format: `bam2nuc_rs <semver> (<os>/<arch>)`.
+/// One-line `--version` string for the binary (suite-wide shape via
+/// [`bismark_meta::version_line`]):
+/// `bam2nuc (Bismark Rust suite) v<semver> (<hash> — <os>/<arch> — built <ts>)`.
 #[must_use]
 pub fn version_string() -> String {
-    format!(
-        "bam2nuc_rs {} ({}/{})",
-        bismark_meta::SUITE_VERSION,
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-    )
+    bismark_meta::version_line("bam2nuc")
 }

--- a/rust/bismark-bam2nuc/src/main.rs
+++ b/rust/bismark-bam2nuc/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `bam2nuc_rs`.
+//! Binary entry point for `bam2nuc`.
 //!
 //! Parses [`Cli`], handles `--version`, validates into a [`ResolvedConfig`],
 //! then runs the nucleotide-coverage report.

--- a/rust/bismark-bam2nuc/tests/golden.rs
+++ b/rust/bismark-bam2nuc/tests/golden.rs
@@ -296,7 +296,7 @@ fn version_flag_long_prints_version_and_exits_zero() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicates::str::contains("bam2nuc_rs "))
+        .stdout(predicates::str::contains("bam2nuc (Bismark Rust suite) "))
         .stdout(predicates::str::contains(std::env::consts::OS));
 }
 
@@ -306,7 +306,7 @@ fn version_flag_short_prints_version_and_exits_zero() {
         .arg("-V")
         .assert()
         .success()
-        .stdout(predicates::str::contains("bam2nuc_rs "));
+        .stdout(predicates::str::contains("bam2nuc (Bismark Rust suite) "));
 }
 
 #[test]

--- a/rust/bismark-bam2nuc/tests/sanity.rs
+++ b/rust/bismark-bam2nuc/tests/sanity.rs
@@ -6,7 +6,10 @@ use bismark_bam2nuc::version_string;
 #[test]
 fn version_string_has_binary_name_and_platform() {
     let v = version_string();
-    assert!(v.starts_with("bam2nuc_rs "), "version: {v}");
+    assert!(
+        v.starts_with("bam2nuc (Bismark Rust suite) "),
+        "version: {v}"
+    );
     assert!(v.contains(std::env::consts::OS), "version omits OS: {v}");
 }
 

--- a/rust/bismark-bedgraph/Cargo.toml
+++ b/rust/bismark-bedgraph/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "bismark2bedGraph"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 clap = { version = "=4.5.30", features = ["derive"] }

--- a/rust/bismark-bedgraph/build.rs
+++ b/rust/bismark-bedgraph/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-bedgraph/src/cli.rs
+++ b/rust/bismark-bedgraph/src/cli.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for `bismark2bedGraph_rs`.
+//! Command-line interface for `bismark2bedGraph`.
 //!
 //! [`Cli`] is the clap-derived parser; [`Cli::validate`] resolves it into a
 //! [`ResolvedConfig`], rejecting unsupported / conflicting flag combos with
@@ -24,13 +24,18 @@ use clap::Parser;
 use crate::error::BismarkBedgraphError;
 use crate::filename;
 
+/// `--help` footer: the per-tool last-modified date (git commit date of this
+/// crate, embedded by `build.rs` via `bismark_meta::last_modified_date`).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 /// Parsed command-line arguments. Use [`Cli::validate`] after parsing.
 #[derive(Parser, Debug)]
 #[command(
-    name = "bismark2bedGraph_rs",
+    name = "bismark2bedGraph",
     about = "Generate a sorted bedGraph + coverage file from Bismark methylation-extractor output",
     long_about = None,
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Methylation-extractor call file(s) (`.txt` or `.txt.gz`). Default
@@ -101,7 +106,7 @@ pub struct Cli {
     pub man: bool,
 
     /// Print version information and exit.
-    #[arg(long = "version")]
+    #[arg(short = 'V', long = "version")]
     pub version: bool,
 }
 
@@ -240,7 +245,7 @@ mod tests {
     use clap::CommandFactory;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
-        let mut full = vec!["bismark2bedGraph_rs"];
+        let mut full = vec!["bismark2bedGraph"];
         full.extend(args.iter().copied());
         Cli::try_parse_from(full)
     }

--- a/rust/bismark-bedgraph/src/lib.rs
+++ b/rust/bismark-bedgraph/src/lib.rs
@@ -3,7 +3,7 @@
 //! Consumes the methylation extractor's per-context call files
 //! (`CpG_OT_*`, `CpG_OB_*`, … and the CHG/CHH equivalents with `--CX`) and
 //! emits a sorted, gzip-compressed bedGraph + coverage file. Installed as
-//! `bismark2bedGraph_rs` during the v0.26 → v1.0 coexistence period.
+//! `bismark2bedGraph` during the v0.26 → v1.0 coexistence period.
 //!
 //! See `SPEC.md` (rev 1) for the binding contract — decompressed-content
 //! byte-identity to Perl v0.25.1, the argv-order chromosome ownership rule,
@@ -35,16 +35,12 @@ pub use error::BismarkBedgraphError;
 
 use std::path::Path;
 
-/// Returns a TG-style provenance string for the binary's `--version`
-/// output. Format: `bismark2bedGraph_rs <semver> (<os>/<arch>)`.
+/// One-line `--version` string for the binary (suite-wide shape via
+/// [`bismark_meta::version_line`]):
+/// `bismark2bedGraph (Bismark Rust suite) v<semver> (<hash> — <os>/<arch> — built <ts>)`.
 #[must_use]
 pub fn version_string() -> String {
-    format!(
-        "bismark2bedGraph_rs {} ({}/{})",
-        bismark_meta::SUITE_VERSION,
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-    )
+    bismark_meta::version_line("bismark2bedGraph")
 }
 
 /// Run the full conversion for a validated [`ResolvedConfig`].

--- a/rust/bismark-bedgraph/src/main.rs
+++ b/rust/bismark-bedgraph/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `bismark2bedGraph_rs`.
+//! Binary entry point for `bismark2bedGraph`.
 //!
 //! Parses CLI via [`bismark_bedgraph::cli::Cli`], handles `--version` /
 //! `--man` short-circuits, validates into a

--- a/rust/bismark-bedgraph/tests/cli_behavior.rs
+++ b/rust/bismark-bedgraph/tests/cli_behavior.rs
@@ -125,7 +125,9 @@ fn version_flag_prints_provenance_and_exits_zero() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("bismark2bedGraph_rs"));
+        .stdout(predicate::str::contains(
+            "bismark2bedGraph (Bismark Rust suite) ",
+        ));
 }
 
 #[test]

--- a/rust/bismark-coverage2cytosine/Cargo.toml
+++ b/rust/bismark-coverage2cytosine/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/lib.rs"
 name = "coverage2cytosine"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 clap = { version = "=4.5.30", features = ["derive"] }

--- a/rust/bismark-coverage2cytosine/build.rs
+++ b/rust/bismark-coverage2cytosine/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-coverage2cytosine/src/cli.rs
+++ b/rust/bismark-coverage2cytosine/src/cli.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for `coverage2cytosine_rs`.
+//! Command-line interface for `coverage2cytosine`.
 //!
 //! [`Cli`] is the clap-derived parser; [`Cli::validate`] resolves it into a
 //! [`ResolvedConfig`], reproducing every Perl `process_commandline`
@@ -18,14 +18,19 @@ use clap::Parser;
 
 use crate::error::BismarkC2cError;
 
+/// `--help` footer: the per-tool last-modified date (git commit date of this
+/// crate, embedded by `build.rs` via `bismark_meta::last_modified_date`).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 /// Parsed command-line arguments. Use [`Cli::validate`] to convert to a
 /// [`ResolvedConfig`].
 #[derive(Parser, Debug)]
 #[command(
-    name = "coverage2cytosine_rs",
+    name = "coverage2cytosine",
     about = "Generate a genome-wide cytosine methylation report from a Bismark coverage file",
     long_about = None,
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Bismark coverage file (`*.bismark.cov[.gz]`). 1-based, tab-separated.
@@ -289,7 +294,7 @@ mod tests {
     use clap::CommandFactory;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
-        let mut full = vec!["coverage2cytosine_rs"];
+        let mut full = vec!["coverage2cytosine"];
         full.extend(args.iter().copied());
         Cli::try_parse_from(full)
     }

--- a/rust/bismark-coverage2cytosine/src/error.rs
+++ b/rust/bismark-coverage2cytosine/src/error.rs
@@ -16,7 +16,7 @@ pub enum BismarkC2cError {
     /// No positional coverage infile was supplied. Perl prints help + exits
     /// (`:2059`); the Rust port surfaces a clear error instead.
     #[error(
-        "no coverage input file supplied — usage: coverage2cytosine_rs -o <out> -g <genome_dir> <input.bismark.cov[.gz]>"
+        "no coverage input file supplied — usage: coverage2cytosine -o <out> -g <genome_dir> <input.bismark.cov[.gz]>"
     )]
     MissingCovInput,
 

--- a/rust/bismark-coverage2cytosine/src/lib.rs
+++ b/rust/bismark-coverage2cytosine/src/lib.rs
@@ -4,7 +4,7 @@
 //! emits a genome-wide per-cytosine report (CpG by default; all-context with
 //! `--CX`). This crate is the second producer (after `bismark-bedgraph`,
 //! epic #797) that unblocks the extractor's Phase H sub-gate 2 byte-identity
-//! gate. The binary is installed as `coverage2cytosine_rs`.
+//! gate. The binary is installed as `coverage2cytosine`.
 //!
 //! See `plans/05292026_bismark-coverage2cytosine/SPEC.md` (rev 3) for the
 //! design contract and the byte-identity-vs-Perl-v0.25.1 discipline.
@@ -78,15 +78,10 @@ pub fn run(config: &ResolvedConfig) -> Result<(), BismarkC2cError> {
     Ok(())
 }
 
-/// TG-style provenance string for the binary's `--version` output.
-///
-/// Format: `coverage2cytosine_rs <semver> (<os>/<arch>)`.
+/// One-line `--version` string for the binary (suite-wide shape via
+/// [`bismark_meta::version_line`]):
+/// `coverage2cytosine (Bismark Rust suite) v<semver> (<hash> — <os>/<arch> — built <ts>)`.
 #[must_use]
 pub fn version_string() -> String {
-    format!(
-        "coverage2cytosine_rs {} ({}/{})",
-        bismark_meta::SUITE_VERSION,
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-    )
+    bismark_meta::version_line("coverage2cytosine")
 }

--- a/rust/bismark-coverage2cytosine/src/main.rs
+++ b/rust/bismark-coverage2cytosine/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `coverage2cytosine_rs`.
+//! Binary entry point for `coverage2cytosine`.
 //!
 //! Parses [`Cli`], handles `--version`, validates into a `ResolvedConfig`,
 //! then runs the genome-wide cytosine report (Phase B).

--- a/rust/bismark-coverage2cytosine/tests/sanity.rs
+++ b/rust/bismark-coverage2cytosine/tests/sanity.rs
@@ -15,7 +15,12 @@ fn version_output_matches_provenance_regex() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(is_match(r"^coverage2cytosine_rs \d+\.\d+\.\d+(-[\w.]+)? \(\S+/\S+\)\n$").unwrap());
+        .stdout(
+            is_match(
+                r"^coverage2cytosine \(Bismark Rust suite\) v\d+\.\d+\.\d+(-[\w.]+)? \(.+\)\n$",
+            )
+            .unwrap(),
+        );
 }
 
 #[test]
@@ -25,7 +30,7 @@ fn short_version_flag_works_too() {
         .arg("-V")
         .assert()
         .success()
-        .stdout(is_match(r"^coverage2cytosine_rs ").unwrap());
+        .stdout(is_match(r"^coverage2cytosine \(Bismark Rust suite\) ").unwrap());
 }
 
 #[test]

--- a/rust/bismark-dedup/Cargo.toml
+++ b/rust/bismark-dedup/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "deduplicate_bismark"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 bismark-io = { version = "=1.0.0", path = "../bismark-io" }

--- a/rust/bismark-dedup/build.rs
+++ b/rust/bismark-dedup/build.rs
@@ -1,0 +1,13 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    // Re-run when this crate's tracked files change (best-effort: the crate dir).
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-dedup/src/cli.rs
+++ b/rust/bismark-dedup/src/cli.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for `deduplicate_bismark_rs`.
+//! Command-line interface for `deduplicate_bismark`.
 //!
 //! [`Cli`] is the clap-derived parser. [`Cli::validate`] resolves the
 //! parsed arguments into a [`ResolvedConfig`] and rejects unsupported /
@@ -37,14 +37,19 @@ use clap::Parser;
 
 use crate::error::BismarkDedupError;
 
+/// `--help` footer: the per-tool last-modified date (git commit date of this
+/// crate, embedded by `build.rs` via `bismark_meta::last_modified_date`).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 /// Parsed command-line arguments. Use [`Cli::validate`] to convert to a
 /// [`ResolvedConfig`] after parsing.
 #[derive(Parser, Debug)]
 #[command(
-    name = "deduplicate_bismark_rs",
+    name = "deduplicate_bismark",
     about = "Remove PCR duplicate alignments from Bismark BAM/SAM/CRAM files",
     long_about = None,
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Bismark BAM/SAM/CRAM file(s) to deduplicate.
@@ -250,7 +255,7 @@ mod tests {
     use clap::CommandFactory;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
-        let mut full = vec!["deduplicate_bismark_rs"];
+        let mut full = vec!["deduplicate_bismark"];
         full.extend(args.iter().copied());
         Cli::try_parse_from(full)
     }

--- a/rust/bismark-dedup/src/lib.rs
+++ b/rust/bismark-dedup/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate is the first downstream binary of the Bismark Rust rewrite, built
 //! on top of [`bismark_io`] for all BAM/SAM/CRAM I/O. The binary is installed as
-//! `deduplicate_bismark_rs` during the v0.26 → v1.0 coexistence period.
+//! `deduplicate_bismark` during the v0.26 → v1.0 coexistence period.
 //!
 //! See `~/.claude/plans/05242026_bismark-dedup-v1/PLAN.md` (rev 3) for the
 //! design contract, behaviour specification, and phased implementation plan.
@@ -44,18 +44,9 @@ pub use dedup::{DedupKey, DedupState, UmiDedupKey, UmiDedupState};
 pub use error::BismarkDedupError;
 pub use report::DedupReport;
 
-/// Returns a TG-style provenance string for the binary's `--version` output.
-///
-/// Format: `deduplicate_bismark_rs <semver> (<os>/<arch>)`.
-///
-/// Phase A keeps the provenance minimal. Phase G will extend this with git
-/// commit hash and ISO-8601 build timestamp via a `build.rs` step.
+/// The uniform suite `--version` one-liner via [`bismark_meta::version_line`]:
+/// `deduplicate_bismark (Bismark Rust suite) v<version> (<hash> — <os>/<arch> — built <ts>)`.
 #[must_use]
 pub fn version_string() -> String {
-    format!(
-        "deduplicate_bismark_rs {} ({}/{})",
-        bismark_meta::SUITE_VERSION,
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-    )
+    bismark_meta::version_line("deduplicate_bismark")
 }

--- a/rust/bismark-dedup/src/main.rs
+++ b/rust/bismark-dedup/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `deduplicate_bismark_rs`.
+//! Binary entry point for `deduplicate_bismark`.
 //!
 //! Parses CLI via [`bismark_dedup::cli::Cli`], validates the flag
 //! combinations into a [`bismark_dedup::cli::ResolvedConfig`], then

--- a/rust/bismark-dedup/tests/sanity.rs
+++ b/rust/bismark-dedup/tests/sanity.rs
@@ -1,7 +1,7 @@
 //! Phase A sanity test.
 //!
-//! Spawns the `deduplicate_bismark_rs` binary with `--version` and asserts the
-//! output matches the documented provenance regex. This is the minimum bar for
+//! Spawns the `deduplicate_bismark` binary with `--version` and asserts the
+//! output matches the uniform suite provenance regex. This is the minimum bar for
 //! Phase A: the binary builds, runs, and emits a recognisable identity string.
 
 use assert_cmd::Command;
@@ -14,10 +14,14 @@ fn version_output_matches_provenance_regex() {
     cmd.arg("--version")
         .assert()
         .success()
-        // `deduplicate_bismark_rs <semver> (<os>/<arch>)` where <semver>
-        // may include a pre-release suffix (e.g. `1.0.0-beta.1`).
+        // Uniform suite one-liner:
+        // `deduplicate_bismark (Bismark Rust suite) v<semver> (<hash> — <os>/<arch> — built <ts>)`
+        // — canonical name (no `_rs`), suite version, provenance body.
         .stdout(
-            is_match(r"^deduplicate_bismark_rs \d+\.\d+\.\d+(-[\w.]+)? \(\S+/\S+\)\n$").unwrap(),
+            is_match(
+                r"^deduplicate_bismark \(Bismark Rust suite\) v\d+\.\d+\.\d+(-[\w.]+)? \(.+\)\n$",
+            )
+            .unwrap(),
         );
 }
 
@@ -27,7 +31,7 @@ fn short_version_flag_works_too() {
     cmd.arg("-V")
         .assert()
         .success()
-        .stdout(is_match(r"^deduplicate_bismark_rs ").unwrap());
+        .stdout(is_match(r"^deduplicate_bismark \(Bismark Rust suite\) ").unwrap());
 }
 
 #[test]

--- a/rust/bismark-extractor/Cargo.toml
+++ b/rust/bismark-extractor/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "bismark_methylation_extractor"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 bismark-io = { version = "=1.0.0", path = "../bismark-io" }

--- a/rust/bismark-extractor/build.rs
+++ b/rust/bismark-extractor/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-extractor/src/cli.rs
+++ b/rust/bismark-extractor/src/cli.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for `bismark_methylation_extractor_rs`.
+//! Command-line interface for `bismark_methylation_extractor`.
 //!
 //! All 35 Perl flags from [SPEC §3](../../SPEC.md) are mapped to clap-derived
 //! fields below. [`Cli::validate`] returns a [`ResolvedConfig`] after
@@ -19,14 +19,19 @@ use clap::Parser;
 
 use crate::error::BismarkExtractorError;
 
+/// `--help` footer: the per-tool last-modified date (git commit date of this
+/// crate, embedded by `build.rs` via `bismark_meta::last_modified_date`).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 /// Parsed command-line arguments. Use [`Cli::validate`] to convert to a
 /// [`ResolvedConfig`] after parsing.
 #[derive(Parser, Debug)]
 #[command(
-    name = "bismark_methylation_extractor_rs",
+    name = "bismark_methylation_extractor",
     about = "Extract methylation calls from Bismark-aligned BAM/SAM/CRAM files",
     long_about = None,
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Bismark BAM/SAM/CRAM file(s) to extract methylation calls from.
@@ -241,7 +246,7 @@ pub struct Cli {
     pub parallel: u32,
 
     // ─── Version (SPEC §3 row 11, Perl 967) ───
-    /// Print TG-style provenance string and exit.
+    /// Print version information and exit.
     #[arg(short = 'V', long = "version")]
     pub version: bool,
 }
@@ -555,7 +560,7 @@ mod tests {
     use clap::CommandFactory;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
-        let mut full = vec!["bismark_methylation_extractor_rs"];
+        let mut full = vec!["bismark_methylation_extractor"];
         full.extend(args.iter().copied());
         Cli::try_parse_from(full)
     }

--- a/rust/bismark-extractor/src/lib.rs
+++ b/rust/bismark-extractor/src/lib.rs
@@ -52,9 +52,8 @@
 //!
 //! ## Binary
 //!
-//! Installs as `bismark_methylation_extractor_rs` (with `_rs` suffix
-//! during the Perl → Rust coexistence period; matches the `bismark-dedup`
-//! precedent).
+//! Installs as `bismark_methylation_extractor` (the canonical name; the
+//! beta-era `_rs` suffix is retired at GA).
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
@@ -93,17 +92,10 @@ pub use params::ExtractParams;
 // without replacing the byte-identity oracle.
 pub use pipeline::{extract_pe, extract_se};
 
-/// Returns a TG-style provenance string for the binary's `--version` output.
-///
-/// Format: `bismark_methylation_extractor_rs <semver> (<os>/<arch>)`.
-/// Matches the `bismark-dedup` precedent. Phase H will extend this with
-/// git commit hash + ISO-8601 build timestamp via `build.rs`.
+/// One-line `--version` string for the binary (suite-wide shape via
+/// [`bismark_meta::version_line`]):
+/// `bismark_methylation_extractor (Bismark Rust suite) v<semver> (<hash> — <os>/<arch> — built <ts>)`.
 #[must_use]
 pub fn version_string() -> String {
-    format!(
-        "bismark_methylation_extractor_rs {} ({}/{})",
-        bismark_meta::SUITE_VERSION,
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-    )
+    bismark_meta::version_line("bismark_methylation_extractor")
 }

--- a/rust/bismark-extractor/src/main.rs
+++ b/rust/bismark-extractor/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `bismark_methylation_extractor_rs`.
+//! Binary entry point for `bismark_methylation_extractor`.
 //!
 //! Processes EACH input file independently (per-file outputs, no
 //! cross-file pooling — faithful to Perl's `foreach my $filename`), then

--- a/rust/bismark-extractor/src/parallel.rs
+++ b/rust/bismark-extractor/src/parallel.rs
@@ -1292,7 +1292,7 @@ mod tests {
         let tmp = tempfile::Builder::new().suffix(".bam").tempfile().unwrap();
         std::fs::write(tmp.path(), b"x").unwrap();
         let path = tmp.path().to_str().unwrap().to_string();
-        let mut args = vec!["bismark_methylation_extractor_rs"];
+        let mut args = vec!["bismark_methylation_extractor"];
         args.extend(extra.iter().copied());
         args.push(&path);
         let cfg = Cli::try_parse_from(&args).unwrap().validate().unwrap();
@@ -1441,7 +1441,7 @@ mod tests {
         // valid one with parallel=4.
         let tmpfile = tempfile::Builder::new().suffix(".bam").tempfile().unwrap();
         std::fs::write(tmpfile.path(), b"x").unwrap();
-        let mut full = vec!["bismark_methylation_extractor_rs"];
+        let mut full = vec!["bismark_methylation_extractor"];
         let input_path = tmpfile.path().to_str().unwrap().to_string();
         full.extend(
             ["--single-end", "--parallel", "4", &input_path]
@@ -1539,13 +1539,9 @@ mod tests {
         std::fs::write(tmpfile.path(), b"x").unwrap();
         let input_path = tmpfile.path().to_str().unwrap().to_string();
         let cli = Cli::try_parse_from(
-            [
-                "bismark_methylation_extractor_rs",
-                "--single-end",
-                &input_path,
-            ]
-            .iter()
-            .copied(),
+            ["bismark_methylation_extractor", "--single-end", &input_path]
+                .iter()
+                .copied(),
         )
         .unwrap();
         let config = cli.validate().unwrap();

--- a/rust/bismark-extractor/tests/sanity.rs
+++ b/rust/bismark-extractor/tests/sanity.rs
@@ -1,6 +1,6 @@
 //! Phase A sanity tests.
 //!
-//! Spawns the `bismark_methylation_extractor_rs` binary with basic flags
+//! Spawns the `bismark_methylation_extractor` binary with basic flags
 //! and asserts the binary boots correctly + `--help` lists all 35 flags
 //! + `--version` matches the provenance regex.
 
@@ -11,8 +11,10 @@ use predicates::str::is_match;
 fn version_output_matches_provenance_regex() {
     let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
     cmd.arg("--version").assert().success().stdout(
-        is_match(r"^bismark_methylation_extractor_rs \d+\.\d+\.\d+(-[\w.]+)? \(\S+/\S+\)\n$")
-            .unwrap(),
+        is_match(
+            r"^bismark_methylation_extractor \(Bismark Rust suite\) v\d+\.\d+\.\d+(-[\w.]+)? \(.+\)\n$",
+        )
+        .unwrap(),
     );
 }
 
@@ -22,7 +24,7 @@ fn short_version_flag_works_too() {
     cmd.arg("-V")
         .assert()
         .success()
-        .stdout(is_match(r"^bismark_methylation_extractor_rs ").unwrap());
+        .stdout(is_match(r"^bismark_methylation_extractor \(Bismark Rust suite\) ").unwrap());
 }
 
 #[test]

--- a/rust/bismark-filter-nonconversion/Cargo.toml
+++ b/rust/bismark-filter-nonconversion/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "filter_non_conversion"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 # Used ONLY for `detect_paired_from_header` (the @PG SE/PE auto-detect). All

--- a/rust/bismark-filter-nonconversion/build.rs
+++ b/rust/bismark-filter-nonconversion/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-filter-nonconversion/src/cli.rs
+++ b/rust/bismark-filter-nonconversion/src/cli.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for `filter_non_conversion_rs`.
+//! Command-line interface for `filter_non_conversion`.
 //!
 //! [`Cli`] is the clap-derived parser; [`Cli::validate`] reproduces Perl
 //! `filter_non_conversion`'s `process_commandline` validation (lines
@@ -24,10 +24,13 @@ use clap::Parser;
 use crate::error::BismarkFilterError;
 use crate::filter::FilterMode;
 
+/// `--help` footer: the per-tool last-modified date (embedded by build.rs).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 /// Parsed command-line arguments. Use [`Cli::validate`] to resolve.
 #[derive(Parser, Debug)]
 #[command(
-    name = "filter_non_conversion_rs",
+    name = "filter_non_conversion",
     about = "Filter reads/read-pairs with apparent incomplete bisulfite conversion \
              (too much non-CG methylation) from Bismark BAM files",
     long_about = None,
@@ -35,7 +38,8 @@ use crate::filter::FilterMode;
     // Accept negative-number values (e.g. `--threshold -1`) so they reach the
     // Perl-style validation checks rather than being mis-parsed as flags.
     // Matches Perl `GetOptions(...=i)`. See cli.rs module docs.
-    allow_negative_numbers = true
+    allow_negative_numbers = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Bismark BAM file(s) to filter. Each is processed independently.
@@ -74,7 +78,7 @@ pub struct Cli {
     pub samtools_path: Option<PathBuf>,
 
     /// Print version information and exit.
-    #[arg(long = "version")]
+    #[arg(short = 'V', long = "version")]
     pub version: bool,
 }
 
@@ -179,7 +183,7 @@ mod tests {
     use clap::CommandFactory;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
-        let mut full = vec!["filter_non_conversion_rs"];
+        let mut full = vec!["filter_non_conversion"];
         full.extend(args.iter().copied());
         Cli::try_parse_from(full)
     }

--- a/rust/bismark-filter-nonconversion/src/error.rs
+++ b/rust/bismark-filter-nonconversion/src/error.rs
@@ -1,4 +1,4 @@
-//! Typed errors for `filter_non_conversion_rs`.
+//! Typed errors for `filter_non_conversion`.
 //!
 //! Display strings echo the Perl `filter_non_conversion` `die`/`warn`
 //! messages where practical. These are surfaced on STDERR (not part of the

--- a/rust/bismark-filter-nonconversion/src/lib.rs
+++ b/rust/bismark-filter-nonconversion/src/lib.rs
@@ -28,17 +28,11 @@ pub use report::FilterReport;
 use std::io::Write as _;
 use std::time::Instant;
 
-/// Version provenance string for the `--version` flag.
-///
-/// Format: `filter_non_conversion_rs <semver> (<os>/<arch>)`.
+/// The uniform suite `--version` one-liner via [`bismark_meta::version_line`]:
+/// `filter_non_conversion (Bismark Rust suite) v<version> (<hash> — <os>/<arch> — built <ts>)`.
 #[must_use]
 pub fn version_string() -> String {
-    format!(
-        "filter_non_conversion_rs {} ({}/{})",
-        bismark_meta::SUITE_VERSION,
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-    )
+    bismark_meta::version_line("filter_non_conversion")
 }
 
 /// Run the filter over every configured input file, each independently

--- a/rust/bismark-filter-nonconversion/src/main.rs
+++ b/rust/bismark-filter-nonconversion/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `filter_non_conversion_rs`.
+//! Binary entry point for `filter_non_conversion`.
 //!
 //! Exit codes: `0` success; `1` any [`BismarkFilterError`] or no input files;
 //! `2` clap parse error (clap convention).

--- a/rust/bismark-genome-preparation/Cargo.toml
+++ b/rust/bismark-genome-preparation/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "bismark_genome_preparation"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 clap = { version = "=4.5.30", features = ["derive"] }

--- a/rust/bismark-genome-preparation/build.rs
+++ b/rust/bismark-genome-preparation/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-genome-preparation/src/cli.rs
+++ b/rust/bismark-genome-preparation/src/cli.rs
@@ -34,11 +34,15 @@ impl Aligner {
     }
 }
 
+/// `--help` footer: the per-tool last-modified date (embedded by build.rs).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 #[derive(Parser, Debug)]
 #[command(
-    name = "bismark_genome_preparation_rs",
+    name = "bismark_genome_preparation",
     about = "Prepare bisulfite-converted genome references (CT + GA) and index them.",
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Path to the folder containing the genome FASTA file(s). Mandatory

--- a/rust/bismark-genome-preparation/src/lib.rs
+++ b/rust/bismark-genome-preparation/src/lib.rs
@@ -41,11 +41,5 @@ pub const BISMARK_VERSION: &str = "v0.25.1";
 /// `--version` banner. Reports the SUITE version (via `bismark_meta`, single
 /// source `rust/VERSION`); not part of the byte-identity gate.
 pub fn version_string() -> String {
-    format!(
-        "\n          Bismark - Bisulfite Mapper and Methylation Caller.\n\n          \
-         Bismark Genome Preparation (Rust port) Version: {}\n        \
-         Copyright 2010-25, Felix Krueger, Altos Bioinformatics\n\n               \
-         https://github.com/FelixKrueger/Bismark\n",
-        bismark_meta::SUITE_VERSION
-    )
+    bismark_meta::version_line("bismark_genome_preparation")
 }

--- a/rust/bismark-genome-preparation/src/main.rs
+++ b/rust/bismark-genome-preparation/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `bismark_genome_preparation_rs`.
+//! Binary entry point for `bismark_genome_preparation`.
 //!
 //! Exit codes: `0` success · `1` any [`GenomePrepError`] · `2` clap parse error.
 

--- a/rust/bismark-meta/src/lib.rs
+++ b/rust/bismark-meta/src/lib.rs
@@ -16,9 +16,42 @@ pub const BUILD_TIMESTAMP: &str = env!("BUILD_TIMESTAMP");
 pub const VERSION_BODY: &str = env!("VERSION_BODY");
 
 /// A one-line `--version` string for a suite tool, e.g.
-/// `bismark_rs (Bismark Rust suite) v2.0.0-beta.1 (abc1234 — linux/x86_64 — built 2026-…Z)`.
+/// `bismark (Bismark Rust suite) v2.0.0 (abc1234 — linux/x86_64 — built 2026-…Z)`.
+/// Every suite binary's `--version` is this exact shape (pass the CANONICAL tool
+/// name — no `_rs` suffix).
 pub fn version_line(tool: &str) -> String {
     format!("{tool} (Bismark Rust suite) v{SUITE_VERSION} ({VERSION_BODY})")
+}
+
+/// Build-time helper: the last-modified date (`YYYY-MM-DD`) of a crate directory,
+/// from git (`git log -1 --date=short` filtered to that dir). Call it from a
+/// dependent crate's `build.rs` (add `bismark-meta` as a `[build-dependencies]`)
+/// to embed a per-tool "Last modified" date in that tool's `--help` footer.
+///
+/// Falls back to the build date (then `"unknown"`) when there is no git checkout
+/// — e.g. a crates.io registry build from the packaged tarball. Release binaries,
+/// the container, and `cargo install --git` are all built from a checkout, so
+/// they bake the tool's true last-commit date.
+pub fn last_modified_date(manifest_dir: &str) -> String {
+    use std::process::Command;
+    let from_git = Command::new("git")
+        .current_dir(manifest_dir)
+        .args(["log", "-1", "--format=%cd", "--date=short", "--", "."])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    from_git.unwrap_or_else(|| {
+        // `BUILD_TIMESTAMP` is `YYYY-MM-DDThh:mm:ssZ`; take the date part.
+        BUILD_TIMESTAMP
+            .split('T')
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("unknown")
+            .to_string()
+    })
 }
 
 #[cfg(test)]
@@ -32,10 +65,12 @@ mod tests {
 
     #[test]
     fn version_line_shape() {
-        let l = version_line("bismark_rs");
-        assert!(l.starts_with("bismark_rs (Bismark Rust suite) v"));
+        let l = version_line("bismark");
+        assert!(l.starts_with("bismark (Bismark Rust suite) v"));
         assert!(l.contains(SUITE_VERSION));
         assert!(l.contains(GIT_SHORT_HASH));
+        // Canonical name only — the `_rs` dev suffix is retired at GA.
+        assert!(!l.contains("_rs"));
     }
 
     #[test]

--- a/rust/bismark-methylation-consistency/Cargo.toml
+++ b/rust/bismark-methylation-consistency/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "methylation_consistency"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 bismark-io = { version = "=1.0.0", path = "../bismark-io" }

--- a/rust/bismark-methylation-consistency/build.rs
+++ b/rust/bismark-methylation-consistency/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-methylation-consistency/src/cli.rs
+++ b/rust/bismark-methylation-consistency/src/cli.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for `methylation_consistency_rs`.
+//! Command-line interface for `methylation_consistency`.
 //!
 //! [`Cli`] is the clap-derived parser; [`Cli::validate`] resolves it into a
 //! [`ResolvedConfig`], applying defaults and the Perl threshold range checks.
@@ -16,13 +16,17 @@ use clap::Parser;
 
 use crate::error::MethConsError;
 
+/// `--help` footer: the per-tool last-modified date (embedded by build.rs).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 /// Parsed command-line arguments. Use [`Cli::validate`] after parsing.
 #[derive(Parser, Debug)]
 #[command(
-    name = "methylation_consistency_rs",
+    name = "methylation_consistency",
     about = "Split a Bismark BAM into three BAMs by read-level methylation consistency",
     long_about = None,
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Bismark BAM file(s) to split by read methylation consistency.
@@ -169,7 +173,7 @@ mod tests {
     use clap::CommandFactory;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
-        let mut full = vec!["methylation_consistency_rs"];
+        let mut full = vec!["methylation_consistency"];
         full.extend(args.iter().copied());
         Cli::try_parse_from(full)
     }

--- a/rust/bismark-methylation-consistency/src/error.rs
+++ b/rust/bismark-methylation-consistency/src/error.rs
@@ -26,7 +26,7 @@ pub enum MethConsError {
 
     /// No positional input files. Mirrors Perl's usage `die` (line 131).
     #[error(
-        "No input file(s) supplied. USAGE is:\n\n\tmethylation_consistency_rs [--min-count=5] [bam file(s)]\n"
+        "No input file(s) supplied. USAGE is:\n\n\tmethylation_consistency [--min-count=5] [bam file(s)]\n"
     )]
     NoInputFiles,
 

--- a/rust/bismark-methylation-consistency/src/lib.rs
+++ b/rust/bismark-methylation-consistency/src/lib.rs
@@ -6,7 +6,7 @@
 //! consistently methylated (`>= upper_threshold`), consistently unmethylated
 //! (`<= lower_threshold`), and mixed — plus a `_consistency_report.txt`. Built
 //! on [`bismark_io`] for all BAM I/O (pure Rust, no `samtools` subprocess);
-//! the binary installs as `methylation_consistency_rs`.
+//! the binary installs as `methylation_consistency`.
 //!
 //! Acceptance contract: byte-identical to the Perl original for the report and
 //! (at the decompressed-record level) the three BAMs. See
@@ -30,15 +30,10 @@ pub use report::Tally;
 
 /// Provenance string for the binary's `--version` output.
 ///
-/// Format: `methylation_consistency_rs <semver> (<os>/<arch>)`. Mirrors
-/// `bismark-dedup`'s `version_string`; uses the crate version, **not** the
-/// Bismark `0.25.1` constant (which methcons never injects into any header).
+/// The uniform suite one-liner via [`bismark_meta::version_line`]:
+/// `methylation_consistency (Bismark Rust suite) v<version> (…)` — the SUITE
+/// version, **not** the Bismark `0.25.1` constant (methcons injects no header).
 #[must_use]
 pub fn version_string() -> String {
-    format!(
-        "methylation_consistency_rs {} ({}/{})",
-        bismark_meta::SUITE_VERSION,
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-    )
+    bismark_meta::version_line("methylation_consistency")
 }

--- a/rust/bismark-methylation-consistency/src/main.rs
+++ b/rust/bismark-methylation-consistency/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `methylation_consistency_rs`.
+//! Binary entry point for `methylation_consistency`.
 //!
 //! Parses CLI via [`bismark_methylation_consistency::Cli`], validates into a
 //! [`ResolvedConfig`], then runs the per-file consistency split via

--- a/rust/bismark-methylation-consistency/tests/integration.rs
+++ b/rust/bismark-methylation-consistency/tests/integration.rs
@@ -437,7 +437,9 @@ fn version_flag_prints_provenance() {
     let dir = TempDir::new().unwrap();
     run(&dir, &["--version"])
         .success()
-        .stdout(predicates::str::contains("methylation_consistency_rs"));
+        .stdout(predicates::str::starts_with(
+            "methylation_consistency (Bismark Rust suite) v",
+        ));
 }
 
 // ── Perl-vs-Rust byte identity (the §7 gate; auto-skips if tooling absent) ──

--- a/rust/bismark-nome-filtering/Cargo.toml
+++ b/rust/bismark-nome-filtering/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/lib.rs"
 name = "NOMe_filtering"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 bismark-io = { version = "=1.0.0", path = "../bismark-io" }

--- a/rust/bismark-nome-filtering/build.rs
+++ b/rust/bismark-nome-filtering/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-nome-filtering/src/cli.rs
+++ b/rust/bismark-nome-filtering/src/cli.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for `NOMe_filtering_rs`.
+//! Command-line interface for `NOMe_filtering`.
 //!
 //! [`Cli`] is the clap-derived parser; [`Cli::validate`] resolves it into a
 //! [`ResolvedConfig`], enforcing the SPEC §4 rules:
@@ -23,13 +23,17 @@ use clap::Parser;
 use crate::error::BismarkNomeError;
 use crate::filename::derive_manowar_name;
 
+/// `--help` footer: the per-tool last-modified date (embedded by build.rs).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 /// Parsed command-line arguments. Use [`Cli::validate`] to resolve.
 #[derive(Parser, Debug)]
 #[command(
-    name = "NOMe_filtering_rs",
+    name = "NOMe_filtering",
     about = "Per-read NOMe-Seq methylation filtering (standalone Bismark NOMe_filtering)",
     long_about = None,
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Yacht input file (from `bismark_methylation_extractor --yacht`).
@@ -149,7 +153,7 @@ mod tests {
     use clap::CommandFactory;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
-        let mut full = vec!["NOMe_filtering_rs"];
+        let mut full = vec!["NOMe_filtering"];
         full.extend(args.iter().copied());
         Cli::try_parse_from(full)
     }

--- a/rust/bismark-nome-filtering/src/lib.rs
+++ b/rust/bismark-nome-filtering/src/lib.rs
@@ -25,17 +25,11 @@ pub mod substr;
 use crate::cli::Cli;
 use crate::error::BismarkNomeError;
 
-/// TG-style provenance string for the binary's `--version` output.
-///
-/// Format: `NOMe_filtering_rs <semver> (<os>/<arch>)`.
+/// The uniform suite `--version` one-liner via [`bismark_meta::version_line`]:
+/// `NOMe_filtering (Bismark Rust suite) v<version> (<hash> — <os>/<arch> — built <ts>)`.
 #[must_use]
 pub fn version_string() -> String {
-    format!(
-        "NOMe_filtering_rs {} ({}/{})",
-        bismark_meta::SUITE_VERSION,
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-    )
+    bismark_meta::version_line("NOMe_filtering")
 }
 
 /// End-to-end entry point: validate the CLI, create the output directory,
@@ -86,7 +80,10 @@ mod tests {
     #[test]
     fn version_string_has_binary_name_and_semver() {
         let v = version_string();
-        assert!(v.starts_with("NOMe_filtering_rs "), "got: {v}");
+        assert!(
+            v.starts_with("NOMe_filtering (Bismark Rust suite) v"),
+            "got: {v}"
+        );
         // Reports the SUITE version (single source: rust/VERSION), not the crate's own.
         assert!(v.contains(bismark_meta::SUITE_VERSION), "got: {v}");
         assert!(v.contains(std::env::consts::OS), "got: {v}");

--- a/rust/bismark-nome-filtering/src/main.rs
+++ b/rust/bismark-nome-filtering/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `NOMe_filtering_rs`.
+//! Binary entry point for `NOMe_filtering`.
 //!
 //! Parses the CLI via [`bismark_nome_filtering::cli::Cli`], handles `--version`
 //! (clap's auto-version is disabled so we can emit a custom provenance string),

--- a/rust/bismark-nome-filtering/tests/cli_phase_a.rs
+++ b/rust/bismark-nome-filtering/tests/cli_phase_a.rs
@@ -19,7 +19,9 @@ fn version_prints_provenance() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicates::str::starts_with("NOMe_filtering_rs "));
+        .stdout(predicates::str::starts_with(
+            "NOMe_filtering (Bismark Rust suite) v",
+        ));
 }
 
 #[test]

--- a/rust/bismark-report/Cargo.toml
+++ b/rust/bismark-report/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/lib.rs"
 name = "bismark2report"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 clap = { version = "=4.5.30", features = ["derive"] }

--- a/rust/bismark-report/build.rs
+++ b/rust/bismark-report/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-report/src/cli.rs
+++ b/rust/bismark-report/src/cli.rs
@@ -8,11 +8,15 @@
 
 use clap::Parser;
 
+/// `--help` footer: the per-tool last-modified date (embedded by build.rs).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 #[derive(Parser, Debug)]
 #[command(
-    name = "bismark2report_rs",
+    name = "bismark2report",
     about = "Generate a graphical HTML report from a Bismark alignment report (+ optional companion reports).",
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Bismark alignment report (mandatory data source). If omitted, auto-detect

--- a/rust/bismark-report/src/discovery.rs
+++ b/rust/bismark-report/src/discovery.rs
@@ -225,11 +225,7 @@ mod tests {
     fn explicit_companion_applies_to_first_report_only() {
         // Perl's line-1256 reset: an explicit `--dedup_report` applies to report
         // #0; report #1 falls back to auto-detect (no match in cwd → None).
-        let cli = Cli::parse_from([
-            "bismark2report_rs",
-            "--dedup_report",
-            "explicit_companion.txt",
-        ]);
+        let cli = Cli::parse_from(["bismark2report", "--dedup_report", "explicit_companion.txt"]);
         let alns = vec![
             PathBuf::from("first_PE_report.txt"),
             PathBuf::from("second_PE_report.txt"),
@@ -244,7 +240,7 @@ mod tests {
 
     #[test]
     fn none_skips_a_companion() {
-        let cli = Cli::parse_from(["bismark2report_rs", "--mbias_report", "none"]);
+        let cli = Cli::parse_from(["bismark2report", "--mbias_report", "none"]);
         let jobs = resolve_companions(&cli, &[PathBuf::from("x_PE_report.txt")]).unwrap();
         assert_eq!(jobs[0].mbias, None);
     }

--- a/rust/bismark-report/src/lib.rs
+++ b/rust/bismark-report/src/lib.rs
@@ -34,13 +34,7 @@ pub const BISMARK_VERSION: &str = "v0.25.1";
 
 /// `--version` banner (dedup/genomeprep precedent). Not part of the gate.
 pub fn version_string() -> String {
-    format!(
-        "\n          Bismark - Bisulfite Mapper and Methylation Caller.\n\n          \
-         Bismark HTML Report Module (Rust port) Version: {}\n        \
-         Copyright 2010-25, Felix Krueger, Altos Bioinformatics\n\n               \
-         https://github.com/FelixKrueger/Bismark\n",
-        bismark_meta::SUITE_VERSION
-    )
+    bismark_meta::version_line("bismark2report")
 }
 
 /// Top-level: resolve the output dir, the alignment report(s) and their

--- a/rust/bismark-report/src/main.rs
+++ b/rust/bismark-report/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `bismark2report_rs`.
+//! Binary entry point for `bismark2report`.
 //!
 //! Exit codes: `0` success · `1` any [`ReportError`] · `2` clap parse error.
 //! `--help`/`--man`/`--version` all exit `0` (Perl's exit-1-on-help quirk is

--- a/rust/bismark-report/tests/perl_vs_rust.rs
+++ b/rust/bismark-report/tests/perl_vs_rust.rs
@@ -77,10 +77,10 @@ fn run_both_and_compare(work: &Path, label: &str) {
         .args(["--dir", "rust/", "--__test_timestamp", "0"])
         .current_dir(work)
         .output()
-        .expect("run bismark2report_rs");
+        .expect("run bismark2report");
     assert!(
         rust_status.status.success(),
-        "bismark2report_rs failed for `{label}`"
+        "bismark2report failed for `{label}`"
     );
 
     let mut html_count = 0;

--- a/rust/bismark-summary/Cargo.toml
+++ b/rust/bismark-summary/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "bismark2summary"
 path = "src/main.rs"
 
+[build-dependencies]
+# Build-time only: `last_modified_date()` for the `--help` footer.
+bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
+
 [dependencies]
 bismark-meta = { version = "1.0.0", path = "../bismark-meta" }
 # bismark2summary opens NO BAM/SAM/CRAM (filename-only) and writes plain-text

--- a/rust/bismark-summary/build.rs
+++ b/rust/bismark-summary/build.rs
@@ -1,0 +1,12 @@
+//! Embeds this crate's last-modified date (its last git commit date) as
+//! `BISMARK_LAST_MODIFIED`, shown in the `--help` footer. Falls back to the
+//! build date outside a git checkout (e.g. a crates.io registry build).
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    println!(
+        "cargo:rustc-env=BISMARK_LAST_MODIFIED={}",
+        bismark_meta::last_modified_date(manifest_dir)
+    );
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/rust/bismark-summary/src/cli.rs
+++ b/rust/bismark-summary/src/cli.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for `bismark2summary_rs`.
+//! Command-line interface for `bismark2summary`.
 //!
 //! [`Cli`] is the clap-derived parser. [`Cli::validate`] resolves it into a
 //! [`ResolvedConfig`], applying Perl's basename/title defaults with Perl
@@ -26,14 +26,18 @@ pub const DEFAULT_BASENAME: &str = "bismark_summary_report";
 /// Default HTML report title (Perl `bismark2summary:211`).
 pub const DEFAULT_TITLE: &str = "Bismark Summary Report";
 
+/// `--help` footer: the per-tool last-modified date (embedded by build.rs).
+const HELP_FOOTER: &str = concat!("Last modified: ", env!("BISMARK_LAST_MODIFIED"));
+
 /// Parsed command-line arguments. Use [`Cli::validate`] to convert to a
 /// [`ResolvedConfig`] after parsing.
 #[derive(Parser, Debug)]
 #[command(
-    name = "bismark2summary_rs",
+    name = "bismark2summary",
     about = "Generate a project-level multi-sample summary (.txt + .html) from Bismark report files",
     long_about = None,
-    disable_version_flag = true
+    disable_version_flag = true,
+    after_help = HELP_FOOTER
 )]
 pub struct Cli {
     /// Optional explicit Bismark BAM file(s). If none are given, the current
@@ -119,7 +123,7 @@ mod tests {
     use clap::CommandFactory;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
-        let mut full = vec!["bismark2summary_rs"];
+        let mut full = vec!["bismark2summary"];
         full.extend(args.iter().copied());
         Cli::try_parse_from(full)
     }

--- a/rust/bismark-summary/src/lib.rs
+++ b/rust/bismark-summary/src/lib.rs
@@ -8,7 +8,7 @@
 //! - `<basename>.txt` — a 15-column tab-delimited table, one row per sample.
 //! - `<basename>.html` — a self-contained plot.ly report (Phase B).
 //!
-//! The binary is installed as `bismark2summary_rs`. The byte-identity target
+//! The binary is installed as `bismark2summary`. The byte-identity target
 //! is Perl Bismark v0.25.1: the `.txt` fully byte-identical, the `.html`
 //! byte-identical modulo the single `localtime` timestamp line.
 //!
@@ -44,16 +44,10 @@ pub use parse::SampleMetrics;
 /// constant (`bismark2summary:25`) so the HTML is byte-identical (SPEC O1).
 pub const BISMARK_VERSION: &str = "0.25.1";
 
-/// Returns a TG-style provenance string for the binary's `--version` output.
-///
-/// Format: `bismark2summary_rs <semver> (<os>/<arch>)`. Help/version text is
+/// The uniform suite `--version` one-liner via [`bismark_meta::version_line`]:
+/// `bismark2summary (Bismark Rust suite) v<version> (…)`. Help/version text is
 /// not byte-gated against Perl (SPEC §4.4).
 #[must_use]
 pub fn version_string() -> String {
-    format!(
-        "bismark2summary_rs {} ({}/{})",
-        bismark_meta::SUITE_VERSION,
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-    )
+    bismark_meta::version_line("bismark2summary")
 }

--- a/rust/bismark-summary/src/main.rs
+++ b/rust/bismark-summary/src/main.rs
@@ -1,4 +1,4 @@
-//! Binary entry point for `bismark2summary_rs`.
+//! Binary entry point for `bismark2summary`.
 //!
 //! Parses the CLI, discovers Bismark BAMs (or takes them from argv), parses
 //! each sample's report set, and writes the project summary outputs.


### PR DESCRIPTION
Pre-GA request (Felix): every suite tool should emit the **same `--version` style**, have consistent `--help`, and show a **per-tool "Last modified: <date>" footer** on `--help`.

## `--version` — one uniform style across all 12 tools
- Each crate's `version_string()` → `bismark_meta::version_line("<canonical>")`:
  `<tool> (Bismark Rust suite) v2.0.0 (<hash> — <os>/<arch> — built <ts>)`.
- The 3 **banner** tools (`bismark`, `bismark_genome_preparation`, `bismark2report`) switch from their multi-line banner to this one-liner.
- **Removes the `_rs` dev-suffix** that leaked into `--version`, the clap `name` (the `Usage:` line), and user-facing usage/error messages (Ph3a renamed the binaries but not these strings). Full-source sweep; only intentional "the `_rs` suffix is retired at GA" doc mentions remain.
- **`-V, --version` on every tool** (was missing on aligner/bedgraph/filter_non_conversion); extractor's flag help fixed.

## `--help` footer — per-tool, git-derived
- New build-callable `bismark_meta::last_modified_date()` (`git log -1 --date=short -- <crate>`; falls back to the build date outside a git checkout, e.g. a registry install).
- Each crate gains a `build.rs` (+ `[build-dependencies] bismark-meta`) emitting `BISMARK_LAST_MODIFIED`, rendered via clap `after_help = "Last modified: <date>"`. Dates are per-tool (each shows its own crate's last-commit date).

## Safety / verification
- **NOT byte-identity affecting:** `version_string()` feeds ONLY `--version`; the `@PG`/report provenance stays the frozen `BISMARK_VERSION = "v0.25.1"` const (verified — separate from `SUITE_VERSION`).
- Tests asserting the old `_rs` format updated (dedup/bam2nuc/bedgraph/coverage2cytosine/extractor/methylation-consistency/nome-filtering sanity+golden+cli; aligner cli banner test).
- `cargo fmt` + `cargo clippy --workspace --all-targets --release -D warnings` clean; **full `cargo test --workspace` passes**; **12-tool audit** confirms uniform `--version` + working `-V` + `Last modified` footer on every tool; **`cargo publish --workspace --dry-run` 14/14** (build.rs survives no-git packaging via the fallback).

Implemented in a worktree off `master`; the 8 one-line crates via two parallel subagents on a proven exemplar (`bismark-dedup`), the 3 banner crates + `bismark-meta` by hand. Resumes the (gated) Ph5 cut once merged.