### PR TITLE
docs: retire the TruSeq DNA-Methylation (EpiGnome) kit from library-types

### DIFF
--- a/docs/src/content/docs/usage/library-types.md
+++ b/docs/src/content/docs/usage/library-types.md
@@ -58,14 +58,6 @@ Here is a table summarising general recommendations for different library types 
             <td align="center">⬜️</td>
         </tr>
         <tr>
-            <td align="left">TruSeq (EpiGnome)</td>
-            <td align="center">8 bp</td>
-            <td align="center">(8 bp)</td>
-            <td align="center">⬜️</td>
-            <td align="center">✅</td>
-            <td align="center">⬜️</td>
-        </tr>
-        <tr>
             <td align="left">Accel-NGS (Swift)</td>
             <td align="center">R1: 10, R2:15bp</td>
             <td align="center">(10 bp)</td>
@@ -133,11 +125,6 @@ The amount of bases that need to be trimmed from the 5' end depends on the lengt
 ### Single-cell
 
 The [scBS-Seq method](http://www.nature.com/nmeth/journal/v11/n8/full/nmeth.3035.html) uses a PBAT-type protocol but employs five rounds of sequence capture and elongation to amplify the starting material so all four different bisulfite strands (OT, CTOT, OB, CTOB) are sequenced. Since 6N oligos are used to for the random priming step, 6 bp need to be removed from the 5' ends. Since scBS and PBAT libraries tend to result in [chimaeric fragments](https://sequencing.qcfail.com/articles/pbat-libraries-may-generate-chimaeric-read-pairs/) we tend to treat scBS-Seq as single-end reads always. Please also see the section _3' Trimming in general_ below.
-
-### TruSeq DNA-Methylation Kit (formerly EpiGnome)
-
-([Manufacturer's page](http://www.illumina.com/products/by-type/sequencing-kits/library-prep-kits/truseq-dna-methylation.html))
-This Illumina kit (previously known as EpiGnome kit from epicentre) also employs a post-bisulfite strategy using 6N oligos, but in contrast to the PBAT technique only the standard original top and bottom strands (OT and OB) are sequenced, meaning that Bismark can be run in default (= directional) mode. Even though the random priming is performed with 6N oligoes we often saw that the methylation bias extends to 7 or 8 bp, so trimming 8 bp off the 5' end(s) is recommended initially. Please do have a look at the M-bias plots nevertheless to see of more bases need removing/ignoring during the methylation extraction process. Please also see the section _3' Trimming in general_ below.
 
 ### Zymo Pico Methyl-Seq
 


### PR DESCRIPTION
The kit is discontinued, so the library-types recommendations table should no longer carry a row standing behind it.

**Removed** (all in `docs/src/content/docs/usage/library-types.md`, the only file in the repo mentioning it under any spelling): the summary-table row, the prose section `### TruSeq DNA-Methylation Kit (formerly EpiGnome)`, and that section's manufacturer link — a dead `http://` illumina.com URL, deliberately not replaced.

**Kept deliberately:** the "Random priming and 3' Trimming in general" section still lists EpiGnome among post-bisulfite methods whose random priming causes mispriming and methylation bias. That is a statement about random priming as a class and stays true of a retired kit — please don't 'finish the job' on that line later.

**Context:** [FelixKrueger/TrimGalore#440](https://github.com/FelixKrueger/TrimGalore/issues/440) asks for library-prep presets in Trim Galore, and this table is the source of truth those presets would be built from. A retired kit here would have shipped as a preset for a product nobody can buy.

**Verified:** diff is **0 insertions / 13 deletions** in one file — no reformatting or re-indentation of neighbouring rows; the table keeps 8 body rows of exactly 6 cells each with no empty row; the rendered page contains `EpiGnome` once (the kept sentence) and `TruSeq` zero times; `npm run build` clean, 27 pages. The pre-existing under-indented `</tr>` on the header row is untouched.

No CHANGELOG or Milestones entry: docs-only commits here have never carried one (fcab091, f98bc52, a1b2837, fb1bc72).