### PR TITLE
fix: clean `-V` provenance (no stray "unknown") + no-args shows help

### DIFF
--- a/rust/bismark/build.rs
+++ b/rust/bismark/build.rs
@@ -17,6 +17,11 @@ use std::env;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+// The pure `.cargo_vcs_info.json` parser lives in `src/meta/vcs_info.rs` so it is
+// covered by the `cargo test` harness (build scripts are not). We `include!` it
+// here to share the exact logic — `parse_cargo_vcs_short_hash` is defined by this.
+include!("src/meta/vcs_info.rs");
+
 /// Git short-hash resolution, most-authoritative first:
 ///  1. `$BISMARK_GIT_HASH` — an explicit override for CI/Docker builds whose
 ///     context has no `.git` (e.g. a `git archive` tarball).
@@ -54,27 +59,13 @@ fn git_short_hash(manifest_dir: &str) -> String {
     "unknown".to_string()
 }
 
-/// Extract the short (7-char) commit hash from a `.cargo_vcs_info.json` embedded
-/// in a packaged crate. The file (at the crate root) looks like
-/// `{"git":{"sha1":"<40-hex>"},"path_in_vcs":"rust/bismark"}`; we do a minimal
-/// hand-parse (no serde in the build graph) tolerant of whitespace.
+/// Read a `.cargo_vcs_info.json` embedded in a packaged crate (at the crate root)
+/// and extract the short commit hash via the shared
+/// [`parse_cargo_vcs_short_hash`] parser (unit-tested in `src/meta/vcs_info.rs`).
 fn cargo_vcs_short_hash(manifest_dir: &str) -> Option<String> {
     let path = std::path::Path::new(manifest_dir).join(".cargo_vcs_info.json");
     let content = std::fs::read_to_string(path).ok()?;
-    let after_key = content.split("\"sha1\"").nth(1)?;
-    let after_colon = after_key.split(':').nth(1)?;
-    let sha = after_colon
-        .trim()
-        .trim_start_matches('"')
-        .split('"')
-        .next()?
-        .trim();
-    let short: String = sha.chars().take(7).collect();
-    if short.len() == 7 && short.chars().all(|c| c.is_ascii_hexdigit()) {
-        Some(short)
-    } else {
-        None
-    }
+    parse_cargo_vcs_short_hash(&content)
 }
 
 fn build_epoch() -> u64 {
@@ -205,6 +196,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../VERSION");
     println!("cargo:rerun-if-changed=VERSION"); // crate-local vendored copy (registry-build fallback)
     println!("cargo:rerun-if-changed=.cargo_vcs_info.json"); // packaged-crate hash fallback
+    println!("cargo:rerun-if-changed=src/meta/vcs_info.rs"); // include!d shared parser
     println!("cargo:rerun-if-env-changed=BISMARK_SUITE_VERSION");
     println!("cargo:rerun-if-env-changed=BISMARK_GIT_HASH");
     println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");

--- a/rust/bismark/build.rs
+++ b/rust/bismark/build.rs
@@ -17,16 +17,64 @@ use std::env;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-fn git_short_hash() -> String {
-    Command::new("git")
+/// Git short-hash resolution, most-authoritative first:
+///  1. `$BISMARK_GIT_HASH` — an explicit override for CI/Docker builds whose
+///     context has no `.git` (e.g. a `git archive` tarball).
+///  2. `git rev-parse --short HEAD` — a working checkout (dev/CI).
+///  3. `.cargo_vcs_info.json` — the VCS record `cargo package`/`cargo publish`
+///     embeds in the crate tarball, so a registry `cargo install` still reports
+///     the real commit instead of `unknown`.
+///  4. `"unknown"` — genuinely no provenance available.
+///
+/// (4) previously fired for a bare `cargo install` from a source tree with no
+/// `.git`, producing the stray `unknown — …` a user reported on `-V`; the
+/// `.cargo_vcs_info.json` tier and the clean-formatting fallback in
+/// `meta::version_line` close that.
+fn git_short_hash(manifest_dir: &str) -> String {
+    if let Ok(h) = env::var("BISMARK_GIT_HASH") {
+        let h = h.trim();
+        if !h.is_empty() {
+            return h.to_string();
+        }
+    }
+    let from_git = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
         .output()
         .ok()
         .filter(|o| o.status.success())
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_string())
+        .filter(|s| !s.is_empty());
+    if let Some(h) = from_git {
+        return h;
+    }
+    if let Some(h) = cargo_vcs_short_hash(manifest_dir) {
+        return h;
+    }
+    "unknown".to_string()
+}
+
+/// Extract the short (7-char) commit hash from a `.cargo_vcs_info.json` embedded
+/// in a packaged crate. The file (at the crate root) looks like
+/// `{"git":{"sha1":"<40-hex>"},"path_in_vcs":"rust/bismark"}`; we do a minimal
+/// hand-parse (no serde in the build graph) tolerant of whitespace.
+fn cargo_vcs_short_hash(manifest_dir: &str) -> Option<String> {
+    let path = std::path::Path::new(manifest_dir).join(".cargo_vcs_info.json");
+    let content = std::fs::read_to_string(path).ok()?;
+    let after_key = content.split("\"sha1\"").nth(1)?;
+    let after_colon = after_key.split(':').nth(1)?;
+    let sha = after_colon
+        .trim()
+        .trim_start_matches('"')
+        .split('"')
+        .next()?
+        .trim();
+    let short: String = sha.chars().take(7).collect();
+    if short.len() == 7 && short.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(short)
+    } else {
+        None
+    }
 }
 
 fn build_epoch() -> u64 {
@@ -131,18 +179,22 @@ fn git_path(file: &str) -> Option<String> {
 }
 
 fn main() {
-    let hash = git_short_hash();
+    let manifest = env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    let hash = git_short_hash(&manifest);
     let timestamp = format_iso8601_utc(build_epoch());
     let version = suite_version();
     let last_mod = last_modified(&timestamp);
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "unknown".to_string());
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "unknown".to_string());
-    let version_body = format!("{hash} — {target_os}/{target_arch} — built {timestamp}");
+    let target = format!("{target_os}/{target_arch}");
 
