### PR TITLE
docs: add CI and Crates.io badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bismark
 
+[![CI](https://github.com/FelixKrueger/Bismark/actions/workflows/rust_ci.yml/badge.svg?branch=master)](https://github.com/FelixKrueger/Bismark/actions/workflows/rust_ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/bismark)](https://crates.io/crates/bismark)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/bismark/README.html)
 
 > **See the documentation**: <https://felixkrueger.github.io/Bismark>


### PR DESCRIPTION
Adds two useful badges to the README header, next to the existing bioconda one:

- **CI** — build status of the Rust CI workflow (`rust_ci.yml`) on `master`
- **Crates.io** — current published version of the `bismark` crate (v3.0.0)

Documentation only, no code changes.

### Note on Homebrew

I did **not** add a Homebrew badge/instructions yet: the homebrew-core formula (Homebrew/homebrew-core#292016) is still open / under review, so `brew install bismark` doesn't resolve yet and the badge/link would be broken. Happy to send a follow-up adding a `### From Homebrew` section + `homebrew/v` badge (like TrimGalore's) as soon as that formula merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)