### PR TITLE
aligner: collapse the score-min trio into one ScoreModel (no behaviour change)

### DIFF
--- a/plans/07292026_local-mapq-denominator/CODE_REVIEW_A.md
+++ b/plans/07292026_local-mapq-denominator/CODE_REVIEW_A.md
@@ -1,0 +1,358 @@
+# CODE REVIEW A — local-mode MAPQ denominator (#1079)
+
+**Reviewer:** A (independent, fresh context — no shared state with Reviewer B)
+**Target:** uncommitted working-tree changes on `rust/local-mapq-denominator` (9 files, +730/−317), base `0a9eeb7`
+**Plan:** `plans/07292026_local-mapq-denominator/PLAN.md` rev 1
+**Report-only:** no source, test or plan file was modified by this review.
+
+---
+
+## 1. Summary
+
+**Verdict: APPROVE for merge after the documentation fixes in §3 (E1–E5).** I found **no correctness
+defect** in the shipped arithmetic, the ladder extraction, or the `(local, aligner)` → `ScoreModel`
+wiring. Everything I could re-derive independently, I did — and it all held.
+
+The findings are concentrated in **documentation and test hygiene**, and two of them are user-facing:
+the CHANGELOG contradicts itself about HISAT2 `--local` (E1), the `mapq.rs` header now makes a false
+byte-identity claim (E2), a comment in `options.rs` still describes the defect that was fixed (E3),
+`rust/README.md`'s aligner **row** was not updated as the plan and the file's own rule require (E4),
+and the CHANGELOG asserts two follow-ups are "tracked separately" while §12 records that neither
+issue has been filed (E5).
+
+### What I verified independently (green tests were the starting point, not the finding)
+
+| # | Claim under review | How I checked it | Result |
+|---|---|---|---|
+| 1 | `calc_mapq_end_to_end` is a faithful extraction | whitespace-normalised text compare of the ladder block, `git show HEAD:…/mapq.rs` vs the new fn body | **byte-exact** — 1607 chars both sides, `IDENTICAL` |
+| 2 | Both ladders untouched and correct | leaf-by-leaf vs upstream `unique.h` v2.5.5 L262–380 (fetched) | every rung + every sub-threshold matches (incl. e2e-0.3 → `32`, which *is* what upstream has) |
+| 3 | **A1** `perfect = 2 × len`, PE sums both mates | `scoring.h:310-316` `perfectScore = monotone ? 0 : rdlen*match(30)`; `#define DEFAULT_MATCH_BONUS_LOCAL 2`; `unique.h:206-209` | confirmed |
+| 4 | **A4** `--ma` unreachable ⇒ `2.0` is a constant | 23 `opts.push` sites, no `--ma`; no `trailing_var_arg`/`allow_hyphen_values` in `cli.rs` | confirmed |
+| 5 | The 6 hand-derived HISAT2 expectations | re-derived from the linear `scMin` in an independent model | **44/44/44/31/1/11 all correct**; old values 44/22/44/40/0/34 → exactly the 4 predicted cells moved |
+| 6 | Reporter's case, perfect-score case, `ln`-boundary, clamp, V10 | independent model | `24` ✓, `44` ✓, `44`/`36` ✓, `diff==1.0` ✓, `28` (old `44`) ✓ |
+| 7 | CHANGELOG's "250 bp at 30 % scored 44, Bowtie 2 gives 22" | independent model **plus** a full Bowtie 2 analogue (int64 `scMin`/`diff`/`bestOver` + `(double)0.8f` thresholds) | old **44**, new **22**, bowtie2 **22** — claim is exactly right |
+| 8 | How much the deliberate f64-vs-int64 divergence (A10) actually costs | 89 976-cell sweep, `len 25..300` × `AS 0..2L`, SE, no second best, `G,20,8` | **361 cells differ = 0.40 %** — the new Bismark values agree with the int64 Bowtie 2 analogue in **99.6 %** of cells. A10/V8's "noise" worry is quantitatively small |
+| 9 | **V7** — PR 1 is call-shape-only | reverse-transformed the new calls back to the trio, then diffed against `HEAD` | test modules of `merge.rs`/`combined.rs`/`mod.rs` **identical modulo rustfmt line-wrapping**; production code has **zero** non-mechanical hunks beyond 2 import lines and the 2 intended `allow` deletions |
+| 10 | §12's claim that the deleted tautological test would still have passed after D1 | recomputed all 6 cells at `diff 51.296` vs `48.704` | **all 6 identical** — the test was genuinely blind; replacing it was necessary, not cosmetic |
+| 11 | **V1** has teeth | injected rev 0's universal clamp into my model and re-ran the exact sweep grid | **127 / 990 cells** would fail, first at `i=0 s=-0.2 len=1 best=0` (frozen 42 → clamped 0) |
+| 12 | Gating airtight | `options.rs:82` pushes `--local` under *the same* predicate `cli.local && aligner == Aligner::Bowtie2` that sets `match_bonus`; exactly **one** `RunConfig` construction (`config.rs:789`); `--local` rejected for minimap2/rammap + all 4 combined-index variants; 5-Base has its own driver (`calc_mapq(` occurs only at `merge.rs:367,740` and `combined.rs:339,711`) | no path reaching `calc_mapq` can get the wrong `match_bonus` |
+| 13 | Arity payoff / allow removals | `check_results_single_end` now 7 args, `select_pe_nondir` 6 (clippy fires at >7); `check_results_paired_end` still 9 and keeps its allow | both removals correct |
+| 14 | Claimed toolchain state | reproduced: `cargo fmt -p bismark --check` clean; `cargo clippy -p bismark --all-targets` **0 warnings**; `cargo test -p bismark` **2107 passed / 0 failed** | confirmed |
+| 15 | Does any CI gate break? | `rust_ci.yml:194-220` `perl-oracle` has **no aligner cell** and no `--local` | no |
+
+### Answers to the specific questions in the brief
+
+- **Is `match_bonus > 0.0` airtight?** Yes — see row 12. The predicate is also *incidentally
+  future-proof*: Bowtie 2 `--ma 0` sets `monotone = true` ⇒ `perfectScore = 0`, so `match_bonus == 0`
+  ⇒ `abs(scMin)` would be the **right** branch. (The *ladder* would still key off `cli.local` and be
+  wrong under `--ma 0` — but `--ma` is unreachable, row 4.) `f64 > 0.0` is exact here because the
+  field is private and only ever set to the literals `2.0` or `0.0`.
+- **`perfect()` for PE:** correct vs `unique.h:207-209` — `scPer = perfectScore(rdlen) + perfectScore(ordlen)`
+  and Bismark's `score_min` sums the same two mates, so numerator and denominator use the same pair.
+  "SE with `read2_len = Some` by mistake" is not reachable (the four call sites are fixed) and would
+  in any case stay *internally consistent* (both `score_min` and `perfect` include the second mate).
+  PE-with-one-mate-unmapped does not exist in Bismark's faithful PE path.
+- **Is the frozen-path claim true?** Yes, structurally and by measurement (rows 1, 9, 11). The
+  `match_bonus == 0.0` arm *is* `sc_min.abs()` and the end-to-end ladder is a byte-exact extraction.
+- **The hand-derived HISAT2 expectations:** all six re-derived correctly (row 5). The
+  `calc_mapq(50, None, 0, Some(-1)) → 31` cell rides an exact knife edge (`best_diff = 1` vs
+  `diff*0.1`, and `10.0 * 0.1 == 1.0` exactly in IEEE-754) — deterministic, but the comment's
+  "= 1 exactly" is load-bearing and correctly flagged as such.
+- **The refactor:** type-safe by construction — replacing three primitives with one distinct type
+  makes a silent argument swap impossible, and row 9 proves nothing else moved. The two fn-pointer
+  aliases reverse-transform cleanly with argument order preserved.
+- **`normalize()` misuse:** the `scMin`↔`diff` pairing is now structurally enforced. Lengths-vs-`as_best`
+  consistency still can't be enforced by the signature (inherent), which is fine.
+- **The V10 fixture:** acceptable. MAPQ reads only `AS:i:`, the decoupling is stated in the doc
+  comment, and I confirmed the discriminating power (old **44** → new **28**; `AS ∈ 2..9` all
+  discriminate; `AS ≥ 2` returns 44 under the old model for *every* value — the saturation pathology
+  in miniature). It proves wiring, which is exactly what it claims. See S5 for the one thing it
+  doesn't cover.
+- **`#[allow(clippy::float_cmp)]`:** the justification still holds for both ladders, and
+  `best_over == diff` is now *more* meaningful in Bowtie 2-local (it means `AS == perfect`, with both
+  sides produced by the same f64 subtraction ⇒ bit-exact). But the copy on `calc_mapq` itself is now
+  dead — see S7.
+- **The two removed `too_many_arguments` allows:** both correct (row 13).
+
+---
+
+## 2. Issues — Logic
+
+### L1 (Medium) — `from_emitted`'s documented invariant is not actually enforced
+
+`rust/bismark/src/aligner/config.rs:81-86`:
+
+> Fields are private: `match_bonus` and `form` must agree (only Bowtie 2-local has a nonzero perfect
+> score, and only Bowtie 2-local is emitted the `G` form), **so they are never settable independently.**
+
+That last clause is false. `from_emitted` is `pub`, takes `form` from the caller, and derives
+`match_bonus` from `(local, aligner)` — so
+
+```rust
+ScoreModel::from_emitted(20.0, 8.0, ScoreMinForm::Linear, true, Aligner::Bowtie2)
+```
+
+builds `match_bonus = 2.0` with `form = Linear`: exactly the incoherent model the comment says cannot
+exist. Field privacy prevents *post-hoc mutation*, not *inconsistent construction*. This matters
+slightly more than usual because `bismark::aligner::config` is a `pub mod` of a published crate, so
+`from_emitted` is external API.
+
+The invariant *is* true of the only production caller (`score_min_params` picks `G` iff
+`cli.local && aligner == Bowtie2`, the same predicate `from_emitted` uses for `match_bonus`), so this
+is a documentation defect, not a live bug.
+
+**Recommended fix** — reword to what is enforced, and optionally assert the rest:
+
+```rust
+/// Fields are private so the model cannot be mutated after construction. `form` is supplied
+/// by the caller (from `options::score_min_params`) rather than re-derived here — that
+/// re-derivation was #1079 D2.
+```
+
+plus, inside `from_emitted`:
+
+```rust
+// The emitted form and the match bonus are two views of the same condition today.
+debug_assert_eq!(
+    matches!(form, ScoreMinForm::Log),
+    local && aligner == Aligner::Bowtie2,
+    "score-min form and match bonus disagree"
+);
+```
+
+### L2 (Low) — `.max(1.0)` silently swallows NaN, `abs()` propagates it
+
+`config.rs:200-204`. Rust's `f64::max` **ignores NaN**, so a NaN `sc_min` yields `diff = 1.0` on the
+Bowtie 2-local branch but `diff = NaN` on the frozen branch. Reachable two ways, both narrow:
+
+- `--score_min` is shape-validated only (A11) and `"nan".parse::<f64>()` succeeds, so `G,nan,8` gets
+  through Bismark's validator;
+- `len == 0` with `slope == 0.0` gives `0.0 * -inf = NaN`.
+
+I checked the resulting MAPQ in both cases: every ladder comparison is `false` either way, so the
+returned rung is the bottom one under old and new code alike — **outcome-neutral today**. Worth one
+line noting the asymmetry (or a numeric `--score_min` validation as a separate follow-up, which A11
+already anticipates).
+
+### L3 (Low, observation) — one live config gets `match_bonus = 2.0` and never reads it
+
+`--illumina_5base --bowtie2 --local` resolves (the `--local` gate only rejects minimap2/rammap and
+combined-index; `resolve_aligner` returns `Aligner::Bowtie2` for `--illumina_5base --bowtie2`), so its
+`ScoreModel` carries `match_bonus = 2.0`. Harmless: `run_pe_five_base` is a separate driver and
+`calc_mapq` is called from nowhere else (row 12), so the field is dead there. Recorded only so
+"`match_bonus == 2.0` ⇒ a Bowtie 2-local MAPQ was computed" isn't read as an invariant.
+
+---
+
+## 3. Issues — Errors / user-facing documentation
+
+### E1 (Medium) — the CHANGELOG contradicts itself about HISAT2 `--local`
+
+`CHANGELOG.md:8` ends:
+
+> The **default end-to-end path is unaffected and stays byte-identical** (there the perfect score is
+> 0, so the two expressions agree), **as does HISAT2 `--local`**.
+
+`CHANGELOG.md:9` says:
+
+> The emitted form is now the single source of truth for both, **so HISAT2 `--local` MAPQ changes.**
+
+In context bullet 1 is scoped to D1 (where HISAT2-local genuinely is unaffected), but as written a
+`--hisat2 --local` user reading bullet 1 concludes their MAPQ is unchanged. This is the single
+highest-impact finding in the review: the whole reason for writing the entry now (plan step 8) was to
+preserve exactly this nuance.
+
+**Recommended fix** for the tail of line 8:
+
+> …so the two expressions agree). HISAT2 `--local` keeps the same denominator, but its `score_min`
+> **form** changes — see the next entry.
+
+### E2 (Medium) — `mapq.rs` header makes a now-false byte-identity claim
+
+`rust/bismark/src/aligner/mapq.rs:10-12`:
+
+> Bowtie 2 `--local` deviates from Perl deliberately … **All other modes remain byte-identical to
+> Perl.**
+
+HISAT2 `--local` does not (D2). In the header of a module whose doc-comment calls its own return
+values "byte-identity-critical", this is the wrong sentence to leave stale.
+
+**Recommended fix:** "…HISAT2 `--local` also deviates: its `scMin` is now the linear form it is
+actually emitted (D2). End-to-end (every aligner) remains byte-identical to Perl."
+
+### E3 (Medium) — `options.rs` still describes the bug that was just fixed
+
+`rust/bismark/src/aligner/options.rs:79-81`:
+
+> HISAT2-local uses the SAME L-form as end-to-end (Perl 7912/7947) — its local-ness is the dropped
+> `--no-softclip` in the HISAT2 tail **+ the ln() MAPQ scMin**, NOT this option.
+
+The `ln()` MAPQ `scMin` is precisely what D2 removed, and this comment sits ~5 lines above the
+function the change touched. The plan's step 8 listed only `mapq.rs`'s header and `config.rs:235` for
+doc updates, so this one slipped through.
+
+**Recommended fix:** "…its local-ness is the dropped `--no-softclip` in the HISAT2 tail + the local
+MAPQ ladder, NOT this option. Its MAPQ `scMin` is linear, matching this L-form (#1079 D2)."
+
+### E4 (Medium) — `rust/README.md`: the Milestones line landed, the aligner **row** did not
+
+Plan step 8 requires "`rust/README.md`: aligner row + dated Milestones line", and the file states the
+rule itself immediately under the table (`rust/README.md:175`): *"every module-merge PR into `master`
+should update that tool's row above **and** add a dated line to Milestones."* Only the Milestones
+line was added.
+
+The row still reads, unqualified: *"byte-identical to Perl v0.25.1 + Bowtie 2 2.5.5 at 1M
+reads/pairs"* and *"HISAT2 … byte-identical to Perl v0.25.1 + HISAT2 2.2.2"*. Those gates were run
+end-to-end (`--local` is non-default), so the claims are true of the default path — but nothing in
+the row now flags that `--local` is a deliberate divergence, and the row is the "at a glance" surface.
+
+**Recommended fix:** append to the aligner row, e.g. *"(byte-identity is the **end-to-end** contract:
+Bowtie 2 and HISAT2 `--local` MAPQ deliberately diverge from Perl v0.25.1 — #1079)"*.
+
+### E5 (Medium) — the CHANGELOG claims tracking that does not exist yet
+
+`CHANGELOG.md:9` — "…is **not** yet claimed to match a HISAT2 reference — **that is tracked
+separately**." `CHANGELOG.md:10` — "Related, unchanged and **tracked separately**: minimap2/rammap…".
+
+PLAN §12 "Not done (by decision)" records: *"The two deferred issues (HISAT2 perfect score;
+minimap2/rammap positive-AS) are **not yet filed**."* Plan step 9 required filing them in PR 2.
+
+Either file both issues before merge (preferred — the reasoning to carry is already written up in
+plan §1 non-goals and A3/A9) or soften the wording. Shipping a release note that points at
+non-existent tracking is the kind of thing that gets rediscovered a year later, which is the failure
+mode #1079 itself illustrates.
+
+---
+
+## 4. Issues — Structure / tests
+
+### S1 (Low–Medium) — `frozen()`'s `local == true` branch is dead
+
+`mapq.rs:634-657`. The helper's doc says *"the pre-#1079 formula, verbatim: diff = abs(scMin), linear
+or ln by `local`"*, but both call sites (`:672`, `:677`) pass `false`, so the `ln` term **and** the
+`calc_mapq_local` arm are unreachable. The helper advertises a capability the test never exercises —
+because HISAT2-local's *values* are deliberately not frozen.
+
+**Recommended fix:** drop the `local` parameter and the two branches (the helper becomes the
+end-to-end frozen reference, which is what it is), and let the HISAT2 assertion stand on its own.
+
+### S2 (Low) — a loop-invariant assertion nested three loops too deep
+
+`mapq.rs:682-687`. The HISAT2 assertion uses only `hd`, which depends on `(i, s, len)` — not on
+`best` (it feeds the discarded `bo`) or `sec`. It therefore runs 6 × 11 × 5 × 3 = **990 times to
+assert 66 distinct facts**. Hoist it to the `len` loop.
+
+### S3 (Low) — the test name and first doc line overstate what is frozen for HISAT2
+
+`fn frozen_paths_match_the_pre_fix_formula` / *"End-to-end and HISAT2-local denominators are
+byte-frozen against the pre-#1079 formula."* The pre-fix HISAT2-local denominator was
+`abs(ln scMin)`; what is frozen is the **shape** (`abs(...)`), not the value. The comment's second
+sentence explains this correctly, so this is a naming/first-line fix — e.g. split into
+`end_to_end_matches_the_pre_fix_formula` + `hisat2_local_denominator_is_abs_of_the_linear_scmin`.
+
+### S4 (Low) — the hand-derived figures in `local_bowtie2_ln_derived_bucket_boundary` are wrong from the 4th digit
+
+`mapq.rs:568-585`. Correct values:
+
+| comment says | actual |
+|---|---|
+| `scMin = 20 + 8·ln(25) = 45.7527…` | **45.751007** |
+| `diff = 4.2473…` | **4.248993** |
+| "the 0.5/0.4 boundary sits at 2.1237" | **2.1244967** |
+
+The conclusions are right (rung 36; `bo = 2.248993`, ratio `0.52930`, margin `0.1245` ≈ "~0.12"), and
+the test passes. But this is a test whose stated purpose is independent hand-derivation, so the digits
+should be exact — otherwise the next reader can't use them to check the code.
+
+### S5 (Low) — V6 is only half met: the clamp's *rung* is unasserted
+
+`local_diff_is_clamped_to_at_least_one` (`mapq.rs:501-509`) asserts `diff == 1.0` and the frozen
+`diff == 0.0`, but not the resulting MAPQ — and the plan's V6 called that out explicitly ("assert
+**which rung** results (risk is a silent top rung, not a panic)"). No test currently exercises the
+ladder with a clamped `diff`.
+
+**Recommended fix:** `assert_eq!(calc_mapq(6, None, 0, None, ScoreModel::bowtie2_local(20.0, 8.0)), 22);`
+
+Also: the doc's "len ≲ 22" is off by one — the clamp is active through **len 23** (`perfect − scMin =
+0.916`); len 24 gives `2.576`. (For the record I checked the "silent top rung" risk under a clamped
+`diff`: any `AS ≥ 36` on a 6 bp read would return 44 — but `AS ≤ perfect = 12` in any
+self-consistent input, so the clamped path always lands on 22 in practice.)
+
+### S6 (Low) — new public API surface is wider than needed
+
+`ScoreModel::normalize` and `::local_ladder` are `pub` on a `pub mod` of a published crate. Both
+callers live in `crate::aligner`, so `pub(crate)` suffices and keeps `normalize` — an internal
+computation — off the crate's API. `ScoreModel` itself must stay `pub` (it is a `RunConfig` field and
+appears in public `merge`/`combined` signatures).
+
+### S7 (Low) — the `#[allow(clippy::float_cmp)]` on `calc_mapq` is now dead
+
+`mapq.rs:22`. After the extraction `calc_mapq` contains no float comparison at all — the `>` in
+`normalize` is not what `float_cmp` fires on, and both ladders carry their own allow. The attribute
+now misdirects a reader into looking for a comparison that isn't there. (For completeness: the crate
+has no `[lints]` table and `lib.rs` deliberately sets no crate-level lint attributes, so
+`clippy::float_cmp` — a pedantic, allow-by-default lint — never fires in CI anyway; all three
+attributes are documentation. That's fine, but then they should be accurate.)
+
+### S8 (Low) — `ScoreModel::end_to_end` hardcodes `Aligner::Bowtie2` while documented "any aligner"
+
+`config.rs:127-135`. Correct (with `local = false` the aligner is irrelevant, and
+`score_model_construction_matrix` locks the equality across all four variants), but it reads as
+"Bowtie 2 end-to-end". A trailing `// aligner is irrelevant when local == false` on that line would
+close the gap.
+
+### S9 (Low, drive-by, outside this diff) — a CI step name that lies
+
+`.github/workflows/rust_ci.yml:194`: *"prove all **12** ran"* while the next lines set
+`EXPECTED=13` and list 13 tests. Cosmetic and pre-existing (the 12→13 growth came with #1030), but
+it's the label on a fail-loud counter.
+
+---
+
+## 5. Efficiency
+
+Nothing to raise. One multiply and one compare added per accepted alignment; `perfect()` is only
+evaluated inside the `match_bonus > 0.0` arm, so the default end-to-end path does strictly no extra
+work beyond one `f64` compare. `ScoreModel` is a 32-byte `Copy` struct passed by value, which is what
+lets the two fn-pointer aliases stay lifetime-free. Net arity **−2** at ~10 sites, retiring two
+`too_many_arguments` allows. The `frozen_paths_…` sweep's 990 iterations are trivial (the whole
+`aligner::mapq` module runs in <0.01 s).
+
+---
+
+## 6. Recommendations, by priority
+
+| Priority | # | Action | Where |
+|---|---|---|---|
+| **Medium** | E1 | Fix the CHANGELOG self-contradiction about HISAT2 `--local` | `CHANGELOG.md:8` |
+| **Medium** | E5 | File the two deferred issues (or soften "tracked separately") | plan step 9 / `CHANGELOG.md:9-10` |
+| **Medium** | E4 | Update the `rust/README.md` **aligner row** with the `--local` divergence caveat | `rust/README.md:161` |
+| **Medium** | E2 | "All other modes remain byte-identical to Perl" is false — HISAT2-local isn't | `mapq.rs:10-12` |
+| **Medium** | E3 | Stale comment: HISAT2-local's "ln() MAPQ scMin" no longer exists | `options.rs:79-81` |
+| **Medium** | L1 | `from_emitted`'s "never settable independently" is not enforced — reword (+ optional `debug_assert!`) | `config.rs:81-86`, `:92-116` |
+| Low | S1 | Drop `frozen()`'s dead `local` parameter and its two unreachable branches | `mapq.rs:634-657` |
+| Low | S5 | Assert the rung under a clamped `diff`; fix "len ≲ 22" → 23 | `mapq.rs:501-509` |
+| Low | S4 | Correct the three hand-derived figures (45.751007 / 4.248993 / 2.1244967) | `mapq.rs:570-585` |
+| Low | S3 | Rename / re-word so HISAT2-local isn't described as value-frozen | `mapq.rs:626-632` |
+| Low | S2 | Hoist the loop-invariant HISAT2 assertion out of the `best`/`sec` loops | `mapq.rs:682-687` |
+| Low | S7 | Remove the now-dead `#[allow(clippy::float_cmp)]` on `calc_mapq` | `mapq.rs:22` |
+| Low | S6 | `normalize`/`local_ladder` → `pub(crate)` | `config.rs:154`, `:196` |
+| Low | L2 | Note (or guard) that `.max(1.0)` converts NaN→1.0 while `abs()` propagates it | `config.rs:200-204` |
+| Low | S8 | Comment why `end_to_end` may hardcode an aligner | `config.rs:127-135` |
+| Low | S9 | CI step name says 12, `EXPECTED=13` (pre-existing, outside the diff) | `rust_ci.yml:194` |
+| — | L3 | No action; recorded for the record | — |
+
+### Optional, not blocking
+
+- A `config::resolve`-level assertion (`assert_eq!(cfg.score_model, ScoreModel::bowtie2_local(20.0, 8.0))`)
+  would guard the wiring more directly and cheaply than V10's integration test. It is currently
+  impractical: `config.rs`'s tests have no genome/index fixture at all (all 11 `resolve` tests
+  exercise pre-I/O rejects only), which is presumably why V10 went end-to-end. Reasonable as it
+  stands; worth a fixture helper if `resolve`-level assertions are wanted later.
+- V10's fixture would be strictly better as a **≥24 bp** read at default `G,20,8` (the plan's cell
+  (a)) — self-consistent AS *and* an unclamped realistic `diff`. That needs a new genome fixture
+  (`make_genome`'s chr1 is 8 bp), so the `G,1,0` route was the right trade. Not worth blocking.
+- On the strength of row 8 (99.6 % agreement with a full int64 Bowtie 2 analogue over ~90 k cells),
+  V8's "real Bowtie 2 oracle" is now well-substantiated in principle even though it was not run. If
+  it is ever revived, the expected disagreement rate to gate on is ~0.4 % for the SE no-second-best
+  ladder at `G,20,8`, `len 25..300`.

--- a/plans/07292026_local-mapq-denominator/CODE_REVIEW_B.md
+++ b/plans/07292026_local-mapq-denominator/CODE_REVIEW_B.md
@@ -1,0 +1,208 @@
+# CODE REVIEW B — Local-mode MAPQ denominator (#1079)
+
+**Reviewer:** B (independent, fresh context)
+**Target:** uncommitted working tree on `rust/local-mapq-denominator`, 9 files, +730/−317
+**Date:** 2026-07-29
+**Verdict:** **APPROVE WITH CHANGES** — the semantics are correct and independently verified against upstream Bowtie 2 v2.5.5. One **High** finding: the D2 wiring (emitted score-min form → `ScoreModel`) has **no test with teeth**, which is the same silent-no-op failure shape the plan named load-bearing. Five **Medium** findings are documentation/gate accuracy, three of them in user-facing release notes.
+
+---
+
+## 1. Summary
+
+The change does what it claims. I verified the arithmetic independently rather than re-running the suite:
+
+**Verified correct**
+
+| Claim | How I checked | Result |
+|---|---|---|
+| Upstream formula | fetched `unique.h` v2.5.5 L195-235 + `scoring.h` L308-316 | `scPer` sums both mates; `diff = max(1, scPer − scMin)`; `bestOver = best − scMin`; `perfectScore = monotone ? 0 : rdlen × match(30)`. Implementation matches. ✅ |
+| Bismark's local ladder | leaf-for-leaf vs `unique.h`'s non-monotone branch | identical (44/42/41/36/28/24/22; 40/39/38/37; 35/25/20, 34/21/19, 33/18/16, 32/17/12, 31/14/9, 11/2, 1/0). ✅ Matters now that the fix makes those rungs reachable. |
+| `calc_mapq_end_to_end` is a faithful extraction | programmatic whitespace-normalized diff of the body vs `git show HEAD:…/mapq.rs` | **86 lines both sides, identical.** No changed threshold or return. ✅ |
+| Frozen-path bit-identity | read both formulas | `intercept + slope·x` in the same association order, `term(l1)` then `+= term(l2)`, then `.abs()`, then `as_best − sc_min`. Bit-identical, not merely equal. ✅ |
+| HISAT2 hand-derived cells (44/44/44/31/1/11) | re-derived from the linear `scMin` in an independent Python ladder | all six ✅ |
+| #1079 reporter cases | same | len 100 → **24** (was 42) ✅; `AS = perfect = 200` → **44**, `bo == diff` ✅; PE `400 − 2·scMin`, and `t + t == 2.0·t` is exact in binary FP so the test's `2.0 *` shortcut is safe ✅ |
+| V10 fixture discrimination | same | len 6 / `G,1,0` / `AS:i:6` → **28** new vs **44** pre-fix ✅ |
+| `ln()`-boundary cell | same | as_best 50 → 44, as_best 48 → 36 ✅ (comment *numbers* are off — see L1) |
+| Gating airtight | traced `options.rs:82`, `:376`, `config.rs:769-778` | `match_bonus != 0` ⟺ `cli.local && aligner == Bowtie2` — the **identical predicate** that pushes `--local` to the aligner and selects the `G` form, resolved once at one construction point. ✅ |
+| Refactor fidelity | diff + grep | 10 signatures, 2 fn-pointer aliases, 6 expansion sites, 4 production call sites; SE passes `None`, PE passes `Some(sequence_2.len())` at all four; **zero** trio leftovers. No swapped/dropped/duplicated argument. ✅ |
+| Allow removals | arg counts | `check_results_single_end` 7, `select_pe_nondir` 6 — both under clippy's `>7`; `check_results_paired_end` is still 9 and correctly keeps its allow. ✅ |
+| Toolchain | re-ran myself | **2107 pass / 0 fail**, `clippy -p bismark --all-targets` clean, `cargo fmt --check` clean. ✅ |
+| CHANGELOG quantitative claims | recomputed | 250 bp @ 30 % of perfect → 44 old / **22** new ✅; HISAT2 `−0.92` vs `−20` at 100 bp ✅ |
+
+**`f64 > 0.0` is the right predicate.** The field is private and only ever the const `2.0` or a literal `0.0` — no rounding can land it in between, and `>` is not `float_cmp`. It is also strictly narrower than gating on `local`, exactly as the plan argued.
+
+**`normalize()`'s API is sound.** Returning `(best_over, diff)` from one length pair structurally prevents the mismatch it was designed to prevent. A caller can still pass wrong lengths, but that is inherent to any signature, and all four production sites pass the right ones.
+
+**The V10 fixture's AS/CIGAR decoupling is acceptable.** MAPQ reads the `AS:i:` tag; the fixture exists to prove the resolved model reaches the BAM. It masks nothing about the MAPQ computation. The residual exposure — that no *real* Bowtie 2 comparison exists (V8) — is a plan-level accepted risk, not a fixture defect.
+
+---
+
+## 2. Issues by area
+
+### Logic
+
+#### **H1 (High) — the D2 wiring is untested: `--score_min G,1,0` is form-blind**
+
+`rust/bismark/tests/aligner_cli.rs:137-141`
+
+D2's entire point is that the emitted score-min **form** is single-sourced from `score_min_params` into `ScoreModel`. Nothing tests that join:
+
+- `options.rs` tests exercise `score_min_params` **in isolation** → they pass whatever `resolve` does with the result.
+- `mapq.rs::score_model_construction_matrix` exercises `from_emitted` **in isolation** → passes a hand-written `form`.
+- **V10 uses `--score_min G,1,0`. With slope 0, `i + s·ln(len)` and `i + s·len` are both exactly `1.0`** — the test cannot see the form at all.
+- The two existing `--hisat2 --local` integration tests (`:2125`, `:2208`) assert the option string and the `2S4M` CIGAR, **no MAPQ**.
+- There is no successful-`resolve` unit test in `config.rs` (every `resolve` test there is an error path, no genome fixture), and `grep score_model` finds no test reading `RunConfig.score_model`.
+
+So a `resolve` that hardcoded `ScoreMinForm::Linear` — giving Bowtie 2-local `scMin = 20 + 8·len` instead of `20 + 8·ln(len)`, badly wrong — would ship with **2107/2107 green**. That is precisely the failure shape §9 calls load-bearing ("a mis-wired `aligner` makes the fix a silent no-op with a fully green suite — the same failure shape that let #1079 ship"); the implementation closed it for `match_bonus` and left it open for `form`.
+
+**Fix (one-line, verified numerically).** Change V10's score-min to a slope-bearing G function. On the existing 6 bp / `AS:i:6` fixture:
+
+| `--score_min` | new + `Log` | new + `Linear` | pre-fix (`abs(scMin)`) |
+|---|---|---|---|
+| `G,1,0` (current) | 28 | **28** ← blind | 44 |
+| **`G,1,1`** | **24** | 22 | 44 |
+| `G,0,1` | 28 | 22 | 44 |
+
+Prefer **`G,1,1`** → expected MAPQ **24**: it discriminates the match bonus *and* the form in one cell, and `scMin = 1 + ln(len) ≥ 1` keeps the strictly-positive property the test comment leans on ("a legal always-positive G function"). `G,0,1` preserves the current expected `28` but has `scMin = 0` at len 1, losing that property. Update the trailing comment to `perfect = 12, scMin = 1 + ln(6) = 2.7918 → diff = 9.2082; bestOver = 3.2082; 3.2082/9.2082 = 0.3484 → 24`, and extend the failure message to name both faults (lost match bonus → 44; wrong form → 22).
+
+#### **M6 (Medium) — V6 half-implemented, and the plan's stated risk is wrong**
+
+`mapq.rs:565-573` (`local_diff_is_clamped_to_at_least_one`)
+
+V6 required "⇒ `diff == 1.0`, **and assert which rung results** (risk is a silent top rung, not a panic)". The test asserts `diff == 1.0` and the frozen `e2e == 0.0`, but never calls `calc_mapq`, so the rung is unpinned.
+
+I computed it: for len 6 / `G,20,8`, `sc_min = 34.334`, so `best_over = as_best − 34.334` is hugely negative and the result is **22 — the bottom rung — for every `as_best` in `0..=perfect`**. The plan's "silent top rung" description is therefore wrong for the only reachable clamp configuration, and it is worth recording that inversion rather than leaving a future reader to re-derive it.
+
+Add, in the same test:
+```rust
+// The clamp lands on the BOTTOM rung, not the top: best_over is -22.33 here.
+assert_eq!(calc_mapq(6, None, 0, None, ScoreModel::bowtie2_local(20.0, 8.0)), 22);
+```
+
+#### **L3 (Low) — `ScoreModel::end_to_end` hardcodes `Aligner::Bowtie2`, and A9 is going to break that**
+
+`config.rs:128-136`
+
+Correct today (every end-to-end match bonus is 0) and `score_model_construction_matrix` pins the aligner-independence, so a future divergence fails loudly rather than silently. But A9 — filed as a follow-up by *this* work — will give minimap2/rammap a nonzero perfect score in the **end-to-end** path, at which point `end_to_end()` becomes Bowtie 2-specific at ~29 call sites and `frozen_paths_match_the_pre_fix_formula` goes blind to two aligners. Add one line to the doc comment: `/// Aligner-independent only while every end-to-end match bonus is 0 — the minimap2/rammap follow-up (A9) must revisit this.`
+
+#### **L8 (Low, informational) — the clamp launders NaN**
+
+`--score_min L,nan,-0.2` parses (Rust's `f64::from_str` accepts `"nan"`/`"inf"`, and validation is shape-only per A11). `f64::max` returns the non-NaN operand, so `(perfect − NaN).max(1.0)` yields `diff = 1.0` while `best_over` stays NaN. Every comparison is still false, so both ladders return their bottom rung (22 / 0) exactly as before — **no behaviour change**, and pre-existing. Noted only because the clamp silently converts a NaN denominator into a finite one; if numeric validation is ever added to `--score_min`, that is the place to reject it.
+
+### Errors
+
+None found. No panic path, no division (both ladders compare only), no overflow, no unwrap on user input in the changed code.
+
+### Efficiency
+
+No issues. `normalize` is one extra multiply plus one compare per accepted alignment; `perfect()` is evaluated only inside the `match_bonus > 0.0` branch; `ScoreModel` is 32 bytes, `Copy`, by value — no lifetime in the two fn-pointer aliases. Arity dropped by 2 at ten sites. One test-only redundancy (L4).
+
+#### **L4 (Low) — a loop-invariant assertion runs 990 times for 66 distinct facts**
+
+`mapq.rs:641-676` — the HISAT2 block inside `frozen_paths_match_the_pre_fix_formula`:
+```rust
+let (_, hd) = ScoreModel::hisat2_local(i, s).normalize(len, None, best);
+assert_eq!(hd, (i + s * len as f64).abs(), …);
+```
+`hd` is the *denominator*, independent of `best` and `sec`, but the assertion sits inside both inner loops (6 × 11 × 5 × 3). Hoist it to the `len` loop.
+
+Substantively: this assertion does have teeth (if HISAT2-local ever acquired a match bonus, `(10.0, −0.2)` at len 1 would give `max(1, 0 − 9.8) = 1.0 ≠ 9.8` and fail), but it only pins the denominator — HISAT2-local is never routed through `calc_mapq` in the sweep, so the *ladder* half of the frozen claim is unswept for that mode. That is unavoidable (the form changed, so no full pre-fix comparison exists) and the doc comment explains it; worth one clarifying clause so the name "frozen paths match the pre-fix formula" isn't read as stronger than it is.
+
+#### **L5 (Low) — the independent reference has no `--score_min` axis**
+
+`mapq.rs:433-465` sweeps `len × as_best × as_second` and PE, but only at `G,20,8`. `G,1,0` (which V10 relies on) and small-slope G forms — the clamp-adjacent regime — are never reference-compared. V1 got a `--score_min` axis for exactly this reason; V2 should get one `(i, s)` pair too (e.g. `(1.0, 1.0)`), which also then covers the cell H1 wants added.
+
+#### **L7 (Low) — V11's `==diff` second-best leaves are only reference-compared**
+
+The reporter's case #2 is pinned for the no-second-best half (`44`), and the `==diff` leaves (`mapq.rs:168,176,184,192,200`) are exercised inside the grid — but only against `bowtie2_local_reference`, never as a pinned rung value. Reference agreement is a real gate (the reference is an independent transcription), so this is a nice-to-have: one `assert_eq!(calc_mapq(25, None, 50, Some(49), bowtie2_local(20.0, 8.0)), 32)` would pin the leaf that became reachable for the first time.
+
+Separately, the surviving `assert_ne!(bowtie2_local(20,8), end_to_end(20,8))` at `:468-471` compares against a nonsense configuration (a *positive* end-to-end slope → `scMin = 420`, MAPQ 0 vs 44). Inherited from the replaced test; harmless but near-zero information.
+
+### Structure & documentation
+
+#### **M1 (Medium) — CHANGELOG and README re-introduce the false equivalence the plan spent §3 refuting**
+
+`CHANGELOG.md` bullet 1 and `rust/README.md:181` both say the end-to-end path is unaffected **"(there the perfect score is 0, so the two expressions agree)"** / **"(perfect score 0 makes the two expressions agree)"**.
+
+They do **not** agree. `max(1, 0 − scMin) ≡ abs(scMin)` only for `scMin ≤ −1`; PLAN §3 ("Why gate on `match_bonus`, not `local`") and rev-1's **C1** exist because rev 0 made this exact claim and it was wrong — the divergence table there lists `L,10,-0.2` at 50 bp going 42 → 0 under a universal clamp. End-to-end is unaffected because the code **branches** on `match_bonus`, keeping `abs(scMin)` untouched.
+
+This is the highest-value doc fix in the change: it is the precise justification a future maintainer would cite to "simplify" the branch away, and `frozen_paths_match_the_pre_fix_formula` exists to catch that fault (§12 records it failing at `len=1` when injected). Shipping the refuted reasoning as release notes undoes that.
+
+Reword both to, e.g.: *"the default end-to-end path is unaffected — it keeps `abs(score_min)` unchanged. The new denominator is applied only where the perfect score is nonzero; the two expressions are **not** equivalent in general, so it is deliberately not applied universally."*
+
+#### **M2 (Medium) — CHANGELOG contradicts itself about HISAT2 `--local`**
+
+Bullet 1 ends: *"The default end-to-end path is unaffected and stays byte-identical …, **as does HISAT2 `--local`**."*
+Bullet 2 states: *"… so **HISAT2 `--local` MAPQ changes**."*
+
+In context bullet 1 means "unaffected *by the denominator change*", but as written a HISAT2-local user reads bullet 1 and concludes nothing changed for them — and their MAPQ values do change (e.g. 50 bp / `AS −1` / no second best: 22 → 44). Qualify bullet 1: *"…as does HISAT2 `--local`'s **denominator** — but its score-min form changes; see below."*
+
+#### **M3 (Medium) — the release notes point at trackers that do not exist**
+
+CHANGELOG bullet 2: *"that is tracked separately"*; bullet 3: *"Left byte-frozen here"* … *"tracked separately"*. PLAN §12 records: *"The two deferred issues (HISAT2 perfect score; minimap2/rammap positive-AS) are **not yet filed**."* Either file them and cite the numbers, or soften to "tracked as a follow-up" until they exist. As written the notes are factually wrong at merge time.
+
+#### **M4 (Medium) — stale `options.rs` comments still assert the pre-D2 model, one of them inside the doc comment that was edited**
+
+- `options.rs:80-81`: *"HISAT2-local uses the SAME L-form as end-to-end … its local-ness is the dropped `--no-softclip` in the HISAT2 tail **+ the ln() MAPQ scMin**, NOT this option."*
+- `options.rs:366-367`: *"HISAT2 uses the L-form even in local mode; **the local-ness is the `ln()` scMin, not the form**"* — sitting five lines above the newly added *"Returns the emitted **form** … `calc_mapq` must evaluate the same function the aligner was given"*. The same doc comment now says both things.
+
+Both statements are now false, and this is the exact stale-comment class that let D2 survive in the first place (PLAN step 8 called for fixing the docs that "describe `local` as selecting `ln()` scMin" — `mapq.rs` and `config.rs` were fixed, `options.rs` was missed). Replace the `ln()` clauses with "the dropped `--no-softclip` in the HISAT2 tail + the local MAPQ ladder".
+
+#### **M5 (Medium) — `rust/README.md` aligner **row** not updated (plan step 8), and not recorded as a deviation**
+
+PLAN step 8 requires *"`rust/README.md`: **aligner row** + dated Milestones line"*. Only the Milestones line (`:181`) landed. Row `:161` — the canonical per-tool status record — still headlines *"**byte-identical** to Perl v0.25.1 + Bowtie 2 2.5.5"* with no mention that Bowtie 2 `--local` now deliberately diverges. Literally true of the *gated* configurations (all end-to-end), but the row is what a reader consults to answer "is this byte-identical to Perl?", and §12 does not list the omission among its two documented deviations, so it reads as done.
+
+Append to row `:161`: *"**Bowtie 2 `--local` deliberately diverges from Perl v0.25.1 since #1079** — MAPQ uses Bowtie 2's own `max(1, perfect − score_min)` denominator (Perl's `abs(score_min)` assumed a perfect score of 0); end-to-end is unaffected and stays byte-identical."*
+
+#### **L1 (Low) — hand-derived comment numbers are wrong in the third decimal**
+
+`mapq.rs:570-586` (`local_bowtie2_ln_derived_bucket_boundary`):
+
+| Comment | Actual |
+|---|---|
+| `scMin = 20 + 8·ln(25) = 45.7527…` | **45.7510066** |
+| `diff = 4.2473…` | **4.2489934** |
+| `best_over 2.247` | **2.2489934** |
+| `0.5/0.4 boundary sits at 2.1237` | **2.1244967** |
+
+The conclusions are right (rung **36**, margin ≈ 0.1245 — the comment's "~0.12" is correct). But this file's gate *is* hand-derivation ("NOT read back from the implementation"), so an inexact audit trail undercuts the one thing that makes these assertions independent. Correct the four figures.
+
+Related, same file: the new HISAT2 cell at `:544-548` relies on `1.0 >= 10.0 * 0.1` being **exactly** true. It is (`10.0 * 0.1 == 1.0` under IEEE-754 round-to-nearest — I checked), and Perl computes the identical double, so it is deterministic and parity-safe. But its margin is **zero**, where the test it replaced explicitly boasted *"Margin to the boundary here is ~0.002, not 1 ULP — the value is robust across platforms."* The comment does flag the exactness; consider adding one neighbouring cell with real margin so the mode isn't pinned solely on a knife edge.
+
+#### **L2 (Low) — the `float_cmp` allow on `calc_mapq` is now vacuous**
+
+`mapq.rs:22`. Every float comparison moved out: into the two ladders (each carries its own allow, correctly) and into `normalize` (which only does `> 0.0` and `.max`, neither being `float_cmp`). The attribute now reads as if `calc_mapq` compares floats. Remove it, or move its explanatory comment to `normalize`.
+
+To answer the brief's question directly: **the justification is now stronger, not weaker.** `best_over == diff` used to mean `as_best == 2·scMin` (an arbitrary coincidence). It now means `as_best == perfect`, and both sides are the *same* f64 subtraction of the *same* `sc_min`, so the equality is exact whenever the integers are equal. (Note for completeness: all three allows are decorative under the current CI config — `clippy::float_cmp` is `pedantic`/allow-by-default, there is no `[lints]` table or crate-level attribute, and CI runs plain `cargo clippy --workspace --all-targets -- -D warnings`. Pre-existing convention; not a defect.)
+
+#### **L6 (Low) — the docs site carries no HISAT2 caveat**
+
+`docs/src/content/docs/options/alignment.md:106` already documents the correct Bowtie 2 formula ("the best possible alignment score is equal to the match bonus (`--ma`) times the length of the read") — which is the plan's own justification for calling this a fix, so no change is needed there. But the page drops the Perl help's HISAT2 sentence ("for HISAT2, it is currently not exactly known how the best alignment is calculated"), so HISAT2-local users get changed MAPQ values with no user-facing note anywhere except the CHANGELOG. One sentence closes it.
+
+#### **L9 (Low, informational) — upstream multiplies by `(double)0.8f`, not `0.8`**
+
+`unique.h` writes every threshold as `diff * (double)0.8f` — a *float* literal widened to double, i.e. `0.800000011920928955078125`. Bismark (like Perl) uses the double `0.8`. Same class as A10's `int64` non-goal and equally out of scope, but it is a second, undocumented int/float divergence, and it reinforces the caveat already on `bowtie2_local_reference` ("deliberately NOT a faithful transcription"). Worth one clause in that doc comment so a future reader doesn't try to make the reference exact.
+
+---
+
+## 3. Recommendations, by priority
+
+| # | Priority | Action | File:line |
+|---|---|---|---|
+| H1 | **High** | Make V10 form-sensitive: `--score_min G,1,0` → **`G,1,1`**, expected MAPQ `28` → **`24`**; update the arithmetic comment and the failure message (44 = lost match bonus, 22 = wrong form) | `tests/aligner_cli.rs:137-141,158-164` |
+| M1 | **Medium** | Delete the "the two expressions agree" parenthetical from both places; state that end-to-end is unaffected because the code branches, and that the expressions are **not** equivalent | `CHANGELOG.md` bullet 1; `rust/README.md:181` |
+| M2 | **Medium** | Qualify "as does HISAT2 `--local`" → "as does HISAT2 `--local`'s denominator; its score-min form does change (see below)" | `CHANGELOG.md` bullet 1 |
+| M3 | **Medium** | File the two deferred issues and cite the numbers, or soften "tracked separately" | `CHANGELOG.md` bullets 2-3 |
+| M4 | **Medium** | Strike the two "local-ness is the `ln()` scMin" clauses (one contradicts the doc comment it sits in) | `options.rs:80-81`, `options.rs:366-367` |
+| M5 | **Medium** | Add the `--local` divergence note to the aligner **row**, per plan step 8 | `rust/README.md:161` |
+| M6 | **Medium** | Assert the clamped rung (**22**, bottom — not top) | `mapq.rs:565-573` |
+| L1 | Low | Fix the four `ln(25)` figures (45.7510 / 4.24899 / 2.24899 / 2.12450) | `mapq.rs:570-586` |
+| L2 | Low | Remove the now-vacuous `float_cmp` allow on `calc_mapq` | `mapq.rs:22` |
+| L3 | Low | Note that `end_to_end()`'s aligner-independence must be revisited by the A9 follow-up | `config.rs:128-136` |
+| L4 | Low | Hoist the loop-invariant HISAT2 denominator assertion out of the `best`/`sec` loops; note that the sweep pins the denominator, not the HISAT2 ladder | `mapq.rs:641-676` |
+| L5 | Low | Add one non-default `(i, s)` to the reference grid | `mapq.rs:433-465` |
+| L6 | Low | One HISAT2 caveat sentence on the `--local` docs page | `docs/…/options/alignment.md:106` |
+| L7 | Low | Pin one `==diff` second-best leaf (e.g. `(25, 50, Some(49)) → 32`) | `mapq.rs:475-500` |
+| L9 | Low | Note upstream's `(double)0.8f` thresholds in the reference's caveat | `mapq.rs:414-421` |
+
+**Nothing here blocks the semantics.** H1 is a gate hole, not a bug: the shipped wiring is correct — I verified `resolve` passes `score_min_form` through and that `score_min_params` returns `Log` iff `cli.local && aligner == Bowtie2`, the same predicate that emits `--local`. H1 is that nothing would *notice* if that stopped being true, in the one place the plan singled out as the failure shape that let #1079 ship.

--- a/plans/07292026_local-mapq-denominator/COVERAGE.md
+++ b/plans/07292026_local-mapq-denominator/COVERAGE.md
@@ -1,0 +1,206 @@
+# Plan Coverage Report
+
+**Mode:** B — code vs. plan (post-implementation; `PLAN.md` rev 1 is the spec, no separate `IMPL.md`)
+**Plan(s):** `plans/07292026_local-mapq-denominator/PLAN.md` (rev 1)
+**Codebase:** `/Users/fkrueger/Github/Bismark`, branch `rust/local-mapq-denominator`, uncommitted working tree
+**Date:** 2026-07-29
+**Verdict:** **INCOMPLETE — 6 items unresolved**
+
+## Summary
+
+- Total items: 54
+- DONE: 46
+- PARTIAL: 4
+- MISSING: 1
+- DEVIATED: 3 (2 documented in §12, 1 undocumented)
+
+Unresolved = 4 PARTIAL + 1 MISSING + 1 undocumented DEVIATED. None of the six is a
+correctness defect in the fix itself; they are missing validation cells and unfinished
+release/tracking chores. The core semantics (D1 + D2), the refactor, and all four
+hand-derived HISAT2 expectations were independently re-derived and confirmed correct.
+
+**Build gates verified, not assumed:**
+
+| Gate | Claimed | Measured |
+|---|---|---|
+| `cargo fmt -p bismark -- --check` | clean | **clean** (exit 0) |
+| `cargo clippy -p bismark --all-targets` | 0 warnings | **0 warnings, 0 errors** |
+| `cargo test -p bismark` | 2107 pass / 0 fail | **2107 passed / 0 failed / 20 ignored** across 77 test binaries |
+
+---
+
+## Coverage ledger
+
+### §5 Implementation outline — PR 1 (mechanical refactor)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `ScoreMinForm` + `ScoreModel` added to `config.rs`; `score_min_params` returns the emitted form | Step 1 (end state) | DONE | `config.rs:68-74` (`ScoreMinForm`), `:87-95` (`ScoreModel`, all 5 fields private), `options.rs:376` returns `(f64, f64, ScoreMinForm)` |
+| 2 | PR 1's constructor must be verbatim-behaviour (`match_bonus = 0.0` everywhere, HISAT2-local still `Log`) so D2 does not land inside the inert step | Step 1 warning box | DEVIATED (documented) | §12 records the resolution: PR 1 left `score_min_params` untouched and set `form = if local { Log } else { Linear }`; `match_bonus`/`perfect()`/`BOWTIE2_LOCAL_MATCH_BONUS` held to PR 2 to avoid `dead_code` under `-D warnings`. Not independently re-verifiable — both PRs sit in one uncommitted tree with no PR-1 commit |
+| 3 | Thread `ScoreModel` in place of the trio at every site, by value; drop 2 `too_many_arguments` allows, keep the PE one | Step 2 | DONE | Verified counts: **2** `merge.rs` signatures (`check_results_single_end`, `check_results_paired_end`), **8** `combined.rs` signatures (`select`, `select_core`, `select_nondir`, `select_pbat`, `select_pe`, `select_pe_nondir`, `select_pe_pbat`, `select_core_pe`), **2** fn-pointer aliases (`SelectFn` `mod.rs:2757`, `SelectFnPe` `mod.rs:2766`), **6** `mod.rs` config-expansion sites (2604, 3138, 3516, 4633, 5235, 5676), `RunConfig.score_model` + its literal, **4** production `calc_mapq` call sites (`merge.rs:367,740`; `combined.rs:339,711`). Passed by value (`score_model: ScoreModel`). Allows deleted at `combined.rs` `select_pe_nondir` and `merge.rs` SE; PE allow retained (`merge.rs:514`). Trio fully retired from `RunConfig` — only local variable names survive inside `config::resolve` |
+
+### §5 Implementation outline — PR 2 (semantics)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 4 | **D1** — `match_bonus > 0.0` dispatch via `model.normalize(...)`; `BOWTIE2_LOCAL_MATCH_BONUS` set for Bowtie 2 + local; stale `// scores vary by up to this much (max AS = 0)` comment rewritten; `float_cmp` allow still holds | Step 4 | DONE | `config.rs:191-208` `normalize()` is character-for-character the plan's §3.4 snippet; `config.rs:78` const `= 2.0`; stale comment gone; `#[allow(clippy::float_cmp)]` retained with its justification on all three ladder fns |
+| 5 | **D2** — `form` straight from `score_min_params` ⇒ HISAT2-local `Linear`; the four affected expectations hand-recomputed | Step 5 | DONE | All four present and **independently re-derived by this audit** against `calc_mapq_local` (`mapq.rs:137-214`): `-1/None` 22→**44** (bestOver 9 ≥ 0.8·10); `0/Some(-1)` 40→**31** (bestDiff 1 ≥ 0.1·10, bestOver==diff); `-1/Some(-1)` 0→**1** (bestDiff 0, bestOver 9 ≥ 0.5·10); PE `150+150 0/Some(-1)` 34→**11** (bestDiff 1 < 0.1·60, bestOver 60 ≥ 30). Test renamed `local_hisat2_uses_the_linear_form_it_was_emitted` |
+| 6 | Retire the two tautologies (`mapq.rs:376` and `:416` — both computed `expect` by calling the function under test with `sc.abs()`) | Step 6 | DONE | `:376`'s host test replaced by `local_bowtie2_matches_independent_reference`; `:416`'s routing loop deleted and replaced with linear-form assertions. No `sc.abs()` self-comparison remains |
+| 7 | Re-home the `ln()`-boundary coverage as a **Bowtie 2-local** case with the same "why this cell" comment style | Step 7 | DONE | `local_bowtie2_ln_derived_bucket_boundary` (len 25, `G,20,8`): re-derived here as scMin 45.7511, perfect 50, diff 4.2489 → AS 50 lands `bestOver == diff` → 44; AS 48 → ratio 0.5293 → rung 36, boundary at 2.1237. Comments name the boundary and its margin |
+| 8 | Docs — `mapq.rs` header + `config.rs` `RunConfig` field doc no longer describe `local` as "`ln()` scMin + local ladder" | Step 8 | DONE | `mapq.rs:1-17` gained the deliberate-deviation paragraph; `config.rs:366-370` rewritten to describe the score model |
+| 9 | Docs — `CHANGELOG.md` under a new `## Unreleased` heading | Step 8 | **PARTIAL** | Present with: Bowtie 2-local now matches Bowtie 2 ✓, local values differ from 3.1.0/v0.25.1 ✓, end-to-end + HISAT2-local unaffected by D1 ✓, HISAT2 perfect score still open ✓, @9xg credited ✓, minimap2/rammap noted ✓. **Missing: O4's note** — that the `bestOver == diff` rungs now mean `AS == perfect`, which is why 39/35/34/… start appearing |
+| 10 | Docs — `rust/README.md` aligner **row** + dated Milestones line | Step 8 | **PARTIAL** | Milestones line added (`README.md:181`, dated 2026-07-29). The `bismark` (aligner) **row** in the per-tool table (`README.md:161`) is untouched — required both by the plan and by the README's own rule at `README.md:175` |
+| 11 | File the two deferred issues (HISAT2 perfect score carrying O3's reasoning; minimap2/rammap positive-AS per A9) | Step 9 | **MISSING** | §12 discloses "not yet filed". Both are referenced from the code and CHANGELOG as "tracked separately", so the references currently point at nothing |
+| 12 | Release cut is NOT part of either PR — all three version literals stay at `3.1.0`, both guard tests pass | Step 10 | DONE | `rust/VERSION`, `rust/bismark/VERSION`, `rust/bismark/Cargo.toml:3` all `3.1.0` and absent from `git diff`; `vendored_version_matches_repo_version` + `cargo_pkg_version_matches_suite_version` green inside the 2107 |
+
+### §9 Validation
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 13 | **V1** — end-to-end + HISAT2-local denominators frozen; sweep `len ∈ 1..=500` × 6 `--score_min` × `as_best` grid × `{None, Some}` × SE **and** PE against a frozen reference fn | V1 | **DEVIATED (undocumented)** | `frozen_paths_match_the_pre_fix_formula` implements the frozen reference verbatim and covers **all 6** `--score_min` cells, `as_best ∈ {0,-1,-5,-20,5}`, `sec ∈ {None, Some(-1), Some(-7)}`, SE + PE, plus the HISAT2-local `abs(scMin)` denominator. But the `len` axis is an **11-point sample** `[1,2,3,4,5,6,20,50,100,250,500]`, not `1..=500`. Not recorded as a deviation in §12 |
+| 14 | **V2** — D1 vs an independent reference: the **f64 analogue** of `unique.h:206-222`, commented as such, gridded over `len × AS × second-best` | V2 | DONE | `bowtie2_local_reference` (`mapq.rs:417-430`) transcribes `scPer` / `max(1, scPer − scMin)` with Bismark's `f64` scMin and says so; grid 5 lens × 5 AS × 3 second-best + 3 PE pairs. Kills the replaced tautology |
+| 15 | **V3** — reporter's case #1: `len=100, G,20,8, AS=100`, no second best ⇒ **24** (was 42) | V3 | DONE | Re-derived here: scMin 56.8414, perfect 200, diff 143.1586, ratio 0.3015 → 24; old ratio 0.759 → 42. Asserted in `local_bowtie2_denominator_uses_perfect_score_issue_1079` |
+| 16 | **V4** — PE sums both mates: `diff = 2×200 − scMin(both)` and differs from the SE-only value | V4 | DONE | Same test: `assert_eq!(diff, 400.0 - sc)` where `sc = 2·(20+8·ln 100)`, plus `assert_ne!(diff, se_diff)` |
+| 17 | **V5** — D2: `scMin == −0.2·len` **and the converse** `!= −0.2·ln(len)`; emitted option still `L,0,-0.2`; the four recomputed values | V5 | DONE | `linear_diff == 10.0` + `assert_ne!(linear_diff, (i + s·ln 50).abs())`; `score_min_params_aligner_and_mode_defaults` pins `(0.0,-0.2,Linear)` for HISAT2-local and `(20.0,8.0,Log)` for Bowtie 2-local; the emitted **string** `L,0,-0.2` is pinned by the pre-existing `hisat2_local_option_string` (`options.rs:634`), still green |
+| 18 | **V6** — the clamp: Bowtie 2-local `diff == 1.0`, **and assert which rung results** (risk is a silent top rung, not a panic); plus end-to-end `scMin == 0` still gives `diff == 0` | V6 | **PARTIAL** | `local_diff_is_clamped_to_at_least_one` asserts `diff == 1.0` (len 6, `G,20,8`) and the frozen `e2e == 0.0`. It **never calls `calc_mapq`**, so the "which rung" half — the whole point, given the plan's own finding that a degenerate `diff` fails by silently winning the top rung — is unasserted |
+| 19 | **V7** — PR 1 is a true no-op: green with **no expected-value edits**, call-shape edits only | V7 | DONE | §12 records a proof-by-inverse-transform (whitespace-normalized test modules byte-identical to `HEAD`). Independently confirmed from the full `git diff`: every `merge.rs` / `combined.rs` / `mod.rs` test edit is exactly `0.0, -0.2, false` → `ScoreModel::end_to_end(0.0, -0.2)`, and every end-to-end expected value in `mapq.rs` (42/40/24/23/8/3/0, 39/38/35, 1/26/33, 42, 42/40) is unchanged. PR 1 cannot be re-run in isolation (single uncommitted tree) |
+| 20 | **V8** — real Bowtie 2 oracle on a fixture, restricted comparison set, every disagreement explained by int-vs-float | V8 | DEVIATED (documented) | Not done. §12 says so explicitly and names V2 as the standing gate — which is exactly the escape §9 V8 authorizes ("if the restricted set can't be built reliably, say so and rely on V2 — do not quietly drop it") |
+| 21 | **V9** — wiring at unit level: the `(local, aligner)` → model matrix, incl. minimap2/rammap + local unreachable | V9 | DONE | `score_model_construction_matrix` pins Bowtie 2-local (`Log`, `diff == perfect − scMin` ⇒ `match_bonus == 2.0`, local ladder), HISAT2-local (`Linear`, `diff == 20.0` = `abs(scMin)`, local ladder), and all **4** aligners end-to-end (`!local_ladder`, `diff == 20.0`, equal to the `end_to_end` ctor). The unreachable arm is covered by the pre-existing `resolve_local_aligner_scope`, `rammap_rejects_local`, `resolve_rejects_local_with_combined_index` |
+| 22 | **V10** — wiring end-to-end: a local MAPQ value out of a real BAM, **two cells** — (a) a ≥23 bp read at default `G,20,8` (len 25 → scMin 45.75, perfect 50); (b) the 6 bp fixture with `--score_min G,1,0` | V10 | **PARTIAL** | Only cell **(b)** built: `make_fake_bowtie2_local_partial_score` (`AS:i:6`) + `bowtie2_local_mapq_uses_the_perfect_score_denominator_end_to_end`. Re-derived here: scMin 1, perfect 12, diff 11, bestOver 5, ratio 0.4545 → **28**; old `abs(scMin)=1` → ratio 5 → **44**. It discriminates, and the failure message names the cause. Cell **(a)** — the realistic-parameters cell — is absent, and §12 does not record dropping it |
+| 23 | **V11** — reporter's case #2: Bowtie 2-local perfect alignment `len=100, AS=200` ⇒ `best_over == diff == 143.1586`; 44 with no second best; the `==diff` leaves reachable with a second best | V11 | DONE | `44` asserted for the SE perfect alignment. The `best_over == diff` equality is asserted for the PE 100+100 analogue (`assert_eq!(bo, 400.0 - sc)`) and at len 25 (`assert_eq!(bo, diff)`) rather than for the SE len-100 cell itself. The `==diff` leaves are exercised inside V2's grid — e.g. len 25 / `as_best` 50 / `sec` 49 gives `bestDiff 1 ≥ 0.2·diff` with `bestOver == diff` → leaf 32 (`mapq.rs:193`) |
+
+### §3 Behavior
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 24 | `score_min_params` returns its selected form; `ScoreModel` built **once** in `config::resolve` from form + aligner + `cli.local`; replaces the three scalars on `RunConfig` | §3.1 | DONE | Single construction at `config.rs:771-777`, after all aligner overrides/guards |
+| 25 | `scMin = intercept + slope × f(len)`, `f = ln` iff `form == Log`, summed over mates, **derived from the emitted form, never re-decided** | §3.2 | DONE | `ScoreModel::score_min` (`config.rs:158-172`); no `local`-based form decision anywhere downstream |
+| 26 | `perfect = match_bonus × (len1 + len2.unwrap_or(0))`; `match_bonus = 2.0` only for Bowtie 2 + local | §3.3 | DONE | `ScoreModel::perfect` (`config.rs:175-177`); `from_emitted` gates on `local && aligner == Aligner::Bowtie2` |
+| 27 | Denominator gated on `match_bonus > 0.0`, **not** on `local` | §3.4 | DONE | `normalize` matches the plan's snippet exactly, including `.max(1.0)` |
+| 28 | `bestOver = as_best − scMin` **unchanged** | §3.5 | DONE | `(as_best as f64 - sc_min, diff)`; structurally coupled to `scMin` by returning the pair together |
+| 29 | Ladder selected by `local_ladder`; both ladders' thresholds and return values untouched | §3.6 | DONE | Diff shows no threshold or return-value edit in either ladder. The end-to-end branch was extracted into `calc_mapq_end_to_end` (§12 documents why: the frozen reference must call the real ladder; the alternative was a forbidden `unreachable!()` stub) |
+
+### §3 Edge cases
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 30 | End-to-end / HISAT2-local invariance byte-identical **by construction** | Edge cases | DONE | The `match_bonus == 0.0` arm is the unmodified `sc_min.abs()`; V1 is the regression net |
+| 31 | Non-default `--score_min` | Edge cases | DONE | V1's 6-cell `--score_min` axis, including `(10,−0.2)` and `(0,0)` |
+| 32 | `len = 0` | Edge cases | DONE | Plan states this is invariant "by reasoning, not by assertion" — no code or test commitment. V1's `len` axis starting at 1 is consistent with that |
+| 33 | `diff` clamp `max(1.0)` per Bowtie 2 | Edge cases | DONE | Present in `normalize`; the rung-assertion shortfall is tracked under item 18 |
+| 34 | `diff == 0` failure shape — no division, so a zero `diff` silently wins the top rung | Edge cases | DONE | Confirmed: neither ladder divides; every comparison is `best_over >= diff * k` |
+| 35 | Bowtie 2-local `scMin` sign guaranteed positive (`bt2_search.cpp:1861`) | Edge cases | DONE | Rationale only — no code commitment; nothing to implement |
+| 36 | PE perfect sums both mates `2·(l1+l2)` | Edge cases | DONE | See item 16 |
+| 37 | `--combined_index` (all 4 variants): `--local` rejected ⇒ all 8 `combined.rs` sites are refactor-only | Edge cases | DONE | Rejection intact (`config.rs:667`) and tested; all 8 `combined.rs` diffs are signature/call-shape only |
+| 38 | 5-Base never calls `calc_mapq` | Edge cases | DONE | Verified: no `calc_mapq` or `score_model` reference in `five_base_deconv.rs` / `five_base_duplex.rs`. `--five_base_min_mapq` (`mod.rs:571,1465`) untouched |
+
+### §8 Assumptions — does the code contradict any?
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| 39 | A1 Bowtie 2-local perfect = `2 × len` per mate, summed for PE | DONE | `perfect()` |
+| 40 | A2 `G` is logarithmic ⇒ Bowtie 2-local `ln()` is correct and kept | DONE | `ScoreMinForm::Log` retained for Bowtie 2-local only |
+| 41 | A3 HISAT2-local perfect = `0` pending investigation | DONE | `match_bonus = 0.0`; the code comment says "deliberately 0 pending #1079" |
+| 42 | A4 `--ma` unreachable ⇒ `2.0` is a constant | DONE | `BOWTIE2_LOCAL_MATCH_BONUS` with the "a future `--ma` passthrough would have to feed this" note |
+| 43 | A5 both ladders correct and untouched | DONE | No threshold/return edits |
+| 44 | A6 `bestOver = as_best − scMin` unchanged | DONE | Enforced structurally by `normalize` |
+| 45 | A7 local mode has no perl-oracle cell (and no aligner cell at all) | DONE | `rust_ci.yml` unchanged — no `--local` cell added, per §10's "Noted" |
+| 46 | A8 read length == the length Bowtie 2 scored | DONE | All 4 call sites still pass `sequence.len()` / `sequence_2.len()`; unchanged |
+| 47 | A9 minimap2/rammap `match_bonus = 0.0` is a **freeze, not a verified value** | DONE | Recorded in the `from_emitted` comment, the CHANGELOG's third bullet, and V9's matrix. (The issue that should carry it is item 11) |
+| 48 | A10 `scMin`/`diff`/`bestOver` stay `f64` | DONE | No truncation introduced anywhere |
+| 49 | A11 `--score_min` may be non-default and is numerically unvalidated | DONE | `options.rs` validation still shape-only; V1 exercises the consequence |
+| 50 | (A-set) no assumption contradicted by the implementation | DONE | — |
+
+### §1 Explicit non-goals — genuinely left alone?
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| 51 | HISAT2 perfect score stays `0` — **not** silently implemented | DONE | `match_bonus` is 0 for HISAT2 in both `from_emitted` and `hisat2_local`; V9 pins `diff == abs(scMin)` there |
+| 52 | Bowtie 2's `int64` truncation **not** adopted | DONE | All arithmetic `f64`; the reference fn explicitly documents the accepted divergence |
+| 53 | minimap2/rammap `perfect = 0` left frozen | DONE | `match_bonus` 0 and `--local` still rejected for both |
+
+### §4 Signature
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| 54 | `ScoreMinForm`, `ScoreModel` (private fields), `BOWTIE2_LOCAL_MATCH_BONUS`, `from_emitted`, the 3 named constructors, `score_min`, `perfect`, `normalize`, and `calc_mapq(.., model)` | DONE | All present with the specified derives and privacy. Two necessary additions the sketch omitted: `normalize` is `pub` (it is consumed from a sibling module, so module-private is impossible) and a `local_ladder()` accessor exists (required by the private-fields design). Neither weakens the invariant the private fields protect |
+
+---
+
+## Gaps (detail)
+
+### Item 9: CHANGELOG missing O4's note
+
+**Expected (step 8):** "Add O4's note (the `bestOver == diff` rungs now mean `AS == perfect`, which is why 39/35/34/… start appearing)."
+**Found:** The `## Unreleased` entry covers every other required point — the normalization change, the saturation symptom with the 250 bp example, `max(1, perfect − score_min)`, SE+PE, the explicit "values differ from 3.1.0 and Perl v0.25.1", end-to-end/HISAT2-local unaffected by D1, HISAT2's perfect score still open, minimap2/rammap noted, @9xg credited. There is no mention of the `==diff` rungs or of new MAPQ values appearing in local output.
+**Gap:** One sentence. It matters because users diffing local BAMs will see MAPQ values (39/35/34/33/32/31) that literally never occurred before — those leaves were unreachable while `diff = abs(scMin)`.
+
+**Related observation (not a plan gap):** as written the entry reads as self-contradictory — bullet 1 ends "…stays byte-identical …, as does HISAT2 `--local`", and bullet 2 opens by saying HISAT2-local MAPQ changes. Bullet 1 means "unaffected *by D1*", which is what the plan asked for, but a reader hitting bullet 1 first will conclude the opposite of bullet 2.
+
+### Item 10: `rust/README.md` aligner row not updated
+
+**Expected (step 8):** "`rust/README.md`: aligner row + dated Milestones line — its own rule (L175) is **per module-merge PR**, so this belongs in PR 2."
+**Found:** Only the Milestones line (`README.md:181`). The `bismark` (aligner) row in the per-tool status table (`README.md:161`) is byte-unchanged; `git diff --stat` shows `rust/README.md | 1 +`.
+**Gap:** Add the `--local` MAPQ change to the aligner row. The row currently claims the aligner is "byte-identical to Perl v0.25.1 + Bowtie 2 2.5.5" with no local-mode carve-out, which is now false for `--local`.
+
+### Item 11: The two deferred issues are not filed
+
+**Expected (step 9):** File (a) HISAT2 perfect score / correct ladder, carrying O3's reasoning that HISAT2 has no `--local` mode and monotone scoring, so `0` is likely genuinely correct rather than provisional; and (b) minimap2/rammap positive-AS ⇒ top-rung MAPQ (A9), the same defect class in a default path.
+**Found:** Nothing filed. §12 discloses "not yet filed".
+**Gap:** File both. Three places now promise a tracking issue that does not exist: `config.rs`'s "deliberately 0 pending #1079" comment, the CHANGELOG's "that is tracked separately", and `mapq.rs`'s "pending that follow-up". Without the issues, O3's reasoning — the reason A3 is probably *correct* and not a stopgap — lives only in this plan file and will be re-derived from scratch next time.
+
+### Item 13 (V1): `len` axis is sampled, not swept
+
+**Expected:** `len ∈ 1..=500`.
+**Found:** `[1, 2, 3, 4, 5, 6, 20, 50, 100, 250, 500]` — 11 points.
+**Gap:** Either widen to `1..=500` (the test is pure arithmetic; 6 × 500 × 5 × 3 × 2 ≈ 90k cells still runs in milliseconds) or record the sampling as a deliberate deviation in §12. Low risk as it stands: every length that matters for the `abs(scMin) == −scMin` boundary is included (1-6 for the default slope, 20 for the `−0.05` cell), and §12 confirms the injected-fault check failed at `len=1`. But the plan specified a sweep, and an 11-point sample is not one.
+
+### Item 18 (V6): the clamped case's rung is never asserted
+
+**Expected:** "Bowtie 2-local `perfect − scMin ∈ [0,1)` … ⇒ `diff == 1.0`, **and assert which rung results** (risk is a silent top rung, not a panic)."
+**Found:** `local_diff_is_clamped_to_at_least_one` asserts `diff == 1.0` and the frozen end-to-end `diff == 0.0`. It calls `normalize` only — never `calc_mapq`, so no MAPQ value is pinned for a clamped `diff`.
+**Gap:** Add a `calc_mapq` assertion for the clamped cell. This is the one gate whose *stated rationale* is the failure mode the plan identified as silent (a degenerate `diff` collapsing every threshold to `>= 0` so the top rung wins). Asserting only `diff == 1.0` verifies the clamp fired, not what the ladder then does with it. Concretely: `calc_mapq(6, None, 0, None, bowtie2_local(20.0, 8.0))` — `bestOver = 0 − 34.33 = −34.33`, `diff = 1.0`, so every rung fails and the no-second-best floor 22 results.
+
+### Item 22 (V10): cell (a) not built
+
+**Expected:** Two cells — (a) a **≥23 bp** read with default `G,20,8` (len 25 → scMin 45.7527, perfect 50, diff 4.2473); (b) the existing 6 bp fixture with `--score_min G,1,0`.
+**Found:** Only (b).
+**Gap:** Build cell (a), or record dropping it. The two cells are not redundant: (b) proves the wiring works but only under a hand-picked non-default `--score_min` on a 6 bp read that real Bowtie 2 could never report; (a) is the only end-to-end cell that would exercise the **default** local parameters at a realistic read length — the configuration real users run. §12 discusses which fixture route discriminates but never says cell (a) was dropped, so this reads as an omission rather than a decision.
+
+---
+
+## Test verification
+
+| Test | File | Maps to | Status |
+|---|---|---|---|
+| `frozen_paths_match_the_pre_fix_formula` | `src/aligner/mapq.rs` | V1 | PASS (len axis sampled — item 13) |
+| `bowtie2_local_reference` (helper) + `local_bowtie2_matches_independent_reference` | `src/aligner/mapq.rs` | V2, V11 `==diff` leaves | PASS |
+| `local_bowtie2_denominator_uses_perfect_score_issue_1079` | `src/aligner/mapq.rs` | V3, V4, V11 | PASS |
+| `local_hisat2_uses_the_linear_form_it_was_emitted` | `src/aligner/mapq.rs` | V5, step 5 | PASS (4 values re-derived independently) |
+| `score_min_params_aligner_and_mode_defaults` | `src/aligner/options.rs` | V5 form plumbing | PASS |
+| `hisat2_local_option_string` (pre-existing, unchanged) | `src/aligner/options.rs` | V5 emitted-option cross-check | PASS |
+| `local_diff_is_clamped_to_at_least_one` | `src/aligner/mapq.rs` | V6 | PASS (rung unasserted — item 18) |
+| `score_model_construction_matrix` | `src/aligner/mapq.rs` | V9 | PASS |
+| `resolve_local_aligner_scope`, `rammap_rejects_local`, `resolve_rejects_local_with_combined_index` (pre-existing) | `src/aligner/config.rs` | V9 unreachable arm | PASS |
+| `local_bowtie2_ln_derived_bucket_boundary` | `src/aligner/mapq.rs` | step 7 | PASS |
+| `bowtie2_local_mapq_uses_the_perfect_score_denominator_end_to_end` | `tests/aligner_cli.rs` | V10 cell (b) | PASS |
+| V10 cell (a) — ≥23 bp read at default `G,20,8`, out of a BAM | — | V10 cell (a) | **MISSING** |
+| V8 — real Bowtie 2 oracle | — | V8 | **MISSING** (documented decision) |
+| `vendored_version_matches_repo_version`, `cargo_pkg_version_matches_suite_version` | `src/meta/mod.rs` | step 10 | PASS |
+| `local_no_second_best_ladder`, `local_second_best_ladder`, `inner_threshold_leaves_pinned`, `no_second_best_ladder`, `with_second_best_top_buckets`, `with_second_best_not_at_diff`, `non_integer_scmin`, `user_score_min_slope` | `src/aligner/mapq.rs` | frozen-path regressions (V7) | PASS, expected values unchanged |
+| Whole crate | `-p bismark` | — | **2107 passed / 0 failed / 20 ignored** |
+
+---
+
+## Verdict
+
+**INCOMPLETE — 6 items unresolved.** The fix itself is complete and correct: D1 and D2 are implemented exactly as §3 specifies, the refactor hit every site the plan enumerated with no expected-value drift, and every hand-derived expectation in the plan (the four HISAT2 values, V3's 24, V10's 28, the len-25 boundary 44/36) was independently re-derived in this audit and matched. What remains is three validation cells and three release/tracking chores:
+
+1. **Item 9 — CHANGELOG:** add O4's note (the `bestOver == diff` rungs now mean `AS == perfect`, which is why MAPQ 39/35/34/33/32/31 start appearing in local output). Optionally reconcile bullet 1's "as does HISAT2 `--local`" with bullet 2, which says HISAT2-local changes.
+2. **Item 10 — `rust/README.md`:** update the `bismark` (aligner) **row** (`README.md:161`), not only the Milestones line. Its unqualified "byte-identical to Perl v0.25.1 + Bowtie 2 2.5.5" is now false for `--local`.
+3. **Item 11 — file both deferred issues:** HISAT2 perfect score/ladder (carrying O3's "HISAT2 has no `--local` mode ⇒ 0 is probably genuinely correct" reasoning) and minimap2/rammap positive-AS (A9). Three code/doc comments already promise them.
+4. **Item 13 (V1) — widen the `len` axis** to `1..=500` as specified, or record the 11-point sample in §12 as a deliberate deviation.
+5. **Item 18 (V6) — assert which rung results when `diff` is clamped.** e.g. `calc_mapq(6, None, 0, None, ScoreModel::bowtie2_local(20.0, 8.0))` → 22. Asserting `diff == 1.0` alone does not cover the silent-top-rung failure this gate exists to catch.
+6. **Item 22 (V10) — build cell (a)** (a ≥23 bp read at the default `G,20,8`, MAPQ read out of a BAM), or record dropping it. Cell (b) proves the wiring under a hand-picked non-default `--score_min` on a read real Bowtie 2 could not report; cell (a) is the only end-to-end coverage of the default local configuration.
+
+Items 1-3 are release/tracking work; items 4-6 are test work. None blocks the semantics, and nothing found here suggests the implemented behaviour is wrong.

--- a/plans/07292026_local-mapq-denominator/PLAN.md
+++ b/plans/07292026_local-mapq-denominator/PLAN.md
@@ -1,0 +1,471 @@
+# PLAN — Local-mode MAPQ denominator: use Bowtie 2's `perfectScore − scMin`
+
+**Issue:** [FelixKrueger/Bismark#1079](https://github.com/FelixKrueger/Bismark/issues/1079) (reported by @9xg, confirmed 2026-07-29)
+**Type:** correctness fix (Bowtie 2 `--local` only) + enabling refactor
+**Revision:** **rev 1** — dual plan-review folded (see §12)
+
+**Decisions locked (Felix):**
+1. Fix **unconditionally** — no compat flag.
+2. Scope = Bowtie 2 denominator (**D1**) + HISAT2 `scMin` form (**D2**). HISAT2 *perfect score* deferred.
+3. **Two PRs** — mechanical refactor, then semantics.
+4. `ScoreModel` lives in **`config.rs`** (next to `Aligner`).
+5. minimap2/rammap defect (**I5**) → assumption row + separate issue, not fixed here.
+
+---
+
+## 1. Goal
+
+Make Bowtie 2 `--local` MAPQ match Bowtie 2's own normalization. Two defects, both faithfully inherited from Perl v0.25.1:
+
+| # | Defect | Fix |
+|---|---|---|
+| **D1** | `diff = abs(scMin)` assumes perfect score 0 — true only end-to-end. Bowtie 2-local awards `--ma 2` per base, so perfect = `2 × len`. | `diff = max(1, perfect − scMin)`, **Bowtie 2-local only** |
+| **D2** | HISAT2 `--local` is passed a **linear** `--score-min L,0,-0.2` but MAPQ recomputes `scMin` with `ln(len)`. | HISAT2-local `scMin` becomes linear, derived from the emitted form |
+
+### Explicit non-goals (documented so they don't resurface every review)
+
+| Non-goal | Why |
+|---|---|
+| **HISAT2 perfect score** stays `0` | Bismark's docs (`bismark:9731`) say it "is currently not exactly known". Likely *correct* rather than provisional — HISAT2 has **no `--local` mode** at all (Bismark's "HISAT2-local" is just dropping `--no-softclip`, `options.rs:341-346`) and its scoring is monotone. Record that reasoning in the deferred issue so it isn't re-derived. |
+| **Matching Bowtie 2's integer arithmetic** | Bowtie 2 computes `scMin`/`diff`/`bestOver` in `int64_t` (`unique.h:213`, `simple_func.h:106` `return (T)ret`); Bismark uses `f64`. Adopting truncation would change **end-to-end** MAPQ (`mapq.rs:259-262` pins `len 51 → scMin −10.2`). **Considered and rejected.** Drives V2/V8's expectations (§9). |
+| **minimap2/rammap** `perfect = 0` | Same defect class as D1 in a *default* path (**I5**) — but minimap2 SE is byte-frozen vs Perl v0.25.1. Separate issue. See A9. |
+
+**Outcome:** end-to-end **and** HISAT2-local denominators are byte-frozen; only Bowtie 2-local `diff` changes. Bowtie 2-local MAPQ stops saturating at 44.
+
+### Why this is a fix, not a behaviour change
+
+Bismark's `--local` help text already **documents** the correct formula (`bismark:9728-9730`):
+
+> "For Bowtie 2, the match bonus `--ma` (default: 2) is used in this mode, and the best possible alignment score is equal to the match bonus (`--ma`) times the length of the read."
+
+Upstream Bowtie 2 v2.5.5 `unique.h:206-218` confirms:
+
+```cpp
+TAlScore scPer = (TAlScore)sc_.perfectScore(rdlen);
+if(s.paired()) scPer += (TAlScore)sc_.perfectScore(ordlen);
+TAlScore diff = std::max<TAlScore>(1, scPer - scMin); // scores can vary by up to this much
+```
+
+Perl copied that trailing comment nearly verbatim while substituting `abs $scMin`, and its own comment concedes the assumption (*"since max AS is 0 for end-to-end alignment"*).
+
+### Measured impact (reproduced by both reviewers)
+
+`abs(scMin)` grows logarithmically; the true denominator grows linearly, so `bestOver/diff` exceeds 1.0 for most local alignments and the ladder saturates:
+
+```
+read len 250, G,20,8, no second best
+    AS  %perfect | current | bowtie2 | delta
+   400     80%   |    44   |   42    |  +2
+   300     60%   |    44   |   36    |  +8
+   200     40%   |    44   |   24    | +20
+   150     30%   |    44   |   22    | +22
+```
+
+---
+
+## 2. Context
+
+### Files (corrected — rev 0 missed `mod.rs` entirely)
+
+| File | Role |
+|---|---|
+| `rust/bismark/src/aligner/config.rs` | **`ScoreModel` lives here** (next to `Aligner`, L21). Build point **L637-638**; `RunConfig` fields L231-238. `--local` rejections: minimap2/rammap L517-529, all four `--combined_index` variants L531-537. |
+| `rust/bismark/src/aligner/mapq.rs` | `calc_mapq` (L19-136) — `diff` at **L43**; `calc_mapq_local` (L143-220); ~28 unit call sites from ~L325. |
+| `rust/bismark/src/aligner/options.rs` | `score_min_params` (**L371-410**) — emits `G,20,8` (Bowtie 2-local) vs `L,0,-0.2` (HISAT2-local + all end-to-end); **shape-only validation** (L405-410). |
+| `rust/bismark/src/aligner/merge.rs` | Call sites **L370** (SE), **L747** (PE); trio params L198, L528. `check_results_paired_end` (L530) **already takes `aligner`**. |
+| `rust/bismark/src/aligner/combined.rs` | **8** trio signatures: 188, 246, 388, 437, 501, 543, **598**, **657**. Call sites **L349** (SE) + **L774** (PE). Test call L1205. `too_many_arguments` allow L535. |
+| **`rust/bismark/src/aligner/mod.rs`** | **6** config-expansion sites: 2599, 3146, 3528, 4647, 5255, 5705. **2 fn-pointer aliases hardcoding the trio: `SelectFn` (L2751-2758), `SelectFnPe` (L2767-2775)** — must change in lockstep with all 8 `combined.rs` selectors or it won't compile. `--five_base_min_mapq` filter at L2052. |
+| `CHANGELOG.md` (repo root — the only one), `rust/README.md`, 3× version literals | release mechanics (§5 step 8) |
+
+**True blast radius:** ~10 fn signatures + 2 fn-pointer aliases + 6 config-expansion sites + 4 production call sites + `RunConfig` + ~29 test call sites. Rev 0's "~10 signatures / 3+ call sites" understated it by roughly half.
+
+### Design rationale (rev 0's premise was false)
+
+Rev 0 claimed "no call site knows which aligner is running". **False** — `merge.rs:530` already takes `aligner`. The `ScoreModel` decision stands on two *correct* grounds:
+1. **Net arity reduction** — replaces 3 params with 1 at ~10 sites, retiring the `#[allow(clippy::too_many_arguments)]` at `combined.rs:535` (`select_pe_nondir` 8→6; clippy's threshold is >7) and at `merge.rs:190` (9→7). `merge.rs:519` stays at 11→9 and keeps its allow.
+2. **One construction point** — `config.rs:637`, where `aligner` is fully resolved (all overrides and 5-Base/combined guards run at L602-628).
+
+### What `local` conflates today
+
+| Mode | `scMin` form | Ladder | perfect/base | `diff` after fix |
+|---|---|---|---|---|
+| Bowtie 2 end-to-end | linear | end-to-end | 0 | `abs(scMin)` — **frozen** |
+| Bowtie 2 `--local` | **ln** (correct — `G` *is* logarithmic) | local | **2.0** | `max(1, perfect − scMin)` ← **only change** |
+| HISAT2 end-to-end | linear | end-to-end | 0 | `abs(scMin)` — **frozen** |
+| HISAT2 `--local` | **linear** ← D2 (was `ln`) | local | 0 (deferred) | `abs(scMin)` — **frozen** |
+| minimap2 / rammap | linear | end-to-end | 0 (**wrong**, see A9) | `abs(scMin)` — **frozen** |
+| `--combined_index` (any) | — | — | — | `--local` rejected ⇒ refactor-only |
+
+Bowtie 2-local's `ln()` is **correct** and stays: Bismark emits `G,20,8`, and `G` is Bowtie 2's logarithmic form (`simple_func.h:88-107`). Only HISAT2's `ln()` is wrong, because it is emitted `L` (linear).
+
+---
+
+## 3. Behavior
+
+1. **Prerequisite** — `score_min_params` returns the **form it selected** alongside the coefficients (it already computes `prefix = "G," | "L,"` at `options.rs:372`). `ScoreModel` is built once in `config::resolve` from that form + `aligner` + `cli.local`, and stored on `RunConfig` in place of the three scalars.
+2. **`scMin`** — `intercept + slope × f(len)`, `f = ln` iff `form == Log`; summed over mates. **Derived from the emitted form, never re-decided** (closes D2's root cause — see §5 step 1).
+3. **Perfect score** — `match_bonus × (len1 + len2.unwrap_or(0))`. `match_bonus = 2.0` **only** for Bowtie 2 + local, else `0.0`.
+4. **Denominator — gated on `match_bonus > 0.0`, NOT on `local`:**
+   ```rust
+   let diff = if self.match_bonus > 0.0 {
+       (self.perfect(len1, len2) - sc_min).max(1.0)   // Bowtie 2-local (unique.h)
+   } else {
+       sc_min.abs()                                   // frozen: all end-to-end + HISAT2-local
+   };
+   ```
+5. **`bestOver`** — `as_best − scMin`. **Unchanged.**
+6. **Ladder** — `local_ladder` selects it; both ladders' thresholds and return values untouched.
+
+### Why gate on `match_bonus`, not `local` (rev-1 correction — this was the plan's most serious flaw)
+
+Rev 0 promised end-to-end byte-identity "by construction (`perfect = 0`)" and narrowed the risk to `len < 5`. **Both were wrong.** The identity is:
+
+```
+max(1, 0 − scMin) ≡ abs(scMin)   ⟺   scMin ≤ −1
+```
+
+which fails two independent ways, **neither** a `len` question:
+
+- **(a) sign** — `abs(scMin)` and `−scMin` diverge for every `scMin > 0`. `--score_min` is **shape-validated only** (`options.rs:405-410` mirrors Perl's permissive `^L,(.+),(.+)$` — no numeric check), so a positive intercept parses fine.
+- **(b) magnitude** — the `len ≥ 5` threshold is really `1/|slope|`: a slope of `−0.05` pushes it to `len < 20`; `−0.001` to `len < 1000`.
+
+Measured divergences under a *universal* clamp (end-to-end, AS = 0):
+
+| `--score_min` | len | old MAPQ | new MAPQ |
+|---|---|---|---|
+| `L,0,-0.2` | 1 | 42 | **0** |
+| `L,0,-0.2` | 3 | 42 | **24** |
+| `L,0,-0.05` | 10 | 42 | **23** |
+| `L,10,-0.2` | 50 | 42 | **0** |
+| `L,0,0` | 50 | 42 | **0** |
+| `L,0,0.2` | 100 | 2 | **39** ← also diverges under a *local-only* clamp |
+
+`L,10,-0.2` at 50 bp is 42 → 0: **every read in the run** drops below a `-q 20` filter. And methylseq emits non-default `--score_min L,0,-N` (`aligner_methylseq_conformance.rs:15,88-96`), so this is a live production configuration, not a hypothetical.
+
+Gating on `match_bonus > 0.0` is strictly narrower than gating on `local`: it also keeps **HISAT2-local** clamp-free, so HISAT2 values move for exactly **one** reason (D2's `scMin` form) rather than two unrelated ones in the same change — honest given that HISAT2's perfect score is admittedly unknown. `abs()` is the right placeholder there.
+
+**Corollary:** the clamp is near-dead code where it *does* apply. A reported alignment satisfies `scMin ≤ AS ≤ perfect`, so `perfect − scMin ≥ 0`; only the `[0,1)` sliver clamps. With `G,20,8`, reads below ~23 bp have `perfect < scMin` outright (len 22 → perfect 44, scMin 44.73) and Bowtie 2 cannot report them at all. So the clamp's only *behaviour-changing* reach would have been end-to-end — the exact opposite of its intent.
+
+### Edge cases
+
+| Case | Handling |
+|---|---|
+| **End-to-end / HISAT2-local invariance** | Byte-identical **by construction** — the `match_bonus == 0.0` branch is the unmodified `sc_min.abs()`. No sweep needed to prove it; V1 is a regression net, not the proof. |
+| Non-default `--score_min` | Covered by the gating above. V1 carries a `--score_min` axis regardless. |
+| `len = 0` | End-to-end: unchanged (same branch). Bowtie 2-local: `ln(0) = −inf` ⇒ `scMin = −inf` ⇒ `diff = +inf`, `best_over = +inf`, and `inf >= inf*0.8` is **true** ⇒ 44, same as before (`abs(−inf) = inf`). Invariant *by reasoning*, not by assertion. |
+| `diff` clamp | `max(1.0)` per Bowtie 2. Reachable only for `perfect − scMin ∈ [0,1)` — practically unreachable in real Bowtie 2-local data, trivially reachable in fake-aligner fixtures (V10). |
+| `diff == 0` failure shape | **There is no division** in either ladder — every comparison is `best_over >= diff * k`. A zero `diff` collapses every threshold to `>= 0` so the **top rung silently wins**; it does not panic. (Rev 0 mis-described this.) |
+| Bowtie 2-local `scMin` sign | **Guaranteed positive**: `bt2_search.cpp:1861` makes Bowtie 2 *die* if the match bonus is >0 and `--score-min` can be ≤0. So `abs(scMin) ≡ scMin` there, and `diff` is the only thing that changes. |
+| PE | perfect sums **both** mates: `2·(l1+l2)`, matching `unique.h:207-209`. No per-mate truncation concern (`2·len` is integral). |
+| `--combined_index` (all 4 variants) | `--local` **rejected** (`config.rs:531-537`) ⇒ `match_bonus` is always 0 there ⇒ all 8 `combined.rs` sites are **refactor-only**. Material risk reduction. |
+| 5-Base | Never calls `calc_mapq` (verified: no `config.score_min_*` site in `five_base_*`); its MAPQ comes from minimap2, and `--local` is rejected for minimap2. |
+
+---
+
+## 4. Signature
+
+Lives in `config.rs` (with `Aligner`), so dependencies run one way: `mapq`/`merge`/`combined` → `config`.
+
+```rust
+/// Which score-min function form was emitted to the aligner. Single source of
+/// truth for both the emitted `--score-min` option and the MAPQ `scMin` form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScoreMinForm {
+    /// `L,<i>,<s>` — `scMin = i + s·len`.
+    Linear,
+    /// `G,<i>,<s>` — `scMin = i + s·ln(len)`.
+    Log,
+}
+
+/// How alignment scores are normalized for MAPQ. Fields are private so an
+/// inconsistent model (e.g. a match bonus without the Bowtie 2-local form)
+/// cannot be constructed. Built once in `config::resolve`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScoreModel {
+    intercept: f64,
+    slope: f64,
+    form: ScoreMinForm,
+    local_ladder: bool,
+    /// Perfect-alignment score per base. `BOWTIE2_LOCAL_MATCH_BONUS` for
+    /// Bowtie 2 `--local`; 0 everywhere else. See A9 for minimap2/rammap.
+    match_bonus: f64,
+}
+
+/// Bowtie 2's `--ma` default. Not settable in Bismark (A4) — if a passthrough is
+/// ever added, this must read it.
+pub const BOWTIE2_LOCAL_MATCH_BONUS: f64 = 2.0;
+
+impl ScoreModel {
+    /// The only general constructor — `form` comes from `score_min_params`, so the
+    /// emitted option and the MAPQ form are the same fact by construction.
+    pub fn from_emitted(intercept: f64, slope: f64, form: ScoreMinForm,
+                        local: bool, aligner: Aligner) -> Self;
+
+    // Named constructors — self-documenting at ~29 test call sites, and they
+    // remove the "which aligner for an end-to-end test?" ambiguity.
+    pub fn end_to_end(intercept: f64, slope: f64) -> Self;
+    pub fn bowtie2_local(intercept: f64, slope: f64) -> Self;
+    pub fn hisat2_local(intercept: f64, slope: f64) -> Self;
+
+    fn score_min(&self, len1: usize, len2: Option<usize>) -> f64;
+    fn perfect(&self, len1: usize, len2: Option<usize>) -> f64;
+
+    /// `(best_over, diff)` together, so a caller cannot pass a `sc_min` computed
+    /// from different lengths, and `best_over`'s formula stays structurally fixed.
+    fn normalize(&self, len1: usize, len2: Option<usize>, as_best: i64) -> (f64, f64);
+}
+
+/// Bismark MAPQ. `read2_len` is `Some` only for paired-end.
+pub fn calc_mapq(
+    read1_len: usize,
+    read2_len: Option<usize>,
+    as_best: i64,
+    as_second: Option<i64>,
+    model: ScoreModel,   // 32 bytes, Copy — by value
+) -> u8;
+```
+
+---
+
+## 5. Implementation outline
+
+### PR 1 — mechanical refactor (zero expected-value changes)
+
+1. **Add `ScoreMinForm` + `ScoreModel`** to `config.rs`. Change `score_min_params` (`options.rs:371`) to return the form it already selects at L372. **In this PR the constructor sets `form` verbatim from the emitted value and `local_ladder = local`, with `match_bonus = 0.0` for *everything*** — so behaviour is bit-identical, including HISAT2-local's current `ln()`.
+   > ⚠️ **Do NOT** set `match_bonus`/the Bowtie 2 form condition here. Rev 0 put `log_score_min = local && aligner == Bowtie2` in this step, which lands **D2 inside the supposedly-inert refactor** and changes 4 HISAT2 expectations. That is what broke rev 0's ordering.
+   >
+   > Concretely: HISAT2-local must still receive `ScoreMinForm::Log` in PR 1 even though it is emitted `L`. The desynchronization *is* D2 and it is repaired in PR 2 step 5.
+2. **Thread `ScoreModel`** in place of the trio: `calc_mapq`; `merge.rs:198,528`; **all 8** `combined.rs` signatures (188, 246, 388, 437, 501, 543, 598, 657); the **2 fn-pointer aliases** `SelectFn` (`mod.rs:2751`) and `SelectFnPe` (`mod.rs:2767`); the 6 `mod.rs` config-expansion sites (2599, 3146, 3528, 4647, 5255, 5705); `RunConfig` (`config.rs:231-238`) and its literal; the 4 production call sites (`merge.rs:370,747`; `combined.rs:349,774`); ~29 test call sites (shape only).
+   - Pass **by value** (`Copy`, 32 bytes) — avoids an elided lifetime in the two fn-pointer aliases.
+   - Delete the now-unneeded `#[allow(clippy::too_many_arguments)]` at `combined.rs:535` and `merge.rs:190`; keep `merge.rs:519`.
+3. **Gate:** V7 — full suite green with **no expected-value edits** (call-shape edits only).
+
+### PR 2 — semantics
+
+4. **D1.** Replace `mapq.rs:43` with the `match_bonus > 0.0` dispatch (§3.4) via `model.normalize(...)`, and set `match_bonus = BOWTIE2_LOCAL_MATCH_BONUS` for Bowtie 2 + local in `from_emitted`. Rewrite the stale comment (`// scores vary by up to this much (max AS = 0)`) to one line, noting the `float_cmp` allow still holds (O4).
+5. **D2.** Fix the desynchronization: `form` now comes straight from `score_min_params`, so HISAT2-local gets `Linear`. **Recompute by hand** the affected expectations in `local_hisat2_default_params_mapq` (`mapq.rs:390-419`):
+
+   | Line | old | new |
+   |---|---|---|
+   | `:397` `calc_mapq(50, None, -1, None, …)` | 22 | **44** |
+   | `:401` `calc_mapq(50, None, 0, Some(-1), …)` | 40 | **31** |
+   | `:402` `calc_mapq(50, None, -1, Some(-1), …)` | 0 | **1** |
+   | `:410` `calc_mapq(150, Some(150), 0, Some(-1), …)` | 34 | **11** |
+
+   (`:396` and `:398` stay 44.) **Re-derive from the linear `scMin` by hand — do not re-baseline from the implementation.** These are genuinely independent assertions; the test's own doc-comment stresses they are "the Perl local ladder hand-applied … NOT self-consistency".
+6. **Retire the tautologies.** `mapq.rs:376` and `:416` compute `expect` by calling the function under test with `sc.abs()` — they cannot fail regardless of the denominator. Rewrite against V2's independent reference.
+7. **Re-home the `ln()`-boundary coverage.** `mapq.rs:386-389,403-409` document that test as the *only* sub-unity-`diff`, `ln()`-derived-boundary coverage. After D2, HISAT2-local is linear and **no configuration produces a sub-unity `diff` in local mode**, so that regime becomes unreachable. Add a **Bowtie 2-local** `ln()`-boundary case (now the only `ln()` consumer), with the same "why this cell" comment style.
+8. **Docs.** (Version literals are **not** touched here — see step 10.)
+   - `mapq.rs` header (L1-17) and `config.rs:235` describe `local` as selecting "`ln()` scMin + the local ladder" — now form- and aligner-dependent. One line each.
+   - `CHANGELOG.md` (repo root) under a new **`## Unreleased`** heading: Bowtie 2-local MAPQ now matches Bowtie 2; local values differ from v0.25.1/3.1.0; end-to-end **and HISAT2-local** unaffected; HISAT2 perfect score still open; credit **@9xg**. Add O4's note (the `bestOver == diff` rungs now mean `AS == perfect`, which is why 39/35/34/… start appearing).
+     > ⚠️ The file currently has **no `Unreleased` convention** — every heading is a released version. PR 2 introduces one; the release cut renames it to `## Bismark <version> (released <date>)`. Writing the entry now (rather than reconstructing it at cut time from `git log`) is what keeps the "HISAT2 is self-consistent but not yet proven correct" nuance from being lost.
+   - `rust/README.md`: aligner row + dated Milestones line — its own rule (L175) is **per module-merge PR**, so this belongs in PR 2, not the cut.
+9. **File the two deferred issues:** HISAT2 perfect score/ladder (carrying O3's reasoning), and minimap2/rammap positive-AS (A9).
+
+### Release cut — NOT part of either PR (Felix, 2026-07-29)
+
+10. The version bump belongs to the **release cut**, not this fix. At cut time, move **all three** literals together — `rust/VERSION`, `rust/bismark/VERSION`, `rust/bismark/Cargo.toml:3` — and rename the `## Unreleased` CHANGELOG heading to the cut version/date.
+    - Two guard tests enforce the lockstep: `meta/mod.rs:51` (`vendored_version_matches_repo_version`) and `meta/mod.rs:73` (`cargo_pkg_version_matches_suite_version`, commented "load-bearing for a GA cut", never skipped). Because PR 1 and PR 2 leave all three at `3.1.0`, they stay mutually consistent and both guards pass — **no version work is needed in either PR**.
+    - Magnitude when cut: **minor** (3.1.0 → 3.2.0) — a behaviour change in a non-default mode is not a patch.
+
+---
+
+## 6. Efficiency
+
+O(1) added arithmetic per accepted alignment (one multiply, one compare); no allocation. `ScoreModel` is `3×f64 + 2×bool + enum` ≈ **32 bytes**, `Copy`, passed **by value**. Arity drops by 2 at ~10 sites.
+
+The real cost is **change-cost, not run-cost**: ~50 edit sites in a module with no aligner Perl-oracle in CI (I5) — which is precisely why PR 1 is separated and gated on V7.
+
+---
+
+## 7. Integration
+
+- **Reads:** `cli.local`, resolved `aligner`, and `score_min_params`' `(intercept, slope, form)` — all available at `config.rs:637`.
+- **Writes:** the BAM MAPQ column, **Bowtie 2 `--local` only**.
+- **Downstream:** dedup and the extractor don't filter on MAPQ. `--five_base_min_mapq` (`mod.rs:2052`) *is* an internal MAPQ filter, but 5-Base is minimap2-only, `--local` is rejected there, and 5-Base MAPQ comes from minimap2 rather than `calc_mapq` — so it is unaffected. External `samtools view -q` users in Bowtie 2-local mode see stricter (correct) filtering: the point of the fix.
+- **CI exposure — worse than rev 0 said.** The `perl-oracle` job's 13 cells (`rust_ci.yml:194-217`) are 7 genome-prep, 4 methylation_consistency, 1 extractor, 1 dedup: **no aligner cell at all**. So end-to-end aligner MAPQ has no Perl oracle either. Total automated protection today = V1 plus **four** MAPQ value assertions across all aligner integration tests (`aligner_cli.rs:422, 705, 706, 2429`) — all end-to-end, all 6 bp, all default `--score_min`. That thinness is why V1's `--score_min` axis and V9/V10 are load-bearing, not nice-to-have.
+- The two existing `--local` integration tests (`aligner_cli.rs:2034`, `:2116`) assert the option string and soft-clip CIGAR only — **no MAPQ** — so they will not break.
+
+---
+
+## 8. Assumptions
+
+| # | Assumption | Status |
+|---|---|---|
+| A1 | Bowtie 2-local perfect = `2 × len` per mate, summed for PE | ✅ Both reviewers verified: `scoring.h:310-316` (`perfectScore = monotone ? 0 : rdlen × match(30)`), `unique.h:207-209` |
+| A2 | `G` is logarithmic ⇒ Bowtie 2-local `ln()` is **correct**, keep it | ✅ `simple_func.h:88-107` |
+| A3 | HISAT2-local perfect = `0` pending investigation | ⚠️ Probably **correct**, not provisional — HISAT2 has no `--local` mode; scoring is monotone. Deferred; reasoning goes in the issue |
+| A4 | `--ma` unreachable ⇒ `2.0` is a constant | ✅ Verified structurally: no free-form aligner-option vector, no `trailing_var_arg`/`allow_hyphen_values`, 23 curated `opts.push` sites, none `--ma` |
+| A5 | Both ladders correct and untouched | ✅ Diffed leaf-by-leaf against `unique.h:223-380` |
+| A6 | `bestOver = as_best − scMin` unchanged | ✅ `unique.h:222`; structurally enforced by `normalize()` |
+| A7 | Local mode not covered by perl-oracle | ✅ …and **no aligner cell at all** (see §7) |
+| **A8** | **Read length == the length Bowtie 2 scored** — the basis for `perfect = 2 × len` | ✅ Verified: no `--trim5/--trim3/-5/-3/--clip_r*` in `options.rs`/`cli.rs`; `sequence` at all 4 call sites is the original uc read; soft-clipped records retain full SEQ (`aligner_cli.rs:2073`); Bowtie 2 also passes the full `rdlen` to `mapq()` |
+| **A9** | **minimap2/rammap perfect = 0 is WRONG but held frozen** | 🟠 They emit **positive** `AS:i:` (`aligner_cli.rs:2463`) through `local = false`, so `bestOver/diff = AS/(0.2·len) + 1 > 1` ⇒ top rung for essentially every unique hit — **the same defect class as #1079, in a default path, today.** Byte-frozen vs Perl v0.25.1 + minimap2 (`rust/README.md:161`), so deferred to its own issue. **`match_bonus = 0.0` for these aligners is a freeze, not a verified value.** |
+| **A10** | `scMin`/`diff`/`bestOver` stay `f64` while Bowtie 2 uses `int64` | ✅ Deliberate non-goal (§1); drives V2/V8 |
+| **A11** | `--score_min` may be **non-default** and is numerically unvalidated | ✅ Load-bearing for §3's gating; methylseq uses non-default forms |
+
+---
+
+## 9. Validation
+
+| # | Verify | How | Expected |
+|---|---|---|---|
+| **V1** | End-to-end **and HISAT2-local** frozen (regression net; the *proof* is now structural) | Sweep `len ∈ 1..=500` × **`--score_min ∈ {(0,−0.2), (0,−0.05), (0,−0.6), (10,−0.2), (0,0), (−1,−0.2)}`** × `as_best` grid × `{None, Some(second)}` × **SE and PE**, against a frozen reference fn (`abs(scMin)` + the pre-change ladders) | Identical in every cell. The `--score_min` and PE axes are mandatory — without them V1 is blind to the whole C1 class |
+| **V2** | D1 against an **independent** reference (kills the tautology) | Transcribe `unique.h:206-222`'s **structure** (`scPer`, `max(1, scPer − scMin)`) but with **Bismark's `f64` `scMin`** — a deliberate f64 analogue, commented as such. Grid over `len × AS × second-best` | Agreement. **Not** a faithful int transcription: Bowtie 2 truncates `scMin` (A10), so a faithful copy disagrees at ~every bucket boundary on a *correct* fix (562 cells over `len ∈ 25..300` SE alone; e.g. len 100/AS 128 → f64 28 vs int 36) |
+| **V3** | Reporter's case #1 | `len=100, G,20,8, AS=100`, no second best | **24** (was 42) |
+| **V4** | PE sums both mates | `len1=len2=100` local; assert `diff = 2×200 − scMin(both)` and that it **differs** from the SE-only value | Matches; differs (guards a single-mate bug) |
+| **V5** | D2 — HISAT2-local `scMin` matches what is emitted | Assert `scMin == −0.2 × len` **and the converse** `scMin != −0.2 × ln(len)` (so a revert to `ln` fails loudly); cross-check the emitted option is still `L,0,-0.2`. Include the four recomputed values from §5 step 5 | Linear used; option unchanged |
+| **V6** | The clamp | Bowtie 2-local `perfect − scMin ∈ [0,1)` (e.g. `len=6, G,20,8` → perfect 12, scMin 34.3) ⇒ `diff == 1.0`, and assert **which rung** results (risk is a silent top rung, not a panic). Plus: end-to-end with `scMin == 0.0` still yields `diff == 0.0` (frozen) | As stated |
+| **V7** | **PR 1 is a true no-op** | Full suite after PR 1, before PR 2 | Green with **no expected-value edits** (call-shape edits only — the signature change forces ~29 of them, so "zero test edits" is impossible by construction) |
+| **V8** | Real Bowtie 2 oracle (bonus gate) | `bismark --local` on a fixture; for SE reads mapping uniquely in one strand instance with no second-best, compare Bismark's MAPQ to Bowtie 2's own | **Agreement except where `floor(scMin)` moves a bucket** — every disagreement must be explained by the int/float difference, and the rate quantified. Triage MAPQ 255 (non-primary) and cross-instance second-best out of the comparison set. **If the restricted set can't be built reliably, say so and rely on V2** — do not quietly drop it |
+| **V9** | **Wiring, unit level** — the `(local, aligner)` → model matrix | All 8 combinations: `--local --bowtie2` → `match_bonus==2.0, form==Log, local_ladder`; `--local --hisat2` → `0.0, Linear, local_ladder`; each aligner's default → `0.0, Linear, !local_ladder`; minimap2/rammap + local unreachable | As stated. Cheap, and the direct guard on the only new logic |
+| **V10** | **Wiring, end-to-end** — a local MAPQ **value out of a real BAM** | `--bowtie2 --local` integration test via the existing `make_fake_bowtie2_mapped` harness (which already asserts MAPQ from a BAM, `aligner_cli.rs:422`). **Two cells:** (a) a **≥23 bp** read with default `G,20,8` (len 25 → scMin 45.75, perfect 50) — realistic params; (b) the existing 6 bp fixture with `--score_min G,1,0` (constant `scMin=1`, `alwaysPositive` ✓, perfect 12, diff 11) — no new fixture needed | A MAPQ that **differs old vs new**. ⚠️ The existing 6 bp fixture at default `G,20,8` returns **22 both before and after** — it discriminates nothing. Either cell must be built deliberately |
+| **V11** | Reporter's case #2 (dropped in rev 0) | Bowtie 2-local **perfect** alignment: `len=100, AS=200` ⇒ `best_over == diff == 143.1586` exactly (same f64 subtraction both sides) | 44 with no second best; with a second best it lands on the `==diff` leaves (`mapq.rs:174,182,190,198,206`) — reachable and meaningful for the first time |
+
+**Load-bearing:** V7 (isolates the refactor), V1 (protects the frozen paths, *with* its new axes), V2 (replaces a test that cannot fail), V9+V10 (without them a mis-wired `aligner` makes the fix a silent no-op with a fully green suite — the same failure shape that let #1079 ship).
+
+---
+
+## 10. Questions or ambiguities
+
+| Priority | Item |
+|---|---|
+| **Resolved** | Gating policy (unconditional); scope (D1 + D2, HISAT2 perfect deferred); **D-EDGE — now decided, not in-flight**: the clamp and new denominator apply only when `match_bonus > 0`; two PRs; `ScoreModel` in `config.rs`; minimap2 → assumption + issue; 3.2.0 minor; credit @9xg |
+| **Resolved** | Version bump → **release cut**, not PR 2 (Felix, 2026-07-29). Neither PR touches the three literals; they stay consistent at 3.1.0 so both guard tests pass. CHANGELOG entry lands in PR 2 under `## Unreleased`. See step 10. |
+| **Deferred (issue)** | HISAT2 perfect score / correct ladder — carry O3's reasoning (no `--local` mode ⇒ likely genuinely 0) |
+| **Deferred (issue)** | minimap2/rammap positive-AS ⇒ top-rung MAPQ (A9) — same defect class, default path, currently byte-frozen |
+| **Noted** | Do **not** add a `--local` cell to `perl-oracle` — it would codify the bug. A **Bowtie 2**-oracle cell (V8) is the right analogue |
+
+---
+
+## 11. Self-Review
+
+**Efficiency** — O(1) added arithmetic; `Copy` by value; net arity reduction. Change-cost (~50 sites) is the real risk and is mitigated by the PR split + V7.
+
+**Logic** — traced all **4** production call sites (rev 0 said 3) and confirmed each carries the read lengths, so no data plumbing is needed beyond the model. Confirmed `bestOver` must not move — only the denominator — else the ladder shifts twice; `normalize()` enforces that structurally.
+
+**Edge cases** — `scMin ≤ −1` (the real condition, now structural), non-default `--score_min`, `len = 0` (reasoned, both branches), the clamp's actual trigger, `diff == 0`'s true failure shape (silent top rung, no division), PE two-mate summation, combined-index (`--local` rejected ⇒ refactor-only), 5-Base (never calls `calc_mapq`), minimap2/rammap (A9).
+
+**Integration** — no internal `calc_mapq` MAPQ consumer; `--five_base_min_mapq` narrowed and cleared; CI exposure corrected (no aligner oracle at all).
+
+**Remaining risks**
+1. **V8 may not be cleanly constructible** — Bismark's cross-instance second-best has no Bowtie 2 counterpart, and int-vs-float boundaries add noise. V2 is the real gate; V8 must report rather than silently drop.
+2. **HISAT2-local becomes self-consistent but not yet provably correct** (perfect score still 0). The CHANGELOG must say exactly that.
+3. **minimap2/rammap ship with a known-wrong denominator** (A9), deliberately frozen. Documented so `match_bonus = 0.0` is never read as verified.
+4. **Bowtie 2-local users see MAPQ change** — intended and approved; needs a clear release note.
+
+---
+
+## 12. Implementation Notes (2026-07-29)
+
+**Branch:** `rust/local-mapq-denominator`, based on `origin/dev` (`0a9eeb7`). Not `master`: `config.rs`/`options.rs`/`mod.rs` differ there (the #1075 `--threads` work), and `origin/dev` is both the PR target and byte-identical to the tree the plan's line numbers were verified against (5 of 6 aligner files; `mod.rs` shifted +10, re-verified).
+
+**Status:** both PRs implemented in one working tree. fmt clean, **0 clippy warnings** (`--all-targets`), **2107 tests pass / 0 fail** (was 2101; +6 net). Not committed — awaiting review.
+
+### PR 1 — mechanical refactor
+
+Site counts came out **exactly** as the reviewers' corrected figures (and not the plan rev-0 figures): 2 `merge.rs` + 8 `combined.rs` trio declarations, 6 `mod.rs` config-expansion sites, 2 fn-pointer aliases, and — the compiler's own count — **4** production `calc_mapq` call sites, confirming `combined.rs:774` was real.
+
+**V7 was verified as a proof, not a green run.** A script inverse-transformed the new `ScoreModel` calls back to the trio and compared whitespace-normalized test modules against `HEAD`: `mapq.rs`, `merge.rs`, `combined.rs`, `mod.rs` all came back **byte-identical** (e.g. `combined.rs` 44999 chars both sides). So PR 1 is provably call-shape-only.
+
+**Arity payoff confirmed:** removing the two `#[allow(clippy::too_many_arguments)]` (the `combined.rs` one whose own comment blamed the trio, plus `merge.rs`'s SE one) leaves clippy silent — exactly Reviewer A's prediction. `merge.rs`'s PE allow stays, as predicted.
+
+**Deviation (documented):** plan step 1 said PR 1 should have `score_min_params` return the form and the constructor take it "verbatim from the emitted value" — that is self-contradictory with the warning box immediately after it, because reading the emitted form *is* D2. Resolved in favour of the warning box: PR 1 leaves `score_min_params` untouched and sets `form = if local { Log } else { Linear }` (verbatim current behaviour); PR 2 introduces the emitted form. Without this, D2 would have landed inside the "inert" step and V7 could not have held.
+
+**Deviation:** `match_bonus`, `perfect()` and `BOWTIE2_LOCAL_MATCH_BONUS` were held back to PR 2. In PR 1 they would be written-but-never-read → `dead_code` → a `-D warnings` failure. PR 1 carries only the fields it reads.
+
+### PR 2 — semantics
+
+`ScoreMinForm` is now returned by `score_min_params` and consumed by `ScoreModel::from_emitted`, so the emitted `--score-min` option and the MAPQ `scMin` are one fact (Reviewer B's I8 — closes D2's class, not just the instance).
+
+**Exactly one existing test changed values** — `local_hisat2_default_params_mapq`, as both reviewers predicted. All four predicted values were **hand-derived from the linear `scMin` before touching the file** and matched the predictions exactly: `:397` 22→**44**, `:401` 40→**31**, `:402` 0→**1**, `:410` 34→**11**. Renamed to `local_hisat2_uses_the_linear_form_it_was_emitted`.
+
+**A latent trap the reviewers' analysis exposed:** the tautological test `local_calc_mapq_uses_ln_scmin_and_local_ladder` **still passed** after D1 — its six cells happen not to cross a rung boundary between `diff = 51.30` and `diff = 48.70`. It was asserting a now-wrong denominator and surviving on luck. Replaced (not re-baselined) with `bowtie2_local_reference`, an explicit **f64 analogue** of `unique.h:206-222`, swept over `len × as_best × second-best` plus PE.
+
+**Structural extraction:** the end-to-end ladder is now `calc_mapq_end_to_end`, mirroring `calc_mapq_local`. Needed so the frozen-path reference can call the real ladder — the first attempt used an `unreachable!()` stub, which the code-quality rule forbids; extracting the ladder removed the need for a stub at all.
+
+### Both new gates were verified to have teeth
+
+A regression test that cannot fail is the defect this whole issue is about, so each load-bearing gate was checked against the failure it exists to catch:
+
+| Gate | Injected fault | Result |
+|---|---|---|
+| **V1** `frozen_paths_match_the_pre_fix_formula` | made the clamp universal (rev 0's "preferred" branch) | **FAILED** at `e2e SE i=0 s=-0.2 len=1` — the exact `len < 5` case |
+| **V10** `bowtie2_local_mapq_..._end_to_end` | forced `match_bonus = 0.0` (simulated lost wiring) | **FAILED** `left: 44, right: 28` with the diagnostic naming the cause |
+
+Both faults were reverted and re-verified green; no `TEMP` markers remain.
+
+**V10 fixture:** Reviewer B was right that the existing 6 bp fixture at default `G,20,8` returns 22 both before and after. Reviewer A's `--score_min G,1,0` route also needed `AS:i:0` → `AS:i:6` to discriminate (a swept table showed `AS ∈ 2..9` discriminate; `AS:i:6` gives old **44** → new **28**). Added `make_fake_bowtie2_local_partial_score`. Worth noting the old model returns 44 for *every* `AS ≥ 2` on that fixture — the saturation pathology in miniature.
+
+**Not done (by decision):** V8 (real Bowtie 2 oracle) — needs a Bowtie 2 binary and a restricted comparison set; V2's independent reference is the standing gate, per §9. Version literals untouched (release cut). The two deferred issues (HISAT2 perfect score; minimap2/rammap positive-AS) are **not yet filed**.
+
+## 12b. Post-review fixes (2026-07-29)
+
+Dual code review (`CODE_REVIEW_A.md` / `CODE_REVIEW_B.md`) + coverage audit (`COVERAGE.md`) → **all findings applied**. Both reviewers APPROVED with no correctness defect; coverage was INCOMPLETE on 6 items, all now closed. Final state: fmt clean, **0 clippy warnings**, **2109 tests pass / 0 fail**.
+
+### The one High finding — V10 was form-blind (B's H1)
+
+V10 used `--score_min G,1,0`. With **slope 0**, `i + s·ln(len)` and `i + s·len` are both exactly `1.0`, so the test could not observe the `scMin` **form** — meaning D2's wiring had no end-to-end gate. My own teeth-check had missed this: I injected a lost `match_bonus` (D1's wiring) and concluded "V10 has teeth", never injecting a wrong *form*.
+
+Fixed by moving to `--score_min G,1,1`, which separates all three states: **24** correct · **22** wrong form · **44** lost match bonus. The failure message now names which fault a wrong value implies.
+
+**Re-verified by injecting each fault** (all reverted, no `TEMP` markers left):
+
+| Injected fault | V10 cell (b) | V10 cell (a) | frozen-path |
+|---|---|---|---|
+| `form` forced to `Linear` | **FAIL** 22≠24 | **FAIL** 22≠36 | — |
+| `match_bonus` forced to `0.0` | **FAIL** | **FAIL** | — |
+| clamp made universal | — | — | **FAIL** at `len=1` |
+
+### The most valuable doc finding — I shipped the refuted reasoning (B's M1)
+
+The CHANGELOG and README both justified end-to-end safety with *"(there the perfect score is 0, so the two expressions agree)"*. **They do not agree** — that is the exact claim rev 0 made, which plan-review C1 refuted and which caused the whole gating redesign (`max(1, −scMin) ≠ abs(scMin)` whenever `scMin > −1`). As B noted, this is precisely the reasoning a future maintainer would cite to "simplify" the branch away — i.e. to reinstate the bug that `end_to_end_matches_the_pre_fix_formula` exists to catch. Both texts now say end-to-end is safe **because the code branches**, and state explicitly that the expressions are *not* equivalent.
+
+### Everything else applied
+
+| Finding | Fix |
+|---|---|
+| **E2** (A) `mapq.rs` header claimed "All other modes remain byte-identical to Perl" — false, HISAT2-local isn't | Header now names **both** deliberate deviations; byte-identity claimed for end-to-end only |
+| **M4/E3** two stale `options.rs` comments asserting the pre-D2 "`ln()` MAPQ scMin", one *inside* the doc comment the change edited | Both rewritten |
+| **M5/E4** `rust/README.md` aligner **row** untouched (only Milestones) | Row now carries the `--local` divergence caveat; byte-identity framed as the end-to-end contract |
+| **M2** CHANGELOG self-contradiction on HISAT2 `--local` | Bullet 1 scoped to the denominator, pointing at bullet 2 |
+| **O4** missing note that `==diff` rungs (39/35/34/33/32/31) become reachable | Added — users diffing local BAMs will see MAPQ values that never occurred before |
+| **M3/E5** release notes promised trackers that didn't exist | **Filed [#1080](https://github.com/FelixKrueger/Bismark/issues/1080)** (HISAT2 perfect score, carrying O3's reasoning) and **[#1081](https://github.com/FelixKrueger/Bismark/issues/1081)** (minimap2/rammap positive-AS); both now cited by number |
+| **V6/M6/S5** clamp test asserted `diff == 1.0` but never called `calc_mapq` — the gate's stated risk is a *silent top rung* | Added the rung assertion (**22**, the floor). Also fixed "len ≲ 22" → the clamp is active through **len 23** |
+| **V1/item 13** `len` axis was an 11-point sample, not the specified `1..=500` | Widened to `1..=500`; `--score_min` cells hoisted to a shared `SCORE_MIN_CELLS` const |
+| **V10/item 22** cell (a) missing | Added `bowtie2_local_mapq_at_default_score_min_end_to_end` — 25 bp read at **default** `G,20,8` (needs ≥23 bp, else `scMin > perfect`), expects **36** |
+| **S1/S3** `frozen()`'s `local` branch dead; name overstated HISAT2 freezing | Split into `end_to_end_matches_the_pre_fix_formula` + `hisat2_local_denominator_is_abs_of_the_linear_scmin` (shape frozen, not values) |
+| **S2/L4** loop-invariant HISAT2 assertion ran 990× for 66 facts | Hoisted into its own test |
+| **S4/L1** four `ln(25)` figures wrong from the 4th digit, in a test whose purpose is hand-derivation | Corrected to 45.7510066 / 4.2489934 / 2.2489934 / 2.1244967 |
+| **B-L1** the `31` cell rides a zero-margin edge (`10.0*0.1 == 1.0` exactly) | Kept (deterministic, and Perl computes the same double) + added three off-boundary cells at 100 bp with margin 1 |
+| **S7/L2** `float_cmp` allow on `calc_mapq` now vacuous (no float compare left after the extraction) | Removed; both ladders keep theirs |
+| **S6** `normalize`/`local_ladder` needlessly `pub` on a published crate | → `pub(crate)` |
+| **L1** (A) "never settable independently" wasn't enforced | Reworded to what is actually guaranteed (private fields + one general constructor) |
+| **L2** (A) NaN asymmetry: `.max(1.0)` swallows NaN, `abs()` propagates it | Documented on `normalize` |
+| **S8/L3** `end_to_end` hardcodes an aligner | Commented why it is sound, with a pointer to revisit under #1081 |
+| **L9** upstream multiplies by `(double)0.8f`, not `0.8` — a second int/float divergence | Noted on `bowtie2_local_reference` so nobody tries to make it exact |
+| **L6** docs site had no HISAT2 MAPQ caveat | Added to `docs/.../options/alignment.md`, citing #1080 |
+| **S9** CI step name said "prove all 12 ran" while `EXPECTED=13` (pre-existing) | Fixed to 13 |
+
+**Reviewer findings deliberately not acted on:** none. **V8** (real Bowtie 2 oracle) remains the one plan item not built — §9 V8 authorizes this explicitly ("if the restricted set can't be built reliably, say so and rely on V2"), and A quantified the residual exposure at **0.40 %** (361 of 89,976 cells differ from a faithful int64 Bowtie 2 analogue, i.e. 99.6 % agreement).
+
+## 13. Revision History
+
+**rev 1 (2026-07-29)** — dual plan-review (`PLAN_REVIEW_A.md`, `PLAN_REVIEW_B.md`) folded. ~12 findings were reached independently by both reviewers. Two contradictions resolved **in B's favour**:
+
+| Contradiction | Resolution |
+|---|---|
+| Step ordering — A called it sound; B showed **D2 lands inside the "no-op" step** (the constructor's `local && aligner == Bowtie2` flips HISAT2-local to linear when threaded), so V7 could not hold | **B correct.** PR 1's constructor is verbatim-behaviour; D2 moved to PR 2 step 5 with hand-recomputed expectations |
+| Denominator gating — A: dispatch on `!local_ladder`; B: dispatch on **`match_bonus > 0`** | **B correct** (strictly narrower) — also keeps HISAT2-local frozen, so its values move for one reason, not two |
+
+Substantive corrections to rev 0:
+- **C1** — end-to-end invariance was asserted from an incomplete condition (`len ≥ 5`); the real condition is `scMin ≤ −1`, breakable by legal non-default `--score_min` at any length. Now structural, and `D-EDGE` is retired as a decided question. V1 gained `--score_min` + PE axes.
+- **C2** — Bowtie 2's `int64` arithmetic recorded as an explicit non-goal; V2 respecified as an f64 analogue; V8's pass criterion reframed.
+- **C3/I4** — added V9 + V10 (wiring), the highest-risk untested path.
+- **Site enumeration** — added `mod.rs` (6 sites + 2 fn-pointer aliases), `combined.rs` 598/657, call site `combined.rs:774`; "~10 signatures / 3 call sites" → ~50 edit sites.
+- **False premise removed** — `merge.rs:530` already takes `aligner`; `ScoreModel` rejustified on arity + single construction point.
+- **New assumptions** — A8 (read length == scored length, verified), A9 (minimap2/rammap same defect, frozen), A10 (f64 vs int64), A11 (`--score_min` unvalidated).
+- **Design upgrades** — score-min form single-sourced from `score_min_params` (closes D2's *class*); private fields + named constructors; `normalize()`; `ScoreModel` in `config.rs`; by-value.
+- **Test fallout corrected** — 4 hand-derived HISAT2 assertions must be recomputed (not just the 2 tautologies); the `ln()`-boundary regime disappears after D2 and needs re-homing; V11 (reporter's case #2) restored; V6/V7 restated; 3 version literals + `rust/README.md`.
+
+**rev 0 (2026-07-29)** — initial plan.

--- a/plans/07292026_local-mapq-denominator/PLAN_REVIEW_A.md
+++ b/plans/07292026_local-mapq-denominator/PLAN_REVIEW_A.md
@@ -1,0 +1,298 @@
+# PLAN REVIEW A — Local-mode MAPQ denominator (issue #1079)
+
+**Plan:** `plans/07292026_local-mapq-denominator/PLAN.md`
+**Reviewer:** A (independent, fresh context)
+**Date:** 2026-07-29
+**Verdict:** **Sound diagnosis, correct core fix, but the validation plan does not yet protect the invariant the plan promises.** Three Critical items must be resolved before implementation; the design itself needs only sharpening.
+
+Everything below was checked against the actual source, Bowtie 2 v2.5.5 upstream, and numeric evaluation — not taken from the plan.
+
+---
+
+## 0. What I verified as correct
+
+Credit where due; these did not need changing and I re-derived each independently.
+
+| Claim | Status |
+|---|---|
+| **D1 diagnosis** (`abs(scMin)` assumes `perfect = 0`) | ✅ `mapq.rs:43` / Perl `bismark:3938` |
+| **Measured-impact table** (len 250: 44/42, 44/36, 44/24, 44/22) | ✅ reproduced all four rows exactly |
+| **V3's expected value** (len 100, `G,20,8`, AS 100 → 24, was 42) | ✅ reproduced |
+| **A1** perfect = `2 × len`, PE sums both mates | ✅ `scoring.h:310-316` — `perfectScore(rdlen) = rdlen * match(30)` when `!monotone`; `monotone = (matchConst == 0)` (`scoring.h:168`) |
+| **A2** `G` form is logarithmic ⇒ Bowtie 2-local `ln()` is **correct** and must stay | ✅ `simple_func.h:99-100` (`SIMPLE_FUNC_LOG → X = log(x)`). This catch (recorded in §11) is the plan's most valuable one — the naive reading of the issue would have broken Bowtie 2-local `scMin`. |
+| **A4** `--ma` never reaches the aligner | ✅ absent from Perl `bismark` (only help text at 9729-9730) **and** the Rust CLI; no arbitrary-option passthrough (`cli.positional: Vec<String>` is input files only, no `allow_hyphen_values` / `trailing_var_arg`). `2.0` is safe **today** |
+| **A5** local ladder is untouched and correct | ✅ diffed every leaf of `calc_mapq_local` (`mapq.rs:143-220`) against `unique.h`'s `else // Local alignment` branch — verbatim match, including the uniform `0.5` sub-threshold |
+| **A7** no `--local` cell in the perl-oracle gate | ✅ no `local` / `score_min` token anywhere in `.github/workflows/rust_ci.yml` |
+| §7's read of the two `--local` integration tests | ✅ `hisat2_local_softclip_roundtrip_and_options` (`aligner_cli.rs:2034`) and `hisat2_local_pe_softclip_roundtrip` (`:2116`) assert the option string + soft-clip CIGAR only — **no MAPQ assertion**. They will not break. |
+| `len ≥ 5` algebra for D-EDGE | ✅ correct — **but only for the default `(0, −0.2)`**; see C1 |
+| Ordering (no-op refactor → semantic fix) | ✅ sound; I found nothing that breaks the isolation (one wording fix in O7) |
+| `config.rs:637` is a valid build point | ✅ `aligner` is fully resolved by then (all overrides, 5-Base and combined-index guards, run above at 602-628) |
+| `--local` unreachable for minimap2 / rammap / combined-index | ✅ `config.rs:517-537` |
+
+---
+
+## 1. Logic review
+
+### 🔴 C1 — The end-to-end invariance claim is false, and **neither** D-EDGE option repairs it
+
+This is the most serious finding. The plan's headline promise is *"end-to-end output unchanged (byte-identical)"*, resting on `perfect = 0 ⇒ max(1, 0 − scMin) ≡ abs(scMin)`. That identity needs **two** conditions, not one:
+
+1. `−scMin ≥ 1` (the plan's D-EDGE — it caught this), **and**
+2. `scMin ≤ 0` (the plan does **not** mention this at all).
+
+`--score_min L,<i>,<s>` is validated **shape-only** (`options.rs:405-410`: non-empty strings, no numeric check) and parsed into arbitrary `f64` (`options.rs:390-396`). So both conditions are user-breakable at *any* read length. I evaluated old vs. new over a grid of legal parameter sets:
+
+| `--score_min` | len | AS | 2nd | old | new (universal clamp) | new (**local-only clamp** = plan's fallback) |
+|---|---|---|---|---|---|---|
+| `L,0,0` | 100 | 0 | none | 42 | **0** | 42 ✅ |
+| `L,0,0` | 100 | −3 | −3 | 33 | **0** | 33 ✅ |
+| `L,0,-0.005` | 100 | 0 | none | 42 | **0** | 42 ✅ |
+| `L,-0.5,0` | 100 | 0 | none | 42 | **23** | 42 ✅ |
+| `L,0,0.2` | 100 | 0 | −1 | 2 | **33** | **39** ❌ |
+| `L,5,0.1` | 100 | 0 | −3 | 0 | **33** | **39** ❌ |
+| `L,0,0.2` | 100 | −1 | −5 | 0 | **33** | **33** ❌ |
+
+Two distinct families:
+
+- **`−1 < scMin ≤ 0`** (e.g. `L,0,0` = "require a perfect alignment" — an entirely plausible user request; `L,-0.5,0`; any tiny slope). The clamp fires → the **universal** clamp diverges. The plan's local-only fallback *does* fix this family.
+- **`scMin > 0`** (positive intercept/slope). Here `0 − scMin` is negative while `abs(scMin)` is positive — the two expressions differ **regardless of the clamp**. The plan's fallback does **not** fix this family.
+
+So the plan's D-EDGE resolution rule is incomplete: *both* of its branches can break end-to-end byte-identity on legal input. And **V1 as specified would not catch it** — V1 sweeps `len ∈ 1..=500 × as_best × {None, Some}` with (implicitly) the default params only. It would go green and the divergence would ship.
+
+**Recommendation** (follows from the plan's own stated priority, "end-to-end byte-identity outranks upstream mimicry"): stop treating D-EDGE as an open in-flight decision and make the denominator mode-dispatched:
+
+```rust
+let diff = if model.local_ladder {
+    (model.perfect(read1_len, read2_len) - sc_min).max(1.0)   // Bowtie 2 unique.h
+} else {
+    sc_min.abs()                                              // frozen end-to-end
+};
+```
+
+That is byte-identical end-to-end **by construction** — no sweep needed to prove it — and it is exactly as faithful to Bowtie 2 in local mode. Keep V1 anyway as a regression net, but add the `(intercept, slope)` and `read2_len` axes to it.
+
+If instead you *want* end-to-end to follow Bowtie 2 for these exotic parameters, that is a defensible second option — but it is a **second behaviour change** outside the locked scope and needs saying out loud in the CHANGELOG, not discovering during V1.
+
+### 🔴 C2 — V2 and V8 cannot reach "agreement": Bowtie 2's `scMin` is an **integer**
+
+`unique.h:213`:
+
+```cpp
+TAlScore scMin = scoreMin_.f<TAlScore>((float)rdlen);
+```
+
+`TAlScore` is `int64_t`, and `SimpleFunc::f<T>` ends with `return (T)ret;` (`simple_func.h:110`) — so Bowtie 2 **truncates** `scMin` (and note the `(float)rdlen` cast before `log`). Bismark and Perl both keep `f64`. `diff` and `bestOver` inherit the difference.
+
+I quantified it. Bowtie 2-local `G,20,8`, SE, no second-best, `len ∈ 25..300` × every legal `AS`: **562 cells disagree** between the f64 model and a faithful integer transcription — always 1–2 rungs, always at a bucket boundary:
+
+```
+len=25 AS=47  bismark=22  bowtie2=28
+len=25 AS=49  bismark=42  bowtie2=44
+len=28 AS=50  bismark=24  bowtie2=28
+len=28 AS=53  bismark=41  bowtie2=42
+```
+
+Consequences:
+
+- **V2** says "Transcribe `unique.h:206-222` into a test-only reference fn … Expected: Agreement across the grid." A *faithful* transcription will fail on a *correct* fix. V2 must state explicitly that the reference reproduces `unique.h`'s **structure** (`scPer`, `max(1, scPer − scMin)`) while keeping **Bismark's f64 `scMin`** — otherwise the load-bearing anti-tautology test is testing the wrong thing.
+- **V8** ("Expected: Agreement") will show real disagreements that are **not** bugs in this fix. Its pass criterion needs to be either "agrees except where `trunc(scMin) ≠ scMin` moves a bucket boundary", or "agrees after truncating `scMin` to `i64`". Otherwise V8 produces noise the implementer must relitigate mid-flight.
+
+Adopting Bowtie 2's truncation to make V8 clean is **not** an option — `scMin = −0.2 × len` is fractional for most end-to-end lengths, so truncating would break the byte-frozen default path. Record it as considered-and-rejected so V2/V8's expectations are principled rather than improvised.
+
+### 🔴 C3 — Nothing, at any level, exercises Bowtie 2 `--local` MAPQ — so the `aligner` wiring is unvalidated
+
+This is the plan's biggest silent-failure hole. The fix's entire effect hinges on `ScoreModel::new` receiving `aligner == Bowtie2` together with `local == true`. But:
+
+- The only `--local` integration tests are **HISAT2** (`aligner_cli.rs:2034`, `:2116`) and they assert no MAPQ.
+- `aligner_methylseq_conformance.rs:196-203` checks only the emitted **option string**.
+- `combined.rs` can never be local (`--local` + `--combined_index` rejected, `config.rs:535`), so `match_bonus` there is always `0`.
+- V3 is a unit test on `calc_mapq` — it proves the formula, not the plumbing.
+
+If the wrong `aligner` reaches `ScoreModel::new` (wrong enum arm, model built too early, a future refactor that drops the argument), `match_bonus` silently becomes `0.0`, the fix becomes a **no-op**, and **V1, V3, V7 and the whole suite still pass**. That is exactly the failure shape that let #1079 ship in the first place.
+
+**Add two validations:**
+
+- **V9** — `config::resolve` assertions on the resolved model: `--local --bowtie2` → `match_bonus == 2.0 && log_score_min && local_ladder`; `--local --hisat2` → `0.0 && !log_score_min && local_ladder`; default (each of the 4 aligners) → `0.0 && !log_score_min && !local_ladder`.
+- **V10** — one fake-Bowtie 2 `--local` CLI test asserting the **BAM MAPQ column**. Constructible with the existing 8 bp fixture genome by passing `--score_min G,1,0` (constant `scMin = 1`; `alwaysPositive` ✓ so it is a legal Bowtie 2-local function): perfect `= 12`, `diff = 11`, so the ladder is exercised on a 6 bp read. This is the only test that would prove config → merge → output carries a `match_bonus = 2.0` model.
+
+### 🟠 I1 — `mod.rs` is missing from the plan entirely (6 sites, 2 of them function pointers)
+
+The Files table lists `mapq.rs`, `config.rs`, `options.rs`, `merge.rs`, `combined.rs`, CHANGELOG, VERSION. `mod.rs` passes the trio at **six** places:
+
+`mod.rs:2599` (SE merge) · `3146` (SE combined, via `select_fn`) · `3528` (`select_nondir`) · `4647` (PE merge) · `5255` (PE combined, via `select_fn`) · `5705` (`select_pe_nondir`)
+
+Two of those (`3146`, `5255`) go through **`select_fn` function pointers**, so collapsing the trio changes a fn-pointer *type*, not just an argument list. Compiler-caught, but an implementer working the plan's site list will be surprised by the largest file in the module.
+
+### 🟠 I2 — `combined.rs` enumeration is incomplete: 8 threading signatures, not 6; 4 call sites, not 3
+
+Actual parameter declarations: `188` (`select`) · `246` (`select_core`) · `388` (`select_nondir`) · `437` (`select_pbat`) · `501` (`select_pe`) · `543` (`select_pe_nondir`) · **`598` (`select_pe_pbat`)** · **`657` (`select_core_pe`)**.
+
+The plan lists the first six and calls them "5 further threading sites". The two it misses matter: `select_core_pe` is the **shared PE core**, and it holds `calc_mapq` **call site `combined.rs:774`** — which the plan never names (§2 says "call sites L349 etc."; §11 says "all three call sites"). Production call sites are **four**: `merge.rs:370`, `merge.rs:747`, `combined.rs:349`, `combined.rs:774`. Plus a test call site at `combined.rs:1205`.
+
+Arity check on the plan's one concrete clippy claim: `select_pe_nondir` is 8 args → 6 after collapsing. Clippy's threshold is >7, so deleting the `#[allow]` at `combined.rs:535` is correct ✅. (`merge.rs:190`'s allow also becomes unnecessary: 9 → 7. `merge.rs:519` stays at 11 → 9 and still needs it.)
+
+### 🟠 I3 — §2's design premise is factually wrong
+
+> "**No call site knows which aligner is running**"
+
+`merge::check_results_paired_end` **already takes `aligner: Aligner`** (`merge.rs:530`), fed from `config.aligner` at `mod.rs:4650`. The claim holds for the SE and combined paths only.
+
+The `ScoreModel` decision is still right — it drops arity instead of raising it, and hand-threading `aligner` into the SE + 8 combined signatures would be worse. But the justification of record should be "net arity reduction + one construction point", not a false premise. (It also means the cheap alternative was cheaper than the plan implies — see Alternatives.)
+
+### 🟠 I4 — Step 4 under-scopes D2's test fallout
+
+The plan flags only `mapq.rs:376` and `:416` (the tautological routing loops). But `local_hisat2_default_params_mapq` (`mapq.rs:390-419`) contains **five hand-derived, genuinely independent** assertions — its own doc-comment stresses they are "the Perl local ladder hand-applied … **NOT** self-consistency" — and **all five change** once HISAT2-local `scMin` goes linear:
+
+| Line | Call | old | new |
+|---|---|---|---|
+| 397 | `calc_mapq(50, None, -1, None, 0, -0.2, true)` | 22 | **44** |
+| 401 | `calc_mapq(50, None, 0, Some(-1), …)` | 40 | **31** |
+| 402 | `calc_mapq(50, None, -1, Some(-1), …)` | 0 | **1** |
+| 410 | `calc_mapq(150, Some(150), 0, Some(-1), …)` | 34 | **11** |
+| 412-418 | routing loop | tautological | rewrite |
+
+These must be **re-derived by hand from the linear `scMin`** (preserving what the test was built to do), not re-baselined from the implementation — the plan's own §11 rationale for the tautology applies verbatim here. Note also that after D2 this test's stated purpose ("targets the `ln()`-ULP-sensitive regime the `(20,8)` tests never reach") **evaporates**: with HISAT2 linear and Bowtie 2 the only `ln()` consumer, the `ln()`-derived-boundary coverage needs re-homing onto a Bowtie 2-local case.
+
+### 🟠 I5 — The same D1 defect exists, unfixed, in the **default** path for `--minimap2` / `--rammap`
+
+minimap2 and rammap emit **positive** `AS:i:` — the repo's own fixtures say so (`aligner_cli.rs:2463`: "minimap2-style tags: a **positive** `AS:i:`"). They route through the same `run_se`/`run_pe` → `calc_mapq` with `local = false`, so `perfect = 0` and `diff = abs(scMin) = 0.2·len`, giving
+
+```
+bestOver/diff = (AS + 0.2·len) / (0.2·len) = AS/(0.2·len) + 1  >  1
+```
+
+i.e. the **top rung for essentially every unique minimap2/rammap hit** — the identical defect class as #1079, in a non-`--local` path, today.
+
+`ScoreModel::new`'s `else { 0.0 }` doesn't just leave this alone; it **codifies** `perfect = 0` for minimap2/rammap in the new type. Since minimap2 SE is byte-frozen against Perl v0.25.1 + minimap2 (per `rust/README.md:161`), deferring is legitimate — but it deserves the same explicit treatment as A3/HISAT2: an assumption row and a deferred issue, not silence. Otherwise the next person reads `match_bonus = 0.0` for `Minimap2` as a verified fact.
+
+### 🟠 I6 — `ScoreModel` can be built in a state the aligners cannot produce
+
+`log_score_min` and `match_bonus != 0` are **the same predicate** (`local && aligner == Bowtie2`). With all five fields `pub`, a hand-built test model — and tests *will* hand-build them — can set one without the other, and nothing catches it. Prefer an enum:
+
+```rust
+enum ScoreModel { EndToEnd { i, s }, Bowtie2Local { i, s }, Hisat2Local { i, s } }
+```
+
+or private fields with `new()` as the only constructor.
+
+Related, and worth recording in the type's docs: after D2, HISAT2-local is `local_ladder = true, match_bonus = 0.0` — a combination **Bowtie 2 itself can never produce**, because Bowtie 2 selects the ladder from `sc_.monotone`, i.e. *from the match bonus* (`unique.h:335` `if(sc_.monotone) … else // Local alignment`). Monotone scoring ⇒ end-to-end ladder, always. Bismark's split is the faithful-to-Perl choice and is exactly what deferred item A3 is about — so make it the in-code marker for that deferred issue rather than an implicit oddity.
+
+### 🟠 I7 — V6 tests the wrong quantity, and there is no division to protect
+
+The clamp fires when **`perfect − scMin ≤ 1`**, not when `scMin ≈ 0`. And "scMin → 0⁻ in local mode" is not a reachable Bowtie 2-local state at all: `bt2_search.cpp:1861` makes Bowtie 2 **die** —
+
+> "Error: the match penalty is greater than 0 … but the `--score-min` function can be less than or equal to zero. Either let the match penalty be 0 or make `--score-min` always positive."
+
+— whenever the match bonus is >0. So Bowtie 2-local `scMin` is **guaranteed positive** (a useful corollary: the old `abs(scMin) ≡ scMin` there, and the new `diff` is the only thing that changes).
+
+The real clamp case is a **short read**: `len = 6, G,20,8` → `perfect = 12`, `scMin = 34.3` → `max(1, −22.3) = 1`. Practically it is unreachable in real data (Bowtie 2 reports nothing when the minimum score exceeds the perfect score, which for `G,20,8` means `len ≲ 22`), but it is trivially reachable in fake-aligner fixtures — which is precisely where V10 above will live.
+
+Also: §3's *"Guards a division-by-~0"* and V6's *"no div-by-zero, no panic"* mis-describe the code. There is **no division** in either ladder — every comparison is `best_over >= diff * k`. The `diff = 0` failure mode is that every threshold collapses to `>= 0` and the **top rung always wins** (silently wrong MAPQ), not a panic. Worth fixing, because it shows the edge case was reasoned about in the wrong shape.
+
+### 🟠 I8 — Release-mechanics gaps in step 7
+
+- **Three** literals mirror the version, not one: `rust/VERSION`, `rust/bismark/VERSION`, `rust/bismark/Cargo.toml:3`. The plan bumps only the first.
+- **`rust/README.md` is absent from the plan.** Its own rule (`rust/README.md:175`) is that *every* module-merge PR into `master` updates that tool's row **and** adds a dated Milestones line. A user-visible MAPQ change in the aligner clearly qualifies.
+- There is exactly one `CHANGELOG.md` (repo root) — no `rust/CHANGELOG.md`. Worth pinning the path.
+- **Question worth asking before implementing:** should a fix PR bump the version at all, or does the bump belong to the release cut? (3.1.0 → 3.2.0 is the right *magnitude* if it is bumped here.)
+
+---
+
+## 2. Assumptions
+
+| # | Plan's assumption | My finding |
+|---|---|---|
+| A1 | perfect = `2 × len`, PE summed | ✅ verified upstream |
+| A2 | `G` is logarithmic; keep `ln()` | ✅ verified; the plan's best catch |
+| A3 | HISAT2 perfect = 0 pending investigation | ⚠️ Probably *not* actually unknown — see O3. Locked as deferred; just don't over-hedge the CHANGELOG if one command settles it |
+| A4 | `--ma` unreachable ⇒ `2.0` constant | ✅ verified today. The plan's caveat is right; consider a one-line doc note on the constant so a future `--ma` passthrough trips over it |
+| A5 | Both ladders correct, untouched | ✅ local ladder diffed leaf-by-leaf against `unique.h` |
+| A6 | `bestOver` unchanged | ✅ and correct to insist on — see O4 for why it now *means* something |
+| A7 | Local not covered by perl-oracle | ✅ verified |
+| — | **Unstated:** `scMin ≤ 0` end-to-end | 🔴 **C1** — false for legal `--score_min` |
+| — | **Unstated:** the `len ≥ 5` threshold assumes `(0, −0.2)` | 🔴 folded into **C1**. `0.2 × len ≥ 1` silently hardcodes the default slope |
+| — | **Unstated:** Bowtie 2's `scMin` is `f64` | 🔴 **C2** — it is `int64_t` |
+| — | **Unstated:** minimap2/rammap perfect = 0 | 🟠 **I5** — false; positive AS, same defect |
+| — | **Unstated:** 5-Base paths don't recompute MAPQ | ✅ verified (`five_base_deconv.rs` / `five_base_duplex.rs` never call `calc_mapq`; 5-Base is minimap2, where `--local` is rejected). Worth one line so a reader needn't check |
+
+---
+
+## 3. Efficiency
+
+Nothing to worry about, and the plan's read is right: `calc_mapq` runs once per accepted alignment, and `diff` adds one multiply + one compare. Arity drops by 2 at ~10 sites. Two nits:
+
+- **O1** — `ScoreModel` is 3×`f64` + 2×`bool` = **32 bytes** with padding, not 40. More to the point, it derives `Copy` but the signature takes `&ScoreModel`; pick one. By value is simpler and the same cost at this size (clippy's `trivially_copy_pass_by_ref` only fires ≤ 8 bytes, so neither form is linted — this is a readability call, not a lint).
+- **O2** — `diff(&self, sc_min, read1_len, read2_len)` makes the caller feed back a value the model can derive, and leaves a caller free to pass a `sc_min` computed some other way. A single `fn normalize(&self, len1, len2, as_best) -> (f64 /*best_over*/, f64 /*diff*/)` is harder to misuse and keeps §3.5's "`bestOver` unchanged" structurally enforced.
+
+---
+
+## 4. Validation sufficiency
+
+The three load-bearing validations are correctly identified (V1/V2/V7) but **two of the three do not currently do their job**, and the highest-risk failure mode has no test at all.
+
+| # | Assessment |
+|---|---|
+| **V1** | 🔴 Insufficient. Add the `(intercept, slope)` axis and a `read2_len` axis, or it goes green while shipping the C1 divergence. Better: make the divergence unreachable (C1's mode-dispatched `diff`) and keep V1 as a net |
+| **V2** | 🔴 Expectation unachievable as worded (C2). Must say "structure of `unique.h`, Bismark's f64 `scMin`" |
+| **V3** | ✅ Correct value, verified. But unit-level only — does not prove the wiring (C3) |
+| **V4** | ✅ Good, and it guards the right bug (single-mate perfect score). `2 × 200 = 400` is right |
+| **V5** | ✅ Good. Also assert the **converse**: `scMin != −0.2 × ln(len)`, so a revert to `ln` fails loudly |
+| **V6** | 🟠 Tests an unreachable state and mis-names the failure mode (I7). Restate as `len = 6, G,20,8 → diff == 1.0`, and assert *which rung* results (the risk is a silently-wrong top rung, not a panic) |
+| **V7** | ✅ Right instinct, wrong wording — see O7 |
+| **V8** | 🟠 Constructible (the plan's triage caveats about MAPQ 255 and cross-instance second-best are the right ones), but its pass criterion must account for C2's integer `scMin` or it will report false failures. The plan's "report if it can't be built rather than quietly drop it" is exactly the right discipline |
+| **V9/V10** | 🔴 **Missing.** The config→model and model→BAM wiring (C3) |
+
+**O7** — V7 says "All green with **zero test edits**." Literally false: `combined.rs:1205` and the `mapq.rs` local tests must construct a `ScoreModel` instead of passing three scalars. Reword to "**zero expected-value changes**" — the distinction is the whole point of the step, and an implementer who reads it literally will think the refactor went wrong.
+
+---
+
+## 5. Alternatives
+
+| Option | Trade-off | Verdict |
+|---|---|---|
+| **A. Enum `ScoreModel`** (`EndToEnd`/`Bowtie2Local`/`Hisat2Local`) | Makes the invalid `log_score_min ⊻ match_bonus` state unrepresentable; the three-way match reads as the §2 table | **Recommended** over the 5-pub-field struct (I6) |
+| **B. Keep the trio, add `aligner`** | Cheaper than the plan implies — PE already has it (I3) — but pushes SE + 8 combined signatures up and *deepens* the `too_many_arguments` debt | Correctly rejected |
+| **C. Mode-dispatched `diff`** (`abs()` when `!local`) | Removes C1 entirely; end-to-end identity by construction, no sweep needed | **Recommended** — supersedes D-EDGE's either/or |
+| **D. `fn perfect(&self, len) -> f64` instead of a `match_bonus` field** | Lets minimap2/rammap (I5) plug in their own match score later with no signature churn; costs nothing now | Worth taking |
+| **E. Truncate `scMin` to `i64` to match Bowtie 2 exactly** | Would make V8 clean, but breaks end-to-end byte-identity (`−0.2 × len` is fractional) | Reject — but **record it as considered-and-rejected** so V2/V8's expectations are principled |
+| **F. Compat flag / opt-in** | Explicitly locked out by Felix | Not revisited |
+
+---
+
+## 6. Action items
+
+### Critical — resolve before implementation
+
+1. **C1** — Make `diff` mode-dispatched (`sc_min.abs()` when `!local_ladder`); demote D-EDGE from an open in-flight decision to a decided one. **Or** accept that end-to-end changes for `scMin > 0` and `−1 < scMin ≤ 0` and say so in the CHANGELOG. Either way, add `(intercept, slope)` and `read2_len` axes to V1 — as written it cannot see this class of divergence. Concrete counterexamples: `L,0,0` @100bp AS 0 no-2nd (42→0 universal) and `L,0,0.2` @100bp AS 0 2nd −1 (2→39 even local-only).
+2. **C2** — Restate V2's reference as "`unique.h` **structure** + Bismark's f64 `scMin`", and give V8 a pass criterion that tolerates Bowtie 2's `int64_t` truncation (562 boundary cells disagree over `len ∈ 25..300` SE alone). Record option E as rejected.
+3. **C3** — Add **V9** (`config::resolve` → resolved-model assertions for all four aligners × `--local`) and **V10** (fake-Bowtie 2 `--local` CLI test asserting the BAM MAPQ; `--score_min G,1,0` makes this work on the existing 8 bp fixture). Without these, a mis-wired `aligner` makes the fix a silent no-op with a fully green suite.
+
+### Important — fix in the plan before handing to an implementer
+
+4. **I1** — Add `mod.rs` to the Files table with its 6 sites (2599, 3146, 3528, 4647, 5255, 5705); call out the two `select_fn` **function-pointer types** at 3146/5255.
+5. **I2** — Correct the `combined.rs` enumeration to **8** signatures (add 598, 657) and **4** production call sites (add `combined.rs:774`) + the test call site at 1205. Fix §11's "all three call sites".
+6. **I3** — Drop the false "no call site knows which aligner" premise (`merge.rs:530` already takes `aligner`); rejustify `ScoreModel` on arity reduction + single construction point.
+7. **I4** — Extend step 5 to the **five hand-derived** HISAT2 assertions at `mapq.rs:397, 401, 402, 410` (with the new expected values), and re-home the `ln()`-boundary coverage that test provided onto a Bowtie 2-local case.
+8. **I5** — Add an assumption row + a deferred issue for **minimap2/rammap**: positive AS through `perfect = 0` is the same D1 defect in a default path, currently held byte-frozen. Do not let `else { 0.0 }` read as verified.
+9. **I6** — Make the invalid `ScoreModel` state unrepresentable (enum, or private fields + `new()`); document `local_ladder && match_bonus == 0` as the HISAT2 deferred marker.
+10. **I7** — Rewrite V6 around `perfect − scMin ≤ 1` (`len = 6, G,20,8`), note that Bowtie 2-local `scMin` is guaranteed positive (`bt2_search.cpp:1861`), and drop the "division by zero" framing — there is no division; the failure mode is a silent top rung.
+11. **I8** — Bump **all three** version literals (`rust/VERSION`, `rust/bismark/VERSION`, `rust/bismark/Cargo.toml:3`); add `rust/README.md` (aligner row + dated Milestones line, per its own rule at :175); pin the CHANGELOG path (repo root, the only one). Confirm whether the bump belongs in this PR or the release cut.
+
+### Optional
+
+12. **O1/O2** — 32 bytes not 40; pick `Copy`-by-value or `&`, not both; consider `normalize()` over `diff(sc_min, …)`.
+13. **O3** — A3 may be settleable in one command: HISAT2 has **no `--local` mode** (Bismark's "HISAT2-local" is just dropping `--no-softclip`) and its scoring is monotone, so `perfect = 0` is likely *correct* rather than provisional. `hisat2 --help | grep -- '--ma'` would confirm. Scope stays deferred — just don't over-hedge the CHANGELOG if it turns out to be knowable.
+14. **O4** — Worth one CHANGELOG line: the fix makes the `bestOver == diff` rungs (39/35/34/…) *meaningful* — they now mean `AS == perfect` instead of `AS == 2·scMin` — which is why they start appearing in local BAMs. The exact-`f64` comparison stays sound (integer `AS`/`perfect`, common `scMin`, minimum gap 1, result ULP ~1e-14), so the `float_cmp` allow keeps its justification; say so in the comment you are rewriting at `mapq.rs:43`.
+15. **O5** — §7's "no internal consumer reads MAPQ" is too broad: `--five_base_min_mapq` **is** an internal MAPQ filter. The conclusion still holds (5-Base is minimap2, `--local` rejected) — narrow the sentence.
+16. **O6** — One line noting 5-Base never recomputes MAPQ, verified, so the reader needn't check.
+17. **O7** — V7: "zero **expected-value** edits", not "zero test edits".
+
+---
+
+## 7. Bottom line
+
+The diagnosis is right, the upstream reading is right, the `ScoreModel` direction is right, and the no-op-then-fix ordering is right. Two of the plan's self-review catches (Bowtie 2-local `ln()` is *correct*; the local tests are tautological) are genuinely good and I confirmed both.
+
+What is not yet safe is the **promise**. "End-to-end is byte-identical" is asserted from an incomplete algebraic condition (C1) and guarded by a sweep that cannot see the counterexamples; the two tests meant to replace the tautology are measured against an oracle that differs from Bismark for reasons unrelated to the fix (C2); and the one thing most likely to go wrong — the aligner never reaching the model — has no test anywhere (C3).
+
+Fix those three in the plan text and this is ready to implement.

--- a/plans/07292026_local-mapq-denominator/PLAN_REVIEW_B.md
+++ b/plans/07292026_local-mapq-denominator/PLAN_REVIEW_B.md
@@ -1,0 +1,296 @@
+# PLAN REVIEW B — Local-mode MAPQ denominator (#1079)
+
+**Reviewer:** B (independent, fresh context)
+**Plan:** `/Users/fkrueger/Github/Bismark/plans/07292026_local-mapq-denominator/PLAN.md`
+**Date:** 2026-07-29
+**Verdict:** the *diagnosis* is correct and well-sourced; the *fix design* has one provably-wrong invariance claim (C1) and one unachievable validation gate (C2), plus a step-ordering contradiction (I1) and a materially incomplete site enumeration (I2). Recommend a rev-1 before implementation.
+
+Everything below was verified against the actual source and against upstream Bowtie 2 v2.5.5 — not taken from the plan.
+
+---
+
+## 0. What I verified as CORRECT
+
+Worth stating plainly, because most of the plan holds up:
+
+| Claim | Status |
+|---|---|
+| A1 — Bowtie 2-local perfect = `2 × len`, summed per mate | ✅ `scoring.h:310-316`: `perfectScore(rdlen) = monotone ? 0 : rdlen * match(30)`; `unique.h:207-209` sums `perfectScore(ordlen)` for pairs. `match(30) = 2` under Bismark's always-on `--ignore-quals` / constant cost model. |
+| A2 — `G` form is logarithmic; Bowtie 2-local `ln()` scMin is **correct** and must stay | ✅ `simple_func.h:88-107`: `SIMPLE_FUNC_LOG` ⇒ `X = log(x)`, `ret = C + L*X`. The plan's catch here is real and important. |
+| A4 — `--ma` never reaches the aligner | ✅ Verified structurally, not just by grep: `Cli` (`cli.rs`) has **no** free-form aligner-option vector (`positional: Vec<String>` is genome/reads), no `trailing_var_arg`/`allow_hyphen_values`/external-subcommand escape, and `options.rs` emits exactly 23 curated `opts.push` sites — none is `--ma`. `2.0` is safe as a constant. |
+| A5 — both ladders' thresholds/returns are correct | ✅ Bismark's `calc_mapq_local` (`mapq.rs:143-220`) is byte-for-byte Bowtie 2's non-monotone ladder (`unique.h:333-380`), including the uniform `diff*0.5` sub-threshold. End-to-end ladder matches `unique.h:223-332`. |
+| A7 — no `--local` cell in the perl-oracle CI gate | ✅ …and **stronger than the plan says** — see I5. |
+| Read length == the length Bowtie 2 scored | ✅ No `--trim5`/`--trim3`/`-5`/`-3`/`--clip_r*` anywhere in `options.rs`/`cli.rs`; `sequence` at all four call sites is the original uc read; soft-clipped records retain full SEQ (asserted at `aligner_cli.rs:2073`); Bowtie 2 also passes the **full** `rdlen` to `mapq()`, not the unclipped length. Nothing to fix here. |
+| minimap2/rammap + `--local` unreachable | ✅ `config.rs:517-529`. |
+| `--local` + `--combined_index` unreachable | ✅ `config.rs:531-537` rejects **all four** variants — see I2c, this is stronger than the plan's edge-case row implies. |
+| §1 impact table arithmetic (len 250) and V3's expected `24` | ✅ Recomputed independently: 42/36/24/22 vs 44/44/44/44, and len 100 / AS 100 → 24. |
+
+---
+
+## 1. Logic review
+
+### C1 (Critical) — "end-to-end is byte-identical **by construction**" is false, and D-EDGE is scoped to the wrong variable
+
+§7 asserts invariance "by construction (`perfect = 0`)"; §3 narrows the risk to `len < 5`. Both rest on the default `--score_min L,0,-0.2`. The actual identity is:
+
+```
+max(1, 0 − scMin) ≡ abs(scMin)   ⟺   scMin ≤ −1
+```
+
+Two independent ways that fails, **neither** of which is a `len` question:
+
+**(a) sign.** `abs(scMin)` and `−scMin` diverge for *every* `scMin > 0`. `--score_min` is shape-validated only (`valid_score_min_l` checks non-empty fields, mirroring Perl's permissive `^L,(.+),(.+)$`), so a positive intercept parses fine.
+
+**(b) magnitude.** The `len ≥ 5` threshold is `1/|slope|`. A user slope of `-0.05` pushes it to `len < 20`; `-0.001` to `len < 1000`.
+
+Measured (frozen ladder vs. plan's proposed universal clamp, end-to-end, AS = 0):
+
+```
+--score_min      len   scMin    old diff  new diff   MAPQ old → new
+L,0,-0.2           1   -0.20      0.20      1.00       42 →  0
+L,0,-0.2           2   -0.40      0.40      1.00       42 →  8
+L,0,-0.2           3   -0.60      0.60      1.00       42 → 24
+L,0,-0.2           4   -0.80      0.80      1.00       42 → 42   (same value, different diff)
+L,0,-0.05         10   -0.50      0.50      1.00       42 → 23
+L,10,-0.2         50    0.00      0.00      1.00       42 →  0
+L,0,0             50    0.00      0.00      1.00       42 →  0
+```
+
+So the plan's D-EDGE "Preferred: keep the clamp universal **if** V1 proves no end-to-end divergence over `len ∈ 1..=500`" is a trap: **V1 as specified sweeps `len × as_best × second-best` but has no `--score_min` dimension**, so it will come back green on the default params and green-light a change that silently alters end-to-end MAPQ for any user with a non-default `--score_min`. methylseq emits `--score_min L,0,-N` (`aligner_methylseq_conformance.rs:15,88-96`), so non-default score-min is a live production configuration.
+
+Compounding it: with an intercept-only user override the divergence is not a rounding wobble — `L,10,-0.2` at 50 bp is **42 → 0**, i.e. every read in the run drops below a `-q 20` filter.
+
+**Required:**
+1. **Pre-decide D-EDGE = clamp is NOT universal.** Do not leave it to V1.
+2. Gate the whole new denominator on `match_bonus > 0.0` (equivalently a `perfect_is_zero` flag), *not* on `local`:
+   ```rust
+   let diff = if self.match_bonus > 0.0 {
+       (self.match_bonus * total_len as f64 - sc_min).max(1.0)   // Bowtie 2-local
+   } else {
+       sc_min.abs()                                              // frozen: all e2e + HISAT2-local
+   };
+   ```
+   This is strictly better than the plan's "clamp only when `local`" fallback, because it also keeps **HISAT2-local** clamp-free. HISAT2-local values already move under D2 (scMin form); gating on `local` would move them for a *second*, unrelated reason (the clamp) in the same commit, and HISAT2's perfect score is admittedly unknown (A3) — so `abs()` is the honest placeholder there, not `max(1, −scMin)`.
+3. Extend V1 with a `--score_min` dimension: at minimum `{(0,−0.2), (0,−0.05), (0,−0.6), (10,−0.2), (0,0), (−1,−0.2)}` × `len ∈ 1..=500`, both SE and PE, both ladders.
+
+**Bonus argument for (2):** the clamp is nearly dead code in Bowtie 2-local anyway. A *reported* alignment satisfies `AS ≥ minsc` and `AS ≤ perfect`, hence `perfect − scMin ≥ 0`; only the `[0,1)` sliver clamps. And with `G,20,8` reads below ~23 bp have `perfect < scMin` outright (len 22 → perfect 44, scMin 44.73), so Bowtie 2 cannot report them at all. The clamp's only *behaviour-changing* reach is end-to-end — the exact opposite of its intent.
+
+### C2 (Critical) — V2 and V8 cannot pass as written: Bowtie 2's `scMin`/`diff`/`bestOver` are **integers**
+
+The plan quotes `unique.h:207-217` verbatim but doesn't register that `TAlScore` is `int64_t`:
+
+```cpp
+TAlScore scMin = scoreMin_.f<TAlScore>((float)rdlen);   // simple_func.h:106 → return (T)ret  ⇒ TRUNCATION
+TAlScore diff  = std::max<TAlScore>(1, scPer - scMin);
+TAlScore bestOver = best - scMin;
+```
+
+Bismark (Perl and Rust) keeps `scMin` as `f64`. For `G,20,8` the log form is essentially never integral, so a **faithful** transcription of `unique.h` disagrees with `calc_mapq` at every bucket boundary. Concrete, verified:
+
+```
+Bowtie 2-local, len 100, G,20,8, AS = 128, no second best
+  Bismark (f64): scMin 56.8414  diff 143.1586  bestOver 71.1586  ratio 0.4972 → MAPQ 28
+  Bowtie 2 (i64): scMin 56      diff 144       bestOver 72       ratio 0.5000 → MAPQ 36
+```
+
+Consequences:
+- **V2** ("Transcribe `unique.h:206-222` … Expected: **Agreement across the grid**") will fail on a large fraction of cells. The reference fn must be the deliberate **f64 analogue** of `unique.h`, with a comment saying so; otherwise the implementer either weakens the grid until it passes (destroying the gate's value) or "fixes" `calc_mapq` by truncating.
+- **Truncating is not an option** and the plan should say so explicitly: `mapq.rs:259-262` (`non_integer_scmin`) pins end-to-end `len 51 → scMin −10.2`. Adopting int semantics would change end-to-end MAPQ — the one thing that must not move.
+- **V8**'s expected result ("Agreement") is therefore wrong even for a perfectly restricted comparison set. V8 must be reframed: *"expect agreement except where int-vs-float truncation moves a bucket; every disagreement must be explained by `floor(scMin)`, and the rate quantified."* As written, V8 will read as a failure and burn a debugging cycle on a non-bug.
+
+Add int-truncation as an **explicit, documented non-goal** in §1, next to the HISAT2 perfect-score deferral. It is the same class of decision and it will otherwise resurface in every future MAPQ review.
+
+### I1 (Important) — step 2 is not a no-op: **D2 lands inside it**, so V7 cannot hold
+
+Step 1 defines the constructor with `log_score_min = local && aligner == Bowtie2`. Step 2 then claims "Refactor-only, zero behaviour change" and V7 claims "All green with **zero test edits**". But step 4 itself admits D2 "falls out of step 1 automatically" — so HISAT2-local's scMin flips from `ln` to linear *during* the supposedly-inert step. Recomputed against `mapq.rs:390-419`, **4 of the 6 hand-computed HISAT2-local expectations change**:
+
+| Assertion (mapq.rs) | current expect | after D2 |
+|---|---|---|
+| `:396` `calc_mapq(50, None, 0, None)` | 44 | 44 (same) |
+| `:397` `calc_mapq(50, None, -1, None)` | 22 | **44** |
+| `:398` `calc_mapq(150, None, 0, None)` | 44 | 44 (same) |
+| `:401` `calc_mapq(50, None, 0, Some(-1))` | 40 | **31** |
+| `:402` `calc_mapq(50, None, -1, Some(-1))` | 0 | **1** |
+| `:410` `calc_mapq(150, Some(150), 0, Some(-1))` | 34 | **11** |
+
+Step 5 only names the two tautologies (`:376`, `:416`) and step 4 only says "add a targeted test" — the plan never says these four must be **recomputed**. An implementer hitting four "unexpected" failures inside a step advertised as a no-op is being set up to re-baseline them, which is exactly the failure mode step 5 exists to prevent.
+
+**Fix the ordering:** step 2's constructor sets `log_score_min = local` (verbatim current behaviour, no aligner term); D2 becomes its own step *after* D1, flipping to `local && aligner == Bowtie2` **and** recomputing those four expectations with the new values shown above.
+
+Also restate V7 honestly: the `calc_mapq` signature change forces edits at **~28 unit call sites** in `mapq.rs` plus `combined.rs:1205`, so "zero test edits" is impossible by construction. The gate you want is **"no expected-*value* edits — call-shape edits only"**. Leaving it as "zero test edits" invites the implementer to conclude the gate is unachievable and skip it.
+
+### I2 (Important) — site enumeration is incomplete; §11's "traced all three call sites" is wrong
+
+Verified counts:
+
+**`calc_mapq` call sites — 4, not 3.** `merge.rs:370` (SE), `merge.rs:747` (PE), `combined.rs:349` (SE combined), **`combined.rs:774` (PE combined — never named)**. Plus the test call at `combined.rs:1205`. All four do carry the read lengths, so the plan's conclusion survives — but the missing one is a *PE* site, precisely where a single-mate perfect-score bug would hide.
+
+**Trio-carrying signatures in `combined.rs` — 8, not 6.** Plan lists 188, 246, 388, 437, 501, 543. Missing: **`select_pe_pbat` (596-598)** and **`select_core_pe` (655-657)**.
+
+**`mod.rs` is absent from the plan's Files table entirely.** It holds:
+- **6 config-expansion call sites**: `2599`, `3146`, `3528`, `4647`, `5255`, `5705`.
+- **2 function-pointer type aliases that hardcode the trio** — `SelectFn` (`mod.rs:2751-2758`) and `SelectFnPe` (`mod.rs:2767-2775`), both literally `fn(…, f64, f64, bool, &mut Counters) -> …`. These *must* change in lockstep with all eight `combined.rs` selectors or the refactor won't compile, and they are the least obvious edit in the whole change.
+
+Corrected blast radius: **10 fn signatures + 2 fn-pointer aliases + 6 config-expansion sites + 4 call sites + `RunConfig` struct/literal + ~29 test call sites.** The plan's "~10 signatures / 3+ call sites" understates it by roughly half.
+
+**I2c — the combined-index edge-case row is misleading.** "Non-directional / combined index — all `combined.rs` call sites take the same `ScoreModel`" reads as though combined + local is a live configuration. `config.rs:531-537` rejects `--local` with **all four** `--combined_index` variants, so `combined.rs` can only ever see `match_bonus = 0`. Say that: all 8 combined sites are **refactor-only** for this fix, which is a meaningful risk reduction and should be stated as such rather than left ambiguous.
+
+### I3 (Important) — the plan drops the reporter's suggested case #2 (perfect local alignment)
+
+Issue #1079 suggests three regression cases. V3 covers #1, V4 covers #3, and **#2 ("Bowtie2 local perfect alignment: expected top local MAPQ") has no counterpart in §9.** This is not decoration: under the new formula `best_over == diff ⟺ as_best == perfect`, so the exact-equality leaves (`35/34/33/32/31` in the local ladder, `mapq.rs:174,182,190,198,206`) become reachable-and-meaningful for the first time. Verified: len 100, AS 200 → `best_over == diff == 143.1586` exactly (same f64 subtraction on both sides) → 44 with no second best; with a second best it lands on the `==diff` leaves. Add it, with and without a second best.
+
+### I4 (Important) — no wiring validation: every proposed gate is a pure unit test
+
+V1–V7 all exercise `calc_mapq`/`ScoreModel` directly. Not one of them would catch a `config::resolve` wiring bug — e.g. `ScoreModel::new(i, s, false, aligner)` (hardcoded `local`), or the intercept/slope swapped in the new 4-positional constructor. The unit suite would be fully green and every production `--local` BAM wrong.
+
+There is a ready-made harness: `aligner_cli.rs` already has `make_fake_bowtie2_mapped` and asserts MAPQ out of a real BAM (`aligner_cli.rs:422`). Add one `--bowtie2 --local` integration test asserting a MAPQ **value** read back from the BAM.
+
+**Critical detail for whoever writes it:** the existing 8 bp genome / 6 bp read fixture is useless for this. At len 6, `G,20,8` gives `scMin = 34.33` and `perfect = 12`, so raw `diff = −22.33` → clamped/negative either way and old and new both return **22**. The fixture must use a read long enough that `2·len > scMin`, i.e. **len ≥ 23** (len 25 → scMin 45.75, perfect 50). Without this note the test gets written against the existing fixture, passes, and discriminates nothing.
+
+### I5 (Important) — A7 is true but understates the exposure; there is **no aligner Perl-oracle in CI at all**
+
+Verified the 13 cells in `.github/workflows/rust_ci.yml:194-217`: 7 are genome-prep (`genome_prep_integration.rs`), 4 methylation_consistency, 1 extractor, 1 dedup. **None is the aligner.** So it isn't only local mode that's unguarded — end-to-end aligner MAPQ has no Perl oracle in CI either.
+
+The total automated protection for the plan's "critical gate" is therefore: V1 (a unit sweep the plan under-specifies, per C1) plus **four** MAPQ value assertions across all aligner integration tests (`aligner_cli.rs:422`, `705`, `706`, `2429`) — all end-to-end, all 6 bp, all default `--score_min`. That is thin enough that C1's fix (adding the `--score_min` dimension to V1) is load-bearing, not nice-to-have. §7 should say this plainly instead of implying the absence of a `--local` oracle is the only gap.
+
+### I6 (Important) — D2 silently destroys the `ln()`-boundary regression coverage, and the plan doesn't replace it
+
+`mapq.rs:386-389` and `:403-409` document that test's purpose explicitly: it is the *only* coverage of the sub-unity-`diff`, `ln()`-derived-bucket-boundary regime, deliberately added because "the `(20,8)` tests (diff=10/integer boundaries) never reach" it. After D2, HISAT2-local is linear, so **no configuration produces a sub-unity `diff` in local mode any more** and that regime becomes unreachable. The plan retires the tautology at `:416` and recomputes nothing else — the ln()-ULP guard just evaporates.
+
+Replace it with a **Bowtie 2-local** ln()-boundary case (that's now the only ln() consumer): pick a `len` where `diff·0.5` or `diff·0.3` sits close to an integer `best_over`, and pin it with the same "why this cell" comment style.
+
+### I7 (Important) — step 7's version bump is incomplete and will fail `cargo test`
+
+"Bump `rust/VERSION` (3.1.0 → 3.2.0)" touches one of three lockstepped locations. Two guard tests enforce the others:
+- `rust/bismark/VERSION` (vendored) — `meta/mod.rs:51` `vendored_version_matches_repo_version`
+- `rust/bismark/Cargo.toml:3` `version = "3.1.0"` — `meta/mod.rs:73` `cargo_pkg_version_matches_suite_version`, which the comment marks "**load-bearing for a GA cut**" and never skips
+
+All three must move together. (On the 3.1.0 → 3.2.0 question in §10: minor is right — a behaviour change in a non-default mode is not a patch.)
+
+### I8 (Important) — single-source the score-min *form* so D2 cannot regress
+
+D2 exists because two independent expressions decide the same thing: `options.rs:82` (`cli.local && aligner == Bowtie2` → emit `G`) and `mapq.rs:31` (`local` → use `ln`). The plan fixes the *values* but keeps two independent expressions — `options.rs:82` and the new `log_score_min = local && aligner == Bowtie2`. That is the same latent defect, relocated.
+
+Have `score_min_params` (`options.rs:371`) return the form it actually selected — it already computes exactly that at `options.rs:372` (`prefix = "G," | "L,"`) — and build `ScoreModel.log_score_min` from that return value. Then the emitted option and the MAPQ form are the *same* fact by construction, and a future `S,`/`C,` form or a `--ma` passthrough can't desynchronize them again. This is a small change that closes the class of bug, not just the instance.
+
+### Minor logic notes
+
+- **§7 "no internal consumer reads MAPQ" is imprecise.** `--five_base_min_mapq` filters on MAPQ at `mod.rs:2052`. The conclusion still holds (5-Base is minimap2-only, `--local` rejected there, and 5-Base MAPQ comes from minimap2 — `calc_mapq` is never called on that path: no `config.score_min_*` site exists in the 5-Base code). Qualify the sentence rather than deleting it.
+- **`len = 0`.** The plan says "assert current behaviour is preserved". Under the C1 recommendation (`abs()` for `match_bonus == 0`) end-to-end `len = 0` is genuinely unchanged. For Bowtie 2-local, `ln(0) = −inf` ⇒ `scMin = −inf` ⇒ `diff = +inf` ⇒ `best_over = +inf` ⇒ `inf >= inf*0.8` is **true** ⇒ 44 (previously `diff = abs(−inf) = inf`, same answer). So it happens to be invariant — but state the reasoning, don't just assert preservation.
+- **PE totals.** `perfect = match_bonus × (len1 + len2)` matches Bowtie 2's per-mate sum exactly (`2·l1 + 2·l2`, no per-mate truncation issue since `2·len` is integral). ✅
+
+---
+
+## 2. Assumptions
+
+| # | Verdict |
+|---|---|
+| A1 | ✅ Confirmed at `scoring.h:310-316` + `unique.h:207-209`. |
+| A2 | ✅ Confirmed at `simple_func.h:88-107`. Good catch by the plan. |
+| A3 | ⚠️ Defensible but probably over-cautious. HISAT2 has **no `--local` mode** — Bismark's "HISAT2-local" is HISAT2's normal soft-clip-permitting mode with `--no-softclip` dropped (`options.rs:341-346`), and its `--ma` is documented as unused outside a local mode HISAT2 doesn't have. So `perfect = 0` is very likely *correct*, not merely provisional. Keep the deferral (it's Felix's call and needs backend confirmation), but the separate issue should record this reasoning so it isn't re-derived from scratch. |
+| A4 | ✅ Verified structurally (see §0). |
+| A5 | ✅ Verified against `unique.h:223-380`. |
+| A6 | ✅ `bestOver = best − scMin` matches `unique.h:222`; correctly identified as must-not-change. |
+| A7 | ✅ True, but understated — see I5. |
+
+**Unstated assumptions the plan should surface:**
+
+1. **`--score_min` is always the default.** Load-bearing for the entire end-to-end invariance argument (C1) and nowhere stated.
+2. **`scMin`/`diff`/`bestOver` stay `f64` while Bowtie 2 uses `int64`.** The single biggest unstated assumption; it determines whether V2/V8 can pass (C2).
+3. **Read length == the length Bowtie 2 scored.** Stated implicitly via "each call site already has the read lengths". It is true (verified in §0), but it is the assumption on which `perfect = 2 × len` rests and deserves to be A8 with its evidence.
+4. **`Aligner` in the constructor introduces a module cycle.** `Aligner` is defined in **`config.rs:21`**, not in `aligner.rs`. Putting `ScoreModel` in `mapq.rs` makes `mapq → config` and `config → mapq`. Rust permits this, but see Alternatives.
+5. **`--local` is unreachable on every combined-index path.** True (`config.rs:531-537`) and materially de-risking; state it as a fact rather than leaving the edge-case row ambiguous.
+
+---
+
+## 3. Efficiency
+
+Correct in substance: O(1) added arithmetic per accepted alignment, no allocation, net arity reduction of 2 at ten sites. Two nits:
+
+- **Size.** `3 × f64 + 2 × bool` = **32 bytes** (24 + 2, padded to 32), not 40.
+- **`Copy` but "passed by reference"** is self-inconsistent. For 32 bytes, **by value** is at least as fast and avoids introducing an elided lifetime into the two `fn`-pointer aliases (`mod.rs:2751`, `2767`) — which the plan hasn't accounted for at all (I2). Pass by value.
+
+The real efficiency question the plan doesn't ask is **change-cost**, not run-cost: per I2 the true blast radius is ~50 edit sites in a module with no CI Perl-oracle (I5). See Alternatives for splitting it.
+
+---
+
+## 4. Alternatives
+
+**A. Gate the denominator on `match_bonus > 0`, not on `local`.** ← recommended, see C1. Strictly narrower than either D-EDGE branch: only Bowtie 2-local's `diff` changes; end-to-end *and* HISAT2-local keep `abs()` verbatim. Also means HISAT2-local moves for exactly one reason (D2's scMin form), which is the honest scope given A3.
+
+**B. Land the refactor as its own PR.** The plan's step-2/step-3 split is the right instinct; given I5 (no aligner CI oracle) and I2 (~50 sites), consider making the boundary a **PR** boundary, not just a commit boundary. PR 1 = pure `ScoreModel` refactor, `diff = sc_min.abs()`, zero expected-value changes, reviewable as mechanical. PR 2 = D1 + D2, small diff, all attention on the semantics. Also gives a clean revert target if a full-scale oxy run surprises.
+
+**C. Skip the struct; pass a single `perfect_per_base: f64`.** Minimal-diff alternative: no arity reduction, doesn't fix D2, keeps the `too_many_arguments` debt. Mention and reject — the struct is better and it's what the reporter asked for. Not worth reopening.
+
+**D. Derive the form from `score_min_params`' own choice.** ← see I8. Should be folded into the design, not treated as an alternative.
+
+**E. Put `ScoreModel` in `config.rs` instead of `mapq.rs`.** `Aligner` already lives there (`config.rs:21`), as does `RunConfig`, so dependencies run one way (`mapq`/`merge`/`combined` → `config`) instead of `config ⇄ mapq`. Compiles either way; this is a cleanliness call the plan should make explicitly rather than by default.
+
+**F. Named constructors.** `ScoreModel::new(0.0, -0.2, false, Aligner::Bowtie2)` is four positional args, two of which are `f64` and one a `bool` — swappable without a compile error, across ~29 test call sites. `ScoreModel::end_to_end(i, s)` / `::bowtie2_local(i, s)` / `::hisat2_local(i, s)`, with the general `from_mode(i, s, local, aligner)` used only by `config::resolve`, makes every test call site self-documenting and removes the "which aligner do I pass in an end-to-end test?" ambiguity the plan leaves open.
+
+**G. Adopt Bowtie 2's int truncation.** Reject explicitly and in writing (C2) — it would break end-to-end (`mapq.rs:259-262`).
+
+---
+
+## 5. Validation sufficiency
+
+| # | Sufficient? | Gap |
+|---|---|---|
+| V1 | ❌ **No** | No `--score_min` dimension ⇒ blind to C1's dominant failure mode, and it's the gate the plan relies on to *decide* D-EDGE. |
+| V2 | ❌ **No** | "Agreement across the grid" is unachievable against a faithful `unique.h` transcription (C2). Must specify the f64 analogue, and must include the exact-perfect cell (I3). |
+| V3 | ✅ | Verified: 24. |
+| V4 | ✅ | Good — the "differs from the SE-only value" clause is what makes it a real single-mate guard. |
+| V5 | ✅ | Add the four recomputed HISAT2 expectations from I1 alongside it. |
+| V6 | ⚠️ | Under recommendation A the clamp only exists in Bowtie 2-local, where `scMin → 0⁻` is unreachable with `G,20,8` (scMin ≥ 20). Restate as: `perfect − scMin ∈ [0,1)` ⇒ `diff == 1.0`, plus an explicit assertion that **end-to-end** with `scMin == 0.0` still yields `diff == 0.0` (frozen). |
+| V7 | ⚠️ | "Zero test edits" is impossible (signature change). Restate as "no expected-*value* edits", and fix the ordering per I1 or it fails outright. |
+| V8 | ⚠️ | Constructible in principle, but "Expected: Agreement" is wrong (C2). Reframe as truncation-explained-disagreement accounting. The plan's instinct to pre-authorize triage is right; the expectation just needs correcting. |
+| — | ❌ **Missing** | Wiring/integration test asserting a local MAPQ value from a real BAM, with a **≥23 bp** read (I4). |
+| — | ❌ **Missing** | `(local, aligner)` → `(log_score_min, local_ladder, match_bonus)` construction matrix — all 8 combinations, including that minimap2/rammap + local is unreachable. Cheap, and it's the direct unit-level guard on the one new piece of logic. |
+| — | ❌ **Missing** | Replacement ln()-boundary case for the coverage D2 removes (I6). |
+
+Net: as written, the fix could ship with `config::resolve` mis-wired, or with end-to-end MAPQ altered for non-default `--score_min` users, and every listed validation would still pass.
+
+---
+
+## 6. Action items
+
+### Critical — resolve before implementation
+
+1. **C1** — Pre-decide D-EDGE: the `max(1, …)` clamp and the new denominator apply **only when `match_bonus > 0`** (Bowtie 2-local). End-to-end and HISAT2-local keep `sc_min.abs()` verbatim. Correct §3's edge-case row (the real condition is `scMin ≤ −1`, not `len ≥ 5`) and §7's "by construction" claim.
+2. **C1** — Add a `--score_min` dimension to V1: `{(0,−0.2), (0,−0.05), (0,−0.6), (10,−0.2), (0,0), (−1,−0.2)}` × `len ∈ 1..=500`, SE and PE.
+3. **C2** — Record in §1 that Bowtie 2 computes `scMin`/`diff`/`bestOver` in `int64` while Bismark uses `f64`; declare matching it an explicit **non-goal** (it would break `mapq.rs:259-262`). Respecify V2's reference as the deliberate f64 analogue, and V8's expectation as "agreement except at truncation boundaries, each disagreement explained".
+
+### Important — fold into rev 1
+
+4. **I1** — Reorder: step 2's constructor uses `log_score_min = local` (verbatim); D2 becomes its own step after D1, and explicitly recomputes `mapq.rs:397 → 44`, `:401 → 31`, `:402 → 1`, `:410 → 11`.
+5. **I1** — Restate V7 as "no expected-**value** edits; call-shape edits only".
+6. **I2** — Complete the enumeration: `combined.rs` **598** + **657**; `calc_mapq` call site **`combined.rs:774`**; add **`mod.rs`** to the Files table with its 6 config-expansion sites (2599, 3146, 3528, 4647, 5255, 5705) and the two fn-pointer aliases **`SelectFn` (2751)** / **`SelectFnPe` (2767)**. Correct §11's "all three call sites" → four.
+7. **I2c** — State that `--local` is rejected on all four `--combined_index` variants (`config.rs:531-537`), so all 8 `combined.rs` sites are refactor-only.
+8. **I3** — Add the reporter's case #2: Bowtie 2-local perfect alignment (len 100, AS 200 → 44), plus a `==diff` leaf with a second best.
+9. **I4** — Add a `--bowtie2 --local` integration test asserting a MAPQ value from the BAM, using the existing `make_fake_bowtie2_mapped` harness and a **≥23 bp** read (the current 6 bp fixture returns 22 both before and after — it discriminates nothing).
+10. **I4** — Add a `ScoreModel` construction-matrix test over all `(local, aligner)` combinations.
+11. **I5** — Correct §7: the perl-oracle job has **no aligner cell at all**, so V1 plus four thin integration assertions are the only automated protection for end-to-end MAPQ.
+12. **I6** — Replace the sub-unity-`diff` ln() coverage that D2 removes with a Bowtie 2-local ln()-boundary case.
+13. **I7** — Step 7 must bump all three: `rust/VERSION`, `rust/bismark/VERSION`, `rust/bismark/Cargo.toml:3` (guarded by `meta/mod.rs:51` and `:73`).
+14. **I8** — Have `score_min_params` return the form it selected and build `log_score_min` from it, so the emitted option and the MAPQ form are one fact.
+
+### Optional
+
+15. Put `ScoreModel` in `config.rs` (where `Aligner` lives) to avoid the `config ⇄ mapq` cycle.
+16. Named constructors (`end_to_end` / `bowtie2_local` / `hisat2_local`) — worthwhile given ~29 test call sites and a 4-positional signature with two `f64`s.
+17. Pass `ScoreModel` **by value** (32 bytes, `Copy`); avoids an elided lifetime in the two `fn`-pointer aliases.
+18. Collapse `score_min` + `diff` into one method returning `(sc_min, diff)`, so a caller can't pass a `sc_min` computed from different lengths.
+19. Consider making step 2 / step 3 a **PR** boundary, not just a commit boundary (Alternative B) — attractive given I5.
+20. Fix §6's "40 bytes" → 32, and the `Copy`-but-by-reference inconsistency.
+21. §10 answers: **3.2.0** (minor) is right; crediting @9xg is right — the analysis in #1079 is accurate and independently reproducible.
+22. Record in the deferred HISAT2 issue that HISAT2 has no `--local` mode at all, so `perfect = 0` is likely correct rather than merely provisional (A3).
+
+---
+
+## 7. Bottom line
+
+The plan diagnoses #1079 correctly, sources it properly against upstream, and its two best catches are genuinely good — Bowtie 2-local's `ln()` is *correct* and must be kept (A2), and the `max(1, …)` clamp needed a proof rather than an assertion (D-EDGE). It also gets the right structural answer (`ScoreModel`) for the right reason.
+
+But the invariance proof it demands of itself is scoped to the wrong variable — the condition is `scMin ≤ −1`, not `len ≥ 5`, and V1 as specified cannot see the difference. The gate meant to *decide* D-EDGE would green-light the unsafe branch. Alongside that, the plan's two upstream-comparison gates (V2, V8) cannot pass as specified because Bowtie 2's MAPQ arithmetic is integer and Bismark's is float — a distinction visible in the very snippet the plan quotes. Fix those two, correct the step ordering so the "no-op" step really is one, complete the site list, and add a single wiring test, and this is ready to implement.
+
+**Report:** `/Users/fkrueger/Github/Bismark/plans/07292026_local-mapq-denominator/PLAN_REVIEW_B.md`

--- a/plans/07292026_local-mapq-denominator/PROGRESS.md
+++ b/plans/07292026_local-mapq-denominator/PROGRESS.md
@@ -1,0 +1,42 @@
+# PROGRESS — Local-mode MAPQ denominator (#1079)
+
+**Plan:** [`PLAN.md`](./PLAN.md) · **Issue:** [#1079](https://github.com/FelixKrueger/Bismark/issues/1079) · **Reporter:** @9xg
+**Last updated:** 2026-07-29
+
+**Status legend:** 📋 Planned · 🔨 In progress · ✅ Done · ⛔ Blocked · ⏸ Awaiting user
+
+| # | Pipeline step | Status | Notes |
+|---|---|---|---|
+| 1 | Triage / verify report | ✅ Done | All 4 claims verified at source, incl. upstream `unique.h` v2.5.5 fetch. Impact quantified (MAPQ saturates at 44; up to +22 too high). Reply posted: [comment](https://github.com/FelixKrueger/Bismark/issues/1079#issuecomment-5116863162) |
+| 2 | Plan written (rev 0) | ✅ Done | `PLAN.md`. Decisions: unconditional fix; Bowtie 2 denominator + HISAT2 `scMin` form; HISAT2 perfect score deferred |
+| 3 | Manual review (Felix) | ✅ Done | Felix reviewed rev 0, sent straight to agent review |
+| 4 | Agent review (dual `plan-reviewer`) | ✅ Done | `PLAN_REVIEW_A.md` + `PLAN_REVIEW_B.md`. **Both verdicts: rev-1 required before implementing.** A: 3 Critical (C1 invariance, C2 int-vs-float oracle, C3 no wiring test). B: 2 Critical (same C1/C2) + 8 Important. ~12 findings agreed independently; 1 contradiction (step ordering — B right, D2 lands inside the "no-op" step) |
+| 4b | Fold findings → PLAN rev 1 | ✅ Done | All Critical + Important folded; both contradictions resolved in B's favour. See PLAN §12 Revision History |
+| 4c | Felix review of rev 1 | ✅ Done | "implement" trigger given 2026-07-29 |
+| 5 | Implement | ✅ Done | Branch `rust/local-mapq-denominator` (off `origin/dev` `0a9eeb7`). Both PRs in one tree. fmt clean, **0 clippy warnings**, **2107 pass / 0 fail**. V7 proven by inverse-transform; V1 + V10 both verified to fail under injected faults. **Not committed** — see PLAN §12 |
+| 6 | Verify (dual `code-reviewer` + `plan-manager`) | ✅ Done | Both reviewers **APPROVE**, no correctness defect. Coverage **INCOMPLETE — 6 items**. Reports: `CODE_REVIEW_A.md`, `CODE_REVIEW_B.md`, `COVERAGE.md` |
+| 6b | Apply all review findings | ✅ Done | **All** findings applied (1 High, 6 Medium, ~12 Low) + all 6 coverage gaps closed. fmt clean, 0 clippy, **2109 pass / 0 fail**. Three fault injections re-verified. See PLAN §12b |
+| 7 | File deferred issues | ✅ Done | **[#1080](https://github.com/FelixKrueger/Bismark/issues/1080)** HISAT2 perfect score · **[#1081](https://github.com/FelixKrueger/Bismark/issues/1081)** minimap2/rammap positive-AS. Both cited in CHANGELOG + code |
+| 8 | CHANGELOG | ✅ Done | Under `## Unreleased`. **Version bump deferred to the release cut** (Felix, 2026-07-29) — all three literals stay at 3.1.0 |
+| 9 | Commit / PR | ⏸ Awaiting | Nothing committed yet; working tree only. Base `origin/dev` |
+
+## Key decisions
+- **2026-07-29** — Fix **unconditionally**, no compat flag. Rationale: Bismark's own `--local` docs (`bismark:9729`) already promise `perfect = --ma × read_length`; no `perl-oracle` CI cell covers local mode; current output is actively misleading (saturation). End-to-end stays byte-identical.
+- **2026-07-29** — Scope = Bowtie 2 denominator (**D1**) + HISAT2 `ln()`→linear `scMin` (**D2**). HISAT2 **perfect score deferred** — Bismark's docs admit it is unknown.
+- **2026-07-29** — Take the fix in-house rather than accept @9xg's offered PR (touches the byte-identity gate + needed the parity-policy call).
+- **2026-07-29** — Design: collapse the `(intercept, slope, local)` trio into one `ScoreModel` rather than add a 4th scalar — *reduces* arity at ~10 threading sites and retires the existing `#[allow(clippy::too_many_arguments)]` at `combined.rs:535`.
+
+## Open items
+- **D-EDGE** — universal vs local-only `max(1, …)` clamp; `max(1,…)` ≠ `abs(scMin)` for reads < 5 bp, so end-to-end invariance must be *proven* (V1), not assumed. Evidence-driven, no user input needed.
+- Version bump: minor (3.2.0) vs patch — confirm.
+- CHANGELOG credit for @9xg — assumed yes.
+
+## Milestones
+- [x] Report triaged + verified against upstream Bowtie 2 — ✅ 2026-07-29
+- [x] Public reply posted on #1079 — ✅ 2026-07-29
+- [x] Plan rev 0 written — ✅ 2026-07-29
+- [ ] Felix manual review of rev 0
+- [ ] Dual plan-reviewer pass
+- [ ] Implementation
+- [ ] Dual code-review + coverage audit
+- [ ] HISAT2 follow-up issue filed

--- a/rust/bismark/src/aligner/combined.rs
+++ b/rust/bismark/src/aligner/combined.rs
@@ -41,6 +41,7 @@
 use std::collections::HashMap;
 
 use crate::aligner::align::{SamPair, SamRecord};
+use crate::aligner::config::ScoreModel;
 use crate::aligner::error::{AlignerError, Result};
 use crate::aligner::mapq::calc_mapq;
 use crate::aligner::merge::{
@@ -183,9 +184,7 @@ struct Cand {
 pub fn select(
     records: &[SamRecord],
     sequence: &str,
-    score_min_intercept: f64,
-    score_min_slope: f64,
-    score_min_local: bool,
+    score_model: ScoreModel,
     counters: &mut Counters,
 ) -> Result<Decision> {
     // Keep only mapped lines (Bowtie 2 emits a single FLAG-4 line for a miss),
@@ -195,14 +194,7 @@ pub fn select(
         .filter(|r| !r.is_unmapped())
         .map(|r| (ReadConv::Ct, r))
         .collect();
-    select_core(
-        mapped,
-        sequence,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
-        counters,
-    )
+    select_core(mapped, sequence, score_model, counters)
 }
 
 /// The shared **Bismark-faithful same-position tie-resolution core** (PLAN 06072026
@@ -241,9 +233,7 @@ pub fn select(
 fn select_core(
     mut mapped: Vec<(ReadConv, &SamRecord)>,
     sequence: &str,
-    score_min_intercept: f64,
-    score_min_slope: f64,
-    score_min_local: bool,
+    score_model: ScoreModel,
     counters: &mut Counters,
 ) -> Result<Decision> {
     if mapped.is_empty() {
@@ -351,9 +341,7 @@ fn select_core(
         None,
         best.alignment_score,
         second_best,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
+        score_model,
     );
     counters.unique_best_alignment_count += 1;
     Ok(Decision::UniqueBest(BestAlignment {
@@ -383,9 +371,7 @@ pub fn select_nondir(
     ct_records: &[SamRecord],
     ga_records: &[SamRecord],
     sequence: &str,
-    score_min_intercept: f64,
-    score_min_slope: f64,
-    score_min_local: bool,
+    score_model: ScoreModel,
     counters: &mut Counters,
 ) -> Result<Decision> {
     // Keep only mapped lines from each pass (Bowtie 2 emits one FLAG-4 line for a
@@ -404,14 +390,7 @@ pub fn select_nondir(
                 .map(|r| (ReadConv::Ga, r)),
         )
         .collect();
-    select_core(
-        mapped,
-        sequence,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
-        counters,
-    )
+    select_core(mapped, sequence, score_model, counters)
 }
 
 /// PBAT combined-index per-read selection over the read's `-k` line group: every
@@ -432,9 +411,7 @@ pub fn select_nondir(
 pub fn select_pbat(
     records: &[SamRecord],
     sequence: &str,
-    score_min_intercept: f64,
-    score_min_slope: f64,
-    score_min_local: bool,
+    score_model: ScoreModel,
     counters: &mut Counters,
 ) -> Result<Decision> {
     // Keep only mapped lines, each tagged G→A (the PBAT pass). The shared core
@@ -444,14 +421,7 @@ pub fn select_pbat(
         .filter(|r| !r.is_unmapped())
         .map(|r| (ReadConv::Ga, r))
         .collect();
-    select_core(
-        mapped,
-        sequence,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
-        counters,
-    )
+    select_core(mapped, sequence, score_model, counters)
 }
 
 // ===========================================================================
@@ -496,9 +466,7 @@ pub fn select_pe(
     pairs: &[SamPair],
     sequence_1: &str,
     sequence_2: &str,
-    score_min_intercept: f64,
-    score_min_slope: f64,
-    score_min_local: bool,
+    score_model: ScoreModel,
     counters: &mut Counters,
 ) -> Result<DecisionPaired> {
     // Drop the PE no-alignment marker (FLAG 77/141 — Bowtie 2 emits one such pair
@@ -509,15 +477,7 @@ pub fn select_pe(
         .filter(|p| !p.is_unmapped_pair())
         .map(|p| (ReadConv::Ct, p))
         .collect();
-    select_core_pe(
-        mapped,
-        sequence_1,
-        sequence_2,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
-        counters,
-    )
+    select_core_pe(mapped, sequence_1, sequence_2, score_model, counters)
 }
 
 /// Non-directional PE combined-index per-pair selection over the UNION of the two
@@ -532,15 +492,12 @@ pub fn select_pe(
 /// `select_core_pe` is reused UNCHANGED — it was built 4-slot-ready in Phase 2 (the
 /// `select_core_pe_uses_literal_scan_order_not_ascending` test locks the only-non-dir-
 /// reachable OB×CTOB collision). `sequence_1`/`_2` are the original (uc) reads.
-#[allow(clippy::too_many_arguments)] // +score_min_local pushed this to 8 (the score-min trio rides together)
 pub fn select_pe_nondir(
     ct_pairs: &[SamPair],
     ga_pairs: &[SamPair],
     sequence_1: &str,
     sequence_2: &str,
-    score_min_intercept: f64,
-    score_min_slope: f64,
-    score_min_local: bool,
+    score_model: ScoreModel,
     counters: &mut Counters,
 ) -> Result<DecisionPaired> {
     // Drop each pass's PE no-alignment marker (FLAG 77/141), tag the C→T pass's pairs
@@ -558,15 +515,7 @@ pub fn select_pe_nondir(
                 .map(|p| (ReadConv::Ga, p)),
         )
         .collect();
-    select_core_pe(
-        mapped,
-        sequence_1,
-        sequence_2,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
-        counters,
-    )
+    select_core_pe(mapped, sequence_1, sequence_2, score_model, counters)
 }
 
 /// PBAT PE combined-index per-pair selection over the pair's `-k 2` group: every
@@ -593,9 +542,7 @@ pub fn select_pe_pbat(
     pairs: &[SamPair],
     sequence_1: &str,
     sequence_2: &str,
-    score_min_intercept: f64,
-    score_min_slope: f64,
-    score_min_local: bool,
+    score_model: ScoreModel,
     counters: &mut Counters,
 ) -> Result<DecisionPaired> {
     // Drop the PE no-alignment marker (FLAG 77/141); tag every surviving pair G→A
@@ -606,15 +553,7 @@ pub fn select_pe_pbat(
         .filter(|p| !p.is_unmapped_pair())
         .map(|p| (ReadConv::Ga, p))
         .collect();
-    select_core_pe(
-        mapped,
-        sequence_1,
-        sequence_2,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
-        counters,
-    )
+    select_core_pe(mapped, sequence_1, sequence_2, score_model, counters)
 }
 
 /// The shared **Bismark-faithful PE tie machine** — `select_core` doubled for two
@@ -652,9 +591,7 @@ fn select_core_pe(
     mut mapped: Vec<(ReadConv, &SamPair)>,
     sequence_1: &str,
     sequence_2: &str,
-    score_min_intercept: f64,
-    score_min_slope: f64,
-    score_min_local: bool,
+    score_model: ScoreModel,
     counters: &mut Counters,
 ) -> Result<DecisionPaired> {
     if mapped.is_empty() {
@@ -776,9 +713,7 @@ fn select_core_pe(
         Some(sequence_2.len()),
         best.sum,
         second_best,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
+        score_model,
     );
     counters.unique_best_alignment_count += 1;
     Ok(DecisionPaired::UniqueBest(BestAlignmentPaired {
@@ -900,7 +835,7 @@ mod tests {
     }
     fn sel(records: &[SamRecord]) -> (Decision, Counters) {
         let mut c = Counters::default();
-        let d = select(records, "ACGTAC", 0.0, -0.2, false, &mut c).unwrap();
+        let d = select(records, "ACGTAC", ScoreModel::end_to_end(0.0, -0.2), &mut c).unwrap();
         (d, c)
     }
 
@@ -1124,9 +1059,7 @@ mod tests {
             "ACGTAC",
             &mut streams,
             true, // directional
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             &mut c,
         )
@@ -1202,7 +1135,10 @@ mod tests {
         match d {
             Decision::UniqueBest(b) => {
                 assert_eq!(b.alignment_score_second_best, None);
-                assert_eq!(b.mapq, calc_mapq(6, None, 0, None, 0.0, -0.2, false));
+                assert_eq!(
+                    b.mapq,
+                    calc_mapq(6, None, 0, None, ScoreModel::end_to_end(0.0, -0.2))
+                );
             }
             other => panic!("expected UniqueBest, got {other:?}"),
         }
@@ -1220,7 +1156,7 @@ mod tests {
     /// Run `select_nondir` over the C→T-pass group `ct` + the G→A-pass group `ga`.
     fn sel_nondir(ct: &[SamRecord], ga: &[SamRecord]) -> (Decision, Counters) {
         let mut c = Counters::default();
-        let d = select_nondir(ct, ga, "ACGTAC", 0.0, -0.2, false, &mut c).unwrap();
+        let d = select_nondir(ct, ga, "ACGTAC", ScoreModel::end_to_end(0.0, -0.2), &mut c).unwrap();
         (d, c)
     }
 
@@ -1393,9 +1329,7 @@ mod tests {
             "ACGTAC",
             &mut streams,
             false, // NON-directional (else index 2/3 → Rejected, merge.rs:352)
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             &mut c,
         )
@@ -1464,7 +1398,7 @@ mod tests {
     /// Run `select_pbat` over the G→A-pass `-k` line group.
     fn sel_pbat(records: &[SamRecord]) -> (Decision, Counters) {
         let mut c = Counters::default();
-        let d = select_pbat(records, "ACGTAC", 0.0, -0.2, false, &mut c).unwrap();
+        let d = select_pbat(records, "ACGTAC", ScoreModel::end_to_end(0.0, -0.2), &mut c).unwrap();
         (d, c)
     }
 
@@ -1490,9 +1424,7 @@ mod tests {
             "ACGTAC",
             &mut streams,
             false, // non-dir/pbat: don't reject the complementary strands
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             &mut c,
         )
@@ -1720,7 +1652,14 @@ mod tests {
     /// Run directional `select_pe` over the candidate pairs.
     fn sel_pe(pairs: &[SamPair]) -> (DecisionPaired, Counters) {
         let mut c = Counters::default();
-        let d = select_pe(pairs, "ACGTACGTAC", "ACGTACGTAC", 0.0, -0.2, false, &mut c).unwrap();
+        let d = select_pe(
+            pairs,
+            "ACGTACGTAC",
+            "ACGTACGTAC",
+            ScoreModel::end_to_end(0.0, -0.2),
+            &mut c,
+        )
+        .unwrap();
         (d, c)
     }
 
@@ -1766,9 +1705,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             true, // directional
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             crate::aligner::config::Aligner::Bowtie2,
             &mut c,
@@ -1935,9 +1872,7 @@ mod tests {
             vec![(ReadConv::Ct, &ob), (ReadConv::Ga, &ctob)],
             "ACGTACGTAC",
             "ACGTACGTAC",
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             &mut c,
         )
         .unwrap();
@@ -1971,8 +1906,14 @@ mod tests {
         let p =
             SamPair::from_lines(r1, &pe_line("r1", 2, 147, "chr1_CT_converted", 200, -2)).unwrap();
         let mut c = Counters::default();
-        let err =
-            select_pe(&[p], "ACGTACGTAC", "ACGTACGTAC", 0.0, -0.2, false, &mut c).unwrap_err();
+        let err = select_pe(
+            &[p],
+            "ACGTACGTAC",
+            "ACGTACGTAC",
+            ScoreModel::end_to_end(0.0, -0.2),
+            &mut c,
+        )
+        .unwrap_err();
         assert!(format!("{err}").contains("alignment score"));
     }
 
@@ -1983,8 +1924,14 @@ mod tests {
         let p =
             SamPair::from_lines(r1, &pe_line("r1", 2, 147, "chr1_CT_converted", 200, -2)).unwrap();
         let mut c = Counters::default();
-        let err =
-            select_pe(&[p], "ACGTACGTAC", "ACGTACGTAC", 0.0, -0.2, false, &mut c).unwrap_err();
+        let err = select_pe(
+            &[p],
+            "ACGTACGTAC",
+            "ACGTACGTAC",
+            ScoreModel::end_to_end(0.0, -0.2),
+            &mut c,
+        )
+        .unwrap_err();
         assert!(format!("{err}").contains("MD tag"));
     }
 
@@ -2001,8 +1948,14 @@ mod tests {
             -2,
         );
         let mut c = Counters::default();
-        let err =
-            select_pe(&[p], "ACGTACGTAC", "ACGTACGTAC", 0.0, -0.2, false, &mut c).unwrap_err();
+        let err = select_pe(
+            &[p],
+            "ACGTACGTAC",
+            "ACGTACGTAC",
+            ScoreModel::end_to_end(0.0, -0.2),
+            &mut c,
+        )
+        .unwrap_err();
         assert!(format!("{err}").contains("same chromosome"));
     }
 
@@ -2078,8 +2031,15 @@ mod tests {
     /// Run non-dir `select_pe_nondir` over the C→T pass pairs + G→A pass pairs.
     fn sel_pe_nondir(ct: &[SamPair], ga: &[SamPair]) -> (DecisionPaired, Counters) {
         let mut c = Counters::default();
-        let d =
-            select_pe_nondir(ct, ga, "ACGTACGTAC", "ACGTACGTAC", 0.0, -0.2, false, &mut c).unwrap();
+        let d = select_pe_nondir(
+            ct,
+            ga,
+            "ACGTACGTAC",
+            "ACGTACGTAC",
+            ScoreModel::end_to_end(0.0, -0.2),
+            &mut c,
+        )
+        .unwrap();
         (d, c)
     }
 
@@ -2107,9 +2067,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             false, // non-directional → index-1/2 reject OFF
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             crate::aligner::config::Aligner::Bowtie2,
             &mut c,
@@ -2251,8 +2209,14 @@ mod tests {
     /// Run pbat `select_pe_pbat` over the single G→A pass's candidate pairs.
     fn sel_pe_pbat(pairs: &[SamPair]) -> (DecisionPaired, Counters) {
         let mut c = Counters::default();
-        let d =
-            select_pe_pbat(pairs, "ACGTACGTAC", "ACGTACGTAC", 0.0, -0.2, false, &mut c).unwrap();
+        let d = select_pe_pbat(
+            pairs,
+            "ACGTACGTAC",
+            "ACGTACGTAC",
+            ScoreModel::end_to_end(0.0, -0.2),
+            &mut c,
+        )
+        .unwrap();
         (d, c)
     }
 

--- a/rust/bismark/src/aligner/config.rs
+++ b/rust/bismark/src/aligner/config.rs
@@ -65,6 +65,97 @@ impl Aligner {
     }
 }
 
+/// Which `--score-min` function form the aligner was given.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScoreMinForm {
+    /// `L,<i>,<s>` — `scMin = i + s·len`.
+    Linear,
+    /// `G,<i>,<s>` — `scMin = i + s·ln(len)`.
+    Log,
+}
+
+/// How alignment scores are normalized for MAPQ. Replaces the former
+/// `(intercept, slope, local)` trio that rode through every merge/select
+/// signature. Built once in [`resolve`], the only place `--local` and the
+/// resolved aligner are both known. Fields are private so the score model can
+/// only be set as a consistent whole.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScoreModel {
+    intercept: f64,
+    slope: f64,
+    form: ScoreMinForm,
+    local_ladder: bool,
+}
+
+impl ScoreModel {
+    /// The general constructor, used by [`resolve`].
+    pub fn from_mode(intercept: f64, slope: f64, local: bool, _aligner: Aligner) -> Self {
+        // The `ln()` scMin follows `--local` alone, for every aligner — including HISAT2,
+        // which is emitted the linear `L` form. Preserved verbatim here; see #1079.
+        Self {
+            intercept,
+            slope,
+            form: if local {
+                ScoreMinForm::Log
+            } else {
+                ScoreMinForm::Linear
+            },
+            local_ladder: local,
+        }
+    }
+
+    /// End-to-end (any aligner).
+    pub fn end_to_end(intercept: f64, slope: f64) -> Self {
+        Self::from_mode(intercept, slope, false, Aligner::Bowtie2)
+    }
+
+    /// Bowtie 2 `--local`.
+    pub fn bowtie2_local(intercept: f64, slope: f64) -> Self {
+        Self::from_mode(intercept, slope, true, Aligner::Bowtie2)
+    }
+
+    /// HISAT2 `--local`.
+    pub fn hisat2_local(intercept: f64, slope: f64) -> Self {
+        Self::from_mode(intercept, slope, true, Aligner::Hisat2)
+    }
+
+    /// Use the `--local` MAPQ ladder (Perl 4082-4178) rather than the end-to-end one.
+    pub(crate) fn local_ladder(&self) -> bool {
+        self.local_ladder
+    }
+
+    /// Minimum valid alignment score, summed over mates (Perl 3932-36).
+    fn score_min(&self, read1_len: usize, read2_len: Option<usize>) -> f64 {
+        let term = |len: usize| {
+            self.intercept
+                + self.slope
+                    * match self.form {
+                        ScoreMinForm::Log => (len as f64).ln(),
+                        ScoreMinForm::Linear => len as f64,
+                    }
+        };
+        let mut sc_min = term(read1_len);
+        if let Some(l2) = read2_len {
+            sc_min += term(l2);
+        }
+        sc_min
+    }
+
+    /// `(bestOver, diff)` — the two MAPQ ladder inputs, derived together so a
+    /// caller cannot combine a `scMin` and a `diff` computed from different reads.
+    pub(crate) fn normalize(
+        &self,
+        read1_len: usize,
+        read2_len: Option<usize>,
+        as_best: i64,
+    ) -> (f64, f64) {
+        let sc_min = self.score_min(read1_len, read2_len);
+        // scores vary by up to this much (max AS = 0)
+        let diff = sc_min.abs();
+        (as_best as f64 - sc_min, diff)
+    }
+}
+
 /// Bisulfite library type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LibraryType {
@@ -228,14 +319,11 @@ pub struct RunConfig {
     pub aligner_options: String,
     /// Gap penalties (for later MAPQ).
     pub gap_penalties: GapPenalties,
-    /// `--score_min` intercept (default `0.0`) — for `calc_mapq`.
-    pub score_min_intercept: f64,
-    /// `--score_min` slope (default `-0.2`) — for `calc_mapq`.
-    pub score_min_slope: f64,
-    /// `--local` mode (= `cli.local`): `calc_mapq` uses `ln(readLen)` scMin + the local
-    /// MAPQ ladder. The `--score_min` defaults are aligner-dependent: Bowtie 2-local =
-    /// `(20.0, 8.0)` (G-form); HISAT2-local = `(0.0, -0.2)` (L-form) — see `score_min_params`.
-    pub score_min_local: bool,
+    /// Score normalization for `calc_mapq`: the `--score_min` parameters, the
+    /// `scMin` function form and the ladder choice. The `--score_min` defaults are
+    /// aligner-dependent: Bowtie 2-local = `(20.0, 8.0)` (G-form); HISAT2-local and
+    /// end-to-end = `(0.0, -0.2)` (L-form) — see `score_min_params`.
+    pub score_model: ScoreModel,
     /// Perl's `$dovetail` variable (8047): `!--no_dovetail`, set for **every**
     /// aligner (the `if($bowtie2)` at 8051 only gates whether `--dovetail` is
     /// pushed to the *aligner options*, NOT this variable). Consumed by the PE
@@ -635,7 +723,9 @@ pub fn resolve(cli: &Cli, command_line: String) -> Result<RunConfig> {
         hisat2_multicore_remap,
     )?;
     let (score_min_intercept, score_min_slope) = options::score_min_params(cli, aligner)?;
-    let score_min_local = cli.local; // --local: ln() scMin + the local MAPQ ladder
+    // The only place `--local` and the resolved aligner are both known.
+    let score_model =
+        ScoreModel::from_mode(score_min_intercept, score_min_slope, cli.local, aligner);
     reject_unsupported_output_flags(cli)?;
     let output = resolve_output(cli)?;
     let read_processing = ReadProcessing {
@@ -685,9 +775,7 @@ pub fn resolve(cli: &Cli, command_line: String) -> Result<RunConfig> {
         detected_aligner,
         aligner_options,
         gap_penalties,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
+        score_model,
         // Perl 8047: `$dovetail = 1 unless $no_dovetail` — independent of the aligner.
         dovetail: !cli.no_dovetail,
         phred64: cli.phred64,

--- a/rust/bismark/src/aligner/mapq.rs
+++ b/rust/bismark/src/aligner/mapq.rs
@@ -7,46 +7,34 @@
 //! **bit-identical `f64`** for this arithmetic, so the exact `==`/`>=` float
 //! comparisons are intentional (an epsilon comparison would break parity).
 
+use crate::aligner::config::ScoreModel;
+
 /// Bismark MAPQ. `read2_len` is `Some` only for paired-end; single-end passes
-/// `None`. `intercept`/`slope` are the `--score_min` parameters (end-to-end
-/// default `0.0`/`-0.2`; local default `20.0`/`8.0`). `local` selects the
-/// `--local` branch: `scMin = intercept + slope·ln(readLen)` (vs the linear
-/// end-to-end form) and the separate local MAPQ ladder (Perl `4082-4178`).
-/// **`local` is bit-safe** — the Phase-0 spike (`plans/06132026_aligner-local-mode/
+/// `None`. `model` carries the `--score_min` parameters, the `scMin` function
+/// form and the ladder choice (see [`ScoreModel`]).
+/// **The `ln()` form is bit-safe** — the Phase-0 spike (`plans/06132026_aligner-local-mode/
 /// spikes/`) proved Perl `log` ≡ Rust `f64::ln()` bit-identical on the gate arch,
 /// so the exact `==`/`>=` `f64` comparisons hold for both branches.
-#[allow(clippy::float_cmp)] // exact f64 equality matches Perl `$bestOver == $diff` (verified bit-identical)
 pub fn calc_mapq(
     read1_len: usize,
     read2_len: Option<usize>,
     as_best: i64,
     as_second: Option<i64>,
-    intercept: f64,
-    slope: f64,
-    local: bool,
+    model: ScoreModel,
 ) -> u8 {
-    // scMin (Perl 3932-36): local uses ln(readLen), end-to-end uses readLen; add
-    // read 2 for PE. The `else` arithmetic is byte-identical to the pre-`--local`
-    // code (when `local == false`, `local` adds nothing) — end-to-end frozen.
-    let mut sc_min = if local {
-        intercept + slope * (read1_len as f64).ln()
+    let (best_over, diff) = model.normalize(read1_len, read2_len, as_best);
+
+    if model.local_ladder() {
+        calc_mapq_local(best_over, diff, as_best, as_second)
     } else {
-        intercept + slope * read1_len as f64
-    };
-    if let Some(l2) = read2_len {
-        sc_min += if local {
-            intercept + slope * (l2 as f64).ln()
-        } else {
-            intercept + slope * l2 as f64
-        };
+        calc_mapq_end_to_end(best_over, diff, as_best, as_second)
     }
-    let diff = sc_min.abs(); // scores vary by up to this much (max AS = 0)
-    let best_over = as_best as f64 - sc_min;
+}
 
-    if local {
-        return calc_mapq_local(best_over, diff, as_best, as_second);
-    }
-
+/// End-to-end MAPQ ladder — a verbatim port of Perl `calc_mapq`'s default branch
+/// (`bismark:3947-4076`). Split out to mirror [`calc_mapq_local`].
+#[allow(clippy::float_cmp)] // exact f64 equality matches Perl `$bestOver == $diff` (verified bit-identical)
+fn calc_mapq_end_to_end(best_over: f64, diff: f64, as_best: i64, as_second: Option<i64>) -> u8 {
     let Some(sec) = as_second else {
         // No second-best hit (3947–54).
         return if best_over >= diff * 0.8 {
@@ -230,35 +218,77 @@ mod tests {
     #[test]
     fn no_second_best_ladder() {
         // bestOver = as_best - scMin = as_best + 10.
-        assert_eq!(calc_mapq(50, None, 0, None, I, S, false), 42); // bestOver 10 = diff (>=0.8)
-        assert_eq!(calc_mapq(50, None, -3, None, I, S, false), 40); // 7 = 0.7·diff
-        assert_eq!(calc_mapq(50, None, -4, None, I, S, false), 24); // 6 = 0.6·diff
-        assert_eq!(calc_mapq(50, None, -5, None, I, S, false), 23); // 5 = 0.5·diff
-        assert_eq!(calc_mapq(50, None, -6, None, I, S, false), 8); // 4 = 0.4·diff
-        assert_eq!(calc_mapq(50, None, -7, None, I, S, false), 3); // 3 = 0.3·diff
-        assert_eq!(calc_mapq(50, None, -10, None, I, S, false), 0); // 0
+        assert_eq!(
+            calc_mapq(50, None, 0, None, ScoreModel::end_to_end(I, S)),
+            42
+        ); // bestOver 10 = diff (>=0.8)
+        assert_eq!(
+            calc_mapq(50, None, -3, None, ScoreModel::end_to_end(I, S)),
+            40
+        ); // 7 = 0.7·diff
+        assert_eq!(
+            calc_mapq(50, None, -4, None, ScoreModel::end_to_end(I, S)),
+            24
+        ); // 6 = 0.6·diff
+        assert_eq!(
+            calc_mapq(50, None, -5, None, ScoreModel::end_to_end(I, S)),
+            23
+        ); // 5 = 0.5·diff
+        assert_eq!(
+            calc_mapq(50, None, -6, None, ScoreModel::end_to_end(I, S)),
+            8
+        ); // 4 = 0.4·diff
+        assert_eq!(
+            calc_mapq(50, None, -7, None, ScoreModel::end_to_end(I, S)),
+            3
+        ); // 3 = 0.3·diff
+        assert_eq!(
+            calc_mapq(50, None, -10, None, ScoreModel::end_to_end(I, S)),
+            0
+        ); // 0
     }
 
     #[test]
     fn with_second_best_top_buckets() {
         // as_best 0 (bestOver 10 == diff), vary second-best.
-        assert_eq!(calc_mapq(50, None, 0, Some(-10), I, S, false), 39); // bestDiff 10 (>=0.9), ==diff
-        assert_eq!(calc_mapq(50, None, 0, Some(-8), I, S, false), 38); // bestDiff 8 (>=0.8), ==diff
-        assert_eq!(calc_mapq(50, None, 0, Some(-5), I, S, false), 35); // bestDiff 5 (>=0.5), ==diff
+        assert_eq!(
+            calc_mapq(50, None, 0, Some(-10), ScoreModel::end_to_end(I, S)),
+            39
+        ); // bestDiff 10 (>=0.9), ==diff
+        assert_eq!(
+            calc_mapq(50, None, 0, Some(-8), ScoreModel::end_to_end(I, S)),
+            38
+        ); // bestDiff 8 (>=0.8), ==diff
+        assert_eq!(
+            calc_mapq(50, None, 0, Some(-5), ScoreModel::end_to_end(I, S)),
+            35
+        ); // bestDiff 5 (>=0.5), ==diff
     }
 
     #[test]
     fn with_second_best_not_at_diff() {
         // as_best -3 (bestOver 7, not == diff 10), second-best near.
-        assert_eq!(calc_mapq(50, None, -3, Some(-3), I, S, false), 1); // bestDiff 0 → else; 7>=6.7
-        assert_eq!(calc_mapq(50, None, -3, Some(-10), I, S, false), 26); // bestDiff 7 = 0.7·diff, not ==diff
-        assert_eq!(calc_mapq(50, None, -3, Some(-13), I, S, false), 33); // bestDiff 10 ≥ 0.9·diff, not ==diff
+        assert_eq!(
+            calc_mapq(50, None, -3, Some(-3), ScoreModel::end_to_end(I, S)),
+            1
+        ); // bestDiff 0 → else; 7>=6.7
+        assert_eq!(
+            calc_mapq(50, None, -3, Some(-10), ScoreModel::end_to_end(I, S)),
+            26
+        ); // bestDiff 7 = 0.7·diff, not ==diff
+        assert_eq!(
+            calc_mapq(50, None, -3, Some(-13), ScoreModel::end_to_end(I, S)),
+            33
+        ); // bestDiff 10 ≥ 0.9·diff, not ==diff
     }
 
     #[test]
     fn non_integer_scmin() {
         // readLen 51 → scMin -10.2, diff 10.2; as_best 0 → bestOver 10.2 >= 8.16 → 42.
-        assert_eq!(calc_mapq(51, None, 0, None, I, S, false), 42);
+        assert_eq!(
+            calc_mapq(51, None, 0, None, ScoreModel::end_to_end(I, S)),
+            42
+        );
     }
 
     #[test]
@@ -311,7 +341,7 @@ mod tests {
             (50, -4, -4, 0),
         ];
         for &(len, ab, asb, want) in cases {
-            let got = calc_mapq(len, None, ab, Some(asb), I, S, false);
+            let got = calc_mapq(len, None, ab, Some(asb), ScoreModel::end_to_end(I, S));
             assert_eq!(got, want, "calc_mapq(len={len}, best={ab}, 2nd={asb})");
         }
     }
@@ -319,8 +349,14 @@ mod tests {
     #[test]
     fn user_score_min_slope() {
         // --score_min L,0,-0.4 on readLen 50 → scMin -20, diff 20.
-        assert_eq!(calc_mapq(50, None, 0, None, 0.0, -0.4, false), 42); // bestOver 20 = diff
-        assert_eq!(calc_mapq(50, None, -6, None, 0.0, -0.4, false), 40); // bestOver 14 = 0.7·20
+        assert_eq!(
+            calc_mapq(50, None, 0, None, ScoreModel::end_to_end(0.0, -0.4)),
+            42
+        ); // bestOver 20 = diff
+        assert_eq!(
+            calc_mapq(50, None, -6, None, ScoreModel::end_to_end(0.0, -0.4)),
+            40
+        ); // bestOver 14 = 0.7·20
     }
 
     // ── --local ladder (Perl 4082-4178) ── values cross-checked against the
@@ -374,12 +410,21 @@ mod tests {
         for as_best in [120_i64, 100, 80, 70, 60, 55] {
             // calc_mapq(local=true) must equal the local ladder fed the ln scMin.
             let expect = calc_mapq_local(as_best as f64 - sc, sc.abs(), as_best, None);
-            assert_eq!(calc_mapq(50, None, as_best, None, 20.0, 8.0, true), expect);
+            assert_eq!(
+                calc_mapq(
+                    50,
+                    None,
+                    as_best,
+                    None,
+                    ScoreModel::bowtie2_local(20.0, 8.0)
+                ),
+                expect
+            );
         }
         // The local branch genuinely diverges from end-to-end for the same args.
         assert_ne!(
-            calc_mapq(50, None, 100, None, 20.0, 8.0, true),
-            calc_mapq(50, None, 100, None, 20.0, 8.0, false)
+            calc_mapq(50, None, 100, None, ScoreModel::bowtie2_local(20.0, 8.0)),
+            calc_mapq(50, None, 100, None, ScoreModel::end_to_end(20.0, 8.0))
         );
     }
 
@@ -393,13 +438,28 @@ mod tests {
         // No-second-best @50bp (diff 0.7824): best_over = as_best + diff. as_best 0 → best_over==diff
         // (≥0.8·diff) → 44; as_best -1 → best_over ≈ -0.218 (< 0.3·diff) → 22. (Sub-unity diff ⇒ ONLY
         // 44/22 reachable in the no-secBest ladder — the interior buckets need diff ≥ ~1; B1's finding.)
-        assert_eq!(calc_mapq(50, None, 0, None, i, s, true), 44);
-        assert_eq!(calc_mapq(50, None, -1, None, i, s, true), 22);
-        assert_eq!(calc_mapq(150, None, 0, None, i, s, true), 44); // readLen-invariant for as_best 0
+        assert_eq!(
+            calc_mapq(50, None, 0, None, ScoreModel::hisat2_local(i, s)),
+            44
+        );
+        assert_eq!(
+            calc_mapq(50, None, -1, None, ScoreModel::hisat2_local(i, s)),
+            22
+        );
+        assert_eq!(
+            calc_mapq(150, None, 0, None, ScoreModel::hisat2_local(i, s)),
+            44
+        ); // readLen-invariant for as_best 0
         // Second-best, as_best 0 @50bp (best_over==diff): best_diff = |second| = 1 ≥ 0.9·diff (0.704)
         // → flat top bucket 40.
-        assert_eq!(calc_mapq(50, None, 0, Some(-1), i, s, true), 40);
-        assert_eq!(calc_mapq(50, None, -1, Some(-1), i, s, true), 0); // best_over<0, best_diff 0
+        assert_eq!(
+            calc_mapq(50, None, 0, Some(-1), ScoreModel::hisat2_local(i, s)),
+            40
+        );
+        assert_eq!(
+            calc_mapq(50, None, -1, Some(-1), ScoreModel::hisat2_local(i, s)),
+            0
+        ); // best_over<0, best_diff 0
         // 🔴 PE summed-ln interior `==diff` leaf — the ln()-DERIVED bucket boundary: readLen
         // 150+150 → scMin = -0.4·ln(150) = -2.004254…, diff = 2.004254…; diff·0.5 = 1.002127, so
         // best_diff 1 falls in the 0.4 bucket (NOT 0.5) and best_over==diff → 34. The bucket is
@@ -407,12 +467,15 @@ mod tests {
         // drop diff·0.5 below 1 → 35), so it pins the local ladder against the real ln() scMin — the
         // regime the (20,8) tests (diff=10/integer boundaries) never reach. (Margin to the boundary
         // here is ~0.002, not 1 ULP — the value is robust across platforms.)
-        assert_eq!(calc_mapq(150, Some(150), 0, Some(-1), i, s, true), 34);
+        assert_eq!(
+            calc_mapq(150, Some(150), 0, Some(-1), ScoreModel::hisat2_local(i, s)),
+            34
+        );
         // Routing: calc_mapq(local=true) delegates to the local ladder fed the ln() scMin, for (0,-0.2).
         for len in [40usize, 50, 75, 100, 150] {
             let sc = i + s * (len as f64).ln();
             assert_eq!(
-                calc_mapq(len, None, 0, Some(-1), i, s, true),
+                calc_mapq(len, None, 0, Some(-1), ScoreModel::hisat2_local(i, s)),
                 calc_mapq_local(0.0 - sc, sc.abs(), 0, Some(-1))
             );
         }

--- a/rust/bismark/src/aligner/merge.rs
+++ b/rust/bismark/src/aligner/merge.rs
@@ -11,7 +11,7 @@
 use std::collections::HashMap;
 
 use crate::aligner::align::{PairedSamStream, SamRecord, SamStream};
-use crate::aligner::config::Aligner;
+use crate::aligner::config::{Aligner, ScoreModel};
 use crate::aligner::error::{AlignerError, Result};
 use crate::aligner::mapq::calc_mapq;
 
@@ -187,15 +187,12 @@ struct Stored {
 
 /// Run the merge for one read across the instances; advances the matching
 /// streams past this read. `sequence` is the original (uc) read (for MAPQ length).
-#[allow(clippy::too_many_arguments)]
 pub fn check_results_single_end<S: SamStream>(
     identifier: &str,
     sequence: &str,
     streams: &mut [S],
     directional: bool,
-    score_min_intercept: f64,
-    score_min_slope: f64,
-    score_min_local: bool,
+    score_model: ScoreModel,
     want_ambig: bool,
     counters: &mut Counters,
 ) -> Result<Decision> {
@@ -372,9 +369,7 @@ pub fn check_results_single_end<S: SamStream>(
         None,
         best.alignment_score,
         second_for_mapq,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
+        score_model,
     );
 
     Ok(Decision::UniqueBest(BestAlignment {
@@ -523,9 +518,7 @@ pub fn check_results_paired_end<S: PairedSamStream>(
     sequence_2: &str,
     streams: &mut [Option<S>],
     directional: bool,
-    score_min_intercept: f64,
-    score_min_slope: f64,
-    score_min_local: bool,
+    score_model: ScoreModel,
     want_ambig: bool,
     aligner: Aligner,
     counters: &mut Counters,
@@ -749,9 +742,7 @@ pub fn check_results_paired_end<S: PairedSamStream>(
         Some(sequence_2.len()),
         best.sum,
         second_for_mapq,
-        score_min_intercept,
-        score_min_slope,
-        score_min_local,
+        score_model,
     );
 
     Ok(DecisionPaired::UniqueBest(BestAlignmentPaired {
@@ -881,9 +872,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             directional,
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             want_ambig,
             &mut c,
         )
@@ -1054,9 +1043,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             true,
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             &mut c,
         );
@@ -1079,9 +1066,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             true,
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             &mut c,
         );
@@ -1103,9 +1088,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             true,
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             &mut c,
         )
@@ -1128,9 +1111,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             false,
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             &mut c,
         )
@@ -1159,9 +1140,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             false,
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             &mut c,
         )
@@ -1193,9 +1172,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             false,
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             &mut c,
         );
@@ -1386,9 +1363,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             directional,
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             want_ambig,
             aligner,
             &mut c,
@@ -1768,9 +1743,7 @@ mod tests {
             "ACGTACGTAC",
             &mut streams,
             false,
-            0.0,
-            -0.2,
-            false,
+            ScoreModel::end_to_end(0.0, -0.2),
             false,
             Aligner::Bowtie2,
             &mut c,

--- a/rust/bismark/src/aligner/mod.rs
+++ b/rust/bismark/src/aligner/mod.rs
@@ -78,7 +78,7 @@ use crate::aligner::align::{
     PairedSamStream, SamRecord, SamStream,
 };
 use crate::aligner::aux_out::AuxKind;
-use crate::aligner::config::{Aligner, LibraryType, ReadFormat, ReadLayout};
+use crate::aligner::config::{Aligner, LibraryType, ReadFormat, ReadLayout, ScoreModel};
 use crate::aligner::genome::{Genome, read_genome_into_memory};
 use crate::aligner::merge::{
     BestAlignment, BestAlignmentPaired, Counters, Decision, DecisionPaired,
@@ -2604,9 +2604,7 @@ fn drive_merge<S: SamStream>(
             &sequence,
             streams,
             directional,
-            config.score_min_intercept,
-            config.score_min_slope,
-            config.score_min_local,
+            config.score_model,
             config.ambig_bam,
             counters,
         )?;
@@ -2756,14 +2754,8 @@ fn combined_aligner_options(config: &RunConfig) -> String {
 /// from the classifier). Threaded into the shared `process_se_chunk_combined` /
 /// `drive_merge_combined` so the (identical) gather loop isn't triplicated across
 /// the directional + pbat paths (the dual-driver back-port trap).
-type SelectFn = fn(
-    &[crate::aligner::align::SamRecord],
-    &str,
-    f64,
-    f64,
-    bool,
-    &mut Counters,
-) -> Result<Decision>;
+type SelectFn =
+    fn(&[crate::aligner::align::SamRecord], &str, ScoreModel, &mut Counters) -> Result<Decision>;
 
 /// The single-pass per-PAIR combined selector — `combined::select_pe` (directional,
 /// C→T pass → OT/OB) or `combined::select_pe_pbat` (pbat, G→A pass → CTOT/CTOB); both
@@ -2776,9 +2768,7 @@ type SelectFnPe = fn(
     &[crate::aligner::align::SamPair],
     &str,
     &str,
-    f64,
-    f64,
-    bool,
+    ScoreModel,
     &mut Counters,
 ) -> Result<DecisionPaired>;
 
@@ -3148,14 +3138,7 @@ fn drive_merge_combined<S: SamStream>(
             stream.advance()?;
         }
 
-        let decision = select_fn(
-            &records,
-            &sequence,
-            config.score_min_intercept,
-            config.score_min_slope,
-            config.score_min_local,
-            counters,
-        )?;
+        let decision = select_fn(&records, &sequence, config.score_model, counters)?;
         route_se_decision(
             decision,
             &identifier,
@@ -3533,9 +3516,7 @@ fn select_and_route_se_nondir(
         ct_records,
         ga_records,
         sequence,
-        config.score_min_intercept,
-        config.score_min_slope,
-        config.score_min_local,
+        config.score_model,
         counters,
     )?;
     route_se_decision(
@@ -4652,9 +4633,7 @@ fn drive_merge_pe(
             &s2,
             streams,
             directional,
-            config.score_min_intercept,
-            config.score_min_slope,
-            config.score_min_local,
+            config.score_model,
             config.ambig_bam,
             config.aligner,
             counters,
@@ -5256,15 +5235,7 @@ fn drive_merge_combined_pe<S: PairedSamStream>(
             stream.advance_pair()?;
         }
 
-        let decision = select_fn(
-            &pairs,
-            &s1,
-            &s2,
-            config.score_min_intercept,
-            config.score_min_slope,
-            config.score_min_local,
-            counters,
-        )?;
+        let decision = select_fn(&pairs, &s1, &s2, config.score_model, counters)?;
         route_pe_decision(
             decision,
             &identifier,
@@ -5705,16 +5676,8 @@ fn select_and_route_pe_nondir(
     sinks: &mut PeSinks,
     counters: &mut Counters,
 ) -> Result<()> {
-    let decision = combined::select_pe_nondir(
-        ct_pairs,
-        ga_pairs,
-        s1,
-        s2,
-        config.score_min_intercept,
-        config.score_min_slope,
-        config.score_min_local,
-        counters,
-    )?;
+    let decision =
+        combined::select_pe_nondir(ct_pairs, ga_pairs, s1, s2, config.score_model, counters)?;
     route_pe_decision(
         decision,
         identifier,


### PR DESCRIPTION
Preparation for the #1079 fix (which follows in a stacked PR). **No behaviour change** — this is the mechanical half, split out so the semantic diff can be small and reviewed on its own.

`calc_mapq` and every merge/select signature leading to it carried `(score_min_intercept, score_min_slope, score_min_local)` as three separate scalars. They are replaced by one `ScoreModel`, built once in `config::resolve` — the only place `--local` and the resolved aligner are both known. `diff` is still `abs(scMin)`, the `scMin` form still follows `--local` alone, and no MAPQ value changes.

Also splits the end-to-end MAPQ ladder into `calc_mapq_end_to_end`, mirroring the existing `calc_mapq_local`, so `calc_mapq` becomes normalize + dispatch.

**Why a struct rather than a fourth scalar:** the perfect alignment score needed by #1079 is aligner-dependent, and no call site knew the aligner. Threading a fourth parameter through ten signatures would have deepened the existing `too_many_arguments` debt; collapsing three into one instead *reduces* arity everywhere and retires two of those allows.

## Verification

- 2101 tests pass, **no expected-value edits** — call-shape edits only.
- Proven, not just green: inverse-transforming the new `ScoreModel` calls back to the trio reproduces the previous test modules token-for-token in all four files.
- `cargo fmt --check` clean, `cargo clippy --all-targets` 0 warnings.

## Sites touched

10 fn signatures, the `SelectFn`/`SelectFnPe` fn-pointer aliases, 6 config-expansion sites in `mod.rs`, `RunConfig`, 4 `calc_mapq` call sites, and the test call shapes. Arity drops by two throughout, retiring the `too_many_arguments` allows on `merge::check_results_single_end` and `combined::select_pe_nondir` (the paired-end one stays at 9 args and keeps its allow).
