### PR TITLE
docs: add Homebrew install option + build docs on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,11 +2,11 @@ name: Docs site (Astro + Starlight)
 
 on:
   push:
-    branches: [master]
+    branches: [dev]
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
-  # Build-only validation on PRs (deploy stays master-only, gated below) so a
+  # Build-only validation on PRs (deploy is gated to a dev push, below) so a
   # docs change is verified to build before it merges — BismarkCI does not build
   # the Astro site.
   pull_request:
@@ -21,7 +21,7 @@ permissions:
   pages: write
   id-token: write
 
-# Per-ref so a PR build never cancels an in-flight master deploy (only master
+# Per-ref so a PR build never cancels an in-flight deploy (only a dev push
 # and workflow_dispatch actually deploy).
 concurrency:
   group: pages-${{ github.ref }}
@@ -52,7 +52,7 @@ jobs:
 
   deploy:
     needs: build
-    # Never deploy from a PR — build-only there; publish only on master push / dispatch.
+    # Never deploy from a PR — build-only there; publish only on dev push / dispatch.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,14 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+  # Build-only validation on PRs (deploy stays master-only, gated below) so a
+  # docs change is verified to build before it merges — BismarkCI does not build
+  # the Astro site.
+  pull_request:
+    branches: [dev, master]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -13,8 +21,10 @@ permissions:
   pages: write
   id-token: write
 
+# Per-ref so a PR build never cancels an in-flight master deploy (only master
+# and workflow_dispatch actually deploy).
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -34,12 +44,16 @@ jobs:
       - run: npm run build
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      # Deploy artifact only for real (non-PR) runs; PRs are build-only.
       - uses: actions/upload-pages-artifact@v3
+        if: github.event_name != 'pull_request'
         with:
           path: docs/dist
 
   deploy:
     needs: build
+    # Never deploy from a PR — build-only there; publish only on master push / dispatch.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ docker pull ghcr.io/felixkrueger/bismark:latest    # or pin a specific release, 
 
 # 4. Prebuilt binaries — download from the Releases page and put on your PATH
 #    https://github.com/FelixKrueger/Bismark/releases
+
+# 5. Homebrew (macOS/Linux) — prebuilt bottle; pulls in bowtie2 + minimap2 (not hisat2)
+brew install bismark
 ```
 
 **External tools on your `PATH`:** an aligner — [Bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/) (default), or optionally [HISAT2](https://ccb.jhu.edu/software/hisat2/index.shtml) or [minimap2](https://lh3.github.io/minimap2/minimap2.html). **No Samtools needed** — all BAM/SAM/CRAM I/O is pure-Rust. The container bundles the aligners for you. See [`rust/README.md`](rust/README.md#installing) for details and per-tool installs.

--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -7,7 +7,7 @@ Bismark is the Rust bisulfite aligner and methylation suite, executed from the c
 
 ## The Bismark Rust suite
 
-There are four ways to install the Rust suite.
+There are five ways to install the Rust suite.
 
 ### Install with `conda` / `mamba` (bioconda)
 
@@ -20,6 +20,16 @@ mamba install -c bioconda -c conda-forge bismark
 ```
 
 You get the single `bismark` binary plus the classic tool-name aliases, with **no `samtools`** dependency (BAM/SAM/CRAM I/O is pure-Rust). To install the legacy Perl implementation instead, pin `bismark=0.25.1`.
+
+### Install with Homebrew (macOS / Linux)
+
+Bismark is in [Homebrew core](https://formulae.brew.sh/formula/bismark), with a pre-built bottle so there is nothing to compile:
+
+```bash
+brew install bismark
+```
+
+Homebrew pulls in **Bowtie 2** and **minimap2** automatically, and the formula tracks new releases (so `brew install bismark` stays current). Unlike the bioconda package it does **not** install HISAT2 — that formula isn't in homebrew-core — so if you use the `--hisat2` aligner, install it separately (e.g. `brew install brewsci/bio/hisat2`).
 
 ### Install from source with `cargo`
 


### PR DESCRIPTION
Prompted by #1071 (thanks @BenjaminDEMAILLE) — Bismark is now in Homebrew core.

### Docs
- Adds `brew install bismark` as an install option in the **README** and the **docs installation page**.
- Notes the Homebrew formula pulls in `bowtie2` + `minimap2` and auto-tracks releases (it already bumped to 3.1.0 on its own), but does **not** install HISAT2 — that formula isn't in homebrew-core (only `brewsci/bio`), and core formulae can't depend on tap formulae. HISAT2 users install it separately.

### CI
- `docs.yml` now also **builds** the Astro site on PRs into `dev`/`master` (build-only; deploy stays gated to master push / `workflow_dispatch`). BismarkCI doesn't build the docs, so this verifies docs changes before merge — this PR self-validates via the new check.
- Concurrency switched to per-ref so a PR build can't cancel an in-flight master deploy.

Follows the branch → PR-into-`dev` workflow.