+    // The parenthesised `--version` body is composed at RUNTIME in
+    // `meta::version_line` from these parts, so a hashless build drops the
+    // `<hash> — ` prefix cleanly rather than baking in a literal `unknown`.
     println!("cargo:rustc-env=BISMARK_SUITE_VERSION={version}");
     println!("cargo:rustc-env=GIT_SHORT_HASH={hash}");
     println!("cargo:rustc-env=BUILD_TIMESTAMP={timestamp}");
-    println!("cargo:rustc-env=VERSION_BODY={version_body}");
+    println!("cargo:rustc-env=BUILD_TARGET={target}");
     println!("cargo:rustc-env=BISMARK_LAST_MODIFIED={last_mod}");
 
     for f in ["HEAD", "index"] {
@@ -152,6 +204,8 @@ fn main() {
     }
     println!("cargo:rerun-if-changed=../VERSION");
     println!("cargo:rerun-if-changed=VERSION"); // crate-local vendored copy (registry-build fallback)
+    println!("cargo:rerun-if-changed=.cargo_vcs_info.json"); // packaged-crate hash fallback
     println!("cargo:rerun-if-env-changed=BISMARK_SUITE_VERSION");
+    println!("cargo:rerun-if-env-changed=BISMARK_GIT_HASH");
     println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
 }

