### PR TITLE
ci: add Dependabot config for docs/ npm, targeting dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /docs
+    # Security updates ignore this and always open against the default branch.
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: build(deps)
+    # One pull request for the whole docs site rather than one per package.
+    groups:
+      docs-deps:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
No `dependabot.yml` existed, so no version updates were configured at all and every bump so far arrived as a *security* update — which is why four of them (astro, svgo, sharp, postcss) landed straight on `master` and left `dev`'s lockfile four bumps behind until `3a6aab8` resynced it.

Weekly npm version updates for `/docs` now target `dev`, grouped into a single PR so a docs dependency sweep is one review rather than five.

**Two GitHub limits apply, neither configurable — worth knowing before this is judged:**

- [Security updates ignore `target-branch`](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/customizing-dependabot-security-prs) and always open against the default branch, so a js-yaml-style advisory still arrives on `master`. This config redirects *version* updates only.
- [Dependabot reads `dependabot.yml` from the default branch only](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates), so **merging this into `dev` leaves it inert** until it reaches `master`.

Validated: parses as YAML, required keys present (`version`, `package-ecosystem`, `directory`, `schedule.interval`), and `/docs` does contain the manifest pair.