### PR TITLE
build(docker): drop samtools from the image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,6 @@ jobs:
           docker run --rm "$IMG" bismark.bin --version
           docker run --rm "$IMG" bismark_methylation_extractor --version
           docker run --rm "$IMG" bowtie2 --version
-          docker run --rm "$IMG" samtools --version | head -1
           # Canonical names (methylseq drop-in) resolve; `bismark --help` also
           # exercises the wrapper's exec of the real `bismark.bin`.
           docker run --rm "$IMG" bismark --help >/dev/null
@@ -351,7 +350,8 @@ jobs:
           # Tools methylseq shells out to (genomeprep → *-build; extractor → gzip).
           # NB assert each individually — `command -v a b c` only resolves the FIRST
           # operand (POSIX), so a single multi-arg call would silently pass.
-          docker run --rm "$IMG" sh -c 'for t in gzip sed printf bowtie2-build hisat2-build samtools ps; do command -v "$t" >/dev/null || { echo "missing: $t"; exit 1; }; done' \
+          # (No samtools: dropped from the image — methylseq's bismark modules never use it.)
+          docker run --rm "$IMG" sh -c 'for t in gzip sed printf bowtie2-build hisat2-build ps; do command -v "$t" >/dev/null || { echo "missing: $t"; exit 1; }; done' \
             || { echo "FAIL: a required co-resident tool is missing"; exit 1; }
 
   # Create the tag + a DRAFT release (gated on the image building OK). Drafting

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY . .
 RUN cargo build --release --locked --manifest-path rust/Cargo.toml -p bismark --bin bismark --features bismark/rammap-inprocess,bismark/binseq-input
 
 # ── Runtime stage ────────────────────────────────────────────
-# micromamba base so the pinned aligners + samtools install cleanly from bioconda.
+# micromamba base so the pinned aligners install cleanly from bioconda.
 FROM mambaorg/micromamba:1.5.8-bookworm-slim
 
 LABEL org.opencontainers.image.source="https://github.com/FelixKrueger/Bismark"
@@ -42,16 +42,14 @@ LABEL org.opencontainers.image.licenses="GPL-3.0-only"
 USER root
 
 # Pinned external tools (byte-identity requires these exact versions).
-# NB the Rust suite itself needs NO samtools (pure-Rust noodles I/O; --samtools_path
-# is accepted-but-ignored). samtools is kept ONLY for nf-core/methylseq co-residency
-# (smoke-test-docker asserts it among methylseq's shell-out tools).
-# TODO(phase4-followup): drop samtools once methylseq's Bismark modules are audited
-# to confirm they never `samtools sort/index/flagstat` inside this image.
+# No samtools: the Rust suite does its own BAM/SAM/CRAM I/O (pure-Rust noodles;
+# --samtools_path is accepted-but-ignored), and nf-core/methylseq's Bismark modules
+# were audited (2026-07-08, methylseq 4.2.0) to never invoke samtools in this image —
+# its sort/index/flagstat/stats run in methylseq's separate samtools container.
 RUN micromamba install -y -n base -c bioconda -c conda-forge \
       bowtie2=2.5.5 \
       hisat2=2.2.2 \
       minimap2=2.31 \
-      samtools=1.23.1 \
     && micromamba clean --all --yes
 ENV PATH=/opt/conda/bin:$PATH
 


### PR DESCRIPTION
Drops `samtools` from the Bismark Rust suite Docker image.

### Why it's safe
- The **Rust suite never shells out to samtools** — all BAM/SAM/CRAM I/O is pure-Rust `noodles` (`--samtools_path` is accepted-but-ignored).
- **Audited nf-core/methylseq 4.2.0** (2026-07-08): all **7 Bismark modules** (`align`, `deduplicate`, `methylationextractor`, `coverage2cytosine`, `genomepreparation`, `report`, `summary`) have **zero** samtools invocations. methylseq's `sort`/`index`/`flagstat`/`stats`/`faidx`/`idxstats` run in its **separate samtools container**, not the bismark one.

This satisfies the Dockerfile's standing `TODO(phase4-followup)` ("drop samtools once methylseq's Bismark modules are audited to confirm they never `samtools sort/index/flagstat` inside this image").

### Changes
- `Dockerfile`: remove `samtools=1.23.1` from the `micromamba install` list; rewrite the "kept for methylseq" comment to record the audit.
- `.github/workflows/release.yml` (smoke-test-docker): remove the standalone `samtools --version` check and drop `samtools` from the co-resident tool-presence list.

### Effect
Forward-looking only — the current `:3.0.0`/`:latest` images are unchanged; this removes samtools from the **next** image build. The release CI's own Docker build + smoke-test is the functional gate.