### PR TITLE
ci: build the docs site on PRs to master (build-only, no deploy)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,14 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+  # Build-only validation on PRs (deploy is gated to a push, below) so a docs
+  # change is verified to build before it merges — BismarkCI does not build the
+  # Astro site, so dependency bumps under docs/ were previously unchecked.
+  pull_request:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -13,8 +21,10 @@ permissions:
   pages: write
   id-token: write
 
+# Per-ref so a PR build never cancels an in-flight deploy (only a push to
+# master and workflow_dispatch actually deploy).
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -34,12 +44,16 @@ jobs:
       - run: npm run build
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      # Deploy artifact only for real (non-PR) runs; PRs are build-only.
       - uses: actions/upload-pages-artifact@v3
+        if: github.event_name != 'pull_request'
         with:
           path: docs/dist
 
   deploy:
     needs: build
+    # Never deploy from a PR — build-only there; publish only on push / dispatch.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
`BismarkCI` doesn't build the Astro site, and `docs.yml` on master only triggers on `push`. So a PR touching `docs/` gets **no build check at all** — its green tick says nothing about whether the site still builds, and a bad change breaks the published docs instead of the PR.

Four dependabot bumps under `docs/` merged that way (#1076, #1077, #1078, #1087). Each had to be built locally by hand to establish it was safe, which only works when someone remembers to do it.

## The change

Adds a `pull_request` trigger with the same paths filter, and gates publishing so PRs are strictly build-only:

- `upload-pages-artifact` and the `deploy` job both skip when `github.event_name == 'pull_request'`
- `concurrency` becomes per-ref (`pages-${{ github.ref }}`), so a PR build can't cancel an in-flight deploy

Push and deploy behaviour on master is otherwise untouched.

This mirrors what `dev` already does (#1072) so the two converge, with **one deliberate difference: `push.branches` stays `[master]`.** Copying dev's file verbatim would set it to `[dev]` and stop master deploying the docs entirely.

## It also converts a silent breakage into a visible one

Worth knowing before the next release, because it cuts the other way from what you'd expect.

`dev`'s copy of this file has `push.branches: [dev]`. Today, a dev→master release merge would apply that **cleanly** — no conflict — leaving master's workflow triggering only on pushes to `dev`. Since the workflow file on master governs pushes to master, a push to master would then match nothing and **the docs would silently stop deploying**. Verified with `git merge-tree`:

```
# without this PR
$ git merge-tree --write-tree origin/master origin/dev
   → clean; master's docs.yml becomes  branches: [dev]

# with this PR
   → CONFLICT (content): Merge conflict in .github/workflows/docs.yml
```

So this PR trades a silent misconfiguration for a merge conflict that forces the question at release time. That question is worth answering deliberately: **both** `dev` and `master` currently have deploying workflows pointing at the same `github-pages` environment, so the published site reflects whichever branch was pushed most recently. I haven't touched that — it predates this PR and it's a real decision about which branch publishes — but the conflict is where it will surface.

## Testing

YAML validated, and the four gates confirmed parsed:

```
triggers:              push, pull_request, workflow_dispatch
push.branches:         ['master']
pull_request.branches: ['master']
concurrency group:     pages-${{ github.ref }}
deploy gated:          github.event_name != 'pull_request'
artifact upload gated: github.event_name != 'pull_request'
```

The workflow's own path filter includes `.github/workflows/docs.yml`, so this PR exercises the new trigger on itself — it should appear as a build-only `Docs site` check here, with `deploy` skipped.
