### PR TITLE
aligner: route -p to minimap2/rammap -t (thread-invariant, default -t 2)

### DIFF
--- a/rust/bismark/src/aligner/cli.rs
+++ b/rust/bismark/src/aligner/cli.rs
@@ -308,7 +308,9 @@ pub struct Cli {
     /// Threads per aligner instance (≥ 2): Bowtie 2 / HISAT2 `-p`, and (#1074)
     /// minimap2 / rammap `-t`. minimap2 `-t` is thread-invariant, so this stays
     /// output-neutral; omitted ⇒ the faithful default (`-t 2` for minimap2/rammap).
-    #[arg(short = 'p', value_name = "int")]
+    /// `--threads` long alias (matches bowtie2's own; nf-core long-name convention,
+    /// requested on nf-core/modules#12385) — `-p` stays valid.
+    #[arg(short = 'p', long = "threads", value_name = "int")]
     pub bowtie_threads: Option<u32>,
     /// `--dovetail` (paired-end; kept for backwards compatibility, no effect here).
     #[arg(long)]

--- a/rust/bismark/src/aligner/cli.rs
+++ b/rust/bismark/src/aligner/cli.rs
@@ -305,7 +305,9 @@ pub struct Cli {
     /// Allow a non-bisulfite mismatch.
     #[arg(long = "non_bs_mm")]
     pub non_bs_mm: bool,
-    /// Threads *per Bowtie 2 instance* (Bowtie 2 -p; ≥ 2).
+    /// Threads per aligner instance (≥ 2): Bowtie 2 / HISAT2 `-p`, and (#1074)
+    /// minimap2 / rammap `-t`. minimap2 `-t` is thread-invariant, so this stays
+    /// output-neutral; omitted ⇒ the faithful default (`-t 2` for minimap2/rammap).
     #[arg(short = 'p', value_name = "int")]
     pub bowtie_threads: Option<u32>,
     /// `--dovetail` (paired-end; kept for backwards compatibility, no effect here).

--- a/rust/bismark/src/aligner/config.rs
+++ b/rust/bismark/src/aligner/config.rs
@@ -178,8 +178,9 @@ pub struct RunConfig {
     pub rammap_subprocess: bool,
     /// Thread count for the in-process rammap pool (rev2 single-source-of-truth). Computed
     /// ONCE in `resolve` (where `cli.multicore: Option` still distinguishes explicit from
-    /// default) by [`inprocess_rammap_threads`]: an explicit `--multicore N` verbatim, else
-    /// a capped `available_parallelism()`. Read by BOTH the backend notice (`lib.rs`) and
+    /// default) by [`inprocess_rammap_threads`]: `-p N` (`bowtie_threads`) first (#1074),
+    /// else an explicit `--multicore N` verbatim, else a capped `available_parallelism()`.
+    /// Read by BOTH the backend notice (`lib.rs`) and
     /// the pool builder (`build_se_inprocess_streams`) so the printed count and the built
     /// pool can never disagree. Separate from `multicore` (never mutated) so auto-scaling
     /// does NOT leak into the fork dispatch for FastA/other paths. Always ≥ 1.
@@ -268,9 +269,12 @@ pub struct RunConfig {
     /// For HISAT2 this is forced to `1` when `--multicore N` is remapped to `-p N`
     /// (see `hisat2_multicore_remap`) — the fork model is not faithful for HISAT2.
     pub multicore: u32,
-    /// `-p` (threads passed to the aligner instance, Perl Bismark `-p`). Used by the
-    /// 5-Base path to set minimap2 `-t` / bowtie2,hisat2 `-p` (precedence over
-    /// `--multicore`, then all logical CPUs). `None` ⇒ aligner default / all cores.
+    /// `-p` (threads-to-aligner knob, Perl Bismark `-p`): the per-instance thread count.
+    /// Applied as bowtie2/hisat2 `-p` and, since #1074, minimap2/rammap `-t` (subprocess)
+    /// / the rammap in-process pool size — not just the 5-Base path. minimap2 `-t` is
+    /// thread-invariant (spike), so a bare `--minimap2`/`--rammap` keeps the faithful
+    /// `-t 2`; `-p N` lifts it. Precedence over `--multicore`, then all logical CPUs.
+    /// `None` ⇒ aligner default / all cores.
     pub bowtie_threads: Option<u32>,
     /// HISAT2 Approach B-faithful (`--hisat2 --multicore N`): when set, `--multicore N`
     /// was interpreted as a single HISAT2 instance with `-p N --reorder` (NOT the fork
@@ -326,16 +330,27 @@ fn hisat2_multicore_threads(aligner: Aligner, cli_multicore: Option<u32>) -> Opt
 const RAMMAP_INPROCESS_THREAD_CAP: usize = 8;
 
 /// Thread count for the in-process rammap pool (rev2, Alt-1 — the single source of truth
-/// read by both the backend notice and the pool builder). An explicit `--multicore N` is
-/// honored verbatim; otherwise the default auto-scales to `min(avail, CAP)` so the default
+/// read by both the backend notice and the pool builder). Precedence (#1074): `-p N`
+/// (`bowtie_threads`, the per-aligner thread knob) first when set; else an explicit
+/// `--multicore N` verbatim; else the default auto-scales to `min(avail, CAP)` so the default
 /// `--rammap` run is multi-threaded (not the ~6× single-threaded regression Alt-1 exists to
 /// prevent). Pure (no I/O — `avail` is passed in) so it is unit-testable fixture-free.
 /// ALWAYS returns ≥ 1: `rayon`'s `num_threads(0)` means "all cores", which we must never
 /// select by accident, so both branches clamp with `.max(1)`.
-fn inprocess_rammap_threads(cli_multicore: Option<u32>, avail: usize) -> usize {
-    let n = match cli_multicore {
-        Some(n) => n as usize,
-        None => avail.min(RAMMAP_INPROCESS_THREAD_CAP),
+fn inprocess_rammap_threads(
+    cli_bowtie_threads: Option<u32>,
+    cli_multicore: Option<u32>,
+    avail: usize,
+) -> usize {
+    // #1074: `-p` (bowtie_threads) is the per-aligner thread knob and takes precedence
+    // when set (>0); otherwise the existing behaviour — explicit `--multicore` verbatim,
+    // else a capped `available_parallelism()`.
+    let n = match cli_bowtie_threads.filter(|&p| p > 0) {
+        Some(p) => p as usize,
+        None => match cli_multicore {
+            Some(n) => n as usize,
+            None => avail.min(RAMMAP_INPROCESS_THREAD_CAP),
+        },
     }
     .max(1);
     debug_assert!(n >= 1, "rammap pool thread count must be >= 1 (never 0)");
@@ -643,6 +658,7 @@ pub fn resolve(cli: &Cli, command_line: String) -> Result<RunConfig> {
         // mutates `multicore` — auto-scaling must not leak into the fork dispatch (a FastA
         // `--rammap` run would otherwise fork N index-reloading workers).
         rammap_inprocess_threads: inprocess_rammap_threads(
+            cli.bowtie_threads,
             cli.multicore,
             // On the rare platform where `available_parallelism()` fails, fall back to 2
             // (not 1) so the default does not silently revert to the single-threaded path
@@ -1610,25 +1626,29 @@ mod tests {
         );
     }
 
-    /// rev2 (Alt-1): the in-process rammap pool thread count. Explicit `--multicore N` is
-    /// honored verbatim; the default auto-scales to `min(avail, CAP)`; never returns 0.
+    /// rev2 (Alt-1) + #1074: the in-process rammap pool thread count.
+    /// Args are `(bowtie_threads /* -p */, multicore, avail)`. `-p` takes precedence
+    /// when set; else explicit `--multicore N` verbatim; else auto-scale `min(avail, CAP)`.
     #[test]
     fn inprocess_rammap_threads_derivation() {
-        // explicit --multicore honored verbatim (even above the cap).
-        assert_eq!(inprocess_rammap_threads(Some(4), 32), 4);
-        assert_eq!(inprocess_rammap_threads(Some(16), 32), 16);
-        assert_eq!(inprocess_rammap_threads(Some(1), 32), 1);
-        // default (no --multicore) → capped available_parallelism.
+        // explicit --multicore (no -p) honored verbatim (even above the cap).
+        assert_eq!(inprocess_rammap_threads(None, Some(4), 32), 4);
+        assert_eq!(inprocess_rammap_threads(None, Some(16), 32), 16);
+        assert_eq!(inprocess_rammap_threads(None, Some(1), 32), 1);
+        // default (no -p, no --multicore) → capped available_parallelism.
         assert_eq!(
-            inprocess_rammap_threads(None, 32),
+            inprocess_rammap_threads(None, None, 32),
             RAMMAP_INPROCESS_THREAD_CAP
         );
         // default on a small host → the (uncapped) core count.
-        assert_eq!(inprocess_rammap_threads(None, 2), 2);
-        // never 0: a degenerate explicit 0 clamps to 1 (validate_multicore also rejects 0
-        // upstream), and avail is always ≥ 1.
-        assert_eq!(inprocess_rammap_threads(Some(0), 8), 1);
-        assert_eq!(inprocess_rammap_threads(None, 1), 1);
+        assert_eq!(inprocess_rammap_threads(None, None, 2), 2);
+        // never 0: a degenerate explicit --multicore 0 clamps to 1, avail always ≥ 1.
+        assert_eq!(inprocess_rammap_threads(None, Some(0), 8), 1);
+        assert_eq!(inprocess_rammap_threads(None, None, 1), 1);
+        // #1074: -p sizes the pool and wins over --multicore + the avail cap.
+        assert_eq!(inprocess_rammap_threads(Some(8), None, 64), 8);
+        assert_eq!(inprocess_rammap_threads(Some(8), Some(4), 64), 8);
+        assert_eq!(inprocess_rammap_threads(Some(8), None, 4), 8);
     }
 
     // ---- #787 Illumina 5-Base mode guards ----------------------------------

--- a/rust/bismark/src/aligner/mod.rs
+++ b/rust/bismark/src/aligner/mod.rs
@@ -1142,9 +1142,29 @@ fn five_base_aligner_options(config: &RunConfig) -> String {
         Aligner::Bowtie2 => format!("-q --score-min L,0,-0.6 -p {n}"),
         Aligner::Hisat2 => format!("-q --no-spliced-alignment --score-min L,0,-0.6 -p {n}"),
         // minimap2 (default 5-Base engine): reuse the resolved options but lift the
-        // faithful `-t 2` to `-t {n}` (all cores) for this non-byte-identical path.
-        _ => config.aligner_options.replace("-t 2", &format!("-t {n}")),
+        // faithful `-t` to `-t {n}` (all cores) for this non-byte-identical path.
+        // Token-safe: a plain `.replace("-t 2", …)` mangled `-t 20`→`-t {n}0` once the
+        // base string carries a resolved `-t {p}` (#1074 C2).
+        _ => replace_minimap2_threads(&config.aligner_options, n),
     }
+}
+
+/// Set the value token after `-t` in a whitespace-separated minimap2 option string,
+/// token-safely. A `str::replace("-t 2", …)` is a SUBSTRING replace: once the base
+/// carries `-t 20`/`-t 25`/… it corrupts them to `-t 200`/`-t 255` (#1074 C2). This
+/// rewrites only the whole value token that immediately follows `-t`.
+///
+/// NB: coupled to `options::minimap2_options`, which renders the `-t <N>` token this
+/// finds; if that flag ever changes, this literal `"-t"` match must change with it.
+fn replace_minimap2_threads(opts: &str, n: usize) -> String {
+    let mut toks: Vec<String> = opts.split_whitespace().map(String::from).collect();
+    for i in 0..toks.len() {
+        if toks[i] == "-t" && i + 1 < toks.len() {
+            toks[i + 1] = n.to_string();
+            break;
+        }
+    }
+    toks.join(" ")
 }
 
 /// Build the per-engine spawn argv for a 5-Base run. minimap2: `<opts> <genome.fa>
@@ -6969,5 +6989,27 @@ mod tests {
             "base/2__CT\t147\tchr1_CT_converted\t1\t40\t6M\t=\t1\t-6\tACGTAC\tFFFFFF\tAS:i:0\tMD:Z:6",
         );
         assert!(broken.is_err(), "tag-after-suffix must fail to pair");
+    }
+
+    /// #1074 C2: the 5-Base `-t` lift must be token-safe. A `str::replace("-t 2", …)`
+    /// corrupts `-t 20`→`-t {n}0` once the base carries a resolved `-t {p}`; the
+    /// token-wise rewrite must set only the whole value after `-t`.
+    #[test]
+    fn replace_minimap2_threads_is_token_safe() {
+        // the C2 regression: -t 20 must stay -t 20 (old bug: -t 200)
+        assert_eq!(
+            replace_minimap2_threads("-a --MD --secondary=no -t 20 -x sr -K 250K", 20),
+            "-a --MD --secondary=no -t 20 -x sr -K 250K"
+        );
+        // faithful base -t 2 lifted to the 5-Base auto-scale
+        assert_eq!(
+            replace_minimap2_threads("-a -t 2 -x sr", 128),
+            "-a -t 128 -x sr"
+        );
+        // -t 25 (also has "-t 2" as a substring) rewritten cleanly
+        assert_eq!(
+            replace_minimap2_threads("-a -t 25 -x sr", 8),
+            "-a -t 8 -x sr"
+        );
     }
 }

--- a/rust/bismark/src/aligner/options.rs
+++ b/rust/bismark/src/aligner/options.rs
@@ -236,10 +236,13 @@ pub fn build_aligner_options(
 }
 
 /// Assemble the minimap2 `aligner_options` from a clean slate (Perl 8358-8413).
-/// Push order: `-a` → `--MD` → `--secondary=no` → `-t 2` → `-x <preset>` →
-/// `-K 250K`. The `-t 2` is hardcoded by Bismark (8372) — independent of any
-/// `--multicore`/`-p` choice (`-p`/`--reorder` were pushed to the Bowtie 2 base,
-/// which this discards). Preset (Perl 8374-8408):
+/// Push order: `-a` → `--MD` → `--secondary=no` → `-t <N>` → `-x <preset>` →
+/// `-K 250K`. `-t` follows Bismark's `-p` thread knob (`cli.bowtie_threads`),
+/// defaulting to the Perl-faithful `-t 2` when `-p` is absent (#1074). minimap2
+/// `-t` is thread-invariant (byte-identical + input-order-preserving across N —
+/// spike `SPIKE_minimap2_thread_invariance.md`), so this is output-neutral: a bare
+/// `--minimap2` still emits `-t 2` (unchanged vs Perl). `--reorder` is Bowtie-2-only
+/// (pushed to the base string this clean slate discards). Preset (Perl 8374-8408):
 /// - `--mm2_short_reads` → `sr`,
 /// - `--mm2_pacbio` → `map-pb`,
 /// - default **or** an explicit `--mm2_nanopore` → `map-ont` (the `else` serves
@@ -277,7 +280,11 @@ fn minimap2_options(cli: &Cli) -> Result<String> {
         // Default OR explicit `--mm2_nanopore` → ONT (Perl 8404-8408).
         "map-ont"
     };
-    Ok(format!("-a --MD --secondary=no -t 2 -x {preset} -K 250K"))
+    // `-t` = Bismark `-p` (threads-to-aligner) knob, default the Perl-faithful 2 when
+    // absent (#1074; minimap2 `-t` is thread-invariant per the spike, so output-neutral).
+    // `bowtie_threads` is ≥ 2 when set (guarded upstream). rammap-subprocess shares this.
+    let t = cli.bowtie_threads.unwrap_or(2);
+    Ok(format!("-a --MD --secondary=no -t {t} -x {preset} -K 250K"))
 }
 
 /// Append the HISAT2-specific option tail (Perl `process_command_line` 8286-8326,
@@ -786,13 +793,37 @@ mod tests {
     // ---- minimap2 clean-slate option assembly (Phase 4) --------------------
 
     /// V2 (hard literal): the default minimap2 string — clean-slate, `-x map-ont`
-    /// (NOT `-ax sr`), `-t 2` hardcoded (Perl 8358-8413; spike Q2).
+    /// (NOT `-ax sr`), faithful `-t 2` when no `-p` is given (Perl 8358-8413; #1074).
     #[test]
     fn minimap2_default_option_string() {
         let cli = cli_from(&[]);
         let (opts, _) =
             build_aligner_options(&cli, Aligner::Minimap2, ReadFormat::FastQ, false, None).unwrap();
         assert_eq!(opts, "-a --MD --secondary=no -t 2 -x map-ont -K 250K");
+    }
+
+    /// #1074: `-p N` lifts minimap2 `-t` to N (spike-confirmed thread-invariant, so
+    /// output-neutral); a bare `--minimap2` stays `-t 2` (covered above).
+    #[test]
+    fn minimap2_p_lifts_t() {
+        let cli = cli_from(&["--minimap2", "-p", "8"]);
+        let (opts, _) =
+            build_aligner_options(&cli, Aligner::Minimap2, ReadFormat::FastQ, false, None).unwrap();
+        assert_eq!(opts, "-a --MD --secondary=no -t 8 -x map-ont -K 250K");
+    }
+
+    /// #1074: rammap-subprocess shares the minimap2 clean-slate path → same `-p`→`-t`.
+    #[test]
+    fn rammap_subprocess_p_lifts_t() {
+        let (opts, _) = build_aligner_options(
+            &cli_from(&["--rammap", "--rammap_subprocess", "-p", "8"]),
+            Aligner::Rammap,
+            ReadFormat::FastQ,
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(opts, "-a --MD --secondary=no -t 8 -x map-ont -K 250K");
     }
 
     /// Phase 3 (T3, design#2): rammap is minimap-like — it reuses the IDENTICAL


### PR DESCRIPTION
Closes #1074.

## What

Unify Bismark's per-aligner thread control: the `-p` knob now routes to **minimap2 `-t`** (and the **rammap** subprocess + in-process pool), not just Bowtie 2 / HISAT2 `-p`. A bare `--minimap2` / `--rammap` still emits the faithful `-t 2` (byte-identical to Perl); `-p N` lifts it.

Before this, minimap2 hard-coded `-t 2` and ignored `-p`/`--multicore`, and rammap keyed only off `--multicore`/auto — so no single thread budget reached all four aligners. This is the Bismark-side change that lets nf-core/modules `bismark/align` (see nf-core/modules#12385) eventually thread minimap2/rammap too.

## Why it's safe to default (no opt-in gate)

Spiked minimap2 `-t` thread-invariance directly (Bismark's exact option set, GRCh38, `map-ont` + `sr` presets, `-t ∈ {1,2,8,16}`): output is **byte-identical AND input-order-preserving** across thread counts (records-only md5 + mapped counts all equal). So — unlike HISAT2, whose splice discovery shifts with `N` — routing `-t` is output-neutral and needs no `never-silent`/concordance gate. The no-`-p` default stays `-t 2`, so faithful/oracle behaviour is unchanged.

## Changes

- `minimap2_options` renders `-t` from `cli.bowtie_threads.unwrap_or(2)` (single source; rammap-subprocess shares this clean-slate path).
- `inprocess_rammap_threads` gains a `-p` tier: precedence `-p` > `--multicore` > capped `available_parallelism()` — so `--rammap -p N` sizes the default in-process pool.
- 5-Base path: the `-t` lift now uses a **token-safe** rewrite (`replace_minimap2_threads`) instead of `str::replace("-t 2", …)`, which was a latent substring bug that would corrupt `-t 20`→`-t 200` once the base string carried a resolved `-t {p}`.
- Docs: `-p` `--help`, `minimap2_options`, `RunConfig.bowtie_threads`, and the rammap-pool docs updated.

## Testing

`cargo test -p bismark --lib` → **1427 passed / 0 failed** (incl. new `-p`-lift, token-safe C2 guard, and rammap-pool `-p` cases); `cargo fmt --check` + `cargo clippy --all-targets` clean. Faithful `-t 2` default proven by the unchanged `minimap2_default_option_string` / `rammap_default_option_string` tests.

## Follow-up (separate, out of scope here)

After a release with this, nf-core/modules `bismark/align` can fold minimap2/rammap into its `-p = cpus/n_instances` divisor and drop the `isMinimapLike` branch (which also closes the pre-existing `--parallel`-guard gap noted on nf-core/modules#12385).
