### PR TITLE
docs: add bioconda install method + homepage hero to conda/mamba

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > **Bismark is now the Rust suite, generally available.** The bisulfite aligner and
 > methylation tools have been rewritten from Perl to Rust: **byte-identical** to Perl `v0.25.1` on the
 > faithful default path, faster, and lower-memory — and this is the **supported default**. Get it via
-> [Installation](#installation) (`cargo install bismark`, container, or prebuilt binaries) and see the
+> [Installation](#installation) (`mamba install -c bioconda bismark`, cargo, container, or prebuilt binaries) and see the
 > **[Rust suite overview](https://felixkrueger.github.io/Bismark/rust/overview/)**.
 > The original **Perl `v0.25.x`** (the scripts at this repo root) is now **legacy / maintenance-freeze**
 > (critical fixes only; tagged [`v0.25.1`](https://github.com/FelixKrueger/Bismark/releases/tag/v0.25.1)).
@@ -33,19 +33,22 @@ There is also an overview of the alignment modes that are currently supported by
 Bismark is now the Rust suite. Pick one:
 
 ```bash
-# 1. crates.io — installs the whole suite (all tools) into ~/.cargo/bin
+# 1. bioconda — also installs the aligners (bowtie2/hisat2/minimap2) for you
+mamba install -c bioconda -c conda-forge bismark
+
+# 2. crates.io — installs the whole suite (all tools) into ~/.cargo/bin
 cargo install bismark
 
-# 2. Container image (nothing to install; drop-in for nf-core/methylseq)
+# 3. Container image (nothing to install; drop-in for nf-core/methylseq)
 docker pull ghcr.io/felixkrueger/bismark:latest    # or pin a specific release, e.g. :3.0.0
 
-# 3. Prebuilt binaries — download from the Releases page and put on your PATH
+# 4. Prebuilt binaries — download from the Releases page and put on your PATH
 #    https://github.com/FelixKrueger/Bismark/releases
 ```
 
 **External tools on your `PATH`:** an aligner — [Bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/) (default), or optionally [HISAT2](https://ccb.jhu.edu/software/hisat2/index.shtml) or [minimap2](https://lh3.github.io/minimap2/minimap2.html). **No Samtools needed** — all BAM/SAM/CRAM I/O is pure-Rust. The container bundles the aligners for you. See [`rust/README.md`](rust/README.md#installing) for details and per-tool installs.
 
-> A bioconda `mamba install bismark` for the Rust suite is coming as a fast-follow; until then the bioconda `bismark` package is the legacy Perl `v0.25.x`.
+> The default bioconda `bismark` package is now the Rust suite (v3.0.0+); `mamba install bismark=0.25.1` still gets the legacy Perl.
 
 ### Legacy: the Perl Bismark (v0.25.x)
 

--- a/docs/src/components/Home.astro
+++ b/docs/src/components/Home.astro
@@ -104,8 +104,8 @@ const gh = 'https://github.com/FelixKrueger/Bismark';
     <div class="steps">
       <div class="step">
         <div class="idx"><span class="sl" aria-hidden="true"></span>1</div>
-        <div class="body"><h4>Install</h4><p>One command via crates.io, or grab a release from GitHub.</p>
-          <div class="code"><pre><span class="ps">cargo install bismark</span></pre></div></div>
+        <div class="body"><h4>Install</h4><p>One command via bioconda — installs the aligners too.</p>
+          <div class="code"><pre><span class="ps">mamba install -c bioconda bismark</span></pre></div></div>
       </div>
       <div class="step">
         <div class="idx"><span class="sl" aria-hidden="true"></span>2</div>
@@ -136,8 +136,8 @@ const gh = 'https://github.com/FelixKrueger/Bismark';
   const term = document.getElementById('home-term');
   if (term) {
     const lines = [
-      { prompt: true, type: true, toks: [{ t: 'cargo install bismark', c: '' }] },
-      { out: true, toks: [{ t: '  ✓ bismark  bowtie2  installed', c: 'ok' }] },
+      { prompt: true, type: true, toks: [{ t: 'mamba install -c bioconda bismark', c: '' }] },
+      { out: true, toks: [{ t: '  ✓ bismark  bowtie2  hisat2  minimap2  installed', c: 'ok' }] },
       { blank: true },
       { prompt: true, type: true, toks: [{ t: 'bismark prepare ', c: '' }, { t: '/ref/GRCh38/', c: 'out' }] },
       { out: true, toks: [{ t: '  building C→T and G→A indices ', c: 'out' }, { t: 'done', c: 'ok' }] },

--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -1,13 +1,25 @@
 ---
 title: "Installation"
-description: "Bismark is the Rust bisulfite aligner and methylation suite — a single binary, byte-identical to Perl v0.25.1. Install via cargo, a container image, or prebuilt binaries."
+description: "Bismark is the Rust bisulfite aligner and methylation suite — a single binary, byte-identical to Perl v0.25.1. Install via conda/bioconda, cargo, a container image, or prebuilt binaries."
 ---
 
 Bismark is the Rust bisulfite aligner and methylation suite, executed from the command line. It ships as a **single `bismark` binary**: run `bismark <subcommand>` (e.g. `bismark align`, `bismark extract`) or use the classic tool names (`deduplicate_bismark`, `bismark_methylation_extractor`, …), which are supported aliases of the same binary. Output is **byte-identical** to Perl Bismark `v0.25.1` on the faithful default path. The original Perl scripts are now archived as tagged legacy (see [Legacy: the Perl Bismark](#legacy-the-perl-bismark) below).
 
 ## The Bismark Rust suite
 
-There are three ways to install the Rust suite.
+There are four ways to install the Rust suite.
+
+### Install with `conda` / `mamba` (bioconda)
+
+The simplest option — one command installs the `bismark` suite **and** its alignment backends (Bowtie 2, HISAT2, minimap2), so nothing else needs to be on your `PATH`:
+
+```bash
+conda install -c bioconda -c conda-forge bismark
+# or, faster:
+mamba install -c bioconda -c conda-forge bismark
+```
+
+You get the single `bismark` binary plus the classic tool-name aliases, with **no `samtools`** dependency (BAM/SAM/CRAM I/O is pure-Rust). To install the legacy Perl implementation instead, pin `bismark=0.25.1`.
 
 ### Install from source with `cargo`
 


### PR DESCRIPTION
bismark 3.0.0 is live on bioconda (recipe PR bioconda-recipes#67004, merged), so document it.

### installation.md
- New **conda / mamba (bioconda)** section, placed first — it's the only method that also installs the aligner backends (bowtie2/hisat2/minimap2) in one command.
- "three ways" → "four ways"; frontmatter description updated.
- cargo / prebuilt-binary / container methods unchanged.

### Home.astro (homepage)
- Quick-Start "Install" step and the animated terminal now show `mamba install -c bioconda bismark` instead of `cargo install bismark`.
- The demo's output line now shows `✓ bismark bowtie2 hisat2 minimap2 installed` — accurate for conda (cargo only builds the bismark binary).

No Altos/prefix.dev internal specifics — standard public bioconda commands only.