--- a/rust/bismark/src/aligner/mod.rs
+++ b/rust/bismark/src/aligner/mod.rs
@@ -125,7 +125,15 @@ pub fn run_main() -> std::process::ExitCode {
 /// `bismark align` passes `argv[2..]` (subcommand token stripped) — both yield a
 /// byte-identical `@PG CL`. Keeps `run_main`'s `--version` short-circuit.
 pub fn run_dispatch(argv: Vec<String>, command_line: String) -> std::process::ExitCode {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
+    // A bare `bismark align` (no genome/reads) is never a valid run: show the
+    // aligner help (exit 2) rather than the terse "No genome folder" error.
+    // (Bare `bismark` with no args is intercepted earlier by the multicall
+    // dispatcher, which prints the composed suite help.)
+    if let Some(code) = crate::cli::help_if_no_args(argv.len(), crate::aligner::cli::Cli::command())
+    {
+        return code;
+    }
     let cli = crate::aligner::cli::Cli::parse_from(&argv);
     if cli.version {
         println!("{}", version_string());

--- a/rust/bismark/src/bam2nuc/mod.rs
+++ b/rust/bismark/src/bam2nuc/mod.rs
@@ -115,7 +115,11 @@ where
     I: IntoIterator,
     I::Item: Into<std::ffi::OsString> + Clone,
 {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
+    let argv: Vec<std::ffi::OsString> = argv.into_iter().map(Into::into).collect();
+    if let Some(code) = crate::cli::help_if_no_args(argv.len(), Cli::command()) {
+        return code;
+    }
     let cli = Cli::parse_from(argv);
     if cli.version {
         println!("{}", version_string());

--- a/rust/bismark/src/bedgraph/mod.rs
+++ b/rust/bismark/src/bedgraph/mod.rs
@@ -62,6 +62,10 @@ where
     I::Item: Into<std::ffi::OsString> + Clone,
 {
     use clap::{CommandFactory, Parser};
+    let argv: Vec<std::ffi::OsString> = argv.into_iter().map(Into::into).collect();
+    if let Some(code) = crate::cli::help_if_no_args(argv.len(), Cli::command()) {
+        return code;
+    }
     let cli = Cli::parse_from(argv);
 
     // `--version` is handled here (clap's auto-version is disabled in

--- a/rust/bismark/src/cli.rs
+++ b/rust/bismark/src/cli.rs
@@ -11,6 +11,24 @@
 use std::ffi::OsString;
 use std::process::ExitCode;
 
+/// "No args is never a valid run → show help" for the suite tools that require
+/// input. When `argv_len` is `<= 1` (only the program name is present), render
+/// `command`'s long help to stderr and return `Some(ExitCode 2)`; otherwise
+/// `None`, and the caller parses `argv` as usual.
+///
+/// Implemented at the runtime entry (not via clap's `arg_required_else_help`) so
+/// `Cli::parse_from([])` keeps returning a defaults `Cli` — the many unit tests
+/// that parse an empty argv and then assert `validate()`'s "no input" error rely
+/// on that. Auto-discovery tools (`bismark2report`, `bismark2summary`) opt OUT:
+/// a bare run there scans the working directory and is a valid mode.
+pub fn help_if_no_args(argv_len: usize, mut command: clap::Command) -> Option<ExitCode> {
+    if argv_len > 1 {
+        return None;
+    }
+    eprint!("{}", command.render_long_help());
+    Some(ExitCode::from(2))
+}
+
 /// A classic binary name (from an `argv[0]` alias/symlink) → that module's `run_main`
 /// (unchanged → byte-identical). Returns `None` if `prog` is not a classic tool name
 /// (i.e. we were invoked as `bismark`).

--- a/rust/bismark/src/coverage2cytosine/mod.rs
+++ b/rust/bismark/src/coverage2cytosine/mod.rs
@@ -104,7 +104,11 @@ where
     I: IntoIterator,
     I::Item: Into<std::ffi::OsString> + Clone,
 {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
+    let argv: Vec<std::ffi::OsString> = argv.into_iter().map(Into::into).collect();
+    if let Some(code) = crate::cli::help_if_no_args(argv.len(), Cli::command()) {
+        return code;
+    }
     let cli = Cli::parse_from(argv);
     if cli.version {
         println!("{}", version_string());

--- a/rust/bismark/src/dedup/mod.rs
+++ b/rust/bismark/src/dedup/mod.rs
@@ -77,7 +77,11 @@ where
     I: IntoIterator,
     I::Item: Into<std::ffi::OsString> + Clone,
 {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
+    let argv: Vec<std::ffi::OsString> = argv.into_iter().map(Into::into).collect();
+    if let Some(code) = crate::cli::help_if_no_args(argv.len(), Cli::command()) {
+        return code;
+    }
     let cli = Cli::parse_from(argv);
 
     // `--version` / `-V` is handled here (clap auto-version is disabled

--- a/rust/bismark/src/extractor/mod.rs
+++ b/rust/bismark/src/extractor/mod.rs
@@ -123,7 +123,11 @@ where
     I: IntoIterator,
     I::Item: Into<std::ffi::OsString> + Clone,
 {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
+    let argv: Vec<std::ffi::OsString> = argv.into_iter().map(Into::into).collect();
+    if let Some(code) = crate::cli::help_if_no_args(argv.len(), Cli::command()) {
+        return code;
+    }
     let cli = Cli::parse_from(argv);
 
     // `--version` / `-V` handled here (clap auto-version disabled in cli.rs

--- a/rust/bismark/src/filter_nonconversion/mod.rs
+++ b/rust/bismark/src/filter_nonconversion/mod.rs
@@ -57,7 +57,11 @@ where
     I: IntoIterator,
     I::Item: Into<std::ffi::OsString> + Clone,
 {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
+    let argv: Vec<std::ffi::OsString> = argv.into_iter().map(Into::into).collect();
+    if let Some(code) = crate::cli::help_if_no_args(argv.len(), Cli::command()) {
+        return code;
+    }
     let cli = Cli::parse_from(argv);
 
     // `--version` handled here (clap auto-version disabled in cli.rs).

--- a/rust/bismark/src/genome_prep/mod.rs
+++ b/rust/bismark/src/genome_prep/mod.rs
@@ -64,6 +64,12 @@ where
     I::Item: Into<std::ffi::OsString> + Clone,
 {
     use clap::{CommandFactory, Parser};
+    let argv: Vec<std::ffi::OsString> = argv.into_iter().map(Into::into).collect();
+    if let Some(code) =
+        crate::cli::help_if_no_args(argv.len(), crate::genome_prep::cli::Cli::command())
+    {
+        return code;
+    }
     let cli = crate::genome_prep::cli::Cli::parse_from(argv);
 
     // `--version` / `-V` handled manually (clap auto-version disabled) so we

--- a/rust/bismark/src/meta/mod.rs
+++ b/rust/bismark/src/meta/mod.rs
@@ -6,6 +6,11 @@
 //! [`version_line`] — distinct from each crate's internal Cargo version (which is
 //! reserved for the eventual crates.io publish at GA).
 
+/// Pure `.cargo_vcs_info.json` parser — shared with `build.rs` via `include!` so
+/// the hash-resolution logic has one home and is unit-tested here (build scripts
+/// aren't in the `cargo test` harness).
+mod vcs_info;
+
 /// The suite version, e.g. `2.0.0-beta.1` (the user-facing version).
 pub const SUITE_VERSION: &str = env!("BISMARK_SUITE_VERSION");
 /// Git short-hash of the build commit (or `unknown` when neither a `.git`

--- a/rust/bismark/src/meta/mod.rs
+++ b/rust/bismark/src/meta/mod.rs
@@ -8,19 +8,37 @@
 
 /// The suite version, e.g. `2.0.0-beta.1` (the user-facing version).
 pub const SUITE_VERSION: &str = env!("BISMARK_SUITE_VERSION");
-/// Git short-hash of the build commit (or `unknown`).
+/// Git short-hash of the build commit (or `unknown` when neither a `.git`
+/// checkout, an embedded `.cargo_vcs_info.json`, nor `$BISMARK_GIT_HASH` was
+/// available at build time — e.g. a bare `cargo install` from a source tree).
 pub const GIT_SHORT_HASH: &str = env!("GIT_SHORT_HASH");
 /// ISO-8601 UTC build timestamp (`SOURCE_DATE_EPOCH`-reproducible).
 pub const BUILD_TIMESTAMP: &str = env!("BUILD_TIMESTAMP");
-/// `<hash> — <os>/<arch> — built <timestamp>` provenance body.
-pub const VERSION_BODY: &str = env!("VERSION_BODY");
+/// Build target, `"<os>/<arch>"` (e.g. `macos/aarch64`).
+pub const BUILD_TARGET: &str = env!("BUILD_TARGET");
+
+/// Compose the parenthesised provenance body, e.g.
+/// `abc1234 — macos/aarch64 — built 2026-…Z`. When the git hash is unavailable
+/// (a release/`cargo install` build with no VCS info) the `<hash> — ` prefix is
+/// dropped so the line reads cleanly (`macos/aarch64 — built …`) instead of the
+/// stray literal `unknown — …` a user reported on `-V`.
+fn version_body(hash: &str, target: &str, timestamp: &str) -> String {
+    if hash.is_empty() || hash == "unknown" {
+        format!("{target} — built {timestamp}")
+    } else {
+        format!("{hash} — {target} — built {timestamp}")
+    }
+}
 
 /// A one-line `--version` string for a suite tool, e.g.
 /// `bismark (Bismark Rust suite) v3.0.0 (abc1234 — linux/x86_64 — built 2026-…Z)`.
 /// Every suite binary's `--version` is this exact shape (pass the CANONICAL tool
 /// name — no `_rs` suffix).
 pub fn version_line(tool: &str) -> String {
-    format!("{tool} (Bismark Rust suite) v{SUITE_VERSION} ({VERSION_BODY})")
+    format!(
+        "{tool} (Bismark Rust suite) v{SUITE_VERSION} ({})",
+        version_body(GIT_SHORT_HASH, BUILD_TARGET, BUILD_TIMESTAMP)
+    )
 }
 
 #[cfg(test)]
@@ -37,9 +55,32 @@ mod tests {
         let l = version_line("bismark");
         assert!(l.starts_with("bismark (Bismark Rust suite) v"));
         assert!(l.contains(SUITE_VERSION));
-        assert!(l.contains(GIT_SHORT_HASH));
+        // The hash only appears when it was resolvable at build time; in a git
+        // checkout (dev/CI) it always is, but a hashless release build must not
+        // surface a literal `unknown` — see `version_body_*` below.
+        if GIT_SHORT_HASH != "unknown" {
+            assert!(l.contains(GIT_SHORT_HASH));
+        }
+        assert!(!l.contains("(unknown "));
         // Canonical name only — the `_rs` dev suffix is retired at GA.
         assert!(!l.contains("_rs"));
+    }
+
+    #[test]
+    fn version_body_includes_hash_when_known() {
+        let b = version_body("abc1234", "macos/aarch64", "2026-07-13T13:12:41Z");
+        assert_eq!(b, "abc1234 — macos/aarch64 — built 2026-07-13T13:12:41Z");
+    }
+
+    #[test]
+    fn version_body_drops_unknown_hash() {
+        // The reported `-V` bug: a hashless build must NOT print `unknown — …`.
+        for missing in ["unknown", ""] {
+            let b = version_body(missing, "macos/aarch64", "2026-07-13T13:12:41Z");
+            assert_eq!(b, "macos/aarch64 — built 2026-07-13T13:12:41Z");
+            assert!(!b.contains("unknown"));
+            assert!(!b.starts_with(" — "));
+        }
     }
 
     /// Drift guard: the crate-local vendored `VERSION` (build.rs's registry-build

--- a/rust/bismark/src/meta/vcs_info.rs
+++ b/rust/bismark/src/meta/vcs_info.rs
@@ -1,0 +1,80 @@
+// Pure parser for the `.cargo_vcs_info.json` that `cargo package`/`cargo publish`
+// embeds at a crate's root, lifted out of `build.rs` so it is covered by the
+// `cargo test` harness (build scripts are not part of the test harness).
+//
+// `build.rs` `include!`s this file to share the exact logic; the library compiles
+// it as `meta::vcs_info` purely so the unit tests below run. It is otherwise unused
+// at runtime (the resolved hash reaches the binary via the `GIT_SHORT_HASH`
+// build-time env const), hence the `dead_code` allow for non-test lib builds.
+//
+// NOTE: plain `//` (not `//!`) comments on purpose. `build.rs` `include!`s this
+// file mid-module, where an inner `//!` doc comment would be a compile error.
+
+/// Extract the short commit hash from the raw `.cargo_vcs_info.json` content. The
+/// file (at the crate root) looks like
+/// `{"git":{"sha1":"<40-hex>"},"path_in_vcs":"rust/bismark"}`; this is a minimal
+/// hand-parse (no serde in the build graph) tolerant of surrounding whitespace.
+/// Returns `None` on any malformed input, so provenance degrades safely to
+/// `unknown` rather than surfacing garbage on `-V`.
+///
+/// The hash is pinned to 7 chars (git's default minimum for `--short`). In a large
+/// repo `git rev-parse --short` can auto-lengthen past 7 for uniqueness, so a
+/// registry build (this path) may report one char fewer than a git-checkout build
+/// of the same commit. That is purely cosmetic: the `-V` line is not byte-gated,
+/// and 7 hex chars unambiguously identify the commit for a human.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn parse_cargo_vcs_short_hash(content: &str) -> Option<String> {
+    let after_key = content.split("\"sha1\"").nth(1)?;
+    let after_colon = after_key.split(':').nth(1)?;
+    let sha = after_colon
+        .trim()
+        .trim_start_matches('"')
+        .split('"')
+        .next()?
+        .trim();
+    let short: String = sha.chars().take(7).collect();
+    if short.len() == 7 && short.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(short)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_cargo_vcs_short_hash;
+
+    #[test]
+    fn parses_real_vcs_info() {
+        // The exact shape `cargo package` writes.
+        let json = r#"{"git":{"sha1":"1fac90fabc1234567890deadbeef0987654321aa"},"path_in_vcs":"rust/bismark"}"#;
+        assert_eq!(parse_cargo_vcs_short_hash(json).as_deref(), Some("1fac90f"));
+    }
+
+    #[test]
+    fn tolerates_whitespace_and_pretty_printing() {
+        let json =
+            "{\n  \"git\": {\n    \"sha1\": \"abcdef0123456789abcdef0123456789abcdef01\"\n  }\n}\n";
+        assert_eq!(parse_cargo_vcs_short_hash(json).as_deref(), Some("abcdef0"));
+    }
+
+    #[test]
+    fn degrades_to_none_on_malformed_input() {
+        // No sha1 key, empty, junk, non-hex, and a too-short sha all → None
+        // (so build.rs falls through to the `unknown` tier, never garbage).
+        for bad in [
+            "",
+            "{}",
+            "not json at all",
+            r#"{"git":{"sha1":""}}"#,
+            r#"{"git":{"sha1":"zzzzzzz1234"}}"#, // non-hex
+            r#"{"git":{"sha1":"abc"}}"#,         // fewer than 7 chars
+        ] {
+            assert_eq!(
+                parse_cargo_vcs_short_hash(bad),
+                None,
+                "expected None for malformed input {bad:?}"
+            );
+        }
+    }
+}

--- a/rust/bismark/src/methylation_consistency/mod.rs
+++ b/rust/bismark/src/methylation_consistency/mod.rs
@@ -59,7 +59,11 @@ where
     I: IntoIterator,
     I::Item: Into<std::ffi::OsString> + Clone,
 {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
+    let argv: Vec<std::ffi::OsString> = argv.into_iter().map(Into::into).collect();
+    if let Some(code) = crate::cli::help_if_no_args(argv.len(), Cli::command()) {
+        return code;
+    }
     let cli = Cli::parse_from(argv);
 
     // `--version` / `-V` handled here (clap auto-version disabled in cli.rs).

--- a/rust/bismark/src/nome_filtering/mod.rs
+++ b/rust/bismark/src/nome_filtering/mod.rs
@@ -51,7 +51,11 @@ where
     I: IntoIterator,
     I::Item: Into<std::ffi::OsString> + Clone,
 {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
+    let argv: Vec<std::ffi::OsString> = argv.into_iter().map(Into::into).collect();
+    if let Some(code) = crate::cli::help_if_no_args(argv.len(), Cli::command()) {
+        return code;
+    }
     let cli = Cli::parse_from(argv);
     if cli.version {
         println!("{}", version_string());

--- a/rust/bismark/tests/aligner_cli.rs
+++ b/rust/bismark/tests/aligner_cli.rs
@@ -118,9 +118,12 @@ fn align_no_genome_errors() {
 
 #[test]
 fn align_no_args_shows_help() {
-    // `bismark align` with no further args is never a valid run, so clap's
-    // `arg_required_else_help` prints the aligner help (exit 2) instead of the
-    // terse "No genome folder specified" error.
+    // `bismark align` with no further args is never a valid run, so
+    // `cli::help_if_no_args` renders the aligner help (exit 2) instead of the
+    // terse "No genome folder specified" error. This is done manually at the
+    // runtime entry, NOT via clap's `arg_required_else_help`: the empty-argv
+    // unit tests depend on `Cli::parse_from([])` still yielding a defaults `Cli`
+    // (see the `help_if_no_args` docstring in `src/cli.rs`).
     bin()
         .arg("align")
         .assert()

--- a/rust/bismark/tests/aligner_cli.rs
+++ b/rust/bismark/tests/aligner_cli.rs
@@ -106,12 +106,26 @@ fn no_args_shows_multicall_help() {
 #[test]
 fn align_no_genome_errors() {
     // The aligner's no-genome error, via the explicit `bismark align` subcommand.
+    // Reads are supplied (so it is NOT a bare no-args run — that shows help, see
+    // `align_no_args_shows_help`) but no genome folder, so resolution errors.
     bin()
-        .arg("align")
+        .args(["align", "-1", "r1.fq", "-2", "r2.fq"])
         .assert()
         .failure()
         .code(1)
         .stderr(predicate::str::contains("No genome folder specified"));
+}
+
+#[test]
+fn align_no_args_shows_help() {
+    // `bismark align` with no further args is never a valid run, so clap's
+    // `arg_required_else_help` prints the aligner help (exit 2) instead of the
+    // terse "No genome folder specified" error.
+    bin()
+        .arg("align")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("Bisulfite read aligner"));
 }
 
 #[test]

--- a/rust/bismark/tests/bam2nuc_sanity.rs
+++ b/rust/bismark/tests/bam2nuc_sanity.rs
@@ -1,5 +1,6 @@
 //! Phase A sanity checks: crate builds, version string + error Display work.
 
+use assert_cmd::Command;
 use bismark::bam2nuc::error::BismarkBam2nucError;
 use bismark::bam2nuc::version_string;
 
@@ -17,4 +18,17 @@ fn version_string_has_binary_name_and_platform() {
 fn error_display_round_trips() {
     let e = BismarkBam2nucError::MissingGenomeFolder;
     assert!(e.to_string().contains("genome folder"));
+}
+
+#[test]
+fn no_args_shows_help() {
+    // No input is never a valid run, so a bare invocation renders the tool's help
+    // (exit 2) via `cli::help_if_no_args` instead of a terse one-line error.
+    Command::cargo_bin("bam2nuc")
+        .unwrap()
+        .assert()
+        .code(2)
+        .stderr(predicates::str::contains(
+            "Calculate mono- and di-nucleotide coverage",
+        ));
 }

--- a/rust/bismark/tests/bedgraph_cli_behavior.rs
+++ b/rust/bismark/tests/bedgraph_cli_behavior.rs
@@ -149,3 +149,14 @@ fn help_flag_smoke() {
         .success()
         .stdout(predicate::str::contains("Usage"));
 }
+
+#[test]
+fn no_args_shows_help() {
+    // No input is never a valid run, so a bare invocation renders the tool's help
+    // (exit 2) via `cli::help_if_no_args` instead of a terse one-line error.
+    Command::cargo_bin("bismark2bedGraph")
+        .unwrap()
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("Generate a sorted bedGraph"));
+}

--- a/rust/bismark/tests/coverage2cytosine_sanity.rs
+++ b/rust/bismark/tests/coverage2cytosine_sanity.rs
@@ -61,6 +61,19 @@ fn missing_output_fails_with_clear_message() {
         .stderr(predicates::str::contains("output"));
 }
 
+#[test]
+fn no_args_shows_help() {
+    // No input is never a valid run, so a bare invocation renders the tool's help
+    // (exit 2) via `cli::help_if_no_args` instead of a terse one-line error.
+    Command::cargo_bin("coverage2cytosine")
+        .unwrap()
+        .assert()
+        .code(2)
+        .stderr(predicates::str::contains(
+            "Generate a genome-wide cytosine methylation report",
+        ));
+}
+
 // (The Phase-A `unsupported_v1x_flag_is_rejected` probe was removed in Phase 3:
 // all v1.x niche flags — --gc/--nome-seq, --drach/--m6A, --ffs — are now
 // supported, so no v1.x flag is rejected. `missing_output_fails_with_clear_message`

--- a/rust/bismark/tests/dedup_sanity.rs
+++ b/rust/bismark/tests/dedup_sanity.rs
@@ -36,10 +36,24 @@ fn short_version_flag_works_too() {
 
 #[test]
 fn invocation_with_no_input_files_errors_with_clear_message() {
+    // A flag but no input file still reaches the validation error (exit 1). A
+    // bare no-args run instead shows the tool's help (exit 2) — see
+    // `no_args_shows_help`.
     let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
-    cmd.assert()
+    cmd.arg("--paired")
+        .assert()
         .failure()
         .stderr(predicates::str::contains("no input file"));
+}
+
+#[test]
+fn no_args_shows_help() {
+    // No input is never a valid run, so a bare invocation prints the tool's help
+    // (exit 2) instead of the terse one-line error it used to.
+    let mut cmd = Command::cargo_bin("deduplicate_bismark").unwrap();
+    cmd.assert()
+        .code(2)
+        .stderr(predicates::str::contains("Remove PCR duplicate alignments"));
 }
 
 #[test]

--- a/rust/bismark/tests/extractor_sanity.rs
+++ b/rust/bismark/tests/extractor_sanity.rs
@@ -29,10 +29,24 @@ fn short_version_flag_works_too() {
 
 #[test]
 fn invocation_with_no_input_files_errors_with_clear_message() {
+    // A mode flag but no input file still reaches the validation error (exit 1).
+    // A bare no-args run instead shows the tool's help (exit 2) — see
+    // `no_args_shows_help`.
     let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
-    cmd.assert()
+    cmd.arg("-s")
+        .assert()
         .failure()
         .stderr(predicates::str::contains("no input file"));
+}
+
+#[test]
+fn no_args_shows_help() {
+    // No input is never a valid run, so a bare invocation prints the tool's help
+    // (exit 2) instead of the terse one-line error it used to.
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
+    cmd.assert()
+        .code(2)
+        .stderr(predicates::str::contains("Extract methylation calls"));
 }
 
 /// All 35 flags must appear in the help output. We don't pin the exact

--- a/rust/bismark/tests/filter_nonconversion_edge_cases.rs
+++ b/rust/bismark/tests/filter_nonconversion_edge_cases.rs
@@ -120,6 +120,15 @@ fn bin() -> Command {
 
 // ─────────────────────────────── tests ─────────────────────────────────
 
+#[test]
+fn no_args_shows_help() {
+    // No input is never a valid run, so a bare invocation renders the tool's help
+    // (exit 2) via `cli::help_if_no_args` instead of a terse one-line error.
+    bin().assert().code(2).stderr(predicates::str::contains(
+        "Filter reads/read-pairs with apparent incomplete",
+    ));
+}
+
 /// C2: PE input with an odd record count (lone trailing R1). Perl dies after
 /// writing the complete preceding pairs, leaving a 0-byte report; the Rust
 /// port must match (exit nonzero, valid partial BAMs, 0-byte report).

--- a/rust/bismark/tests/genome_prep_integration.rs
+++ b/rust/bismark/tests/genome_prep_integration.rs
@@ -183,6 +183,19 @@ fn binary_no_fasta_dir_errors() {
         .failure();
 }
 
+#[test]
+fn no_args_shows_help() {
+    // No genome folder is never a valid run, so a bare invocation renders the
+    // tool's help (exit 2) via `cli::help_if_no_args` instead of a terse error.
+    Command::cargo_bin("bismark_genome_preparation")
+        .unwrap()
+        .assert()
+        .code(2)
+        .stderr(predicates::str::contains(
+            "Prepare bisulfite-converted genome references",
+        ));
+}
+
 /// Run the Perl script and the Rust binary on copies of the same genome and
 /// assert the converted CT + GA FASTA are byte-identical. Auto-skips if `perl`
 /// is unavailable. Uses a fake `bowtie2-build` on PATH so both complete Step III.

--- a/rust/bismark/tests/methylation_consistency_integration.rs
+++ b/rust/bismark/tests/methylation_consistency_integration.rs
@@ -125,6 +125,19 @@ fn run(dir: &TempDir, args: &[&str]) -> assert_cmd::assert::Assert {
     cmd.assert()
 }
 
+#[test]
+fn no_args_shows_help() {
+    // No input is never a valid run, so a bare invocation renders the tool's help
+    // (exit 2) via `cli::help_if_no_args` instead of a terse one-line error.
+    Command::cargo_bin("methylation_consistency")
+        .unwrap()
+        .assert()
+        .code(2)
+        .stderr(predicates::str::contains(
+            "Split a Bismark BAM into three BAMs",
+        ));
+}
+
 // ── Phase A: single-end ─────────────────────────────────────────────────────
 
 #[test]

--- a/rust/bismark/tests/nome_filtering_cli_phase_a.rs
+++ b/rust/bismark/tests/nome_filtering_cli_phase_a.rs
@@ -43,6 +43,15 @@ fn missing_genome_errors_nonzero() {
 }
 
 #[test]
+fn no_args_shows_help() {
+    // No input is never a valid run, so a bare invocation renders the tool's help
+    // (exit 2) via `cli::help_if_no_args` instead of a terse one-line error.
+    bin().assert().code(2).stderr(predicates::str::contains(
+        "Per-read NOMe-Seq methylation filtering",
+    ));
+}
+
+#[test]
 fn valid_invocation_produces_gzipped_report() {
     // Phase B: a valid invocation with a real (suitable) yacht read processes
     // the input and writes the always-gzipped `.manOwar.txt.gz` report.


### PR DESCRIPTION
Two small CLI/UX fixes for the Rust suite, isolated onto `master` (only the two
bugfix commits, no unrelated work).

## 1. `bismark -V` printed a stray `unknown`

```
bismark (Bismark Rust suite) v3.1.0 (unknown — macos/aarch64 — built 2026-…Z)
```

Any build made outside a `.git` checkout (a bare `cargo install` from a source
tree, a `git archive` tarball) had `build.rs`'s `git rev-parse` fail and fall
straight to the literal `"unknown"`.

- `build.rs` resolves the short hash most-authoritative-first: `$BISMARK_GIT_HASH`
  (CI/Docker override) → `git rev-parse` (checkout) → `.cargo_vcs_info.json`
  (the VCS record `cargo package`/`cargo publish` embeds in the tarball, so a
  registry install reports the real commit) → `unknown`.
- The parenthesised `--version` body is now composed at runtime in
  `meta::version_line`; when the hash is still unavailable the `<hash> — ` prefix
  is dropped, so the line reads `(macos/aarch64 — built …)` rather than surfacing
  a bare `unknown`.

Verified in all three states (vcs-info fallback → real short hash; no git + no
vcs-info → clean line; normal checkout → real hash).

## 2. Running a tool with no arguments printed a terse `error:`

Perl prints a tool's usage/help on a bare invocation; the Rust suite printed a
one-line `error:` and exited 1. A shared `cli::help_if_no_args` now renders the
tool's long help to stderr and returns exit code **2** when only the program
name is present.

Done at each tool's runtime entry point (not clap's `arg_required_else_help`) on
purpose: it keeps `Cli::parse_from([])` returning a defaults `Cli`, which the many
unit tests that parse an empty argv and then assert `validate()`'s "no input"
error depend on.

**Scope:** aligner + `dedup`, `extract`, `bedgraph`, `cov2cyt`, `prepare`,
`bam2nuc`, `nome`, `filter`, `consistency`.

**Deliberately excluded:** `bismark2report` / `bismark2summary` — a bare run there
scans the working directory (auto-discovery) and is a valid mode matching Perl.
Bare `bismark` (no subcommand) is unchanged: the multicall dispatcher still
prints the composed suite help (exit 0). Partial-args paths are untouched, so the
per-tool validation errors still fire when some args are present but input is
missing.

## Byte-identity

No analytical-output path is touched. `-V`/help text and stderr are covered by no
byte-identity gate; only timestamp/hash/help surfaces change.

## Tests

New: `meta::version_body_{includes_hash_when_known,drops_unknown_hash}`; per-tool
`no_args_shows_help` (dedup, extractor) + `align_no_args_shows_help`. Updated: the
`..._no_input_files_errors...` sanity tests pass a flag so they still exercise the
validation error; `align_no_genome_errors` supplies reads-without-genome.

`cargo test -p bismark` green (1426 lib + all integration); `cargo fmt --all --
check` and `cargo clippy --all-targets --release -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)