### PR TITLE
docs(changelog): stamp the 3.0.0 release date (2026-07-07)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Bismark Changelog
 
 
-## Bismark 3.0.0 — the Rust suite
+## Bismark 3.0.0 (released 2026-07-07) — the Rust suite
 
 Bismark is now a single Rust binary; the Perl scripts are archived as tagged legacy. Highlights:
 


### PR DESCRIPTION
Post-GA tidy: Phase 6 (#1063) left the 3.0.0 CHANGELOG header undated because the exact cut date wasn't known before merge. The GA cut published on **2026-07-07** (crates.io `bismark` 3.0.0, tag `bismark-rust-v3.0.0`, GHCR `:latest`/`:3.0.0`), so this stamps `## Bismark 3.0.0 (released 2026-07-07) — the Rust suite`. One-line docs change.