### PR TITLE
cli: accept short options in either letter case, as Perl did (#1084)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Bismark Changelog
 
 
+## Unreleased
+
+### All tools
+
+- **Short options are accepted in either letter case again, matching Perl Bismark ([#1084](https://github.com/FelixKrueger/Bismark/issues/1084)).** Perl's `Getopt::Long` is case-insensitive by default, so Perl Bismark accepted `-N`/`-L` *and* `-n`/`-l` for the Bowtie 2 seed settings — and its own help documents the uppercase spellings (`-n`/`-l` are described there as retired Bowtie 1's flags). The Rust CLI copied Perl's lowercase declarations verbatim, but clap is case-sensitive, so `bismark -N 1 -L 20` — the form the documentation shows — was rejected. Both spellings now work, so existing command lines and scripts port unchanged. Likewise `-v` is accepted alongside `-V` for `--version` across the suite, as Perl accepted it via single-dash abbreviation. Reported by @alexg9010.
+
 ## Bismark 3.1.0 (released 2026-07-13)
 
 ### bismark (aligner)

--- a/docs/src/content/docs/options/alignment.md
+++ b/docs/src/content/docs/options/alignment.md
@@ -74,6 +74,9 @@ The full path `</../../>` to the HISAT2 installation on your system. If not spec
 
 ##### Alignment:
 
+The Bowtie 2 seed options below may be given in either letter case (`-N`/`-n`, `-L`/`-l`) — both are
+accepted, as they were in Perl Bismark.
+
 - `-N <int>`
 
   Sets the number of mismatches to be allowed in a seed alignment during multiseed alignment. Can be set to 0 or 1. Setting this higher makes alignment slower (often _much_ slower) but increases sensitivity. Default: 0.

--- a/rust/bismark/src/aligner/cli.rs
+++ b/rust/bismark/src/aligner/cli.rs
@@ -268,10 +268,13 @@ pub struct Cli {
 
     // ---- Bowtie 2 alignment parameters ------------------------------------
     /// Multiseed mismatches, 0 or 1 (Bowtie 2 -N).
-    #[arg(short = 'n', long = "seedmms", value_name = "int")]
+    // Perl declared `n|seedmms` but Getopt::Long ignores case, so -N (as the help documents,
+    // -n being retired Bowtie 1's flag) worked too. Accept both (#1084).
+    #[arg(short = 'n', short_alias = 'N', long = "seedmms", value_name = "int")]
     pub seedmms: Option<i64>,
     /// Seed length (Bowtie 2 -L).
-    #[arg(short = 'l', long = "seedlen", value_name = "int")]
+    // As for -N/-n above: Perl documented -L, declared `l|seedlen`, accepted both (#1084).
+    #[arg(short = 'l', short_alias = 'L', long = "seedlen", value_name = "int")]
     pub seedlen: Option<u32>,
     /// Consecutive seed-extension fails (Bowtie 2 -D).
     #[arg(short = 'D', value_name = "int")]
@@ -431,6 +434,7 @@ pub struct Cli {
     /// Print version information and exit.
     #[arg(
         short = 'V',
+        short_alias = 'v',
         long = "version",
         help = "Print version information and exit"
     )]

--- a/rust/bismark/src/aligner/options.rs
+++ b/rust/bismark/src/aligner/options.rs
@@ -443,6 +443,36 @@ mod tests {
         Cli::parse_from(v)
     }
 
+    /// Perl's `Getopt::Long` is case-insensitive by default, so `'n|seedmms=i'` /
+    /// `'l|seedlen=i'` accepted `-N`/`-L` as well — and Perl's own help documents the
+    /// UPPERCASE spellings (`-n`/`-l` are described there as retired Bowtie 1's flags).
+    /// clap is case-sensitive, so both spellings need declaring explicitly (#1084).
+    ///
+    /// Asserted on the emitted option string, not the parsed field, so the aliases are
+    /// pinned to behaviour: swapping them for the other case must remain a no-op.
+    #[test]
+    fn seed_options_accept_both_letter_cases_like_perl() {
+        let build = |args: &[&str]| {
+            let cli = cli_from(args);
+            build_aligner_options(&cli, Aligner::Bowtie2, ReadFormat::FastQ, false, None)
+                .unwrap()
+                .0
+        };
+        let upper = build(&["-N", "1", "-L", "20"]); // as Perl's help documents them
+        let lower = build(&["-n", "1", "-l", "20"]); // as Perl declared them
+        assert_eq!(upper, lower);
+        assert!(
+            upper.contains("-N 1"),
+            "seedmms must reach Bowtie 2 as -N: {upper}"
+        );
+        assert!(
+            upper.contains("-L 20"),
+            "seedlen must reach Bowtie 2 as -L: {upper}"
+        );
+        // Mixed casing works too — Getopt::Long imposed no consistency requirement.
+        assert_eq!(build(&["-N", "1", "-l", "20"]), upper);
+    }
+
     #[test]
     fn default_se_options_match_phase0_spike() {
         let cli = cli_from(&[]);

--- a/rust/bismark/src/bam2nuc/cli.rs
+++ b/rust/bismark/src/bam2nuc/cli.rs
@@ -65,7 +65,7 @@ pub struct Cli {
     pub genomic_composition_only: bool,
 
     /// Print version information and exit.
-    #[arg(short = 'V', long = "version")]
+    #[arg(short = 'V', short_alias = 'v', long = "version")]
     pub version: bool,
 }
 

--- a/rust/bismark/src/bedgraph/cli.rs
+++ b/rust/bismark/src/bedgraph/cli.rs
@@ -106,7 +106,7 @@ pub struct Cli {
     pub man: bool,
 
     /// Print version information and exit.
-    #[arg(short = 'V', long = "version")]
+    #[arg(short = 'V', short_alias = 'v', long = "version")]
     pub version: bool,
 }
 

--- a/rust/bismark/src/coverage2cytosine/cli.rs
+++ b/rust/bismark/src/coverage2cytosine/cli.rs
@@ -89,7 +89,7 @@ pub struct Cli {
     pub gzip: bool,
 
     /// Print version information and exit.
-    #[arg(short = 'V', long = "version")]
+    #[arg(short = 'V', short_alias = 'v', long = "version")]
     pub version: bool,
 
     /// GpC-context report (`{stem}.GpC_report.txt` + `.GpC.cov`), emitted in

--- a/rust/bismark/src/dedup/cli.rs
+++ b/rust/bismark/src/dedup/cli.rs
@@ -126,7 +126,7 @@ pub struct Cli {
     pub samtools_path: Option<PathBuf>,
 
     /// Print version information and exit.
-    #[arg(short = 'V', long = "version")]
+    #[arg(short = 'V', short_alias = 'v', long = "version")]
     pub version: bool,
 }
 

--- a/rust/bismark/src/extractor/cli.rs
+++ b/rust/bismark/src/extractor/cli.rs
@@ -247,7 +247,7 @@ pub struct Cli {
 
     // ─── Version (SPEC §3 row 11, Perl 967) ───
     /// Print version information and exit.
-    #[arg(short = 'V', long = "version")]
+    #[arg(short = 'V', short_alias = 'v', long = "version")]
     pub version: bool,
 }
 

--- a/rust/bismark/src/filter_nonconversion/cli.rs
+++ b/rust/bismark/src/filter_nonconversion/cli.rs
@@ -78,7 +78,7 @@ pub struct Cli {
     pub samtools_path: Option<PathBuf>,
 
     /// Print version information and exit.
-    #[arg(short = 'V', long = "version")]
+    #[arg(short = 'V', short_alias = 'v', long = "version")]
     pub version: bool,
 }
 

--- a/rust/bismark/src/genome_prep/cli.rs
+++ b/rust/bismark/src/genome_prep/cli.rs
@@ -102,7 +102,7 @@ pub struct Cli {
     pub man: bool,
 
     /// Print version and exit.
-    #[arg(long, short = 'V')]
+    #[arg(long, short = 'V', short_alias = 'v')]
     pub version: bool,
 }
 

--- a/rust/bismark/src/methylation_consistency/cli.rs
+++ b/rust/bismark/src/methylation_consistency/cli.rs
@@ -74,7 +74,7 @@ pub struct Cli {
     pub quiet: bool,
 
     /// Print version information and exit.
-    #[arg(short = 'V', long = "version")]
+    #[arg(short = 'V', short_alias = 'v', long = "version")]
     pub version: bool,
 }
 

--- a/rust/bismark/src/nome_filtering/cli.rs
+++ b/rust/bismark/src/nome_filtering/cli.rs
@@ -78,7 +78,7 @@ pub struct Cli {
     pub merge_cpgs: bool,
 
     /// Print version information and exit.
-    #[arg(short = 'V', long = "version")]
+    #[arg(short = 'V', short_alias = 'v', long = "version")]
     pub version: bool,
 }
 

--- a/rust/bismark/src/report/cli.rs
+++ b/rust/bismark/src/report/cli.rs
@@ -63,6 +63,6 @@ pub struct Cli {
     pub man: bool,
 
     /// Print version and exit.
-    #[arg(long, short = 'V')]
+    #[arg(long, short = 'V', short_alias = 'v')]
     pub version: bool,
 }

--- a/rust/bismark/src/summary/cli.rs
+++ b/rust/bismark/src/summary/cli.rs
@@ -58,7 +58,7 @@ pub struct Cli {
     pub verbose: bool,
 
     /// Print version information and exit.
-    #[arg(short = 'V', long = "version")]
+    #[arg(short = 'V', short_alias = 'v', long = "version")]
     pub version: bool,
 
     /// Alias for `--help` (Perl accepts `--help|--man`). Prints the long


### PR DESCRIPTION
Fixes #1084.

`bismark -N 1 -L 20` — the form the docs and existing scripts use — was rejected by the Rust CLI, which only accepted `-n`/`-l`.

The cause isn't a transcription slip: Perl declares these **lowercase too** (`'n|seedmms=i'`, `'l|seedlen=i'`), and the Rust port copied that faithfully. Perl accepted the uppercase spellings because **`Getopt::Long` is case-insensitive by default** and `bismark` never reconfigures it. Verified against Getopt::Long directly — all four spellings parse there:

```
  -n -> 7      -l -> 7
  -N -> 7      -L -> 7
```

clap is case-sensitive, so only the declared case survived the port.

So this adds **aliases** rather than swapping the declarations, as #1084 suggested: `-n`/`-l` have to keep working, since Perl accepted them. Swapping would have traded one broken spelling for another.

Interesting wrinkle that explains the lowercase declarations — Perl's own help says:

> `-N <int>` Sets the number of mismatches to allowed in a seed alignment … (Bowtie 1 see `-n`).

`-n`/`-l` are documented as *retired Bowtie 1's* flags. The lowercase declarations are a Bowtie 1-era artifact that case-insensitivity kept invisible for years.

## Also: `-v` for `--version`

Perl accepted `-v` via single-dash abbreviation of `--version`, and `bismark --help` documents it as `-v/--version`. Rust declared only `-V`. Now both work, across the suite. Every tool except `methylation_consistency` had a Perl `'version'` option; that one gets the alias for consistency rather than compatibility.

## Sweep of the other tools

I checked all 12 Perl tools' help text against their ports' short options, looking for any casing a tool's own documentation uses but its port rejects. `-N`, `-L` and `-v` are the only ones.

Three others surfaced and are false positives, listed so the sweep is reproducible: `-U` and `-x` are **Bowtie 2's own** flags appearing inside the constructed command line, and `-d` is Perl's `-d` file-test operator (`if (-d $path_to_bowtie2)`) — none is a Bismark option.

Safe to alias: no tool declares both cases of any letter, so nothing is shadowed.

## Not done deliberately

Perl accepted *any* casing of *any* option (`--GENOME`, `--Non_Directional`), because `ignore_case` is global. Full parity would mean a case-insensitive CLI, which masks typos and is unusual for a modern tool. This fixes the spellings the documentation actually tells you to use.

## Testing

2102 tests pass (2101 + 1 new); `cargo fmt --check` clean; `cargo clippy --all-targets` 0 warnings.

The regression test asserts the emitted **Bowtie 2 option string** is identical for `-N 1 -L 20`, `-n 1 -l 20` and a mixed pairing — pinning the aliases to observable behaviour rather than to a parsed struct field. Confirmed it fails (`unexpected argument '-N' found`) when an alias is removed.

Also verified by running the built binary: `-N 1 -L 20` now gets past option parsing, `-n 1 -l 20` still does, and `-v`/`-V` both print the version for every subcommand.

Reported by @alexg9010.
