### PR TITLE
tests: #1095 validation gates — XG⟺FLAG contract + PE/four-strand idempotence (+ CI samtools repair)

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -93,14 +93,16 @@ jobs:
         run: cargo build -p bismark --all-targets --features rammap-inprocess
       - name: cargo clippy -p bismark --features rammap-inprocess -D warnings
         run: cargo clippy -p bismark --all-targets --features rammap-inprocess -- -D warnings
-      - name: Install minimap2 (5-Base #787 ground-truth gates)
-        # `cargo test -p bismark` runs the 5-Base real-aligner gates, which panic
-        # when $CI is set and minimap2 is missing (they must not pass vacuously). This
-        # feature job runs them too, so it needs minimap2 like the main `cargo test` job.
+      - name: Install minimap2 + samtools (5-Base #787 / #1095 gates)
+        # `cargo test -p bismark` runs the 5-Base real-aligner gates (minimap2) and the
+        # #1095 bisulfite-convention gates (samtools), which panic when $CI is set and
+        # the tool is missing (they must not pass vacuously). This feature job runs
+        # them too, so it needs both like the main `cargo test` job.
         run: |
           sudo apt-get update || sudo apt-get update
-          sudo apt-get install -y --no-install-recommends minimap2
+          sudo apt-get install -y --no-install-recommends minimap2 samtools
           minimap2 --version
+          samtools --version | head -1
       - name: cargo test -p bismark --features rammap-inprocess
         run: cargo test -p bismark --features rammap-inprocess
 
@@ -131,14 +133,16 @@ jobs:
         run: cargo build -p bismark --all-targets --features binseq-input
       - name: cargo clippy -p bismark --features binseq-input -D warnings
         run: cargo clippy -p bismark --all-targets --features binseq-input -- -D warnings
-      - name: Install minimap2 (5-Base #787 ground-truth gates)
-        # `cargo test -p bismark` runs the 5-Base real-aligner gates, which panic
-        # when $CI is set and minimap2 is missing (they must not pass vacuously). This
-        # feature job runs them too, so it needs minimap2 like the main `cargo test` job.
+      - name: Install minimap2 + samtools (5-Base #787 / #1095 gates)
+        # `cargo test -p bismark` runs the 5-Base real-aligner gates (minimap2) and the
+        # #1095 bisulfite-convention gates (samtools), which panic when $CI is set and
+        # the tool is missing (they must not pass vacuously). This feature job runs
+        # them too, so it needs both like the main `cargo test` job.
         run: |
           sudo apt-get update || sudo apt-get update
-          sudo apt-get install -y --no-install-recommends minimap2
+          sudo apt-get install -y --no-install-recommends minimap2 samtools
           minimap2 --version
+          samtools --version | head -1
       - name: cargo test -p bismark --features binseq-input
         run: cargo test -p bismark --features binseq-input
 

--- a/plans/08072026_1095-validation-gates/CODE_REVIEW_A.md
+++ b/plans/08072026_1095-validation-gates/CODE_REVIEW_A.md
@@ -1,0 +1,69 @@
+# Code Review A — #1095 validation gates (commit `010e46f`)
+
+**Reviewer:** A (independent, fresh context) · **Date:** 2026-08-07
+**Scope:** commit `010e46f` on branch `1095-validation-gates` — `rust/bismark/tests/aligner_five_base_bisulfite.rs` (4 new tests + helper refactor), `.github/workflows/rust_ci.yml` (samtools mirrored into the two feature jobs). Plan: `plans/08072026_1095-validation-gates/PLAN.md` rev 1.
+
+## Summary
+
+**Verdict: APPROVE.** The implementation matches the plan exactly (the one signature deviation — `assert_xg_iff_flag` returning `(QNAME, FLAG, XG)` triples instead of the plan's `(FLAG, XG)` pairs — is documented in PLAN.md §12 and is required by the pair census). Every empirical claim in the code and commit message that I could reach was re-verified independently and held. No Critical or High findings; four Low observations, all cosmetic or scoped-out coverage notes.
+
+### What I verified empirically (not trusted from comments)
+
+| Claim | Method | Result |
+|---|---|---|
+| `nondir_pe_1030.bam`: 20 records; (99,CT)×4, (147,CT)×4, (83,GA)×6, (163,GA)×6 | `samtools view` + awk census | **Matches exactly** |
+| Pair structure: file-order adjacent same-QNAME pairs, FLAGs (147,99)×4 and (163,83)×6 | `awk | paste - -` | **Matches** — all 10 pairs adjacent, same QNAME, higher-flag record first |
+| All 20 records carry `XG:Z:` | awk tag count | 20/20 |
+| `softclip_indel_se.bam`: 8 records, (0,CT)×4, (16,GA)×4 | census | **Matches** |
+| `synth_barcode_10k…pe.bam`: 12,974 records, 0 `CB:Z:` tags, 42 indel records | `samtools view -c`, grep, CIGAR awk | **Matches** (12974 / 0 / 42) |
+| §9.8 biconditional holds on both Gate-1 fixtures | census cross-check: {0,99,147}→CT, {16,83,163}→GA | Holds on every record |
+| 11/11 gates green | `cargo test -p bismark --test aligner_five_base_bisulfite` | 11 passed, 1.91 s |
+| fmt / clippy | `cargo fmt -p bismark -- --check`; `clippy --all-targets -- -D warnings` on default **and** `rammap-inprocess` | All clean |
+| $CI panic guard fires for the new tests | ran the test binary with `CI=1 PATH=/usr/bin:/bin` (samtools absent) | Both Gate-1 tests **and** all 3 round-trip tests FAIL loudly (0 passed); without `CI` they skip green |
+| No leftover falsifiability instrumentation | grep for `TEMP falsifiability` in `rust/` | none |
+| No other workflow runs `cargo test` | grep `.github/workflows/` | only `rust_ci.yml`; the `perl-oracle` job already installs samtools |
+
+### Vacuous-pass analysis (per assignment)
+
+- **Gate 1 (both tests):** cannot pass vacuously. `assert_xg_iff_flag` over an empty body would return an empty census, but each caller pins `census.len()` (20 / 8) and the four/two `(FLAG, XG)` counts sum to the pinned total, so the census is fully determined — any drift in count, combination, or pair order fails. `sam_body` asserts `samtools view` exit status, so a broken read cannot masquerade as an empty-but-passing census.
+- **Gate 2 (all three round trips):** `expected_records` is asserted on the *input* body before the equality, so two empty streams cannot satisfy the comparison (plan G19). Converter exit status and output-file existence are asserted first.
+- **Pair census:** asserts each adjacent pair is `(147,99) | (163,83)` with shared QNAME; the per-shape counts (4 and 6) are not asserted directly but are forced by the record census — no gap (see Low-4).
+- **CI-red repair claim:** I could not reach the GitHub API from this environment (TLS interception, known off-infra limitation), so run `31204223600` stands on the plan reviews' verification. The fix is nonetheless correct by construction: both feature jobs run `cargo test -p bismark`, which includes this test file, whose guard I demonstrated panics under `$CI` without samtools; the mirrored install step is textually the main `test` job's (verified against lines 35–45 of the yaml).
+
+## Issues by area
+
+### Logic
+None. The set-form biconditional is the correct one (147 is reverse-strand *and* CT — the bit-form footgun is called out in the doc comment and correctly absent from the code). The `chunks(2)` pair walk is sound given the empirically-verified adjacency, and the `else panic!("odd record count")` arm is defensively correct even though `len()==20` makes it unreachable.
+
+### Efficiency
+Trivial — 12,974 records through a debug converter in under 2 s total suite time. No concerns.
+
+### Errors
+None found. All failure paths are loud: missing `XG` panics with the offending line, unexpected `XG` values fail the domain assert, samtools absence fails hard under `$CI` and skips visibly otherwise.
+
+### Structure
+Two cosmetic points (Low-1, Low-2 below). Naming follows the file's property-style convention; doc comments explain *why* each gate exists (emergence of the XG⟺FLAG agreement, the #1030 pair structure as the non-directional guard) at appropriate length.
+
+## Fixes applied
+
+None — per the review instructions, this shared worktree must not be edited concurrently; everything below is a recommendation for the caller.
+
+## Recommendations
+
+| # | Priority | Recommendation |
+|---|---|---|
+| 1 | Low | **Deduplicate the `count` closure** shared by the two Gate-1 tests (`aligner_five_base_bisulfite.rs` lines 192–197 and 224–229) into a small helper (e.g. `fn count(census: &[(String, u16, String)], flag: u16, xg: &str) -> usize`). Pure cosmetics; fine to leave. |
+| 2 | Low | **Move the input census before the converter run** in `assert_bisulfite_round_trip` (lines 102–119): compute `before` and assert `expected_records` *before* `run_converter`, so a drifted fixture fails on the drift message without first executing (and potentially mis-attributing a failure to) the converter. Behaviourally identical today. |
+| 3 | Low | **Tag scan breadth (informational):** `fields.find_map(|f| f.strip_prefix("XG:Z:"))` scans mandatory fields 3–11 as well as the tag region; a pathological RNAME beginning `XG:Z:` would be misread. Zero risk on these fixtures and consistent with the file's existing `xms` closure — note only, no change needed. |
+| 4 | Low | **Coverage note, scoped out by the plan:** the PE round trips compare `samtools view` *body* only; header preservation (@SQ/@PG) on PE inputs is unasserted — the duplicate-@PG-ID test runs only over the SE fixture. If a PE header regression ever matters, extend `appends_a_pg_with_a_distinct_id` over `nondir_pe_1030.bam`; not required now. Relatedly, the pair census's per-shape counts are forced by the record census — if anyone ever deletes the record-count asserts, the pair census alone would accept e.g. 10×(163,83). |
+
+## Plan conformance
+
+- §3 Gate 1: implemented as specified (set form only, both fixtures, record + pair + count censuses). ✓
+- §3 Gate 2: SE test extracted to `assert_bisulfite_round_trip` with the non-vacuity census; two PE tests with exactly the planned names and constants. ✓
+- §3 CI repair: both feature jobs' install steps now mirror the main `test` job (packages, version echoes, comment updated to name both guards). ✓
+- §5.d module doc: updated — three fixtures named, Gate-1 contract explained, SE-only implication dropped. ✓
+- §12 implementation notes are accurate against the diff (single `replace_all` plausible — the two replaced steps were byte-identical pre-change; triple-return deviation documented).
+- Only remaining unvalidated row from §9 is "all six CI jobs green", which requires the PR run — correctly flagged as pending in §12.
+
+**Report:** `/Users/fkrueger/Github/Bismark/plans/08072026_1095-validation-gates/CODE_REVIEW_A.md`

--- a/plans/08072026_1095-validation-gates/CODE_REVIEW_B.md
+++ b/plans/08072026_1095-validation-gates/CODE_REVIEW_B.md
@@ -1,0 +1,66 @@
+# Code Review B — #1095 validation gates (commit `010e46f`)
+
+**Reviewer:** B (independent, fresh context) · **Date:** 2026-08-07
+**Scope:** `rust/bismark/tests/aligner_five_base_bisulfite.rs` (4 new tests + round-trip helper refactor), `.github/workflows/rust_ci.yml` (samtools mirrored into `rammap-inprocess` + `binseq-input`), against `plans/08072026_1095-validation-gates/PLAN.md` rev 1.
+**Note:** per instruction, no fixes were applied — everything is a recommendation; the worktree was left untouched except this report.
+
+## Verdict
+
+**APPROVE.** No Critical, High, or Medium findings. The implementation matches the plan exactly (one documented, correct deviation), every census constant reproduces independently from the fixtures, no assertion can pass vacuously, and the CI repair is confirmed to be complete and sufficient against the actual failed run on `dev`.
+
+## What I verified empirically (not taken from comments or the plan)
+
+| Claim | Method | Result |
+|---|---|---|
+| 11/11 gates green | `cargo test -p bismark --test aligner_five_base_bisulfite` | 11 passed, 0 failed (2.11s) |
+| nondir_pe_1030 census | `samtools view` + awk, independent of the test code | 20 records; (99,CT)×4, (147,CT)×4, (83,GA)×6, (163,GA)×6 — matches lines 198–201 |
+| nondir pair structure | qname/flag `paste - -` pairing | (147,99)×4, (163,83)×6, zero QNAME mismatches — the #1030 swap census (lines 202–211) is correct and every pair is adjacent in file order, so `chunks(2)` is sound |
+| SE fixture census | same | 8 records; (0,CT)×4, (16,GA)×4 — matches lines 230–231 |
+| synth_barcode fixture | same | 12,974 records; 42 CIGARs with `I`/`D`; 0 `CB:Z:` tags; barcode is a QNAME suffix (`…:1000:TTAGTTGT`); mate fields (`RNEXT`=`=`, PNEXT, TLEN ±215) present — every doc-comment claim on `real_pe_…` (lines 143–144) is true |
+| SE fixture is the only committed FLAG-16 witness | flags in synth are 99/147/83/163 only | confirmed — doc claim on line 214–215 holds |
+| XG⟺FLAG contract | independent awk re-implementation of the biconditional | 0 violations on nondir, SE, **and** synth (12,974 records) |
+| dev's red CI is exactly the samtools guard | `gh run view 31204223600 --log-failed` | both feature jobs: 3 failures each, all panics at `aligner_five_base_bisulfite.rs:52` ("samtools not found but $CI is set"); the minimap2 gates and all 1475 unit tests pass — **plan assumption 7 verified: samtools is the only missing dependency, so the two-line mirror fully repairs `dev`** |
+| Hygiene | `cargo fmt -p bismark -- --check`; `cargo clippy -p bismark --all-targets -- -D warnings` | both clean |
+| No leftover falsifiability instrumentation | `grep TEMP` on the test file; `git diff 010e46f` | no matches; worktree identical to the commit |
+
+## Vacuous-pass audit (every new assertion)
+
+- **Gate 1 (both tests):** `census.len() == 20/8` blocks the empty-stream pass; the per-combination counts block a degenerate distribution; the pair loop blocks a directional regeneration (pairs (99,147)/(83,163) fail `matches!`). Combined with the record census, the pair counts (147,99)×4 / (163,83)×6 are fully pinned even though the loop itself only checks membership.
+- **The biconditional is total, not census-limited:** a hypothetical (147, GA) record fails the `assert_eq!` at line 169, not just the counts — a corrupted fixture cannot slip through on an unobserved FLAG value.
+- **Gate 2:** `expected_records` is asserted on the *input* body before the equality, so two empty streams can never satisfy the comparison; a zero-record output fails the equality against a pinned-non-empty `before`.
+- **Missing-XG records** panic (line 166) rather than being skipped — a tag-stripped fixture fails loudly.
+- **CI skip-removal intact:** all five samtools-gated tests route through `samtools_available()`, whose `$CI` panic is unchanged; Gate 1's two tests guard before calling the helper.
+
+## Plan conformance
+
+- Test names, fixture choices, censuses, module-doc update, CI step name/comment/`samtools --version | head -1` — all exactly per PLAN.md §3/§5.
+- **One deviation, documented and correct (§12):** `assert_xg_iff_flag` returns `(QNAME, u16, String)` triples instead of the plan's `Vec<(u16, String)>` (§4). The plan was internally inconsistent — its own §3 pair census needs QNAMEs — so the implementation resolved it the only sensible way.
+- SE round-trip refactor is a pure extraction plus the one added census; the original test's three assertions (converter success + stderr, output exists, body equality) are all preserved in the helper.
+- Only §9 validation row not executable locally: "all six CI jobs green" pends the PR run. Given the failed-run analysis above, the residual risk is negligible.
+
+## Issues by area
+
+### Logic
+None. The set-form biconditional (deliberately not the `0x10` bit form) is correct for PE — independently confirmed: FLAG 147 records carry `XG:Z:CT` in both PE fixtures.
+
+### Errors
+None found.
+
+### Efficiency
+None. Full suite runs in ~2s; the 12,974-record debug-build conversion is well inside test-time norms. CI adds one apt package to two jobs.
+
+### Structure
+Two Low-grade nits, below.
+
+## Recommendations
+
+| # | Priority | Recommendation |
+|---|---|---|
+| R1 | Low | The 6-line `count` closure is duplicated verbatim between the two Gate 1 tests (lines 192–197 and 224–229). A free function `fn xg_flag_count(census: &[(String, u16, String)], flag: u16, xg: &str) -> usize` next to `assert_xg_iff_flag` would remove it. Borderline — fine to leave. |
+| R2 | Low | `assert_xg_iff_flag` scans every field after FLAG for the `XG:Z:` prefix, so RNAME/SEQ/QUAL are searched too. Any accidental shadow fails loudly on the `CT|GA` assert (and the fixtures are static), so this is precision, not correctness: skipping to the tag region (`fields.nth(8)` past RNAME…QUAL before the `find_map`) would make the parse strictly tag-scoped. |
+| R3 | Low (optional) | Gate 1 could be parameterised over the synth fixture for one more line — I verified 0 contract violations across its 12,974 records, which carry all four record-level (FLAG, XG) combinations at real scale. The plan deliberately scoped Gate 1 to the two fixtures, so this is an offer, not a gap. |
+| R4 | Low | In `assert_bisulfite_round_trip`, the input record-count census runs *after* the converter; moving it before `run_converter` would fail faster on fixture drift and keep drift from being reported mid-round-trip. Cosmetic — the failure message ("fixture record count drifted") is unambiguous either way. |
+
+## Fixes applied
+
+None — deliberately, per the shared-worktree instruction. All four recommendations are safe to defer or drop; none blocks merge.

--- a/plans/08072026_1095-validation-gates/COVERAGE.md
+++ b/plans/08072026_1095-validation-gates/COVERAGE.md
@@ -1,0 +1,88 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs. implementation plan)
+**Plan(s):** plans/08072026_1095-validation-gates/PLAN.md (rev 1) — §3 Behavior, §5 Implementation outline, §9 Validation
+**Implementation:** commit `010e46f` on branch `1095-validation-gates`
+**Date:** 2026-08-07
+**Verdict:** COMPLETE
+
+One §9 row ("all six CI jobs green") is **PENDING** the PR run by design — the branch is not
+yet pushed and the row is not executable locally (plan §12 says the same). It is not counted
+as a gap.
+
+## Summary
+
+- Total items: 23
+- DONE: 21
+- DEVIATED (documented): 1
+- PENDING (external, by design): 1
+- PARTIAL: 0
+- MISSING: 0
+
+All checks below were re-executed by this audit (not taken from §12): the 11-test suite, the
+three fixture censuses via samtools, fmt, and clippy on both feature sets.
+
+## Coverage ledger
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `assert_xg_iff_flag` helper: extract FLAG + `XG:Z:`, assert `XG ∈ {CT,GA}`, set-form biconditional `XG=="CT" ⟺ FLAG ∉ {16,83,163}`, no bit-form, return census | §3 Gate 1 / §4 | DEVIATED | Documented in §12: returns `Vec<(String, u16, String)>` (QNAME, FLAG, XG) instead of §4's `Vec<(u16, String)>` — QNAME needed by the pair census; a superset of the planned return. Also: the samtools skip/panic guard sits in each Gate 1 *test* rather than inside the helper; no path reaches the helper unguarded — functionally equivalent. Set form asserted exactly as specified; bit-form footgun documented in the doc comment |
+| 2 | Gate 1 test `xg_ct_iff_forward_flags_over_all_four_strand_indices`: 20 records; (CT,99)×4, (CT,147)×4, (GA,83)×6, (GA,163)×6; pair census (147,99)×4 + (163,83)×6, same-QNAME file-order pairs | §3 Gate 1.1 | DONE | Test exists and passes; census constants independently re-verified against the fixture with samtools (record census 4/4/6/6; pair census 4×(147,99) + 6×(163,83); all pairs share QNAME) |
+| 3 | Gate 1 test `xg_iff_flag_holds_on_the_se_fixture`: 8 records; (CT,0)×4, (GA,16)×4 — witnesses FLAG 16 | §3 Gate 1.2 | DONE | Passes; fixture census re-verified with samtools (4× `0 CT`, 4× `16 GA`) |
+| 4 | `assert_bisulfite_round_trip(fixture, expected_records)`: skip/panic guard, `run_converter`, `<stem>.bisulfite.bam` output path, decompressed `sam_body` comparison, non-vacuity record-count census | §3 Gate 2.1 / §4 | DONE | All five elements present; guard inside the helper as specified; "fixture record count drifted" census prevents empty-stream passes (G19) |
+| 5 | SE test `bisulfite_input_round_trips_to_identical_sam_text` becomes thin call `(fixture(), 8)`, name kept | §3 Gate 2.2 | DONE | — |
+| 6 | `nondir_pe_all_four_strand_indices_round_trip_identically` → `(dedup_fixture("nondir_pe_1030.bam"), 20)` | §3 Gate 2.3 | DONE | Passes |
+| 7 | `real_pe_with_mate_fields_and_indels_round_trips_identically` → `(dedup_fixture("synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam"), 12974)` | §3 Gate 2.4 | DONE | Passes; fixture re-verified: 12,974 records, 0 `CB:Z:` tags, 42 indel records |
+| 8 | CI repair: both feature jobs install `minimap2 samtools` (`--no-install-recommends`), no other workflow change | §3 CI repair | DONE | `rust_ci.yml` lines 103 + 143; commit diff touches only the two install steps; main `test` job (line 43) and perl-oracle samtools step untouched |
+| 9 | §5.1: extend step name/comment to mention #1095 samtools guard; add `samtools --version \| head -1` after `minimap2 --version` | §5.1 | DONE | Both jobs: step renamed "Install minimap2 + samtools (5-Base #787 / #1095 gates)", comment names the $CI panic guard, version echo added |
+| 10 | §5.2a: `dedup_fixture()` helper | §5.2a / §4 | DONE | `data_dir().join("dedup").join(name)` exactly as §4 |
+| 11 | §5.2b: refactor SE body into helper + add the two PE tests | §5.2b | DONE | See items 4–7 |
+| 12 | §5.2c: `assert_xg_iff_flag` + two Gate 1 tests with §3 censuses | §5.2c | DONE | See items 1–3 |
+| 13 | §5.2d: module doc comment — idempotence over three fixtures; Gate 1 pins `XG`⟺FLAG contract (runs no converter code); SE-only implication dropped | §5.2d | DONE | Doc comment updated with all three elements, including the emergent/`XR` note |
+| 14 | §5.3: nothing else changes | §5.3 | DONE | Commit touches only the test file, `rust_ci.yml`, and `plans/` (PLAN §12 + PROGRESS); no source, fixture, CLI or docs changes |
+| 15 | §5.4: run tests (expect 11), fmt, clippy default + `rammap-inprocess` | §5.4 | DONE | Re-executed by this audit — see Test verification |
+
+### §9 Validation rows
+
+| # | Row | Status | Notes |
+|---|-----|--------|-------|
+| 16 | Gates pass first time — 11/11 green (7 existing + 4 new) | DONE | Re-run by this audit: `ok. 11 passed; 0 failed` in 2.03s |
+| 17 | Gate 1 is falsifiable (invert biconditional → both Gate 1 tests FAIL) | DONE | Executed as temporary sabotage-then-revert per §12; failures cannot be re-observed without editing code (out of scope for this report-only audit). Final code verified: `grep -rn 'TEMP falsifiability' rust/ .github/` → 0 hits; the committed assertion is the plan's final set form `assert_eq!(xg == "CT", !matches!(flag, 16 \| 83 \| 163))` — no leftover inversion |
+| 18 | Pair census is falsifiable ((99,147) order → nondir test FAILS) | DONE | Per §12, reverted; committed assertion is `matches!((*f1, *f2), (147, 99) \| (163, 83))` — the plan's final form |
+| 19 | Gate 2 is falsifiable (wrong `expected_records` → census FAILS) | DONE | Per §12 ("fixture record count drifted" observed); committed values are the verified 8 / 20 / 12974 |
+| 20 | SE refactor preserves assertions (test green; diff = extraction + census arg only) | DONE | Diff inspected: body moved verbatim into the helper; only additions are the record-count census and the `<stem>`-generalised output name; original success/exists/equality assertions intact; SE test green |
+| 21 | CI-skip removal intact (helpers panic when samtools absent + `$CI` set) | DONE | `samtools_available()` untouched by the commit; `$CI` panic path present in the current file (lines 62–65) |
+| 22 | Hygiene: fmt + clippy both feature sets | DONE | Re-run by this audit: `cargo fmt -p bismark -- --check` clean; `clippy --all-targets -- -D warnings` clean on default and `--features rammap-inprocess` |
+| 23 | All six CI jobs green (push, open PR into `dev`, watch run) | PENDING | Branch not yet pushed (`origin/1095-validation-gates` absent), no PR. Not executable locally by design (plan §12 says the same). Marked pending, not MISSING, per instruction — must be confirmed on the PR run |
+
+## Gaps (detail)
+
+None. The single DEVIATED item (return-type triples, guard placement — item 1) is documented
+in PLAN.md §12, is a strict superset of the planned behavior, and required no action.
+
+## Test verification
+
+| Test name | File | Status |
+|-----------|------|--------|
+| bisulfite_input_round_trips_to_identical_sam_text | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+| nondir_pe_all_four_strand_indices_round_trip_identically | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+| real_pe_with_mate_fields_and_indels_round_trips_identically | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+| xg_ct_iff_forward_flags_over_all_four_strand_indices | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+| xg_iff_flag_holds_on_the_se_fixture | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+| bisulfite_input_reports_a_zero_flip_rate | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+| xm_is_left_untouched | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+| appends_a_pg_with_a_distinct_id | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+| requires_illumina_5base | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+| rejects_input_without_bismark_tags | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+| rejects_both_standalone_bam_modes_together | rust/bismark/tests/aligner_five_base_bisulfite.rs | PASS |
+
+11/11 — matches §5.4's expectation (7 existing + 2 Gate 1 + 2 Gate 2). Working tree is
+identical to `010e46f` for both implementation files (no post-commit drift).
+
+## Verdict
+
+**COMPLETE.** Every §3 behavior, §5 task, and §9 validation row is implemented and verified,
+with one documented, harmless deviation (§12: census return type + guard placement) and one
+row pending by design: **§9 "all six CI jobs green" awaits the branch push + PR run** — the
+two feature jobs going green there is the remaining real-world confirmation of the CI repair
+(and of plan assumption 7, that samtools was the jobs' only missing dependency).

--- a/plans/08072026_1095-validation-gates/PLAN.md
+++ b/plans/08072026_1095-validation-gates/PLAN.md
@@ -1,62 +1,108 @@
-# Plan — close the two worthwhile #1095 validation gaps (rev 0)
+# Plan — close the two worthwhile #1095 validation gaps (rev 1)
 
 **Date:** 2026-08-07 · **Branch:** `1095-validation-gates` (off `dev` @ `26eb28a`) · **Parent feature:** `plans/08062026_five-base-bisulfite-bam/` (#1095, shipped on `dev`)
+
+## Revision history
+
+- **rev 1 (2026-08-07)** — folds in the dual plan review (`PLAN_REVIEW_A.md`, `PLAN_REVIEW_B.md`;
+  every contested claim re-verified at source before adoption):
+  - **CI fix now in scope** (both Criticals-1): `dev`'s Rust CI is red at `7be9dde` — the
+    `rammap-inprocess` and `binseq-input` jobs run the #1095 gates but install only minimap2, so
+    the samtools `$CI` panic guard fails 3 tests per job (verified: run 31204223600 + yaml). Two
+    line-edits to `rust_ci.yml` mirror samtools into those jobs; this also repairs `dev`.
+  - **Gate 1 bit-gloss deleted** (both Criticals-2): `FLAG & 0x10 == 0` is false on 10/20 records
+    (147 is reverse *and* `CT`). Only the §9.8 **set form** `FLAG ∉ {16,83,163}` remains.
+  - **Uniqueness claim corrected + pair-structure census added** (A-3/B): `synth_barcode…pe.bam`
+    also has all four record-level (XG, FLAG) pairs; what is unique to `nondir_pe_1030.bam` is
+    the pair-level #1030 FLAG swap — now asserted directly.
+  - **Gate 1 parameterised over the SE fixture** (B): witnesses FLAG `16`, otherwise unwitnessed
+    on a PE-only fixture. SE census verified: (CT,0)×4, (GA,16)×4.
+  - **`CB:Z:` claim removed, test renamed** (A-4): the synth fixture has zero `CB:Z:` tags
+    (verified) — the barcode lives in the QNAME.
+  - **"Pure extraction" reworded** (A-5/B): the helper adds one non-vacuity census to the SE test.
+  - **Honesty note** (B): Gate 1 runs no converter code; it pins the data contract the converter
+    relies on, on committed fixtures.
+  - Open-3 rationale softened.
+- **rev 0 (2026-08-07)** — initial plan.
 
 ## 1. Goal
 
 Codify two properties of `--five_base_bisulfite_bam` that four reviews verified but no committed
 test asserts (handoff §5 G9; parent `PLAN.md` §9.8 + §10b; `CODE_REVIEW_A` §"Recommendation";
-`CODE_REVIEW_B` H-suggestion + L10):
+`CODE_REVIEW_B` H-suggestion + L10), and make the gates actually runnable in CI:
 
-1. **Gate 1 — §9.8 `XG` ⟺ FLAG (R8).** Assert `XG == "CT" ⟺ FLAG ∉ {16, 83, 163}` over
-   `tests/data/dedup/nondir_pe_1030.bam` — the only committed fixture with all four `XG`/FLAG
-   combinations. The equivalence is **load-bearing and invisible to the idempotence gate**
-   (property G1(2) is *emergent*: `methylation_call` branches on `XR`, not `XG`).
+1. **Gate 1 — §9.8 `XG` ⟺ FLAG (R8).** Assert `XG == "CT" ⟺ FLAG ∉ {16, 83, 163}` per record
+   over `dedup/nondir_pe_1030.bam` **and** `five_base_bisulfite/softclip_indel_se.bam`. The
+   equivalence is **load-bearing and invisible to the idempotence gate** (property G1(2) is
+   *emergent*: `methylation_call` branches on `XR`, not `XG`). Gate 1 executes no converter code:
+   it pins the Bismark-BAM data contract the converter's encoding table relies on, so fixture
+   drift or a future flag-table change breaks a test rather than the science.
 2. **Gate 2 — PE / four-strand idempotence.** Parameterise the round-trip gate over the two
-   committed PE fixtures: `dedup/nondir_pe_1030.bam` (20 records, all four strand indices) and
-   `dedup/synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam` (12,974 records, 42 with `I`/`D`).
-   #1095 is a PE-only feature whose committed gates are currently SE-only, covering 2 of 4
-   strand indices.
+   committed PE fixtures: `dedup/nondir_pe_1030.bam` (20 records, the four strand indices via
+   #1030-swapped pairs) and `dedup/synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam` (12,974
+   records, 42 with `I`/`D`). #1095 is a PE-only feature whose committed gates are currently
+   SE-only.
+3. **CI repair (prerequisite for 1–2, fixes `dev`'s red CI).** Mirror the samtools install into
+   the `rammap-inprocess` and `binseq-input` jobs of `.github/workflows/rust_ci.yml`, which run
+   the #1095 gates and currently panic on the samtools `$CI` guard (3 tests each). Without this,
+   the branch cannot go green and the new gates raise the panic count to 6 per job.
 
-Both codify already-verified results — Reviewer A ran the parameterised round-trip ("zero risk —
-I have run it"); Reviewer B measured byte-identity on both PE fixtures (12974/12974 re-encoded,
-flip rate `0.000000`, `masked 0`) — so they should pass first time. Test-only change: **no source
-edits**, no fixture edits, no behaviour change.
+Both gates codify already-verified results — Reviewer A ran the parameterised round-trip ("zero
+risk — I have run it"); Reviewer B re-measured byte-identity on both PE fixtures (20/20 and
+12974/12974 re-encoded, flip rate `0.000000`, `masked 0`) — so they should pass first time.
+No source edits, no fixture edits, no behaviour change; the only non-test change is the CI
+install step.
 
 ## 2. Context
 
-- **File:** `rust/bismark/tests/aligner_five_base_bisulfite.rs` — the existing 7 integration
-  gates. New tests go here (they are #1095 driver gates; same helpers, same conventions).
+- **Files touched (2):**
+  - `rust/bismark/tests/aligner_five_base_bisulfite.rs` — the existing 7 integration gates.
+    New tests go here (same helpers, same conventions).
+  - `.github/workflows/rust_ci.yml` — the two feature jobs' install steps (currently minimap2
+    only, lines ~96–103 and ~134–141; the main `test` job's step at ~35–45 is the model).
 - **Helpers to reuse:** `bismark_bin()`, `data_dir()`, `samtools_available()` (panics under
   `$CI` — gates must not skip silently, G8), `sam_body()`, `run_converter()`.
-- **Fixtures (committed, untouched):**
-  - `rust/bismark/tests/data/dedup/nondir_pe_1030.bam` — 20 records; FLAGs {99, 147, 83, 163};
-    both `XG` values; the #1030 CTOT/CTOB FLAG-swap pairs.
+- **Fixtures (committed, untouched; all censuses verified empirically 2026-08-07):**
+  - `rust/bismark/tests/data/dedup/nondir_pe_1030.bam` — 20 records; record census
+    (CT,99)×4, (CT,147)×4, (GA,83)×6, (GA,163)×6; **pair census (file order, same-qname):
+    (147,99)×4, (163,83)×6** — every pair #1030-swapped, which is what makes this fixture the
+    non-directional guard (`synth_barcode` also has all four record-level pairs; a directional
+    regeneration of *this* fixture must fail the pair census).
   - `rust/bismark/tests/data/dedup/synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam` — 12,974
-    records incl. indels and `CB:Z:`/barcode aux tags.
-  - `rust/bismark/tests/data/five_base_bisulfite/softclip_indel_se.bam` — the existing SE
-    fixture; its dedicated test remains as-is.
-- **CI:** `rust_ci.yml` `test` job installs samtools (added by #1095), so the new gates run
-  there for real; `RUSTFLAGS: -D warnings` at workflow scope (G26).
+    records incl. 42 with indels; barcode is a **QNAME suffix** (zero `CB:Z:` tags).
+  - `rust/bismark/tests/data/five_base_bisulfite/softclip_indel_se.bam` — 8 records;
+    (CT,0)×4, (GA,16)×4; witnesses FLAG `16` for Gate 1; its round-trip test remains as-is.
+- **CI:** `rust_ci.yml` sets `RUSTFLAGS: -D warnings` at workflow scope (G26). The main `test`
+  job installs minimap2 + samtools; the two feature jobs install only minimap2 and are **red on
+  `dev` today** (run 31204223600 @ `7be9dde`) — the dual-driver trap: the minimap2 guard was
+  mirrored when added, the samtools one was not.
 
 ## 3. Behavior
 
-### Gate 1 — `xg_ct_iff_forward_flags_over_all_four_strand_indices`
+### Gate 1 — `XG` ⟺ FLAG, two tests over one helper
 
-1. Skip (locally) / panic (CI) via `samtools_available()`.
-2. `sam_body(dedup/nondir_pe_1030.bam)` → iterate lines; extract FLAG (field 2) and the
-   `XG:Z:` tag.
-3. Every record must have an `XG` tag, and its value must be `CT` or `GA` — anything else fails.
-4. Assert the biconditional per record: `XG == "CT"` ⇔ `FLAG & 0x10 == 0` for this fixture's
-   FLAG set — concretely `FLAG ∈ {99, 147}` for `CT` and `FLAG ∈ {83, 163}` for `GA`. Assert
-   via the §9.8 formulation (`FLAG ∉ {16, 83, 163}`) so the test text matches the spec.
-5. **Non-vacuity census:** assert exactly 20 records and that **all four** (XG, FLAG) pairs
-   (CT,99), (CT,147), (GA,83), (GA,163) occur — a truncated or regenerated fixture must fail
-   loudly rather than weaken the gate to a subset of the table.
+Helper `assert_xg_iff_flag(bam: &Path) -> Vec<(u16, String)>`: skip (locally) / panic (CI) via
+`samtools_available()`; `sam_body(bam)`; per line extract FLAG (field 2) and the `XG:Z:` tag;
+assert every record has `XG ∈ {CT, GA}`; assert the **set-form biconditional** per record:
 
-### Gate 2 — PE round-trip idempotence (two tests)
+```
+XG == "CT"  ⟺  FLAG ∉ {16, 83, 163}
+```
 
-1. Extract the body of `bisulfite_input_round_trips_to_identical_sam_text` into a helper
+(no bit-form: `FLAG & 0x10` does **not** track `XG` on PE — FLAG 147 is reverse *and* CT).
+Return the (FLAG, XG) list for the caller's census.
+
+1. `xg_ct_iff_forward_flags_over_all_four_strand_indices` — over `nondir_pe_1030.bam`:
+   - census: exactly 20 records; record pairs (CT,99)×4, (CT,147)×4, (GA,83)×6, (GA,163)×6;
+   - **pair-structure census:** consecutive file-order pairs share a QNAME and their FLAGs are
+     exactly (147,99)×4 then/and (163,83)×6 — pins the #1030 swap, so a regenerated directional
+     fixture fails loudly instead of silently weakening the gate.
+2. `xg_iff_flag_holds_on_the_se_fixture` — over `softclip_indel_se.bam`:
+   - census: exactly 8 records; (CT,0)×4, (GA,16)×4 — witnesses the `16` element of the set.
+
+### Gate 2 — PE round-trip idempotence (two new tests)
+
+1. Extract the body of `bisulfite_input_round_trips_to_identical_sam_text` into
    `assert_bisulfite_round_trip(fixture: &Path, expected_records: usize)`:
    - skip/panic via `samtools_available()`;
    - `run_converter(fixture, tmp)`; assert success;
@@ -64,79 +110,93 @@ edits**, no fixture edits, no behaviour change.
    - compare `sam_body(fixture) == sam_body(produced)` (decompressed text — BGZF blocks are
      writer-dependent and `NM` is re-encoded as i32);
    - **non-vacuity:** assert the input body has `expected_records` lines, so two empty streams
-     can never satisfy the gate (G19).
-2. Keep the existing SE test as a thin call: `assert_bisulfite_round_trip(fixture(), 8)`.
-3. Add `nondir_pe_all_four_strand_indices_round_trip_identically` →
-   `assert_bisulfite_round_trip(dedup/nondir_pe_1030.bam, 20)`.
-4. Add `real_pe_with_mate_fields_and_aux_tags_round_trips_identically` →
-   `assert_bisulfite_round_trip(dedup/synth_barcode_10k_..._pe.bam, 12974)`.
+     can never satisfy the gate (G19). This is an **extraction plus one added census** — the SE
+     test's existing assertions are otherwise unchanged.
+2. SE test becomes a thin call: `assert_bisulfite_round_trip(fixture(), 8)`.
+3. `nondir_pe_all_four_strand_indices_round_trip_identically` →
+   `assert_bisulfite_round_trip(dedup_fixture("nondir_pe_1030.bam"), 20)`.
+4. `real_pe_with_mate_fields_and_indels_round_trips_identically` →
+   `assert_bisulfite_round_trip(dedup_fixture("synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam"), 12974)`.
+
+### CI repair
+
+In `.github/workflows/rust_ci.yml`, change both feature jobs' install step to
+`sudo apt-get install -y --no-install-recommends minimap2 samtools` (+ the `samtools --version`
+echo, mirroring the main `test` job's step and comment). No other workflow change.
 
 Edge cases: none new — inputs are committed static fixtures; failure modes are the assertions
-themselves. The helper must not change the SE test's assertions (pure extraction).
+themselves.
 
 ## 4. Signatures
 
 ```rust
-fn xg_flag(line: &str) -> (u16, String)          // parse FLAG + XG:Z: from one SAM line (Gate 1, local)
+fn dedup_fixture(name: &str) -> PathBuf                 // data_dir()/dedup/<name>
+fn assert_xg_iff_flag(bam: &Path) -> Vec<(u16, String)> // per-record biconditional; returns census input
 fn assert_bisulfite_round_trip(fixture: &Path, expected_records: usize)
 ```
 
 ## 5. Implementation outline
 
-1. `rust/bismark/tests/aligner_five_base_bisulfite.rs`:
-   a. Add `fn dedup_fixture(name: &str) -> PathBuf { data_dir().join("dedup").join(name) }`.
+1. `.github/workflows/rust_ci.yml`: add ` samtools` to the two feature jobs' `apt-get install`
+   lines; extend each step name/comment to mention the #1095 samtools guard; add
+   `samtools --version | head -1` after the existing `minimap2 --version`.
+2. `rust/bismark/tests/aligner_five_base_bisulfite.rs`:
+   a. Add `dedup_fixture()`.
    b. Refactor: move the body of `bisulfite_input_round_trips_to_identical_sam_text` into
-      `assert_bisulfite_round_trip(&Path, usize)`; the three `#[test]`s call it (SE keeps its
-      current name so history/reports line up; the two PE tests get the names in §3).
-   c. Add the Gate 1 test with the per-record biconditional + the four-pair census + `== 20`.
-   d. Update the module doc comment: the idempotence gate now runs over three fixtures; delete
-      the "committed tests are SE-only" implication if present.
-2. No changes outside this one file.
-3. Run: `cargo test -p bismark --test aligner_five_base_bisulfite` (all gates, expect 10 tests
-   green first time), then `cargo fmt -p bismark -- --check` (G27) and
+      `assert_bisulfite_round_trip(&Path, usize)`; the SE test keeps its name and calls it with
+      `(fixture(), 8)`; add the two PE tests named as in §3.
+   c. Add `assert_xg_iff_flag()` and the two Gate 1 tests (censuses as in §3, constants from §2).
+   d. Update the module doc comment: idempotence now runs over three fixtures; Gate 1 pins the
+      `XG`⟺FLAG data contract (runs no converter code); drop any SE-only implication.
+3. Nothing else changes.
+4. Run: `cargo test -p bismark --test aligner_five_base_bisulfite` (expect 11 green: 7 existing
+   + 2 Gate 1 + 2 Gate 2), then `cargo fmt -p bismark -- --check` (G27) and
    `RUSTFLAGS="-D warnings" cargo clippy -p bismark --all-targets -- -D warnings` plus the
    `--features rammap-inprocess` variant (G26).
 
 ## 6. Efficiency
 
-12,974 records through a debug-build converter plus two `samtools view` invocations — seconds.
-No fixture is added; repository size unchanged.
+12,974 records through a debug-build converter plus a handful of `samtools view` invocations —
+seconds. No fixture is added; repository size unchanged. CI: one extra apt package in two jobs.
 
 ## 7. Integration
 
-- Test-only; no source, fixture, CLI or docs changes. The dedup fixtures are read-only inputs —
-  already shared with `dedup_rs` tests; nothing writes next to them (`run_converter` writes to a
-  `tempfile::tempdir()`).
-- CI: the gates join the existing #1095 gate set in the `test` job; samtools present; the CI
-  panic guard keeps them non-skippable there.
-- Downstream: closes two of the five G9 items. The remaining three (unmapped pass-through
-  fixture, lower-case `MD`, fixture letter census) stay documented-not-closed — see §10.
+- Test file + CI yaml only; no source, fixture, CLI or docs changes. The dedup fixtures are
+  read-only inputs shared with `dedup_rs` tests; `run_converter` writes to `tempfile::tempdir()`.
+- **The CI step also repairs `dev`'s currently-red pipeline** once merged — worth stating in the
+  PR body. Until merged, `dev` stays red for the pre-existing reason.
+- Downstream: closes two of the five G9 items. The remaining three (unmapped pass-through,
+  lower-case `MD`, fixture letter census) stay documented-not-closed — see §10.
 
 ## 8. Assumptions
 
-1. `nondir_pe_1030.bam` has exactly 20 records, FLAGs ⊆ {99,147,83,163}, every record tagged
-   `XG:Z:CT` or `XG:Z:GA`, all four pairs present. **Verified empirically 2026-08-07** (G20 —
-   constants read off the fixture, not review prose): (CT,99)×4, (CT,147)×4, (GA,83)×6,
-   (GA,163)×6; the biconditional holds on all 20.
-2. `synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam` has exactly 12,974 records (**verified
-   empirically 2026-08-07**) and round-trips byte-identically (CODE_REVIEW_B rows; byte-identity
-   itself is re-proven by the gate, not assumed).
-3. The converter's output name for `X.bam` is `X.bisulfite.bam` (Open-2; existing SE test).
-4. `--illumina_5base --five_base_bisulfite_bam` accepts PE Bismark BAMs with no further flags
-   (Reviewer A/B both ran exactly this).
-5. Fixed rule, not configurable: the §9.8 equivalence is a property of Bismark-produced BAMs;
-   the test pins it on this fixture only.
+1. `nondir_pe_1030.bam`: exactly 20 records; record census (CT,99)×4, (CT,147)×4, (GA,83)×6,
+   (GA,163)×6; file-order same-qname pairs (147,99)×4, (163,83)×6. **Verified empirically
+   2026-08-07** (G20 — constants read off the fixture, not review prose).
+2. `synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam`: exactly 12,974 records, zero `CB:Z:` tags
+   (**verified empirically 2026-08-07**); round-trips byte-identically (re-proven by the gate,
+   not assumed — and independently re-measured by both plan reviewers).
+3. `softclip_indel_se.bam`: 8 records, (CT,0)×4, (GA,16)×4 (**verified empirically 2026-08-07**).
+4. The converter's output name for `X.bam` is `X.bisulfite.bam` (Open-2; existing SE test).
+5. `--illumina_5base --five_base_bisulfite_bam` accepts PE Bismark BAMs with no further flags
+   (Reviewers A and B both ran exactly this).
+6. Fixed rule, not configurable: the §9.8 equivalence is a property of Bismark-produced BAMs;
+   the tests pin it on these committed fixtures only.
+7. The two feature jobs' only missing dependency is samtools (their minimap2 guard already
+   passes; the `test` job with both tools installed is green on `7be9dde`).
 
 ## 9. Validation
 
 | What | How | Expected |
 |---|---|---|
-| Gates pass first time | `cargo test -p bismark --test aligner_five_base_bisulfite` | 10/10 green (7 existing + 3 new) |
-| Gate 1 is falsifiable | temporarily invert the biconditional (`==` → `!=`) locally, run, revert | test FAILS — never-observed-failing is not a check (G19) |
+| Gates pass first time | `cargo test -p bismark --test aligner_five_base_bisulfite` | 11/11 green (7 existing + 4 new) |
+| Gate 1 is falsifiable | temporarily invert the biconditional (`==` → `!=`) locally, run, revert | both Gate 1 tests FAIL — never-observed-failing is not a check (G19) |
+| Pair census is falsifiable | temporarily assert (99,147) order, run, revert | nondir Gate 1 test FAILS |
 | Gate 2 is falsifiable | temporarily point one PE test at a wrong `expected_records`, run, revert | test FAILS on the census assertion |
-| SE refactor is pure | existing SE test still green, same assertions | green; `git diff` shows extraction only |
-| CI-skip removal intact | helper still panics when samtools absent + `$CI` set | code path unchanged (inherited from helper reuse) |
+| SE refactor preserves assertions | existing SE test still green; `git diff` shows extraction + the census arg only | green |
+| CI-skip removal intact | helpers still panic when samtools absent + `$CI` set | code path unchanged (inherited) |
 | Hygiene | `cargo fmt -p bismark -- --check`; clippy both feature sets (G26/G27) | clean |
+| **All six CI jobs green** | push branch, open PR into `dev`, watch the run | test, clippy, fmt, perl-oracle, **rammap-inprocess, binseq-input** all green — the two feature jobs are red on `dev` today, so green here is a real signal, not a rubber stamp |
 
 ## 10. Questions or ambiguities
 
@@ -144,24 +204,25 @@ No fixture is added; repository size unchanged.
 
 | # | Priority | Question | Assumption taken |
 |---|---|---|---|
-| Open-1 | Open | samtools-text or noodles for the new gates? Reviewer B suggested noodles `RecordBuf` comparison (no samtools, no skip) | **samtools text**, matching every other gate in the file; the CI panic guard already prevents silent skips. Noodles is a coherent future refactor of the whole file, not something to mix in piecemeal |
-| Open-2 | Open | Also assert report contents (flip rate `0.000000`) for the PE fixtures? | **No** — the SE report test already pins the report format; the PE gates' job is byte-identity + strand coverage. Adding report assertions would duplicate coverage and couple two more tests to report wording |
-| Open-3 | Open | Close the other three G9 gaps here too? | **Out of scope.** Unmapped pass-through needs a fixture change that invalidates existing counts; lower-case `MD` is unreachable via Bismark-produced BAMs; the letter census is unit-covered. This plan is the two gaps the handoff called "worth closing" |
+| Open-1 | Open | samtools-text or noodles for the new gates? Reviewer B (and the parent reviews) note noodles would drop the samtools dependency entirely | **samtools text**, matching every other gate in the file; the CI panic guard prevents silent skips and the CI repair (§3) makes the dependency real in all jobs. A noodles port of the *whole file* is a coherent future refactor, not something to mix in piecemeal |
+| Open-2 | Open | Also assert report contents (flip rate `0.000000`) for the PE fixtures? | **No** — byte-identity implies zero flips; the SE report test already pins report wording. Both reviewers concur |
+| Open-3 | Open | Close the other three G9 gaps here too? | **Out of scope.** Unmapped pass-through would need either a fixture change or (B) a separate tiny committed fixture — feasible later, deliberately not here; lower-case `MD` is unreachable via Bismark-produced BAMs; the letter census is unit-covered. This plan is the two gaps the handoff called "worth closing" |
+| Open-4 | Open | Land the CI repair separately on `dev` first? | **No — carried in this branch** (Felix accepted this recommendation): it is two line-edits, belongs with the #1095 follow-up, and the PR's green feature jobs then demonstrate both the repair and the new gates at once |
 
 ## 11. Self-Review
 
-- **Logic:** Gate 1's biconditional is asserted per record *and* backed by a completeness census —
-  without the census, a fixture regenerated with only OT pairs would render the gate vacuous
-  (the G19 failure mode). Gate 2's `expected_records` serves the same role for the round trip.
-- **Edge cases:** static fixtures, so the interesting "edges" are fixture drift — both gates fail
-  loudly on record-count or combination-set change. Empty-stream comparison is excluded by the
-  census. No new error paths.
+- **Logic:** Gate 1's set-form biconditional is asserted per record and backed by three censuses
+  (record pairs, pair structure, record counts); the bit-form footgun is called out inline so it
+  cannot resurface at implementation. Gate 2's `expected_records` excludes empty-stream passes.
+- **Edge cases:** static fixtures — the "edges" are fixture drift, and every census fails loudly
+  on count, combination-set, or pair-order change. No new error paths.
 - **Efficiency:** trivial; largest fixture is 12,974 records.
-- **Integration:** pure extraction refactor of the SE test is the only touch to existing code;
-  validation row 4 checks it. Names chosen to read as properties, matching the file's style.
-- **Adjusted during self-review:** added assumption 1's "verify empirically before writing
-  assertions" (constants must be read off the fixture, not off review prose — G20: do not take
-  agent reviewers at face value); added the falsifiability rows in §9 (observe each new gate
-  failing once before trusting it — G19).
-- **Remaining risk:** if Reviewer B's byte-identity result does not reproduce (e.g. environment
-  drift since 2026-08-07), Gate 2 fails honestly — that would be a finding, not a test bug.
+- **Integration:** the CI change is copy-of-existing-step, lowest-risk; the SE test refactor is
+  extraction plus one census; validation row 5 checks it. Names read as properties, matching the
+  file's style.
+- **Adjusted in rev 1:** everything under "Revision history" above; both Critical findings were
+  verified against the live CI run and the fixtures before adoption, per G20.
+- **Remaining risks:** (1) if byte-identity fails to reproduce in CI's environment, Gate 2 fails
+  honestly — a finding, not a test bug; (2) the feature jobs may hide a *second* missing
+  dependency behind the samtools panic — assumption 7 addresses this (their minimap2-dependent
+  gates already pass), and the PR run will settle it.

--- a/plans/08072026_1095-validation-gates/PLAN.md
+++ b/plans/08072026_1095-validation-gates/PLAN.md
@@ -242,3 +242,16 @@ Implemented exactly per §5 — **no deviations**. Single pass, no failed iterat
 - Hygiene: `cargo fmt -p bismark -- --check` clean; `clippy --all-targets -- -D warnings` clean
   on default **and** `rammap-inprocess` (G26/G27).
 - §9's "all six CI jobs green" row pends the PR run (the only validation not executable locally).
+
+**Post-review fixes (2026-08-07)** — dual code review verdicts: **A APPROVE, B APPROVE** (no
+Critical/High/Medium); coverage audit **COMPLETE** (21 DONE, 1 documented DEVIATED, 1 PENDING =
+the PR run). The three Low findings both reviewers agreed on were applied: record-count census
+moved *before* the converter run (cleaner drift attribution); duplicated `count` closure hoisted
+to `count_of()`; `XG` scan tag-scoped with `.skip(9)`. Re-verified: 11/11 green, fmt clean,
+clippy `-D warnings` clean on default + `rammap-inprocess`. Not adopted (recommendations, out of
+plan scope): Gate 1 over the synth fixture (B verified 0 violations across its 12,974 records —
+free coverage if ever wanted); PE header/`@PG` preservation gate (A; body-only comparison is the
+§9.1 contract, header pinned on SE). Notable extra evidence from review: A ran the suite with
+`CI=1` and samtools off PATH — all five samtools-gated tests fail loudly, proving the guard
+live; B pulled dev run 31204223600's logs — both feature jobs fail with exactly 3 guard panics
+and nothing else, verifying assumption 7.

--- a/plans/08072026_1095-validation-gates/PLAN.md
+++ b/plans/08072026_1095-validation-gates/PLAN.md
@@ -1,0 +1,167 @@
+# Plan — close the two worthwhile #1095 validation gaps (rev 0)
+
+**Date:** 2026-08-07 · **Branch:** `1095-validation-gates` (off `dev` @ `26eb28a`) · **Parent feature:** `plans/08062026_five-base-bisulfite-bam/` (#1095, shipped on `dev`)
+
+## 1. Goal
+
+Codify two properties of `--five_base_bisulfite_bam` that four reviews verified but no committed
+test asserts (handoff §5 G9; parent `PLAN.md` §9.8 + §10b; `CODE_REVIEW_A` §"Recommendation";
+`CODE_REVIEW_B` H-suggestion + L10):
+
+1. **Gate 1 — §9.8 `XG` ⟺ FLAG (R8).** Assert `XG == "CT" ⟺ FLAG ∉ {16, 83, 163}` over
+   `tests/data/dedup/nondir_pe_1030.bam` — the only committed fixture with all four `XG`/FLAG
+   combinations. The equivalence is **load-bearing and invisible to the idempotence gate**
+   (property G1(2) is *emergent*: `methylation_call` branches on `XR`, not `XG`).
+2. **Gate 2 — PE / four-strand idempotence.** Parameterise the round-trip gate over the two
+   committed PE fixtures: `dedup/nondir_pe_1030.bam` (20 records, all four strand indices) and
+   `dedup/synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam` (12,974 records, 42 with `I`/`D`).
+   #1095 is a PE-only feature whose committed gates are currently SE-only, covering 2 of 4
+   strand indices.
+
+Both codify already-verified results — Reviewer A ran the parameterised round-trip ("zero risk —
+I have run it"); Reviewer B measured byte-identity on both PE fixtures (12974/12974 re-encoded,
+flip rate `0.000000`, `masked 0`) — so they should pass first time. Test-only change: **no source
+edits**, no fixture edits, no behaviour change.
+
+## 2. Context
+
+- **File:** `rust/bismark/tests/aligner_five_base_bisulfite.rs` — the existing 7 integration
+  gates. New tests go here (they are #1095 driver gates; same helpers, same conventions).
+- **Helpers to reuse:** `bismark_bin()`, `data_dir()`, `samtools_available()` (panics under
+  `$CI` — gates must not skip silently, G8), `sam_body()`, `run_converter()`.
+- **Fixtures (committed, untouched):**
+  - `rust/bismark/tests/data/dedup/nondir_pe_1030.bam` — 20 records; FLAGs {99, 147, 83, 163};
+    both `XG` values; the #1030 CTOT/CTOB FLAG-swap pairs.
+  - `rust/bismark/tests/data/dedup/synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam` — 12,974
+    records incl. indels and `CB:Z:`/barcode aux tags.
+  - `rust/bismark/tests/data/five_base_bisulfite/softclip_indel_se.bam` — the existing SE
+    fixture; its dedicated test remains as-is.
+- **CI:** `rust_ci.yml` `test` job installs samtools (added by #1095), so the new gates run
+  there for real; `RUSTFLAGS: -D warnings` at workflow scope (G26).
+
+## 3. Behavior
+
+### Gate 1 — `xg_ct_iff_forward_flags_over_all_four_strand_indices`
+
+1. Skip (locally) / panic (CI) via `samtools_available()`.
+2. `sam_body(dedup/nondir_pe_1030.bam)` → iterate lines; extract FLAG (field 2) and the
+   `XG:Z:` tag.
+3. Every record must have an `XG` tag, and its value must be `CT` or `GA` — anything else fails.
+4. Assert the biconditional per record: `XG == "CT"` ⇔ `FLAG & 0x10 == 0` for this fixture's
+   FLAG set — concretely `FLAG ∈ {99, 147}` for `CT` and `FLAG ∈ {83, 163}` for `GA`. Assert
+   via the §9.8 formulation (`FLAG ∉ {16, 83, 163}`) so the test text matches the spec.
+5. **Non-vacuity census:** assert exactly 20 records and that **all four** (XG, FLAG) pairs
+   (CT,99), (CT,147), (GA,83), (GA,163) occur — a truncated or regenerated fixture must fail
+   loudly rather than weaken the gate to a subset of the table.
+
+### Gate 2 — PE round-trip idempotence (two tests)
+
+1. Extract the body of `bisulfite_input_round_trips_to_identical_sam_text` into a helper
+   `assert_bisulfite_round_trip(fixture: &Path, expected_records: usize)`:
+   - skip/panic via `samtools_available()`;
+   - `run_converter(fixture, tmp)`; assert success;
+   - output path = `<stem>.bisulfite.bam` (Open-2 naming), assert it exists;
+   - compare `sam_body(fixture) == sam_body(produced)` (decompressed text — BGZF blocks are
+     writer-dependent and `NM` is re-encoded as i32);
+   - **non-vacuity:** assert the input body has `expected_records` lines, so two empty streams
+     can never satisfy the gate (G19).
+2. Keep the existing SE test as a thin call: `assert_bisulfite_round_trip(fixture(), 8)`.
+3. Add `nondir_pe_all_four_strand_indices_round_trip_identically` →
+   `assert_bisulfite_round_trip(dedup/nondir_pe_1030.bam, 20)`.
+4. Add `real_pe_with_mate_fields_and_aux_tags_round_trips_identically` →
+   `assert_bisulfite_round_trip(dedup/synth_barcode_10k_..._pe.bam, 12974)`.
+
+Edge cases: none new — inputs are committed static fixtures; failure modes are the assertions
+themselves. The helper must not change the SE test's assertions (pure extraction).
+
+## 4. Signatures
+
+```rust
+fn xg_flag(line: &str) -> (u16, String)          // parse FLAG + XG:Z: from one SAM line (Gate 1, local)
+fn assert_bisulfite_round_trip(fixture: &Path, expected_records: usize)
+```
+
+## 5. Implementation outline
+
+1. `rust/bismark/tests/aligner_five_base_bisulfite.rs`:
+   a. Add `fn dedup_fixture(name: &str) -> PathBuf { data_dir().join("dedup").join(name) }`.
+   b. Refactor: move the body of `bisulfite_input_round_trips_to_identical_sam_text` into
+      `assert_bisulfite_round_trip(&Path, usize)`; the three `#[test]`s call it (SE keeps its
+      current name so history/reports line up; the two PE tests get the names in §3).
+   c. Add the Gate 1 test with the per-record biconditional + the four-pair census + `== 20`.
+   d. Update the module doc comment: the idempotence gate now runs over three fixtures; delete
+      the "committed tests are SE-only" implication if present.
+2. No changes outside this one file.
+3. Run: `cargo test -p bismark --test aligner_five_base_bisulfite` (all gates, expect 10 tests
+   green first time), then `cargo fmt -p bismark -- --check` (G27) and
+   `RUSTFLAGS="-D warnings" cargo clippy -p bismark --all-targets -- -D warnings` plus the
+   `--features rammap-inprocess` variant (G26).
+
+## 6. Efficiency
+
+12,974 records through a debug-build converter plus two `samtools view` invocations — seconds.
+No fixture is added; repository size unchanged.
+
+## 7. Integration
+
+- Test-only; no source, fixture, CLI or docs changes. The dedup fixtures are read-only inputs —
+  already shared with `dedup_rs` tests; nothing writes next to them (`run_converter` writes to a
+  `tempfile::tempdir()`).
+- CI: the gates join the existing #1095 gate set in the `test` job; samtools present; the CI
+  panic guard keeps them non-skippable there.
+- Downstream: closes two of the five G9 items. The remaining three (unmapped pass-through
+  fixture, lower-case `MD`, fixture letter census) stay documented-not-closed — see §10.
+
+## 8. Assumptions
+
+1. `nondir_pe_1030.bam` has exactly 20 records, FLAGs ⊆ {99,147,83,163}, every record tagged
+   `XG:Z:CT` or `XG:Z:GA`, all four pairs present. **Verified empirically 2026-08-07** (G20 —
+   constants read off the fixture, not review prose): (CT,99)×4, (CT,147)×4, (GA,83)×6,
+   (GA,163)×6; the biconditional holds on all 20.
+2. `synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam` has exactly 12,974 records (**verified
+   empirically 2026-08-07**) and round-trips byte-identically (CODE_REVIEW_B rows; byte-identity
+   itself is re-proven by the gate, not assumed).
+3. The converter's output name for `X.bam` is `X.bisulfite.bam` (Open-2; existing SE test).
+4. `--illumina_5base --five_base_bisulfite_bam` accepts PE Bismark BAMs with no further flags
+   (Reviewer A/B both ran exactly this).
+5. Fixed rule, not configurable: the §9.8 equivalence is a property of Bismark-produced BAMs;
+   the test pins it on this fixture only.
+
+## 9. Validation
+
+| What | How | Expected |
+|---|---|---|
+| Gates pass first time | `cargo test -p bismark --test aligner_five_base_bisulfite` | 10/10 green (7 existing + 3 new) |
+| Gate 1 is falsifiable | temporarily invert the biconditional (`==` → `!=`) locally, run, revert | test FAILS — never-observed-failing is not a check (G19) |
+| Gate 2 is falsifiable | temporarily point one PE test at a wrong `expected_records`, run, revert | test FAILS on the census assertion |
+| SE refactor is pure | existing SE test still green, same assertions | green; `git diff` shows extraction only |
+| CI-skip removal intact | helper still panics when samtools absent + `$CI` set | code path unchanged (inherited from helper reuse) |
+| Hygiene | `cargo fmt -p bismark -- --check`; clippy both feature sets (G26/G27) | clean |
+
+## 10. Questions or ambiguities
+
+**No critical questions.** Non-critical, with assumptions taken:
+
+| # | Priority | Question | Assumption taken |
+|---|---|---|---|
+| Open-1 | Open | samtools-text or noodles for the new gates? Reviewer B suggested noodles `RecordBuf` comparison (no samtools, no skip) | **samtools text**, matching every other gate in the file; the CI panic guard already prevents silent skips. Noodles is a coherent future refactor of the whole file, not something to mix in piecemeal |
+| Open-2 | Open | Also assert report contents (flip rate `0.000000`) for the PE fixtures? | **No** — the SE report test already pins the report format; the PE gates' job is byte-identity + strand coverage. Adding report assertions would duplicate coverage and couple two more tests to report wording |
+| Open-3 | Open | Close the other three G9 gaps here too? | **Out of scope.** Unmapped pass-through needs a fixture change that invalidates existing counts; lower-case `MD` is unreachable via Bismark-produced BAMs; the letter census is unit-covered. This plan is the two gaps the handoff called "worth closing" |
+
+## 11. Self-Review
+
+- **Logic:** Gate 1's biconditional is asserted per record *and* backed by a completeness census —
+  without the census, a fixture regenerated with only OT pairs would render the gate vacuous
+  (the G19 failure mode). Gate 2's `expected_records` serves the same role for the round trip.
+- **Edge cases:** static fixtures, so the interesting "edges" are fixture drift — both gates fail
+  loudly on record-count or combination-set change. Empty-stream comparison is excluded by the
+  census. No new error paths.
+- **Efficiency:** trivial; largest fixture is 12,974 records.
+- **Integration:** pure extraction refactor of the SE test is the only touch to existing code;
+  validation row 4 checks it. Names chosen to read as properties, matching the file's style.
+- **Adjusted during self-review:** added assumption 1's "verify empirically before writing
+  assertions" (constants must be read off the fixture, not off review prose — G20: do not take
+  agent reviewers at face value); added the falsifiability rows in §9 (observe each new gate
+  failing once before trusting it — G19).
+- **Remaining risk:** if Reviewer B's byte-identity result does not reproduce (e.g. environment
+  drift since 2026-08-07), Gate 2 fails honestly — that would be a finding, not a test bug.

--- a/plans/08072026_1095-validation-gates/PLAN.md
+++ b/plans/08072026_1095-validation-gates/PLAN.md
@@ -226,3 +226,19 @@ seconds. No fixture is added; repository size unchanged. CI: one extra apt packa
   honestly — a finding, not a test bug; (2) the feature jobs may hide a *second* missing
   dependency behind the samtools panic — assumption 7 addresses this (their minimap2-dependent
   gates already pass), and the PR run will settle it.
+
+## 12. Implementation notes (2026-08-07)
+
+Implemented exactly per §5 — **no deviations**. Single pass, no failed iterations.
+
+- The two feature-job install steps were textually identical, so one `replace_all` edit
+  mirrored samtools into both (`rust_ci.yml`).
+- `assert_xg_iff_flag` returns `(QNAME, FLAG, XG)` triples (QNAME needed by the pair census).
+- **11/11 gates green first time**, as both plan reviewers' pre-runs predicted.
+- **Falsifiability observed (G19), then reverted:** inverted biconditional → both Gate 1 tests
+  FAIL; pair order flipped to `(99,147)` → nondir test fails on the pair census with the
+  intended message; `expected_records` off by one → `real_pe` test fails on "fixture record
+  count drifted". `grep -c 'TEMP falsifiability'` = 0 after reverts, full suite re-run green.
+- Hygiene: `cargo fmt -p bismark -- --check` clean; `clippy --all-targets -- -D warnings` clean
+  on default **and** `rammap-inprocess` (G26/G27).
+- §9's "all six CI jobs green" row pends the PR run (the only validation not executable locally).

--- a/plans/08072026_1095-validation-gates/PLAN_REVIEW_A.md
+++ b/plans/08072026_1095-validation-gates/PLAN_REVIEW_A.md
@@ -1,0 +1,138 @@
+# Plan Review A — #1095 validation gates (PLAN.md rev 0)
+
+**Reviewer:** A (fresh context) · **Date:** 2026-08-07
+**Plan:** `plans/08072026_1095-validation-gates/PLAN.md`
+**Verdict:** Sound in intent and mostly well-verified, but **not implementable as written**. Two critical problems: (1) the plan's CI claims are wrong — the branch base's `rust_ci` is **already red** in the two feature jobs the new gates will also run in, and the plan's "no changes outside this one file" scope cannot deliver its own "gates green in CI" validation; (2) Gate 1's step 4 states a bit-level formulation (`FLAG & 0x10 == 0`) that is **provably false on 10 of the fixture's 20 records** — the plan contradicts itself within one paragraph. Both are cheap to fix at plan level.
+
+Everything below was checked against the actual fixtures (`samtools view`), the parent artifacts, `rust_ci.yml`, and the live CI run history — not taken from the plan's prose.
+
+---
+
+## 1. Logic review
+
+### 1.1 Gate 1, step 4 — the bit-level biconditional is wrong for PE (Critical)
+
+The plan writes: *"Assert the biconditional per record: `XG == "CT"` ⇔ `FLAG & 0x10 == 0` for this fixture's FLAG set — concretely `FLAG ∈ {99, 147}` for `CT` …"*
+
+These two clauses contradict each other. Verified census of `rust/bismark/tests/data/dedup/nondir_pe_1030.bam`:
+
+```
+(CT, 99)×4   99  = 0x63 → 0x10 CLEAR
+(CT, 147)×4  147 = 0x93 → 0x10 SET      ← violates "CT ⇔ 0x10 clear"
+(GA, 83)×6   83  = 0x53 → 0x10 SET
+(GA, 163)×6  163 = 0xA3 → 0x10 CLEAR    ← violates it from the other side
+```
+
+If an implementer codes the `FLAG & 0x10 == 0` clause, the test fails on 10/20 records. The parent plan states the bit form **for SE only** (§3.8: "SE … `FLAG & 0x10 ⟺ XG == "GA"`"); for PE the invariant is `patter`'s `is_bottom` — equivalently *reverse bit == second-in-pair bit ⟺ XG == "CT"* — and §9.8's enumerated-set form `XG == "CT" ⟺ FLAG ∉ {16, 83, 163}` is the correct cross-mode statement (verified to hold on all 20 records, and on all 12,974 records of the synth fixture with zero violations).
+
+The failure mode is not silent (the test fails loudly), but a self-contradictory spec paragraph is exactly what sends an implementer to "fix" the wrong side — weaken the assertion or blame the fixture. Delete the `& 0x10` clause; assert the §9.8 set form, with a comment giving the correct PE bit-level reading.
+
+### 1.2 "The only committed fixture with all four XG/FLAG combinations" is false, and the census does not pin what makes this fixture special (Important)
+
+Verified: `dedup/synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam` **also** has all four (XG, FLAG) pairs — (CT,99)×3217, (CT,147)×3217, (GA,83)×3270, (GA,163)×3270. This is not an accident: *any* directional PE Bismark BAM has all four, because R2 of an OT pair is (CT,147) and R2 of an OB pair is (GA,163). The claim is inherited from parent §9.8/CODE_REVIEW_A verbatim; both are imprecise at the (XG,FLAG)-pair level.
+
+What actually makes `nondir_pe_1030.bam` unique — verified in file order — is that **all ten of its pairs are #1030 flag-swapped CTOT/CTOB pairs**: the first record of every QNAME pair carries the 0x80 second-in-pair bit — 4 pairs with file-order FLAGs (147,99) (index 2, CTOT) and 6 with (163,83) (index 1, CTOB). It contains **no OT or OB pairs at all**. Per parent §3.8, the loaded half of the equivalence is exactly these indices ("they agree *because of* the index-1/2 R1↔R2 swap").
+
+Consequence for step 5's census: a fixture regenerated as a **directional** OT/OB file would produce the same four (XG,FLAG) pairs and pass the census unchanged — silently losing the swap-dependent witness, which is the one §9.8 exists for. The plan's self-review claims the census makes regeneration "fail loudly rather than weaken the gate"; that is true for truncation/subsetting but false for this — the most on-topic — drift. Fix: assert the pair structure (adjacent QNAME pairs; every pair's (first, second) FLAGs ∈ {(147,99), (163,83)}), or at minimum the full multiset 4/4/6/6 **plus** "first-of-pair always has 0x80 set".
+
+### 1.3 Gate 1 never runs the converter (observation)
+
+As specified, Gate 1 is `sam_body(fixture)` only — a lint on a static committed file. It exercises zero #1095 code. Its end-to-end meaning comes solely from composition with Gate 2's round-trip over the *same* fixture (identity transfers the property to the output). That composition is sound and matches §9.8's own wording, but the plan never states the dependency. Also note the gate breaks on an aligner flag-table change **only when fixtures are regenerated** — worth one line in the test's doc comment so nobody over-trusts it.
+
+### 1.4 "Pure extraction" is contradicted by the plan's own helper (Important, wording)
+
+§3 Gate 2 step 1 adds a **new** assertion to the shared helper (input body has `expected_records` lines), then closes with "The helper must not change the SE test's assertions (pure extraction)", and §9 row 4 requires "`git diff` shows extraction only". Both statements are false as written: the SE test gains an assertion (8 records — true, consistent with the report test's `records read\t8`, so it passes). Harmless behaviorally, but the coverage audit (`/plan-manager`) will flag the mismatch, and an implementer honoring "pure extraction" literally would drop the census. Reword to "pure extraction **plus** the shared non-vacuity census (SE: 8)".
+
+### 1.5 What checks out (verified independently)
+
+- Census constants: `nondir_pe_1030.bam` = 20 records, (CT,99)×4, (CT,147)×4, (GA,83)×6, (GA,163)×6 — matches assumption 1 exactly. Synth fixture = 12,974 records, 42 with `I`/`D` in CIGAR, FLAGs {99,147,83,163} — matches assumption 2 and CODE_REVIEW_B row 38.
+- The §9.8 equivalence holds on **both** PE fixtures (0 violations out of 12,994 records total) — Gate 1 and Gate 2 should indeed pass first time.
+- 7 existing `#[test]`s in `rust/bismark/tests/aligner_five_base_bisulfite.rs`; +3 = the plan's 10.
+- Helpers exist as described: `samtools_available()` panics under `$CI` (line 51–57), `run_converter` writes to the passed out-dir, output naming `<stem>.bisulfite.bam` (line 99).
+- Parent citations accurate: §9.8 at PLAN.md:498–500; §10b "Not done" lists §9.8 as "Worth adding"; CODE_REVIEW_A:77 ("zero risk — I have run it") and HIGH-2; CODE_REVIEW_B rows 38–39, L10, and the noodles suggestion (line 144, action 2); COVERAGE.md row 71 = MISSING/admitted.
+- `rust_ci.yml`: workflow-scope `RUSTFLAGS: -D warnings` (line 15); `test` job installs minimap2 + samtools (lines 35–45); `rammap-inprocess` feature exists (lines 92–95). **But see §4.1.**
+
+---
+
+## 2. Assumptions
+
+| # | Plan assumption | Check |
+|---|---|---|
+| 1 | nondir fixture counts/pairs | **Confirmed** by direct census (above) |
+| 2 | synth fixture 12,974 records, round-trips | **Confirmed** count + 42 indel records; round-trip re-proven by the gate itself, as the plan says |
+| 3 | Output naming `<stem>.bisulfite.bam` | **Confirmed** (existing SE test) |
+| 4 | PE accepted with no further flags | Consistent with both reviewers' runs; converter is per-record, no PE-specific flags exist |
+| 5 | "§9.8 equivalence is a property of Bismark-produced BAMs; test pins it on this fixture only" | Sound — parent §3.8 derives it from `output.rs` for SE and all four PE indices |
+| — | **Implicit, wrong:** "the new gates run in CI only via the `test` job, where samtools is present" | **False** — the same test binary runs in two more jobs without samtools; see §4.1 |
+| — | **Implicit, wrong:** "this fixture is the only four-combination fixture, so the census pins its identity" | **False** — see §1.2 |
+| — | **Implicit, false as stated:** synth fixture has "CB:Z:/barcode aux tags" (§2 context) | **0 `CB:Z:` tags** in the file; the barcode is a QNAME suffix (`…:TTAGTTGT`). `CB:Z:` is what dedup's `--add_barcode` writes into the *deduplicated* sibling. The fixture's real distinctive value — scale, RNEXT/PNEXT/TLEN mate fields, indels, both strands — is plenty; describe it truthfully. The proposed name `real_pe_with_mate_fields_and_aux_tags_…` also oversells ("real" for a file literally named `synth_barcode…`; NM/MD/XM/XR/XG are ordinary Bismark tags) |
+
+---
+
+## 3. Efficiency
+
+No issues. Two extra debug-build converter runs over ≤12,974 records plus `samtools view` — seconds; `sam_body` holds ~4–5 MB strings. No fixture added. The refactor-to-helper is the right call (three call sites). Run commands in §5.3 are correct and match CI (clippy `--features rammap-inprocess` variant included).
+
+---
+
+## 4. Validation sufficiency
+
+### 4.1 The base CI is already red, and the plan's CI story misses the jobs that matter (Critical)
+
+Verified against live CI: run **31204223600** on `dev` @ `7be9dde` (the #1095 review-fix commit, an ancestor of this branch's base `26eb28a`) — `cargo test` / clippy / fmt / perl-oracle **pass**, but **`rammap-inprocess` and `binseq-input` both FAIL**. Log excerpt:
+
+```
+thread 'bisulfite_input_round_trips_to_identical_sam_text' panicked at
+  bismark/tests/aligner_five_base_bisulfite.rs:52:9
+thread 'xm_is_left_untouched' panicked at ...:52:9
+thread 'appends_a_pg_with_a_distinct_id' panicked at ...:52:9
+```
+
+Cause: both feature jobs run `cargo test -p bismark --features …` — which includes `aligner_five_base_bisulfite.rs` — but their install steps add **only minimap2** (`rust_ci.yml:97–105`, `:135–143`); #1095 added samtools **only to the `test` job**. The `$CI` panic guard then fires, exactly as designed. (This is the dual-driver back-port trap: the guard was copied from the minimap2 gates, whose dependency *is* installed in the feature jobs; samtools was not.)
+
+Consequences for this plan:
+
+- §2 ("`rust_ci.yml` `test` job installs samtools … so the new gates run there for real") and §7 ("samtools present") are **incomplete to the point of being wrong**: the gates also run in two jobs where samtools is absent and the guard panics.
+- §9 row 1's "gates pass first time" and the implicit "CI green" cannot be met: the PR will inherit two red jobs, and the three new gates raise the panicking-test count in those jobs from 3 to 6.
+- §5.2 "No changes outside this one file" is therefore untenable. The fix is two lines — add `samtools` to both feature jobs' `apt-get install` lines — and it is squarely in this plan's remit (its entire subject is "#1095 gates run for real"). Alternatively, state it as an explicit prerequisite fix landed first; what the plan may not do is stay silent.
+- Add a §9 row: "feature jobs green — `rammap-inprocess` and `binseq-input` pass on the PR run" (they never have since `7be9dde`).
+
+### 4.2 Otherwise the validation section is good
+
+The falsifiability rows (observe each gate failing once) are exactly right, and non-vacuity via `expected_records` + the four-pair census kills the empty-stream and truncation failure modes. Remaining gaps, in risk order:
+
+1. Census does not pin the CTOT/CTOB pair structure (§1.2) — the highest-value drift goes undetected.
+2. Nothing constrains FLAGs outside the biconditional's enumerated set: a drifted record (CT, 2048-supplementary) satisfies `FLAG ∉ {16,83,163}` and the census can still find its four pairs among the other 19 records. Asserting per-record `FLAG ∈ {99,147,83,163}` (or the full 4/4/6/6 multiset) closes this for free — the plan already verified the exact counts.
+3. §9 row 4's "extraction only" criterion will fail its own check (§1.4) — fix the criterion, not the code.
+
+---
+
+## 5. Alternatives
+
+- **Open-1 (samtools text vs noodles):** the plan's choice (samtools text, consistent with the file) is defensible, but note §4.1 shifts the trade-off: Reviewer B's noodles `RecordBuf` comparison would make the gates dependency-free and dissolve the feature-job problem for the *new* tests (not the three existing ones). The 2-line CI fix is still cheaper and fixes all six; either resolves it — the plan must pick one explicitly rather than assume CI is green.
+- **Open-2 (report assertions for PE):** agree with the plan, with a stronger argument than it gives — byte-identity of the output *implies* flip rate 0, so a report assertion adds only report-wording coverage, which the SE test already pins.
+- **Open-3 (defer the other three G9 gaps):** the decision matches the handoff scope and stands, but the stated rationale for the unmapped pass-through — "needs a fixture change that invalidates existing counts" — is only true for editing the existing fixture in place; a **new** small mixed mapped+unmapped fixture invalidates nothing. Don't let that sentence survive into the next planning round; the module NOTE (test file lines 289–295) records the honest state.
+- **Gate 1 over the output instead of the input:** asserting the biconditional over the *converter output* of the fixture would make Gate 1 exercise #1095 code directly at identical cost; with Gate 2's identity it is mathematically the same assertion, so this is a taste call — at minimum document the Gate-1/Gate-2 pairing (§1.3).
+- **Run Gate 1's biconditional over the synth fixture too:** ~3 extra lines with a shared per-line checker; extends the equivalence witness to directional-style PE at scale (verified holding, 0/12,974 violations). Purely additive.
+
+---
+
+## 6. Action items
+
+### Critical
+
+1. **Fix the CI story (§4.1).** Add `samtools` to the `rammap-inprocess` and `binseq-input` install steps in `.github/workflows/rust_ci.yml` (2 lines) — inside this plan, or as an explicitly-sequenced prerequisite. Update §2/§7 to name all three jobs that run these tests, drop §5.2's "no changes outside this one file" if the fix rides along, and add a §9 row requiring both feature jobs green. Without this the plan's own validation criteria are unmeetable and the new gates add 3 more panicking tests to already-red jobs.
+2. **Fix Gate 1 step 4 (§1.1).** Delete the `XG == "CT" ⇔ FLAG & 0x10 == 0` clause — it is false for (CT,147) and (GA,163), i.e. 10 of 20 records. Assert the §9.8 set form `XG == "CT" ⟺ FLAG ∉ {16,83,163}`; if a bit-level comment is wanted, the correct PE statement is *reverse bit == second-in-pair bit ⟺ XG == "CT"* (parent §3.8's `is_bottom`).
+
+### Important
+
+3. **Pin the pair structure in Gate 1's census (§1.2).** Assert adjacent-QNAME pairing with per-pair (first,second) FLAGs ∈ {(147,99), (163,83)} (4 and 6 pairs respectively), or at least the full 4/4/6/6 multiset plus "first-of-pair carries 0x80". Correct the "only committed fixture with all four XG/FLAG combinations" claim (§1, §2, and the parent-inherited wording): the synth fixture also has all four; this fixture's uniqueness is that every pair is a #1030-swapped CTOT/CTOB pair.
+4. **Fix the synth-fixture description and test name (§2 Assumptions table).** Remove "CB:Z:/barcode aux tags" (the file has none — barcode is in the QNAME); rename `real_pe_with_mate_fields_and_aux_tags_round_trips_identically` to something truthful, e.g. `pe_at_scale_with_mate_fields_and_indels_round_trips_identically`.
+5. **Reword the "pure extraction" claims (§1.4).** §3's closing line and §9 row 4 must acknowledge the helper's added `expected_records` assertion (SE: 8), or the coverage audit will flag a false mismatch.
+
+### Optional
+
+6. Per-record `FLAG ∈ {99,147,83,163}` guard in Gate 1 (subsumed by item 3's multiset).
+7. Document the Gate-1 ↔ Gate-2 composition in the test doc comment, and note that Gate 1 detects flag-table changes only via fixture regeneration (§1.3).
+8. Extend the Gate-1 biconditional over the synth fixture (verified holding; ~3 lines).
+9. Rephrase Open-3's unmapped-pass-through rationale ("new fixture invalidates nothing"; deferral itself stands).

--- a/plans/08072026_1095-validation-gates/PLAN_REVIEW_B.md
+++ b/plans/08072026_1095-validation-gates/PLAN_REVIEW_B.md
@@ -1,0 +1,292 @@
+# Plan Review B — `plans/08072026_1095-validation-gates/PLAN.md` (rev 0)
+
+**Reviewer:** B (fresh context) · **Date:** 2026-08-07
+**Verdict: SOUND IN INTENT, NOT LANDABLE AS WRITTEN.** The two gates are the right ones and I
+independently re-verified every fixture constant and both round trips — the tests themselves will
+pass. But the plan's CI premise is false: **dev's last Rust CI run is already red because the
+existing #1095 gates panic in two jobs that don't install samtools**, this plan adds three more
+such gates, and §5.2 ("no changes outside this one file") forbids the only fix. One clause of
+Gate 1's specification is also mathematically wrong on the very fixture it targets.
+
+Everything below was checked against the repo, the fixtures (via samtools), the converter source,
+the parent artifacts, and live GitHub Actions results — not taken from the plan's prose.
+
+---
+
+## 1. Logic review
+
+### 1.1 CRITICAL — the plan's CI claim is wrong, and the branch cannot go green under the plan's own constraints
+
+Plan §2: *"`rust_ci.yml` `test` job installs samtools (added by #1095), so the new gates run
+there for real"* — true but fatally incomplete. §7: *"CI: the gates join the existing #1095 gate
+set in the `test` job; samtools present."*
+
+What the workflow actually does (`.github/workflows/rust_ci.yml`):
+
+- `test` job (line 35): installs **minimap2 + samtools** — fine.
+- `rammap-inprocess` job (line ~96) and `binseq-input` job (line ~134): install **minimap2
+  only**, then run `cargo test -p bismark --features …` — which compiles and runs the *same*
+  `tests/aligner_five_base_bisulfite.rs` integration suite. `samtools_available()` (test file
+  line 42–58) **panics whenever `$CI` is set and samtools is absent**.
+
+This is not hypothetical. The most recent Rust CI run on `dev` — run **31204223600**, for
+`7be9dde` (the very commit that added the panic guard) — concluded **failure**:
+
+| Job | Conclusion |
+|---|---|
+| cargo test | success |
+| cargo clippy / fmt / perl-oracle | success |
+| **cargo build/test (rammap-inprocess feature)** | **failure** |
+| **cargo build/test (binseq-input feature)** | **failure** |
+
+The failed-job logs show exactly the predicted panic, three times per job:
+`panicked at bismark/tests/aligner_five_base_bisulfite.rs:52: samtools not found but $CI is set …
+Refusing to no-op.` (failing tests: `bisulfite_input_round_trips_to_identical_sam_text`,
+`xm_is_left_untouched`, `appends_a_pg_with_a_distinct_id`). The two subsequent `dev` commits are
+docs-only and did not trigger the workflow (it is path-filtered to `rust/**` +
+`rust_ci.yml`), so red is the current baseline — and the handoff's "dev is clean, in sync"
+framing masked it. This plan's branch touches `rust/**`, so pushing it **will** trigger all jobs,
+and the three new samtools-gated tests raise the per-job failure count from 3 to 6.
+
+Consequences for the plan as written:
+
+- §9 row 1 "Gates pass first time … 10/10 green" is only true locally and in the `test` job.
+- §5.2 "No changes outside this one file" makes green CI unachievable.
+- The fix is two one-line additions (`samtools` in each feature job's `apt-get install`), or
+  adopting the noodles comparison (see §1.5 / Open-1). Either way the plan must own this —
+  ideally as a separate first commit, since the red CI is a pre-existing #1095 defect this
+  "close the validation gaps" plan is the natural home for. Note this is the dual-driver
+  back-port trap in CI-job form: the G8 fix was applied to one job while two sibling jobs run
+  the identical tests.
+
+### 1.2 CRITICAL (one-line fix) — Gate 1 step 4's bit-test gloss is false on this fixture
+
+§3 Gate 1 step 4 opens: *"Assert the biconditional per record: `XG == "CT"` ⇔
+`FLAG & 0x10 == 0` for this fixture's FLAG set"*. That equivalence is **wrong for 10 of the 20
+records**:
+
+- FLAG **147** = 0x1|0x2|**0x10**|0x80 — reverse bit **set**, yet `XG:Z:CT` (4 records);
+- FLAG **163** = 0x1|0x2|0x20|0x80 — reverse bit **clear**, yet `XG:Z:GA` (6 records).
+
+R2 of an OT pair is reverse-complemented and R2 of an OB pair is forward — XG tracks the *pair's*
+originating strand, not the record's orientation bit. (The record-level bit truth on this fixture
+is `XG == "CT" ⇔ (FLAG & 0x10 != 0) == (FLAG & 0x80 != 0)`, but do not put bit arithmetic in the
+test at all.) The step's own continuation — "concretely `FLAG ∈ {99,147}` for CT and
+`FLAG ∈ {83,163}` for GA … assert via the §9.8 formulation (`FLAG ∉ {16,83,163}`)" — **is
+correct** and matches my census, so the operative instruction survives. But a plan whose step 4
+states a false equivalence as the property being pinned invites the implementer to transcribe it
+into an assertion (immediate loud failure, then a risky "repair" that could weaken the gate —
+e.g. asserting R1 records only). Delete the `FLAG & 0x10` clause; keep only the set formulation.
+This is the same FLAG-bit-reasoning-on-PE error class #1030 documented; it should not appear in a
+plan whose fixture exists *because* of #1030.
+
+### 1.3 The census constants are right — verified independently
+
+`samtools view` census of `rust/bismark/tests/data/dedup/nondir_pe_1030.bam` (my run,
+2026-08-07): **(CT,99)×4, (CT,147)×4, (GA,83)×6, (GA,163)×6 — 20 records**, every record carries
+`XG:Z:` ∈ {CT, GA}, and the biconditional holds on all 20. Matches Assumption 1 exactly.
+`synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam`: **12,974 records** (FLAG census
+99×3217 / 147×3217 / 83×3270 / 163×3270), **42** records with `I`/`D` in CIGAR. Matches
+Assumption 2 and the plan's §2 description.
+
+### 1.4 "The only committed fixture with all four `XG`/FLAG combinations" is false
+
+Inherited verbatim from parent §9.8 and CODE_REVIEW_A/B — and disproven by the census above:
+**`synth_barcode…_pe.bam` also contains all four (XG, FLAG) pairs** (any directional PE Bismark
+BAM does, because R2's orientation is flipped relative to R1). What is genuinely unique about
+`nondir_pe_1030.bam` is **pair-level**: CTOT/CTOB pairs whose R1/R2 FLAG bits are #1030-swapped —
+a structure the proposed **record-level** scan never inspects. The gate is still the right gate
+on the right fixture (smallest, and the one carrying the swap pairs), but the plan should correct
+the claim rather than propagate it, and should not imply the test distinguishes four *strand
+indices* — at record level it distinguishes four (XG, FLAG) pairs that a directional fixture also
+has. (The test name `nondir_pe_all_four_strand_indices_round_trip_identically` is fine — the
+*fixture* does contain all four strand indices; the *Gate 1 assertion* just doesn't see them.)
+
+### 1.5 What Gate 1 actually tests — data, not code
+
+Gate 1 as specified (§3 step 2) scans `sam_body(dedup/nondir_pe_1030.bam)` — the committed,
+Perl-v0.25.1-produced fixture. **No #1095 (or any Rust) code executes.** Parent §9.8's stated
+purpose — "a future change to the flag table must break a test rather than the science" — is not
+achieved by scanning a static fixture: the Rust aligner's index→(FLAG, XG) table is never
+consulted. What the gate *does* buy, and the plan should say so plainly:
+
+1. It pins the cross-tool contract that makes the converter's XG-only design safe: the converter
+   derives the (meth, unmeth) pair from `XG` alone (`XgStrand::from_tag`,
+   `aligner/mod.rs:785`; FLAG is only read for pass-through routing at `mod.rs:740`), while
+   downstream `patter` infers strand from **FLAG** (handoff G15: OT selector {99,147}, OB
+   {83,163} — exactly the fixture's partition). If XG⟺FLAG broke, the converter would still
+   "round-trip" happily and the science would be silently wrong downstream — which is precisely
+   why the invariant deserves its own gate.
+2. It fail-louds fixture regeneration/truncation (the census).
+
+Combined with Gate 2 over the same fixture (output text == input text), the property transfers to
+converter output — the plan's §1 "invisible to the idempotence gate" framing is correct (verified
+against `five_base_bisulfite.rs:15-17`: `methylation_call` branches on `XR`, not `XG`; the
+XG→base map is emergent). Fine — but one honest sentence in the plan about "this gate asserts a
+property of committed Bismark output, it runs no product code" prevents a future reader from
+believing the Rust aligner's flag table is under test. Binding *that* table would belong in the
+groundtruth suite (aligner-produced BAMs) — a legitimate follow-up, not this plan.
+
+### 1.6 `FLAG ∉ {16, 83, 163}`: correct, non-vacuous — but the `16` member is dead weight here
+
+Directly answering the formulation question:
+
+- **Correct** on this fixture: CT ↔ {99,147} (both ∉ set), GA ↔ {83,163} (both ∈ set). Holds on
+  all 20 records — verified.
+- **Non-vacuous**: both XG values occur and both directions of the biconditional are
+  instantiated; the four-pair census plus `== 20` closes the G19 hole. Good design.
+- **But `16` is never exercised**: this PE-only fixture has no SE record, so a test that
+  (wrongly) used `{83,163}` would pass identically. The SE half of the §9.8 table is one
+  parameterisation away: `softclip_indel_se.bam` has FLAGs **0×4 (XG:CT) and 16×4 (XG:GA)**
+  (verified). Running the same scan over it (census 8, pairs (CT,0)/(GA,16)) instantiates the
+  `16` member and covers the full spec set. Cheap and worth doing; otherwise the plan should
+  admit the `16` is asserted-but-unwitnessed.
+
+### 1.7 Gate 2 — refactor and new tests are sound; round trips re-verified
+
+I ran the shipped converter over both PE fixtures myself (debug binary, no extra flags):
+**both byte-identical** on decompressed bodies (`cmp` clean), 20/20 and 12,974/12,974 re-encoded,
+flip rate `0.000000`, `masked 0`. So Assumptions 2–4 hold and the two new tests will pass first
+time; output naming `<stem>.bisulfite.bam` confirmed in `aligner/mod.rs:708` and on disk.
+
+Two wrinkles in the refactor description:
+
+- **"Pure extraction" is overstated.** The helper adds a non-vacuity census
+  (`expected_records`) that the current SE test does not have, so the SE test *gains* an
+  assertion. That is a strengthening, not a risk (the SE fixture has exactly 8 records — report
+  and `xm` test agree), but §3's "must not change the SE test's assertions (pure extraction)"
+  and §9 row 4's "same assertions; git diff shows extraction only" contradict the plan's own
+  §3 step 1. Reword to "extraction plus one added census; no assertion removed or weakened".
+- The helper must derive the produced filename from `fixture.file_stem()` (the current test
+  hardcodes it); the plan implies but never states this. One clarifying clause avoids a
+  hardcoded-name helper that only works for one fixture.
+
+Test arithmetic checks out: 7 existing + 3 new = 10, matching §5.3.
+
+## 2. Assumptions
+
+| # | Plan assumption | Check | Verdict |
+|---|---|---|---|
+| A1 | nondir census (20; 4/4/6/6; biconditional holds) | Recounted via samtools | ✅ exact |
+| A2 | synth = 12,974 records, round-trips byte-identically | Recounted + re-ran converter + `cmp` | ✅ |
+| A3 | Output name `<stem>.bisulfite.bam` | `mod.rs:708` + observed on disk | ✅ |
+| A4 | PE BAM accepted with no further flags | Ran it | ✅ |
+| A5 | §9.8 equivalence is a fixed Bismark property, pinned on this fixture only | Consistent with G15's patter selectors | ✅ reasonable |
+
+**Unstated assumptions the plan missed:**
+
+- **"CI is green at baseline" — FALSE** (§1.1). The load-bearing one.
+- "The gates run in CI only via the `test` job" — false; two feature jobs run them too.
+- "`nondir_pe_1030.bam` is the only fixture with all four XG/FLAG combinations" — false at the
+  record level (§1.4).
+- MD/NM present on every record of both PE fixtures (the converter hard-requires them,
+  `mod.rs:777-783`) — true, but it is an input precondition the round-trip silently depends on;
+  my successful runs confirm it.
+
+## 3. Efficiency
+
+No concerns. My timed runs: nondir < 0.1 s, synth ≈ 1 s (debug build) plus two `samtools view`
+per test; the whole suite stays in single-digit seconds. No fixture added; repo size unchanged.
+One micro-note: Gate 1 and the nondir round-trip test each invoke `samtools view` on the same
+fixture — merging them would save one subprocess but blur two properties into one test; the
+plan's separation is the better trade.
+
+## 4. Validation sufficiency
+
+**Good:** the falsifiability rows (§9 rows 2–3 — observe each gate fail once) and the census/
+non-vacuity design are exactly the right G19 medicine; the refactor-purity row and hygiene rows
+are appropriate.
+
+**Gaps, in order of risk:**
+
+1. **No "all CI jobs green" validation row** — the highest-risk failure mode for this change is
+   not a wrong assertion but the branch turning (staying) red in `rammap-inprocess`/
+   `binseq-input`. Add: push, then assert **all six** workflow jobs pass. As written the plan
+   would be "validated" locally while deepening a red CI.
+2. **Gate 1's falsifiability row under-specifies**: inverting `==`→`!=` proves the biconditional
+   direction fires; also falsify the **census** (e.g. require a fifth pair or count 21) once, so
+   both halves of the gate are observed failing. Row 3 does this for Gate 2 only.
+3. **The `16` member of the spec set is unwitnessed** (§1.6) — either extend Gate 1 over the SE
+   fixture or record the limitation.
+4. Minor: no row confirms the two new PE tests' output files land in the tempdir with the
+   derived names (implicitly covered by the helper's exists-assert — fine once the helper's
+   stem-derivation is stated).
+
+## 5. Alternatives
+
+1. **noodles `RecordBuf` comparison (Open-1) deserves a real re-decision, not a default.** The
+   plan dismisses it as "the CI panic guard already prevents silent skips" — but the panic guard
+   is exactly what has two CI jobs red today, and **both** parent reviewers suggested in-process
+   comparison (CODE_REVIEW_B §"noodles"; CODE_REVIEW_A: "shows the comparison can be done
+   in-process with noodles and the external dependency dropped entirely" — the plan attributes
+   it to B alone). A noodles gate needs no samtools, no skip logic, no workflow edit, and runs
+   identically in all six jobs. Keeping samtools text for file-wide consistency is defensible —
+   but then the two-line workflow fix is mandatory, and the Open-1 row should cite the red run
+   as the cost of the chosen path.
+2. **Parameterise Gate 1 over the SE fixture too** — closes the {0,16} half of the §9.8 table
+   for the cost of one function call (§1.6).
+3. **Assert Gate 1's scan over converter output as well as input** — nearly free inside the
+   round-trip helper, and makes Gate 1 exercise product code; largely redundant given Gate 2's
+   equality, so optional.
+4. **Open-3's unmapped-pass-through rationale is overstated**: "needs a fixture change that
+   invalidates existing counts" is only true if the *existing* fixture is edited. A separate
+   1–2-record fixture (unmapped + full tags) invalidates nothing — CODE_REVIEW_B's H-list even
+   proposed synthesising it. Deferral is still legitimate (the handoff scoped this plan to two
+   gaps), but the recorded reason should be scope, not impossibility.
+
+## 6. Action items
+
+### Critical
+
+1. **Resolve the red-CI conflict before or with this change** (§1.1). Either add `samtools` to
+   the `rammap-inprocess` and `binseq-input` install steps in `.github/workflows/rust_ci.yml`
+   (two one-line edits; drop §5.2's "no changes outside this one file"), or adopt the noodles
+   comparison so the gates need no samtools anywhere. Add an "all CI jobs green" row to §9.
+   Evidence: run 31204223600 (`dev` @ 7be9dde) — both feature jobs failed with the
+   `aligner_five_base_bisulfite.rs:52` panic.
+2. **Delete the false `FLAG & 0x10 == 0` gloss from §3 Gate 1 step 4** (§1.2). FLAG 147 (XG:CT)
+   and FLAG 163 (XG:GA) violate it — 10/20 records. Keep only the set formulation
+   `FLAG ∉ {16,83,163}` ⟺ `XG == "CT"`, which I verified holds on all 20.
+
+### Important
+
+3. Correct "the only committed fixture with all four XG/FLAG combinations" (§1.4) — synth has
+   all four too; nondir's uniqueness is the pair-level #1030 FLAG swap, which the record-level
+   gate does not inspect.
+4. State in the plan (and ideally the test doc comment) that Gate 1 asserts a property of
+   committed Bismark-Perl data and runs no product code; its value is pinning the
+   converter↔patter FLAG/XG contract and fail-louding fixture drift — not gating the Rust
+   aligner's flag table (§1.5).
+5. Either extend Gate 1 over `softclip_indel_se.bam` (FLAGs 0/16, verified) so the `16` in the
+   spec set is witnessed, or record that it is not (§1.6).
+6. Fix the "pure extraction / same assertions" wording (§1.7): the helper adds the
+   `expected_records` census to the SE test — say so, and make §9 row 4 check "no assertion
+   removed or weakened" instead of "extraction only". Also state that the helper derives the
+   output name from the fixture stem.
+
+### Optional
+
+7. Falsify Gate 1's census once (not just the biconditional) before trusting it (§4.2).
+8. Re-open Open-1 as a genuine decision with the CI evidence on the table; correct the
+   attribution (both reviewers proposed noodles).
+9. Reword Open-3's unmapped-pass-through rationale from "invalidates existing counts" to a
+   scope decision; note the separate-tiny-fixture route for whoever closes it later.
+
+---
+
+### What I verified independently (so the next reader doesn't have to)
+
+- Fixture censuses (both PE fixtures + SE fixture) via `samtools view` — all constants in §8
+  A1/A2 are exact.
+- Both PE round trips: ran `./rust/target/debug/bismark --illumina_5base
+  --five_base_bisulfite_bam <fixture> --output_dir <tmp>`; `cmp` of decompressed bodies clean;
+  reports: 20/20 and 12974/12974 re-encoded, flip rate 0.000000, masked 0.
+- Converter branches on XG only; FLAG used solely for pass-through routing
+  (`rust/bismark/src/aligner/mod.rs:740, 785`; `five_base_bisulfite.rs:15-17, 32-42`).
+- Output naming `<stem>.bisulfite.bam` (`mod.rs:708`).
+- CI: workflow env `RUSTFLAGS: -D warnings`; samtools installed in `test` job only; feature jobs
+  run the same integration tests; run 31204223600 red with the samtools panic in both feature
+  jobs; workflow path-filtered so the two later docs commits never re-ran it.
+- Parent artifacts: §9.8 wording, G9 list (SESSION_HANDOFF.md:109-115), CODE_REVIEW_A
+  recommendations (lines 62, 77, 96), CODE_REVIEW_B fixture table rows 38-39 + L10 + noodles
+  suggestion, COVERAGE.md rows 40 and 71.

--- a/plans/08072026_1095-validation-gates/PROGRESS.md
+++ b/plans/08072026_1095-validation-gates/PROGRESS.md
@@ -1,0 +1,18 @@
+# Progress: #1095 validation gates (XG ⟺ FLAG + PE/four-strand idempotence)
+
+**Last updated:** 2026-08-07
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | PLAN.md (rev 0) |
+| Plan Review | 📋 Planned | after Felix's manual review |
+| Impl Plan | 📋 Planned | — |
+| Implementation | 📋 Planned | awaits explicit trigger |
+| Code Review | 📋 Planned | — |
+| Coverage | 📋 Planned | — |
+
+## History
+
+- 2026-08-07: Plan → ✅ Complete (PLAN.md rev 0 written on branch `1095-validation-gates`)

--- a/plans/08072026_1095-validation-gates/PROGRESS.md
+++ b/plans/08072026_1095-validation-gates/PROGRESS.md
@@ -8,13 +8,14 @@
 |------|--------|-------|
 | Plan | ✅ Complete | PLAN.md (rev 1 — review findings folded in; awaiting implementation trigger) |
 | Plan Review | ✅ Complete | PLAN_REVIEW_A.md, PLAN_REVIEW_B.md (dual, independent) |
-| Impl Plan | 📋 Planned | — |
-| Implementation | 📋 Planned | awaits explicit trigger |
+| Impl Plan | ✅ Complete | PLAN.md §5 (rev 1) served as the implementation plan |
+| Implementation | ✅ Complete | 11/11 gates green; falsifiability observed; fmt+clippy clean (PLAN.md §12) |
 | Code Review | 📋 Planned | — |
 | Coverage | 📋 Planned | — |
 
 ## History
 
+- 2026-08-07: Implementation → ✅ Complete (2 files: rust_ci.yml samtools mirror + 4 new gates; 11/11 green first time)
 - 2026-08-07: Plan → rev 1 (CI repair in scope; bit-gloss deleted; pair-structure + SE censuses added; CB:Z:/uniqueness/wording corrections)
 - 2026-08-07: Plan Review → ✅ Complete (dual reviewers; agreed Criticals: base CI red in feature jobs, Gate 1 bit-gloss wrong; all contested claims re-verified at source)
 - 2026-08-07: Plan → ✅ Complete (PLAN.md rev 0 written on branch `1095-validation-gates`)

--- a/plans/08072026_1095-validation-gates/PROGRESS.md
+++ b/plans/08072026_1095-validation-gates/PROGRESS.md
@@ -15,6 +15,7 @@
 
 ## History
 
+- 2026-08-07: PR #1097 opened into dev; CI 6/6 green on both runs (incl. rammap-inprocess + binseq-input, red on dev since 7be9dde) — §9's last validation row satisfied; awaiting Felix's merge
 - 2026-08-07: Implementation → ✅ Complete (2 files: rust_ci.yml samtools mirror + 4 new gates; 11/11 green first time)
 - 2026-08-07: Plan → rev 1 (CI repair in scope; bit-gloss deleted; pair-structure + SE censuses added; CB:Z:/uniqueness/wording corrections)
 - 2026-08-07: Plan Review → ✅ Complete (dual reviewers; agreed Criticals: base CI red in feature jobs, Gate 1 bit-gloss wrong; all contested claims re-verified at source)

--- a/plans/08072026_1095-validation-gates/PROGRESS.md
+++ b/plans/08072026_1095-validation-gates/PROGRESS.md
@@ -6,8 +6,8 @@
 
 | Step | Status | Notes |
 |------|--------|-------|
-| Plan | ✅ Complete | PLAN.md (rev 0) |
-| Plan Review | 📋 Planned | after Felix's manual review |
+| Plan | ✅ Complete | PLAN.md (rev 1 — review findings folded in; awaiting implementation trigger) |
+| Plan Review | ✅ Complete | PLAN_REVIEW_A.md, PLAN_REVIEW_B.md (dual, independent) |
 | Impl Plan | 📋 Planned | — |
 | Implementation | 📋 Planned | awaits explicit trigger |
 | Code Review | 📋 Planned | — |
@@ -15,4 +15,6 @@
 
 ## History
 
+- 2026-08-07: Plan → rev 1 (CI repair in scope; bit-gloss deleted; pair-structure + SE censuses added; CB:Z:/uniqueness/wording corrections)
+- 2026-08-07: Plan Review → ✅ Complete (dual reviewers; agreed Criticals: base CI red in feature jobs, Gate 1 bit-gloss wrong; all contested claims re-verified at source)
 - 2026-08-07: Plan → ✅ Complete (PLAN.md rev 0 written on branch `1095-validation-gates`)

--- a/plans/08072026_1095-validation-gates/PROGRESS.md
+++ b/plans/08072026_1095-validation-gates/PROGRESS.md
@@ -10,8 +10,8 @@
 | Plan Review | ✅ Complete | PLAN_REVIEW_A.md, PLAN_REVIEW_B.md (dual, independent) |
 | Impl Plan | ✅ Complete | PLAN.md §5 (rev 1) served as the implementation plan |
 | Implementation | ✅ Complete | 11/11 gates green; falsifiability observed; fmt+clippy clean (PLAN.md §12) |
-| Code Review | 📋 Planned | — |
-| Coverage | 📋 Planned | — |
+| Code Review | ✅ Complete | CODE_REVIEW_A.md + CODE_REVIEW_B.md — both APPROVE; 3 agreed Low fixes applied |
+| Coverage | ✅ Complete | COVERAGE.md — Verdict COMPLETE (21 DONE, 1 documented DEVIATED, 1 PENDING = PR CI run) |
 
 ## History
 

--- a/rust/bismark/tests/aligner_five_base_bisulfite.rs
+++ b/rust/bismark/tests/aligner_five_base_bisulfite.rs
@@ -99,6 +99,13 @@ fn assert_bisulfite_round_trip(input: &Path, expected_records: usize) {
         eprintln!("skipping: samtools not on PATH");
         return;
     }
+    let before = sam_body(input);
+    assert_eq!(
+        before.lines().count(),
+        expected_records,
+        "fixture record count drifted"
+    );
+
     let tmp = tempfile::tempdir().unwrap();
     let out = run_converter(input, tmp.path());
     assert!(
@@ -110,13 +117,6 @@ fn assert_bisulfite_round_trip(input: &Path, expected_records: usize) {
     let stem = input.file_stem().unwrap().to_string_lossy();
     let produced = tmp.path().join(format!("{stem}.bisulfite.bam"));
     assert!(produced.exists(), "no output BAM written");
-
-    let before = sam_body(input);
-    assert_eq!(
-        before.lines().count(),
-        expected_records,
-        "fixture record count drifted"
-    );
     // Compare decompressed SAM bodies, not bytes: BGZF block boundaries are writer-dependent
     // and `NM` is re-encoded as i32, so a byte comparison would fail for reasons that have
     // nothing to do with the conversion.
@@ -162,6 +162,7 @@ fn assert_xg_iff_flag(bam: &Path) -> Vec<(String, u16, String)> {
         let qname = fields.next().unwrap().to_string();
         let flag: u16 = fields.next().unwrap().parse().unwrap();
         let xg = fields
+            .skip(9) // RNAME..QUAL — search only the optional tags
             .find_map(|f| f.strip_prefix("XG:Z:"))
             .unwrap_or_else(|| panic!("record without XG tag: {line}"))
             .to_string();
@@ -174,6 +175,13 @@ fn assert_xg_iff_flag(bam: &Path) -> Vec<(String, u16, String)> {
         census.push((qname, flag, xg));
     }
     census
+}
+
+fn count_of(census: &[(String, u16, String)], flag: u16, xg: &str) -> usize {
+    census
+        .iter()
+        .filter(|(_, f, x)| *f == flag && x == xg)
+        .count()
 }
 
 /// The converter's encoding table keys on `XG` and its orientation handling on FLAG; their
@@ -189,16 +197,10 @@ fn xg_ct_iff_forward_flags_over_all_four_strand_indices() {
     }
     let census = assert_xg_iff_flag(&dedup_fixture("nondir_pe_1030.bam"));
     assert_eq!(census.len(), 20, "fixture record count drifted");
-    let count = |flag: u16, xg: &str| {
-        census
-            .iter()
-            .filter(|(_, f, x)| *f == flag && x == xg)
-            .count()
-    };
-    assert_eq!(count(99, "CT"), 4);
-    assert_eq!(count(147, "CT"), 4);
-    assert_eq!(count(83, "GA"), 6);
-    assert_eq!(count(163, "GA"), 6);
+    assert_eq!(count_of(&census, 99, "CT"), 4);
+    assert_eq!(count_of(&census, 147, "CT"), 4);
+    assert_eq!(count_of(&census, 83, "GA"), 6);
+    assert_eq!(count_of(&census, 163, "GA"), 6);
     for pair in census.chunks(2) {
         let [(q1, f1, _), (q2, f2, _)] = pair else {
             panic!("odd record count in a paired fixture");
@@ -221,14 +223,8 @@ fn xg_iff_flag_holds_on_the_se_fixture() {
     }
     let census = assert_xg_iff_flag(&fixture());
     assert_eq!(census.len(), 8, "fixture record count drifted");
-    let count = |flag: u16, xg: &str| {
-        census
-            .iter()
-            .filter(|(_, f, x)| *f == flag && x == xg)
-            .count()
-    };
-    assert_eq!(count(0, "CT"), 4);
-    assert_eq!(count(16, "GA"), 4);
+    assert_eq!(count_of(&census, 0, "CT"), 4);
+    assert_eq!(count_of(&census, 16, "GA"), 4);
 }
 
 /// The report must say so too — 0 flips, 0 masked. `flipped == 0` is the file-level assertion

--- a/rust/bismark/tests/aligner_five_base_bisulfite.rs
+++ b/rust/bismark/tests/aligner_five_base_bisulfite.rs
@@ -9,7 +9,13 @@
 //! `SEQ` already carries meth/unmeth at every letter position — so it exercises the encoding
 //! table, the `XG`→pair mapping, the positional zip, OB-strand orientation, the `NM`/`MD`
 //! arithmetic, **and** the masking rule (whose set is provably empty on unmasked input) in
-//! one comparison, using a committed fixture and no 5-Base data.
+//! one comparison, using committed fixtures and no 5-Base data. It runs over three fixtures:
+//! the SE soft-clip/indel one and both PE dedup fixtures, including the #1030 non-directional
+//! BAM whose FLAG-swapped pairs cover all four strand indices.
+//!
+//! The `XG` ⟺ FLAG gates (§9.8) pin the Bismark-BAM data contract the converter's encoding
+//! table relies on; they run no converter code, and the contract is invisible to the
+//! idempotence gate (`methylation_call` branches on `XR`, so the agreement is emergent).
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -37,6 +43,11 @@ fn fixture() -> PathBuf {
     data_dir()
         .join("five_base_bisulfite")
         .join("softclip_indel_se.bam")
+}
+
+/// Committed PE fixtures shared with the dedup tests.
+fn dedup_fixture(name: &str) -> PathBuf {
+    data_dir().join("dedup").join(name)
 }
 
 fn samtools_available() -> bool {
@@ -81,32 +92,143 @@ fn run_converter(input: &Path, out_dir: &Path) -> std::process::Output {
         .expect("run bismark")
 }
 
-/// 🔑 The idempotence gate. A bisulfite BAM in must give identical SAM text out.
-#[test]
-fn bisulfite_input_round_trips_to_identical_sam_text() {
+/// Round-trip body shared by the three idempotence gates. `expected_records` pins the
+/// input's record count so two empty streams can never satisfy the comparison.
+fn assert_bisulfite_round_trip(input: &Path, expected_records: usize) {
     if !samtools_available() {
         eprintln!("skipping: samtools not on PATH");
         return;
     }
     let tmp = tempfile::tempdir().unwrap();
-    let out = run_converter(&fixture(), tmp.path());
+    let out = run_converter(input, tmp.path());
     assert!(
         out.status.success(),
         "converter failed: {}",
         String::from_utf8_lossy(&out.stderr)
     );
 
-    let produced = tmp.path().join("softclip_indel_se.bisulfite.bam");
+    let stem = input.file_stem().unwrap().to_string_lossy();
+    let produced = tmp.path().join(format!("{stem}.bisulfite.bam"));
     assert!(produced.exists(), "no output BAM written");
 
+    let before = sam_body(input);
+    assert_eq!(
+        before.lines().count(),
+        expected_records,
+        "fixture record count drifted"
+    );
     // Compare decompressed SAM bodies, not bytes: BGZF block boundaries are writer-dependent
     // and `NM` is re-encoded as i32, so a byte comparison would fail for reasons that have
     // nothing to do with the conversion.
     assert_eq!(
-        sam_body(&fixture()),
+        before,
         sam_body(&produced),
         "converting a bisulfite BAM must not change a single record"
     );
+}
+
+/// 🔑 The idempotence gate. A bisulfite BAM in must give identical SAM text out.
+#[test]
+fn bisulfite_input_round_trips_to_identical_sam_text() {
+    assert_bisulfite_round_trip(&fixture(), 8);
+}
+
+/// PE + all four strand indices: the #1030 non-directional fixture (every pair
+/// FLAG-swapped) must round-trip identically — the SE fixture covers only two of four.
+#[test]
+fn nondir_pe_all_four_strand_indices_round_trip_identically() {
+    assert_bisulfite_round_trip(&dedup_fixture("nondir_pe_1030.bam"), 20);
+}
+
+/// Real-scale PE: mate fields (`RNEXT`/`PNEXT`/`TLEN`), 42 records with indels, and
+/// QNAME-suffix barcodes survive re-encoding byte-for-byte.
+#[test]
+fn real_pe_with_mate_fields_and_indels_round_trips_identically() {
+    assert_bisulfite_round_trip(
+        &dedup_fixture("synth_barcode_10k_R1_val_1_bismark_bt2_pe.bam"),
+        12974,
+    );
+}
+
+// ---- XG ⟺ FLAG (§9.8) ----------------------------------------------------------------
+
+/// §9.8: `XG == "CT" ⟺ FLAG ∉ {16, 83, 163}` per record. Set form on purpose — the bit
+/// form (`FLAG & 0x10 == 0`) is FALSE on PE, where R2 of an OT pair (FLAG 147) is
+/// reverse-strand yet `XG:Z:CT`. Returns the (QNAME, FLAG, XG) census for the caller.
+fn assert_xg_iff_flag(bam: &Path) -> Vec<(String, u16, String)> {
+    let mut census = Vec::new();
+    for line in sam_body(bam).lines() {
+        let mut fields = line.split('\t');
+        let qname = fields.next().unwrap().to_string();
+        let flag: u16 = fields.next().unwrap().parse().unwrap();
+        let xg = fields
+            .find_map(|f| f.strip_prefix("XG:Z:"))
+            .unwrap_or_else(|| panic!("record without XG tag: {line}"))
+            .to_string();
+        assert!(xg == "CT" || xg == "GA", "unexpected XG value {xg}");
+        assert_eq!(
+            xg == "CT",
+            !matches!(flag, 16 | 83 | 163),
+            "XG ⟺ FLAG contract violated: FLAG {flag}, XG {xg} ({qname})"
+        );
+        census.push((qname, flag, xg));
+    }
+    census
+}
+
+/// The converter's encoding table keys on `XG` and its orientation handling on FLAG; their
+/// agreement is emergent (`methylation_call` branches on `XR`) and invisible to the
+/// idempotence gate. This test runs no converter code — it pins the data contract on the
+/// non-directional fixture, plus the #1030 pair structure that makes that fixture the
+/// non-directional guard (a directional regeneration passes the record census but not this).
+#[test]
+fn xg_ct_iff_forward_flags_over_all_four_strand_indices() {
+    if !samtools_available() {
+        eprintln!("skipping: samtools not on PATH");
+        return;
+    }
+    let census = assert_xg_iff_flag(&dedup_fixture("nondir_pe_1030.bam"));
+    assert_eq!(census.len(), 20, "fixture record count drifted");
+    let count = |flag: u16, xg: &str| {
+        census
+            .iter()
+            .filter(|(_, f, x)| *f == flag && x == xg)
+            .count()
+    };
+    assert_eq!(count(99, "CT"), 4);
+    assert_eq!(count(147, "CT"), 4);
+    assert_eq!(count(83, "GA"), 6);
+    assert_eq!(count(163, "GA"), 6);
+    for pair in census.chunks(2) {
+        let [(q1, f1, _), (q2, f2, _)] = pair else {
+            panic!("odd record count in a paired fixture");
+        };
+        assert_eq!(q1, q2, "file-order pair must share a QNAME");
+        assert!(
+            matches!((*f1, *f2), (147, 99) | (163, 83)),
+            "pair FLAGs must be #1030-swapped, got ({f1}, {f2}) for {q1}"
+        );
+    }
+}
+
+/// The same contract on the SE fixture — the only committed witness of FLAG `16` (the PE
+/// fixture's reverse FLAGs are 83/163), so every element of the §9.8 set is exercised.
+#[test]
+fn xg_iff_flag_holds_on_the_se_fixture() {
+    if !samtools_available() {
+        eprintln!("skipping: samtools not on PATH");
+        return;
+    }
+    let census = assert_xg_iff_flag(&fixture());
+    assert_eq!(census.len(), 8, "fixture record count drifted");
+    let count = |flag: u16, xg: &str| {
+        census
+            .iter()
+            .filter(|(_, f, x)| *f == flag && x == xg)
+            .count()
+    };
+    assert_eq!(count(0, "CT"), 4);
+    assert_eq!(count(16, "GA"), 4);
 }
 
 /// The report must say so too — 0 flips, 0 masked. `flipped == 0` is the file-level assertion


### PR DESCRIPTION
Closes the two #1095 validation gaps worth closing (handoff G9) and repairs the currently-red Rust CI on `dev`. Test-only plus a two-line CI change — no behaviour change.

- **Gate 1 (§9.8):** `XG == "CT" ⟺ FLAG ∉ {16, 83, 163}` per record over `nondir_pe_1030.bam` (with record, pair-swap and count censuses pinning the #1030 FLAG-swapped structure) and the SE fixture (the only committed witness of FLAG 16). The contract is load-bearing for the converter's encoding table and invisible to the idempotence gate.
- **Gate 2:** the idempotence round trip now also runs over both committed PE fixtures (20 and 12,974 records, byte-identical) — #1095 is PE-only but its committed gates were SE-only.
- **CI repair:** `rammap-inprocess` and `binseq-input` now install samtools like the main `test` job. They run the #1095 gates, whose `$CI` panic guard has kept both jobs red on `dev` since `7be9dde` (run 31204223600: exactly 3 guard panics per job, nothing else — the minimap2 guard was mirrored when added, the samtools one wasn't).

Pipeline: plan (rev 0→1) + dual plan review, implementation, dual code review (A+B APPROVE) + coverage audit (COMPLETE), all under `plans/08072026_1095-validation-gates/`. Every census constant was measured off the fixtures; every new assertion was observed failing once under temporary sabotage before being trusted. 11/11 gates green locally; fmt + clippy (`-D warnings`, default and `rammap-inprocess`) clean.
