### PR TITLE
feat(extractor): opt-in --allow_discordant for aligner-agnostic input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Bismark Changelog
 
 
+## Bismark (unreleased)
+
+### bismark extract (methylation extractor)
+
+- **New opt-in `--allow_discordant` for aligner-agnostic input.** The methylation extractor can now consume BAMs from general-purpose bisulfite aligners that emit Bismark-format `XM`/`XR`/`XG` tags — not just the Bismark aligner — without an external `samtools view -f 0x2 -F 0x900` pre-filter. With the flag it skips (and counts) secondary (`0x100`) / supplementary (`0x800`) alignments, calls cross-chromosome and same-chromosome discordant pairs independently, and calls orphan reads whose mate is unmapped; every new class is tallied in a dedicated splitting-report section. It is **OFF by default and byte-identical to the previous behaviour when off** (including the historical cross-chromosome / unpaired-record errors). A stderr warning (not gated by `--quiet`) fires when more than 20% of records are orphans, which usually means the input is not name-grouped (query-sorted / name-collated).
+
+
 ## Bismark 3.1.0 (released 2026-07-13)
 
 ### bismark (aligner)

--- a/rust/bismark/src/extractor/cli.rs
+++ b/rust/bismark/src/extractor/cli.rs
@@ -212,6 +212,22 @@ pub struct Cli {
     #[arg(long = "mbias_off")]
     pub mbias_off: bool,
 
+    // ─── Aligner-agnostic discordant handling ───
+    /// Opt-in: call methylation on records a Bismark aligner never emits, so
+    /// output from a general-purpose bisulfite aligner (emitting Bismark-format
+    /// XM/XR/XG tags) can be consumed directly — no `samtools view -f 0x2 -F
+    /// 0x900` pre-filter. Skips (and counts) secondary (0x100) / supplementary
+    /// (0x800) alignments; calls cross-chromosome and same-chromosome
+    /// discordant pairs independently; calls orphan reads whose mate is
+    /// unmapped. OFF by default; the default path is byte-identical to Bismark's
+    /// (including its cross-chr / unpaired-record errors). Everything the mode
+    /// does is tallied in the splitting report. PE enables the full package; in
+    /// -s mode it enables just the 0x900 skip. A stderr warning is emitted (not
+    /// gated by --quiet) if >20% of records are orphans, which usually means the
+    /// input is not name-grouped (query-sorted / name-collated).
+    #[arg(long = "allow_discordant")]
+    pub allow_discordant: bool,
+
     // ─── Console diagnostics (#882) ───
     /// Suppress the informational stderr log (banner, mode, parameter summary,
     /// header provenance, progress counter, final summary, kept/deleted).
@@ -351,6 +367,10 @@ pub struct ResolvedConfig {
     pub quiet: bool,
     /// Include `@SQ` lines in header provenance (#882).
     pub verbose: bool,
+    /// Aligner-agnostic discordant handling: skip+count secondary/supplementary,
+    /// call cross-chr / same-chr discordant pairs independently, call orphans.
+    /// OFF by default; gates every new code path so the default is byte-identical.
+    pub allow_discordant: bool,
 }
 
 impl ResolvedConfig {
@@ -550,6 +570,7 @@ impl Cli {
             parallel: self.parallel as usize,
             quiet: self.quiet,
             verbose: self.verbose,
+            allow_discordant: self.allow_discordant,
         })
     }
 }

--- a/rust/bismark/src/extractor/downstream_filenames.rs
+++ b/rust/bismark/src/extractor/downstream_filenames.rs
@@ -420,6 +420,7 @@ mod tests {
             parallel: 1,
             quiet: false,
             verbose: false,
+            allow_discordant: false,
         }
     }
 

--- a/rust/bismark/src/extractor/logging.rs
+++ b/rust/bismark/src/extractor/logging.rs
@@ -105,8 +105,14 @@ impl Logger {
     }
 
     /// Final per-context methylation summary (mirror of `_splitting_report.txt`).
-    pub fn final_summary(&self, report: &SplittingReport) {
+    /// When `allow_discordant` is set, the `--allow_discordant` section is
+    /// appended (mirroring the splitting-report section); off by default it adds
+    /// nothing, so the stderr summary is unchanged.
+    pub fn final_summary(&self, report: &SplittingReport, allow_discordant: bool) {
         self.info(&final_summary_text(report));
+        if allow_discordant {
+            self.info(&crate::extractor::output::discordant_section_text(report));
+        }
     }
 }
 

--- a/rust/bismark/src/extractor/mod.rs
+++ b/rust/bismark/src/extractor/mod.rs
@@ -69,6 +69,7 @@ pub mod mbias_writer;
 pub mod output;
 pub mod output_mode;
 pub mod overlap;
+pub mod pair_class;
 pub mod parallel;
 pub mod params;
 pub mod pipeline;
@@ -83,7 +84,8 @@ pub use mbias_writer::{derive_mbias_basename, mbias_txt_path, write_mbias_txt};
 pub use output_mode::{
     CpGOrNonCpG, OutputKey, mode_keys, orient_byte, route_to_key, write_yacht_row,
 };
-pub use overlap::{drop_overlap, is_forward_pair_strand};
+pub use overlap::{drop_overlap, drop_overlap_generic, is_forward_pair_strand};
+pub use pair_class::{PairClass, classify_pair};
 pub use parallel::{extract_pe_parallel, extract_se_parallel};
 pub use params::ExtractParams;
 // PHASE F INVARIANT: the legacy single-threaded `extract_se` / `extract_pe`

--- a/rust/bismark/src/extractor/output.rs
+++ b/rust/bismark/src/extractor/output.rs
@@ -727,6 +727,21 @@ pub struct SplittingReport {
     pub calls_chh_meth: u64,
     /// `h`.
     pub calls_chh_unmeth: u64,
+
+    // ─── `--allow_discordant` class counters (all zero when the flag is off) ───
+    /// Cross-chromosome pairs called independently (`PairClass::Independent`
+    /// with different refids).
+    pub pairs_cross_chr_independent: u64,
+    /// Same-chromosome discordant pairs called independently
+    /// (`PairClass::Independent` with the same refid — e.g. FF/RR or annihilated
+    /// geometry).
+    pub pairs_same_chr_independent: u64,
+    /// Orphan reads (mapped primary whose mate was unmapped/filtered) called.
+    pub orphan_reads_called: u64,
+    /// Secondary alignments (FLAG 0x100) skipped by the io filter.
+    pub secondary_skipped: u64,
+    /// Supplementary alignments (FLAG 0x800) skipped by the io filter.
+    pub supplementary_skipped: u64,
 }
 
 impl SplittingReport {
@@ -761,6 +776,21 @@ impl SplittingReport {
         self.calls_chg_unmeth = self.calls_chg_unmeth.saturating_add(other.calls_chg_unmeth);
         self.calls_chh_meth = self.calls_chh_meth.saturating_add(other.calls_chh_meth);
         self.calls_chh_unmeth = self.calls_chh_unmeth.saturating_add(other.calls_chh_unmeth);
+        self.pairs_cross_chr_independent = self
+            .pairs_cross_chr_independent
+            .saturating_add(other.pairs_cross_chr_independent);
+        self.pairs_same_chr_independent = self
+            .pairs_same_chr_independent
+            .saturating_add(other.pairs_same_chr_independent);
+        self.orphan_reads_called = self
+            .orphan_reads_called
+            .saturating_add(other.orphan_reads_called);
+        self.secondary_skipped = self
+            .secondary_skipped
+            .saturating_add(other.secondary_skipped);
+        self.supplementary_skipped = self
+            .supplementary_skipped
+            .saturating_add(other.supplementary_skipped);
     }
 }
 
@@ -1076,9 +1106,40 @@ pub fn write_splitting_report(
         )?;
     }
 
+    // Step 20b: `--allow_discordant` section (opt-in; absent when the flag is
+    // off, so the report is byte-identical to the default path). A run's report
+    // states the policy that was active even when all counts are zero.
+    if config.allow_discordant {
+        w.write_all(discordant_section_text(report).as_bytes())?;
+    }
+
     // Step 21: flush.
     w.flush()?;
     Ok(())
+}
+
+/// The `--allow_discordant` splitting-report / stderr section. Pure `String`
+/// builder so `write_splitting_report` (file) and `logging::final_summary`
+/// (stderr) render byte-identical text. The section carries no leading `\n`:
+/// on the file path the preceding percentage block's trailing `\n\n\n` supplies
+/// the blank-line separator, and on stderr `logging::final_summary` emits it via
+/// a separate `info()` call (its own line break).
+#[must_use]
+pub fn discordant_section_text(report: &SplittingReport) -> String {
+    format!(
+        "Discordant read handling (--allow_discordant)\n\
+         =============================================\n\
+         Cross-chromosome pairs called independently:\t{cross}\n\
+         Same-chromosome discordant pairs called independently:\t{same}\n\
+         Orphan reads (mate unmapped) called:\t{orphan}\n\
+         Secondary alignments skipped:\t{sec}\n\
+         Supplementary alignments skipped:\t{supp}\n",
+        cross = report.pairs_cross_chr_independent,
+        same = report.pairs_same_chr_independent,
+        orphan = report.orphan_reads_called,
+        sec = report.secondary_skipped,
+        supp = report.supplementary_skipped,
+    )
 }
 
 #[cfg(test)]
@@ -1226,6 +1287,11 @@ mod tests {
             calls_chg_unmeth: 100,
             calls_chh_meth: 80,
             calls_chh_unmeth: 170,
+            pairs_cross_chr_independent: 3,
+            pairs_same_chr_independent: 4,
+            orphan_reads_called: 5,
+            secondary_skipped: 6,
+            supplementary_skipped: 7,
         };
         let b = SplittingReport {
             records_processed: 250,
@@ -1237,6 +1303,11 @@ mod tests {
             calls_chg_unmeth: 250,
             calls_chh_meth: 220,
             calls_chh_unmeth: 330,
+            pairs_cross_chr_independent: 11,
+            pairs_same_chr_independent: 12,
+            orphan_reads_called: 13,
+            secondary_skipped: 14,
+            supplementary_skipped: 15,
         };
         // a + b
         let mut a_into_b = SplittingReport {
@@ -1249,6 +1320,11 @@ mod tests {
             calls_chg_unmeth: b.calls_chg_unmeth,
             calls_chh_meth: b.calls_chh_meth,
             calls_chh_unmeth: b.calls_chh_unmeth,
+            pairs_cross_chr_independent: b.pairs_cross_chr_independent,
+            pairs_same_chr_independent: b.pairs_same_chr_independent,
+            orphan_reads_called: b.orphan_reads_called,
+            secondary_skipped: b.secondary_skipped,
+            supplementary_skipped: b.supplementary_skipped,
         };
         a_into_b.add(&a);
         // b + a
@@ -1262,6 +1338,11 @@ mod tests {
             calls_chg_unmeth: a.calls_chg_unmeth,
             calls_chh_meth: a.calls_chh_meth,
             calls_chh_unmeth: a.calls_chh_unmeth,
+            pairs_cross_chr_independent: a.pairs_cross_chr_independent,
+            pairs_same_chr_independent: a.pairs_same_chr_independent,
+            orphan_reads_called: a.orphan_reads_called,
+            secondary_skipped: a.secondary_skipped,
+            supplementary_skipped: a.supplementary_skipped,
         };
         b_into_a.add(&b);
 
@@ -1277,6 +1358,23 @@ mod tests {
         assert_eq!(a_into_b.calls_chg_unmeth, b_into_a.calls_chg_unmeth);
         assert_eq!(a_into_b.calls_chh_meth, b_into_a.calls_chh_meth);
         assert_eq!(a_into_b.calls_chh_unmeth, b_into_a.calls_chh_unmeth);
+        // `--allow_discordant` class counters also sum commutatively.
+        assert_eq!(
+            a_into_b.pairs_cross_chr_independent,
+            b_into_a.pairs_cross_chr_independent
+        );
+        assert_eq!(
+            a_into_b.pairs_same_chr_independent,
+            b_into_a.pairs_same_chr_independent
+        );
+        assert_eq!(a_into_b.orphan_reads_called, b_into_a.orphan_reads_called);
+        assert_eq!(a_into_b.secondary_skipped, b_into_a.secondary_skipped);
+        assert_eq!(
+            a_into_b.supplementary_skipped,
+            b_into_a.supplementary_skipped
+        );
+        assert_eq!(a_into_b.pairs_cross_chr_independent, 14); // 3 + 11
+        assert_eq!(a_into_b.orphan_reads_called, 18); // 5 + 13
         // Sanity sums:
         assert_eq!(a_into_b.records_processed, 350);
         assert_eq!(a_into_b.call_strings_processed, 700);
@@ -1331,6 +1429,7 @@ mod tests {
             parallel: 1,
             quiet: false,
             verbose: false,
+            allow_discordant: false,
         }
     }
 

--- a/rust/bismark/src/extractor/overlap.rs
+++ b/rust/bismark/src/extractor/overlap.rs
@@ -39,6 +39,8 @@
 //! iteration order (descending for OT R2 via `$start - $index`; ascending
 //! for OB R2 via `$start + $index`). Inherited from SAM CIGAR semantics.
 
+use rustc_hash::FxHashSet;
+
 use crate::io::{BismarkPair, BismarkStrand, CigarExt};
 
 use crate::extractor::call::MethCall;
@@ -131,6 +133,46 @@ pub fn drop_overlap(
         r2_calls.retain(|c| c.ref_pos < r1_ref_start);
     }
     Ok(r2_calls)
+}
+
+/// Generic reference-position overlap dedup for `--allow_discordant`
+/// **same-chromosome Independent** pairs.
+///
+/// Unlike [`drop_overlap`], this is **orientation-agnostic**: it does NOT
+/// assume the strand-implied FR geometry the half-plane predicates require.
+/// It drops every R2 call whose reference position is also called by R1 (R1's
+/// calls are kept), so an FF/RR or dovetailed-past overlapping same-chr pair —
+/// which [`drop_overlap`]'s half-plane `retain` would silently mangle — is
+/// deduplicated exactly, never double-counting the shared cytosines.
+///
+/// Independent same-chromosome pairs are **not** all span-disjoint: the
+/// [`crate::extractor::pair_class`] gate routes same-orientation (FF/RR) pairs
+/// to Independent regardless of geometry (they fail its complementary-
+/// orientation check before the span gate is even evaluated), and those may
+/// overlap and share reference positions. For such pairs this dedup is
+/// load-bearing — it is the reason overlapping FF/RR mates are not
+/// double-counted (see `same_chr_ff_overlapping_pair_not_double_counted`). It
+/// degenerates to a no-op for the genuinely span-disjoint Independent pairs
+/// (the complementary-orientation, geometry-disjoint case `pair_class` proves
+/// disjoint) and for opposite-strand-of-origin pairs (`OT`+`OB` / `CTOB`+`CTOT`,
+/// also routed to Independent): a top-strand and a bottom-strand cytosine never
+/// occupy the same reference position, so R1 and R2 share none and every call
+/// is kept, each attributed to its own strand. Together these make the
+/// Independent path exact for every geometry.
+///
+/// Only valid for **same-chromosome** pairs: cross-chromosome reference
+/// positions can coincide numerically but denote different loci, so the caller
+/// must NOT invoke this for cross-chr pairs.
+#[must_use]
+pub fn drop_overlap_generic(r1_calls: &[MethCall], mut r2_calls: Vec<MethCall>) -> Vec<MethCall> {
+    if r1_calls.is_empty() || r2_calls.is_empty() {
+        return r2_calls;
+    }
+    // `FxHashSet` (the repo's dedup convention, cf. `dedup::dedup`) over u32 ref
+    // positions — no cryptographic hashing needed for this per-pair dedup.
+    let r1_positions: FxHashSet<u32> = r1_calls.iter().map(|c| c.ref_pos).collect();
+    r2_calls.retain(|c| !r1_positions.contains(&c.ref_pos));
+    r2_calls
 }
 
 /// Forward-class pair strands: R1's mapped position is the upstream end of

--- a/rust/bismark/src/extractor/pair_class.rs
+++ b/rust/bismark/src/extractor/pair_class.rs
@@ -1,0 +1,307 @@
+//! Discordant-pair classification for `--allow_discordant`.
+//!
+//! A general-purpose bisulfite aligner emitting Bismark-format `XM`/`XR`/`XG`
+//! tags (unlike the Bismark aligner) also emits cross-chromosome pairs,
+//! same-chromosome discordant-orientation pairs, and half-mapped pairs. Under
+//! `--allow_discordant` the producer classifies each adjacent primary pair into
+//! one of two processing paths via [`classify_pair`].
+//!
+//! This module is shared by both `parallel.rs` (the shipping pipeline) and
+//! `pipeline.rs` (the single-threaded byte-identity reference) so the
+//! "parallel ≡ single-threaded" oracle stays valid for the new classes.
+//!
+//! ## Byte-identity
+//!
+//! [`classify_pair`] runs **only** under `--allow_discordant`. With the flag
+//! off, the producer forms pairs exactly as before (`from_mates` → `Pe`), so
+//! this code is never reached and the default path is unchanged.
+//!
+//! For every pair the Bismark aligner can emit (proper FR pairs whose two mates
+//! carry complementary strand classes — `OT`↔`CTOT`, `OB`↔`CTOB`), the result
+//! is always [`PairClass::Concordant`], so flag-on output on Bismark input is
+//! byte-identical to the default path (modulo the opt-in report section).
+
+use crate::extractor::overlap::is_forward_pair_strand;
+use crate::io::{BismarkPair, BismarkStrand};
+
+/// How a pair of adjacent primary records is processed under
+/// `--allow_discordant`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairClass {
+    /// Same reference id, proper FR orientation, geometry consistent with the
+    /// strand class → today's concordant path verbatim (pair-strand routing +
+    /// the Perl half-plane `drop_overlap`).
+    Concordant,
+    /// Different reference ids, OR same-chr with an orientation/geometry that
+    /// the half-plane `drop_overlap` cannot handle. Each mate is called
+    /// independently, single-end style. Same-chromosome overlaps are handled
+    /// by a generic reference-position dedup in the worker (`drop_overlap` is
+    /// NOT reused — its half-plane predicate is valid only for FR pairs).
+    Independent,
+}
+
+/// Classify an adjacent primary pair, evaluated only under `--allow_discordant`.
+///
+/// A pair is [`PairClass::Concordant`] iff **all** of:
+/// 1. `r1_refid == r2_refid` (same chromosome), AND
+/// 2. the two mates carry **complementary** strand classes — one forward
+///    (`OT`/`CTOB`), one reverse (`OB`/`CTOT`). Every Bismark FR pair satisfies
+///    this (`OT`↔`CTOT`, `OB`↔`CTOB`); a same-orientation (FF/RR) discordant
+///    pair does not, and `drop_overlap`'s half-plane predicate would silently
+///    mangle it — so it routes to [`PairClass::Independent`], AND
+/// 3. the two mates share a **strand of origin** — both top (`OT`/`CTOT`,
+///    `XG=CT`) or both bottom (`OB`/`CTOB`, `XG=GA`). Orientation (condition 2)
+///    is orthogonal to origin, so on its own it still admits the two
+///    opposite-origin combos an aligner can emit at a discordant locus but
+///    Bismark never does — `OT`+`OB` and `CTOB`+`CTOT`. Those route to
+///    [`PairClass::Independent`], where each mate is called against its own
+///    strand (see the check's inline comment for why routing them to
+///    `Concordant` would lose and mis-attribute the mate's calls), AND
+/// 4. the reference spans are consistent with the strand-implied direction
+///    (forward-class: R2 not entirely upstream of R1; reverse-class: R2 not
+///    entirely downstream). A pair failing this gate is provably span-disjoint
+///    (the annihilation case the half-plane predicate would drop wholesale), so
+///    routing it to `Independent` and calling both mates fully is exact.
+///
+/// Spans are **untrimmed** (independent of `--ignore_3prime`): trimming only
+/// shrinks R1's effective span, and the concordant cases hold for any shrinkage.
+///
+/// Conditions 2 and 3 are byte-neutral for Bismark input (every Bismark pair is
+/// complementary and same-origin) and only re-route pairs the Bismark aligner
+/// never emits; they keep same-orientation and opposite-origin overlapping pairs
+/// off the FR-only half-plane `drop_overlap` path.
+#[must_use]
+pub fn classify_pair(pair: &BismarkPair, r1_refid: usize, r2_refid: usize) -> PairClass {
+    if r1_refid != r2_refid {
+        return PairClass::Independent;
+    }
+
+    // Complementary-orientation check: a proper FR pair has one forward-class
+    // and one reverse-class mate. A same-orientation (FF/RR) pair fails this
+    // and must NOT take the half-plane `drop_overlap` path.
+    let r1_forward = is_forward_pair_strand(pair.r1().record_strand());
+    let r2_forward = is_forward_pair_strand(pair.r2().record_strand());
+    if r1_forward == r2_forward {
+        return PairClass::Independent;
+    }
+
+    // Strand-of-origin check. Forward/reverse orientation is ORTHOGONAL to which
+    // original strand a mate came from (the `XG` tag: `CT` = top {OT,CTOT},
+    // `GA` = bottom {OB,CTOB}). A genuine Bismark concordant pair has BOTH mates
+    // from the same original strand — `{OT,CTOT}` (both top) or `{OB,CTOB}`
+    // (both bottom). The orientation check alone still admits the two
+    // opposite-origin combos an aligner can emit at a discordant locus but
+    // Bismark never does — `OT`+`OB` and `CTOB`+`CTOT`. Routed to `Concordant`,
+    // those take the FR-only half-plane `drop_overlap`, which mis-drops the
+    // mate's overlap-region calls AND mis-attributes its surviving calls to R1's
+    // strand's output files (R2's genuinely opposite-strand cytosines are never
+    // at a ref position R1 also calls, so they are lost, not deduped). Require
+    // same origin and route the mismatches to `Independent`, where each mate is
+    // called against its own strand. Order-agnostic: non-directional libraries
+    // present a valid pair as `r1=CTOT, r2=OT` (see `from_mates_ctot_pair_non_directional`).
+    if is_top_origin(pair.r1().record_strand()) != is_top_origin(pair.r2().record_strand()) {
+        return PairClass::Independent;
+    }
+
+    // Geometry gate (untrimmed spans). `pair_strand()` is R1's record strand,
+    // so `r1_forward` is exactly `is_forward_pair_strand(pair.pair_strand())`.
+    let (Some(r1_start), Some(r2_start)) =
+        (pair.r1().alignment_start(), pair.r2().alignment_start())
+    else {
+        // A mapped primary always has an alignment start; defensively route a
+        // start-less record to Independent rather than risk a wrong drop.
+        return PairClass::Independent;
+    };
+    let r1_ref_end = reference_end_of(pair.r1(), r1_start);
+    let r2_ref_end = reference_end_of(pair.r2(), r2_start);
+
+    let concordant = if r1_forward {
+        // Forward-class (OT/CTOB): R1 is the upstream mate. R2 not entirely
+        // upstream of R1.
+        r2_ref_end >= r1_start
+    } else {
+        // Reverse-class (OB/CTOT): R1 is the downstream mate. R2 not entirely
+        // downstream of R1.
+        r2_start <= r1_ref_end
+    };
+
+    if concordant {
+        PairClass::Concordant
+    } else {
+        PairClass::Independent
+    }
+}
+
+/// Strand of origin (the `XG` tag): `true` for the top strand (`OT`/`CTOT`,
+/// `XG=CT`), `false` for the bottom strand (`OB`/`CTOB`, `XG=GA`). Two mates of
+/// a genuine Bismark concordant pair always agree on this.
+fn is_top_origin(strand: BismarkStrand) -> bool {
+    matches!(strand, BismarkStrand::OT | BismarkStrand::CTOT)
+}
+
+/// 1-based inclusive last reference position covered by `record`, from its
+/// 1-based `start` and its CIGAR (InDel-aware via [`crate::io::CigarExt`]).
+fn reference_end_of(record: &crate::io::BismarkRecord, start: usize) -> usize {
+    use crate::io::CigarExt;
+    record.cigar().reference_end(start)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::{BismarkPair, BismarkRecord, BismarkStrand};
+    use bstr::BString;
+    use noodles_core::Position;
+    use noodles_sam::alignment::record::Flags;
+    use noodles_sam::alignment::record::cigar::Op;
+    use noodles_sam::alignment::record::cigar::op::Kind;
+    use noodles_sam::alignment::record::data::field::Tag;
+    use noodles_sam::alignment::record_buf::data::field::Value;
+    use noodles_sam::alignment::record_buf::{Cigar, RecordBuf, Sequence};
+
+    /// Synthesize a single-`M` `BismarkRecord`.
+    fn synth(xr: &[u8], xg: &[u8], start: usize, len: usize, refid: usize) -> BismarkRecord {
+        let mut record = RecordBuf::default();
+        *record.name_mut() = Some(BString::from(b"q".to_vec()));
+        *record.flags_mut() = Flags::from(0x1);
+        *record.sequence_mut() = Sequence::from(vec![b'A'; len]);
+        *record.alignment_start_mut() = Some(Position::try_from(start).unwrap());
+        *record.reference_sequence_id_mut() = Some(refid);
+        *record.cigar_mut() = Cigar::from(vec![Op::new(Kind::Match, len)]);
+        let xm = vec![b'.'; len];
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XR"), Value::String(BString::from(xr.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
+        record
+            .data_mut()
+            .insert(Tag::from(*b"XM"), Value::String(BString::from(xm)));
+        BismarkRecord::from_noodles_record(record).unwrap()
+    }
+
+    /// OT R1 (XR=CT,XG=CT, forward), CTOT R2 (XR=GA,XG=CT, reverse): proper FR.
+    fn fr_pair(r1_start: usize, r2_start: usize, len: usize, refid: usize) -> BismarkPair {
+        let r1 = synth(b"CT", b"CT", r1_start, len, refid);
+        let r2 = synth(b"GA", b"CT", r2_start, len, refid);
+        assert_eq!(r1.record_strand(), BismarkStrand::OT);
+        assert_eq!(r2.record_strand(), BismarkStrand::CTOT);
+        BismarkPair::from_mates(r1, r2).unwrap()
+    }
+
+    #[test]
+    fn cross_chr_is_independent() {
+        let r1 = synth(b"CT", b"CT", 100, 50, 0);
+        let r2 = synth(b"GA", b"CT", 100, 50, 1);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(classify_pair(&pair, 0, 1), PairClass::Independent);
+    }
+
+    #[test]
+    fn forward_r2_downstream_disjoint_is_concordant() {
+        // OT R1 [100,149], CTOT R2 [200,249] — disjoint, R2 downstream.
+        let pair = fr_pair(100, 200, 50, 0);
+        assert_eq!(classify_pair(&pair, 0, 0), PairClass::Concordant);
+    }
+
+    #[test]
+    fn forward_dovetail_overlap_is_concordant() {
+        // OT R1 [100,149], CTOT R2 [90,139] — R2 starts upstream but overlaps.
+        let pair = fr_pair(100, 90, 50, 0);
+        assert_eq!(classify_pair(&pair, 0, 0), PairClass::Concordant);
+    }
+
+    #[test]
+    fn forward_r2_entirely_upstream_is_independent() {
+        // OT R1 [200,249], CTOT R2 [100,149] — R2 end (149) < R1 start (200).
+        let pair = fr_pair(200, 100, 50, 0);
+        assert_eq!(classify_pair(&pair, 0, 0), PairClass::Independent);
+    }
+
+    #[test]
+    fn forward_boundary_equality_is_concordant() {
+        // OT R1 [150,199], CTOT R2 [100,150] — r2_ref_end (150 == r1_start 150).
+        // Boundary equality routes to Concordant per the `>=` gate.
+        let r1 = synth(b"CT", b"CT", 150, 50, 0);
+        let r2 = synth(b"GA", b"CT", 100, 51, 0); // ends at 150
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(classify_pair(&pair, 0, 0), PairClass::Concordant);
+    }
+
+    #[test]
+    fn reverse_class_mirror_disjoint_is_independent() {
+        // OB R1 (XR=CT,XG=GA, reverse) [100,149], CTOB R2 (XR=GA,XG=GA, forward)
+        // [200,249] — R2 start (200) > R1 end (149) → Independent.
+        let r1 = synth(b"CT", b"GA", 100, 50, 0);
+        let r2 = synth(b"GA", b"GA", 200, 50, 0);
+        assert_eq!(r1.record_strand(), BismarkStrand::OB);
+        assert_eq!(r2.record_strand(), BismarkStrand::CTOB);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(classify_pair(&pair, 0, 0), PairClass::Independent);
+    }
+
+    #[test]
+    fn reverse_class_overlap_is_concordant() {
+        // OB R1 [100,149], CTOB R2 [120,169] — r2_start (120) <= r1_end (149).
+        let r1 = synth(b"CT", b"GA", 100, 50, 0);
+        let r2 = synth(b"GA", b"GA", 120, 50, 0);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(classify_pair(&pair, 0, 0), PairClass::Concordant);
+    }
+
+    #[test]
+    fn same_orientation_ff_pair_is_independent() {
+        // Both mates forward-class (OT R1 + CTOB R2, both forward) on the same
+        // chromosome, overlapping — a same-orientation (FF) discordant pair.
+        // The complementary-orientation check routes it to Independent even
+        // though the geometry gate alone would say Concordant.
+        let r1 = synth(b"CT", b"CT", 100, 50, 0); // OT (forward)
+        let r2 = synth(b"GA", b"GA", 120, 50, 0); // CTOB (forward)
+        assert_eq!(r1.record_strand(), BismarkStrand::OT);
+        assert_eq!(r2.record_strand(), BismarkStrand::CTOB);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(classify_pair(&pair, 0, 0), PairClass::Independent);
+    }
+
+    #[test]
+    fn opposite_origin_ot_ob_pair_is_independent() {
+        // OT R1 (forward, top-origin XG=CT) + OB R2 (reverse, bottom-origin
+        // XG=GA), same chr, OVERLAPPING. Complementary orientation passes, but
+        // the mates come from opposite original strands — a pair Bismark never
+        // emits. Must route to Independent (not Concordant), else drop_overlap
+        // would mis-drop/mis-attribute R2's bottom-strand calls.
+        let r1 = synth(b"CT", b"CT", 100, 50, 0); // OT
+        let r2 = synth(b"CT", b"GA", 120, 50, 0); // OB
+        assert_eq!(r1.record_strand(), BismarkStrand::OT);
+        assert_eq!(r2.record_strand(), BismarkStrand::OB);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(classify_pair(&pair, 0, 0), PairClass::Independent);
+    }
+
+    #[test]
+    fn opposite_origin_ctob_ctot_pair_is_independent() {
+        // CTOB R1 (forward, bottom-origin XG=GA) + CTOT R2 (reverse, top-origin
+        // XG=CT), same chr, overlapping. The mirror of the OT+OB case.
+        let r1 = synth(b"GA", b"GA", 100, 50, 0); // CTOB
+        let r2 = synth(b"GA", b"CT", 120, 50, 0); // CTOT
+        assert_eq!(r1.record_strand(), BismarkStrand::CTOB);
+        assert_eq!(r2.record_strand(), BismarkStrand::CTOT);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(classify_pair(&pair, 0, 0), PairClass::Independent);
+    }
+
+    #[test]
+    fn non_directional_swapped_order_ctot_ot_is_concordant() {
+        // Non-directional libraries can present a genuine top-origin pair in
+        // swapped file order: r1=CTOT (reverse), r2=OT (forward). Same origin
+        // (both top), complementary orientation, overlapping → must remain
+        // Concordant (the order-agnostic origin check must not regress this).
+        let r1 = synth(b"GA", b"CT", 120, 50, 0); // CTOT (reverse)
+        let r2 = synth(b"CT", b"CT", 100, 50, 0); // OT (forward)
+        assert_eq!(r1.record_strand(), BismarkStrand::CTOT);
+        assert_eq!(r2.record_strand(), BismarkStrand::OT);
+        let pair = BismarkPair::from_mates(r1, r2).unwrap();
+        assert_eq!(classify_pair(&pair, 0, 0), PairClass::Concordant);
+    }
+}

--- a/rust/bismark/src/extractor/parallel.rs
+++ b/rust/bismark/src/extractor/parallel.rs
@@ -72,8 +72,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::io::{
-    AlignmentKind, BismarkIoError, BismarkPair, BismarkRecord, BismarkStrand, ThreadedBamReader,
-    open_reader, open_reader_without_sort_check,
+    AlignmentKind, BismarkIoError, BismarkPair, BismarkRecord, BismarkStrand, ReadIdentity,
+    RecordFilter, SkipCounts, ThreadedBamReader, open_reader, open_reader_without_sort_check,
 };
 use crossbeam_channel::{Receiver, RecvError, Sender, bounded};
 
@@ -83,7 +83,8 @@ use crate::extractor::error::BismarkExtractorError;
 use crate::extractor::header::build_chr_name_table;
 use crate::extractor::mbias::MbiasTable;
 use crate::extractor::output::SplittingReport;
-use crate::extractor::overlap::drop_overlap;
+use crate::extractor::overlap::{drop_overlap, drop_overlap_generic};
+use crate::extractor::pair_class::{PairClass, classify_pair};
 use crate::extractor::pipeline::derive_basename;
 use crate::extractor::route::compute_yacht_columns;
 use crate::extractor::state::ExtractState;
@@ -127,6 +128,25 @@ pub(crate) enum WorkerInputItem {
     /// enum size proportional to the smallest variant
     /// (clippy::large_enum_variant); BismarkPair is ~2× BismarkRecord.
     Pe { pair: Box<BismarkPair>, chr_id: u32 },
+    /// NEW (`--allow_discordant`): a pair whose mates are called
+    /// **independently** (cross-chromosome, or same-chr with an orientation the
+    /// half-plane `drop_overlap` cannot handle). Carries BOTH chr ids since a
+    /// cross-chr pair has two. Constructed only under `--allow_discordant`.
+    PeIndependent {
+        pair: Box<BismarkPair>,
+        r1_chr_id: u32,
+        r2_chr_id: u32,
+    },
+    /// NEW (`--allow_discordant`): a mapped primary read whose mate is absent
+    /// (unmapped, so filtered upstream). Read identity comes from FLAG
+    /// 0x40/0x80 (a general aligner sets these truthfully; Bismark never emits
+    /// orphans, so the #1030 flag-swap concern does not apply). Called
+    /// single-end style.
+    Orphan {
+        record: BismarkRecord,
+        chr_id: u32,
+        identity: ReadIdentity,
+    },
     /// Error encountered by the producer (read error, unpaired final record,
     /// pairing error, refid overflow / missing). Carried as a per-item result
     /// so it keeps its within-batch slot for deterministic Err selection.
@@ -166,10 +186,13 @@ pub(crate) enum WorkerOutput {
     },
     /// Sent exactly once by each worker at exit (after `recv()` returns
     /// `Err(Disconnected)`). Carries this worker's accumulated counters.
-    /// Semantics UNCHANGED from the per-record design.
+    /// Semantics UNCHANGED from the per-record design. `report` is boxed to keep
+    /// this (rare, once-per-worker) variant from bloating the whole enum
+    /// (clippy::large_enum_variant) after the `--allow_discordant` counters grew
+    /// `SplittingReport`.
     FinalDelta {
         mbias: [MbiasTable; 2],
-        report: SplittingReport,
+        report: Box<SplittingReport>,
     },
 }
 
@@ -252,7 +275,7 @@ fn run_pipeline(
     // coordinate-sorted input is valid — faithful to Perl
     // `bismark_methylation_extractor`, which only sort-checks paired-end input
     // (`test_positional_sorting` is gated `if ($paired)`).
-    let reader = if is_bam {
+    let mut reader = if is_bam {
         if is_paired {
             ProducerReader::Threaded(ThreadedBamReader::from_path(input, DECODE_THREADS)?)
         } else {
@@ -268,6 +291,16 @@ fn run_pipeline(
             input, /*cram_ref=*/ None,
         )?)
     };
+    // `--allow_discordant`: drop + count secondary (0x100) / supplementary
+    // (0x800) records at the io layer, BEFORE record validation (a SEQ-less
+    // secondary can't construct a BismarkRecord) and BEFORE pairing (they break
+    // R1/R2 adjacency). Default (flag off) is a no-op filter → byte-identical.
+    if config.allow_discordant {
+        reader.set_filter(RecordFilter {
+            drop_secondary: true,
+            drop_supplementary: true,
+        });
+    }
     let chr_table: Arc<[String]> = Arc::from(build_chr_name_table(reader.header())?);
 
     // Console diagnostics (#882) — emit once on the main thread while we still
@@ -319,10 +352,17 @@ fn run_pipeline(
 
     // Spawn the producer on a dedicated thread.
     let producer_tx_input = tx_input.clone();
+    let allow_discordant = config.allow_discordant;
     let producer_handle = std::thread::Builder::new()
         .name("bismark-extractor-producer".to_string())
         .spawn(move || {
-            producer_loop(reader, is_paired, producer_tx_input, logger);
+            producer_loop(
+                reader,
+                is_paired,
+                allow_discordant,
+                producer_tx_input,
+                logger,
+            )
         })
         .map_err(|e| BismarkExtractorError::InternalError {
             message: format!("failed to spawn producer thread: {e}"),
@@ -348,6 +388,14 @@ fn run_pipeline(
     // Join producer last (it was almost certainly already done by the time
     // collector exited — its tx_input drop is what signaled EOS).
     let producer_join_result = producer_handle.join();
+    // Secondary/supplementary skip counts from the io filter (Copy; zero unless
+    // `--allow_discordant`). Extracted by-ref so the panic-precedence logic
+    // below can still move `producer_join_result` on the Err path.
+    let producer_skip_counts: SkipCounts = producer_join_result
+        .as_ref()
+        .ok()
+        .copied()
+        .unwrap_or_default();
 
     // Apply error precedence (Reviewer B C2 fix):
     //   1. Collector caught an explicit Err → use it (most specific —
@@ -401,6 +449,17 @@ fn run_pipeline(
             Err(e)
         }
         Ok(()) => {
+            // Fold the producer-local io-filter skip counts into the merged
+            // report (single add on the main thread, after the collector merged
+            // the per-worker deltas, before finalize writes the report).
+            state.report.secondary_skipped = state
+                .report
+                .secondary_skipped
+                .saturating_add(producer_skip_counts.secondary);
+            state.report.supplementary_skipped = state
+                .report
+                .supplementary_skipped
+                .saturating_add(producer_skip_counts.supplementary);
             state.finalize(config)?;
             Ok(())
         }
@@ -433,6 +492,20 @@ impl ProducerReader {
             ProducerReader::Threaded(r) => Box::new(r.records()),
         }
     }
+
+    fn set_filter(&mut self, filter: RecordFilter) {
+        match self {
+            ProducerReader::Any(r) => r.set_filter(filter),
+            ProducerReader::Threaded(r) => r.set_filter(filter),
+        }
+    }
+
+    fn skip_counts(&self) -> SkipCounts {
+        match self {
+            ProducerReader::Any(r) => r.skip_counts(),
+            ProducerReader::Threaded(r) => r.skip_counts(),
+        }
+    }
 }
 
 /// Producer loop: drive the reader's `records()` iterator, accumulate
@@ -447,10 +520,38 @@ impl ProducerReader {
 /// already buffered in the partial batch still ship (today they are emitted
 /// before the producer short-circuits; dropping them would break byte-identity
 /// on error inputs). The producer still `return`s after the first error.
+///
+/// Returns the reader's [`SkipCounts`] (secondary/supplementary dropped by the
+/// io-layer filter under `--allow_discordant`; all zero otherwise). `run_pipeline`
+/// folds it into the splitting report. `allow_discordant` selects the
+/// discordant-tolerant PE loop (orphan pushback + geometric classification);
+/// with the flag off the PE loop is exactly as before.
 fn producer_loop(
     mut reader: ProducerReader,
     is_paired: bool,
+    allow_discordant: bool,
     tx_input: Sender<InputBatch>,
+    logger: crate::extractor::logging::Logger,
+) -> SkipCounts {
+    // Drive the reader in an inner fn so its mutable borrow of `reader` (via
+    // `records()`) ends before we read the io-layer `skip_counts()`.
+    drive_reader(&mut reader, is_paired, allow_discordant, &tx_input, logger);
+    // tx_input drops here → channel disconnects → workers exit.
+    drop(tx_input);
+    // Secondary/supplementary counts accumulated by the io filter (zero unless
+    // `--allow_discordant` set the filter). Folded into the report by the caller.
+    reader.skip_counts()
+}
+
+/// Inner producer driver. Kept separate from [`producer_loop`] so the reader's
+/// mutable borrow (via `records()`) is released before `skip_counts()` is read.
+/// Holds the historical SE/PE loop control flow verbatim (the `return;`
+/// early-exits) plus the `--allow_discordant` PE branch.
+fn drive_reader(
+    reader: &mut ProducerReader,
+    is_paired: bool,
+    allow_discordant: bool,
+    tx_input: &Sender<InputBatch>,
     logger: crate::extractor::logging::Logger,
 ) {
     // `lines_read` counts every SAM record consumed (one per `records_iter.next()`
@@ -551,7 +652,7 @@ fn producer_loop(
                 None => break, // clean EOF
             }
         }
-    } else {
+    } else if !allow_discordant {
         // PE: take adjacent records, pair them on the producer thread; one item
         // per pair.
         loop {
@@ -635,6 +736,116 @@ fn producer_loop(
                 batch_seq += 1; // mid-loop flush continues → next seq
             }
         }
+    } else {
+        // PE with `--allow_discordant`: orphan-tolerant pairing (qname
+        // pre-compare + one-slot pushback) + geometric classification. Only
+        // reached under the flag; the flag-off PE loop above is unchanged.
+        //
+        // `pending` holds a record read as an R2 whose qname did not match its
+        // R1 (its mate was unmapped/filtered) — it becomes the next R1.
+        let mut pending: Option<BismarkRecord> = None;
+        loop {
+            // R1: from a pushed-back record (already ticked) or the next read.
+            let r1 = match pending.take() {
+                Some(r) => r,
+                None => match records_iter.next() {
+                    Some(Ok(r)) => {
+                        tick(&logger, &mut lines_read); // +1 SAM line (R1)
+                        r
+                    }
+                    Some(Err(e)) => {
+                        items.push(WorkerInputItem::Err { error: e.into() });
+                        let _ = flush_batch!();
+                        return;
+                    }
+                    None => break, // clean EOF
+                },
+            };
+            // R2.
+            let r2 = match records_iter.next() {
+                Some(Ok(r)) => {
+                    tick(&logger, &mut lines_read); // +1 SAM line (R2)
+                    r
+                }
+                Some(Err(e)) => {
+                    // R1 is a valid mapped primary → emit it as an orphan first,
+                    // then surface the read error (keeps R1's calls; deterministic
+                    // lower-index slot for the orphan).
+                    push_orphan(&mut items, r1);
+                    items.push(WorkerInputItem::Err { error: e.into() });
+                    let _ = flush_batch!();
+                    return;
+                }
+                None => {
+                    // EOF after R1: the historical `UnpairedFinalRecord` case is
+                    // now an orphan (its mate is simply absent).
+                    push_orphan(&mut items, r1);
+                    break;
+                }
+            };
+
+            // qname pre-compare via the shared pairing predicate (the same one
+            // `from_mates` uses). A mismatch means R1's mate was filtered/
+            // unmapped → R1 is an orphan, and R2 belongs to the next template
+            // (pushed back as the next R1).
+            if !BismarkPair::qnames_match(&r1, &r2) {
+                push_orphan(&mut items, r1);
+                pending = Some(r2);
+                if items.len() >= BATCH_SIZE {
+                    if !flush_batch!() {
+                        return;
+                    }
+                    batch_seq += 1;
+                }
+                continue;
+            }
+
+            // Resolve both refids (independent pairs carry two chr ids).
+            let r1_refid = match resolve_refid(r1.inner().reference_sequence_id(), "R1") {
+                Ok(v) => v,
+                Err(error) => {
+                    items.push(WorkerInputItem::Err { error });
+                    let _ = flush_batch!();
+                    return;
+                }
+            };
+            let r2_refid = match resolve_refid(r2.inner().reference_sequence_id(), "R2") {
+                Ok(v) => v,
+                Err(error) => {
+                    items.push(WorkerInputItem::Err { error });
+                    let _ = flush_batch!();
+                    return;
+                }
+            };
+
+            // qnames match → form the pair (Ok by construction) and classify.
+            let pair = match BismarkPair::from_mates(r1, r2) {
+                Ok(p) => p,
+                Err(e) => {
+                    items.push(WorkerInputItem::Err { error: e.into() });
+                    let _ = flush_batch!();
+                    return;
+                }
+            };
+            let item = match classify_pair(&pair, r1_refid as usize, r2_refid as usize) {
+                PairClass::Concordant => WorkerInputItem::Pe {
+                    pair: Box::new(pair),
+                    chr_id: r1_refid,
+                },
+                PairClass::Independent => WorkerInputItem::PeIndependent {
+                    pair: Box::new(pair),
+                    r1_chr_id: r1_refid,
+                    r2_chr_id: r2_refid,
+                },
+            };
+            items.push(item);
+            if items.len() >= BATCH_SIZE {
+                if !flush_batch!() {
+                    return; // all workers gone
+                }
+                batch_seq += 1; // mid-loop flush continues → next seq
+            }
+        }
     }
 
     // Flush the partial final batch at clean EOF (skip an empty trailing batch —
@@ -642,8 +853,38 @@ fn producer_loop(
     if !items.is_empty() {
         let _ = flush_batch!();
     }
-    // tx_input drops as this function returns → channel disconnects → workers exit.
-    drop(tx_input);
+    // `tx_input` is a borrow here; the owning `producer_loop` drops the survivor
+    // after this returns, disconnecting the channel so workers exit.
+}
+
+/// Resolve a record's `reference_sequence_id` to `u32` with a defensive
+/// `try_from` (matches the precedent in the flag-off PE loop / `process_se`).
+fn resolve_refid(refid: Option<usize>, mate: &str) -> Result<u32, BismarkExtractorError> {
+    match refid {
+        Some(r) => u32::try_from(r).map_err(|_| BismarkExtractorError::InternalError {
+            message: format!("PE {mate} reference_sequence_id {r} overflows u32"),
+        }),
+        None => Err(BismarkExtractorError::InternalError {
+            message: format!("PE {mate} missing reference_sequence_id"),
+        }),
+    }
+}
+
+/// Push an `--allow_discordant` orphan (a mapped primary whose mate is absent)
+/// into the batch. Read identity comes from the record's own FLAG bits. On a
+/// refid-resolution failure, pushes an `Err` item instead (keeping its slot for
+/// deterministic error selection).
+fn push_orphan(items: &mut Vec<WorkerInputItem>, record: BismarkRecord) {
+    let identity = record.read_identity();
+    let refid = record.inner().reference_sequence_id();
+    match resolve_refid(refid, "orphan") {
+        Ok(chr_id) => items.push(WorkerInputItem::Orphan {
+            record,
+            chr_id,
+            identity,
+        }),
+        Err(error) => items.push(WorkerInputItem::Err { error }),
+    }
 }
 
 // ─── Worker ──────────────────────────────────────────────────────────────────
@@ -716,6 +957,46 @@ fn worker_loop(
                                 Err(error) => WorkerOutputItem::Err { error },
                             }
                         }
+                        WorkerInputItem::PeIndependent {
+                            pair,
+                            r1_chr_id,
+                            r2_chr_id,
+                        } => {
+                            match process_pe_independent(
+                                &pair,
+                                r1_chr_id,
+                                r2_chr_id,
+                                &chr_table,
+                                &config,
+                                mbias_only,
+                                mbias_only,
+                                &mut mbias,
+                                &mut report,
+                            ) {
+                                Ok(routed_calls) => WorkerOutputItem::Ok { routed_calls },
+                                Err(error) => WorkerOutputItem::Err { error },
+                            }
+                        }
+                        WorkerInputItem::Orphan {
+                            record,
+                            chr_id,
+                            identity,
+                        } => {
+                            match process_orphan(
+                                &record,
+                                chr_id,
+                                identity,
+                                &chr_table,
+                                &config,
+                                mbias_only,
+                                mbias_only,
+                                &mut mbias,
+                                &mut report,
+                            ) {
+                                Ok(routed_calls) => WorkerOutputItem::Ok { routed_calls },
+                                Err(error) => WorkerOutputItem::Err { error },
+                            }
+                        }
                         // Forward a producer-side error; never short-circuit the
                         // batch (preserves within-batch index alignment).
                         WorkerInputItem::Err { error } => WorkerOutputItem::Err { error },
@@ -731,7 +1012,10 @@ fn worker_loop(
             }
             Err(RecvError) => {
                 // Channel disconnected (EOS). Emit FinalDelta and exit.
-                let _ = tx_output.send(WorkerOutput::FinalDelta { mbias, report });
+                let _ = tx_output.send(WorkerOutput::FinalDelta {
+                    mbias,
+                    report: Box::new(report),
+                });
                 return;
             }
         }
@@ -955,6 +1239,205 @@ fn process_pe(
     // `pipeline.rs:275-276` for the legacy single-threaded PE path.
     report.records_processed = report.records_processed.saturating_add(1);
     report.call_strings_processed = report.call_strings_processed.saturating_add(2);
+
+    Ok(routed_calls)
+}
+
+/// Process an `--allow_discordant` **Independent** pair on the worker thread:
+/// each mate is called independently (single-end style), routed by its OWN
+/// `record_strand()`, against its own chromosome. No `drop_overlap` (its
+/// half-plane predicate is only valid for FR pairs); instead, for a same-chr
+/// pair, R2 calls at reference positions R1 also calls are dropped via the
+/// orientation-agnostic [`drop_overlap_generic`] (gated on `--no_overlap`, like
+/// the concordant path). Cross-chr pairs share no reference locus, so no dedup.
+#[allow(clippy::too_many_arguments)]
+fn process_pe_independent(
+    pair: &BismarkPair,
+    r1_chr_id: u32,
+    r2_chr_id: u32,
+    chr_table: &Arc<[String]>,
+    config: &ResolvedConfig,
+    mbias_only_silence: bool,
+    mbias_only: bool,
+    mbias: &mut [MbiasTable; 2],
+    report: &mut SplittingReport,
+) -> Result<Vec<RoutedCall>, BismarkExtractorError> {
+    for chr_id in [r1_chr_id, r2_chr_id] {
+        if (chr_id as usize) >= chr_table.len() {
+            return Err(BismarkExtractorError::InternalError {
+                message: format!(
+                    "independent-pair chr_id {} out of range vs header (count {})",
+                    chr_id,
+                    chr_table.len()
+                ),
+            });
+        }
+    }
+
+    // Each mate routes by its OWN record strand (SE semantics) — the pair
+    // fragment model has broken down, so R1's strand is not R2's.
+    let r1_strand = pair.r1().record_strand();
+    let r2_strand = pair.r2().record_strand();
+
+    let r1_calls = extract_calls(
+        pair.r1(),
+        config.ignore_5p_r1,
+        config.ignore_3p_r1,
+        mbias_only_silence,
+    )?;
+    let r2_calls_raw = extract_calls(
+        pair.r2(),
+        config.ignore_5p_r2,
+        config.ignore_3p_r2,
+        mbias_only_silence,
+    )?;
+    // Same-chromosome overlapping pairs: dedup generically so shared cytosines
+    // are not double-counted (keep R1's, drop R2's at shared ref positions).
+    // Disjoint same-chr pairs share no positions → this is a no-op. Cross-chr:
+    // positions denote different loci → never dedup. Skipped under
+    // `--include_overlap` (config.no_overlap == false), matching the concordant
+    // path where `drop_overlap` is likewise skipped.
+    let r2_calls = if r1_chr_id == r2_chr_id && config.no_overlap {
+        drop_overlap_generic(&r1_calls, r2_calls_raw)
+    } else {
+        r2_calls_raw
+    };
+
+    let mode = config.output_mode;
+    let r1_qname_arc: Arc<[u8]> = qname_arc_for(pair.r1());
+    let r2_qname_arc: Arc<[u8]> = qname_arc_for(pair.r2());
+
+    let mut routed_calls: Vec<RoutedCall> = if mbias_only {
+        Vec::new()
+    } else {
+        Vec::with_capacity(r1_calls.len() + r2_calls.len())
+    };
+
+    // R1 — M-bias idx 0, own strand, own chromosome.
+    for call in r1_calls {
+        if !config.mbias_off {
+            let pos_1based = call.read_pos.saturating_add(1);
+            mbias[0].accumulate(call.context, pos_1based, call.methylated);
+        }
+        increment_counters(report, call);
+        if mbias_only {
+            continue;
+        }
+        let (yacht_col6, yacht_col7) = compute_yacht_columns(mode, pair.r1(), r1_strand)?;
+        routed_calls.push(RoutedCall {
+            call,
+            strand: r1_strand,
+            yacht_col6,
+            yacht_col7,
+            qname: Arc::clone(&r1_qname_arc),
+            chr_id: r1_chr_id,
+        });
+    }
+
+    // R2 — M-bias idx 1, own strand, own chromosome.
+    for call in r2_calls {
+        if !config.mbias_off {
+            let pos_1based = call.read_pos.saturating_add(1);
+            mbias[1].accumulate(call.context, pos_1based, call.methylated);
+        }
+        increment_counters(report, call);
+        if mbias_only {
+            continue;
+        }
+        let (yacht_col6, yacht_col7) = compute_yacht_columns(mode, pair.r2(), r2_strand)?;
+        routed_calls.push(RoutedCall {
+            call,
+            strand: r2_strand,
+            yacht_col6,
+            yacht_col7,
+            qname: Arc::clone(&r2_qname_arc),
+            chr_id: r2_chr_id,
+        });
+    }
+
+    // Same counter semantics as a concordant pair: one "line", two call strings.
+    report.records_processed = report.records_processed.saturating_add(1);
+    report.call_strings_processed = report.call_strings_processed.saturating_add(2);
+    // Class counter for the splitting-report section.
+    if r1_chr_id == r2_chr_id {
+        report.pairs_same_chr_independent = report.pairs_same_chr_independent.saturating_add(1);
+    } else {
+        report.pairs_cross_chr_independent = report.pairs_cross_chr_independent.saturating_add(1);
+    }
+
+    Ok(routed_calls)
+}
+
+/// Process an `--allow_discordant` **orphan** (a mapped primary whose mate was
+/// unmapped/filtered) on the worker thread. Called single-end style: trims
+/// selected by read identity (R1/Single → R1 trims, R2 → R2 trims), routed by
+/// the record's own `record_strand()`, M-bias slot by identity (R1/Single → 0,
+/// R2 → 1). No overlap dedup (there is no mate).
+#[allow(clippy::too_many_arguments)]
+fn process_orphan(
+    record: &BismarkRecord,
+    chr_id: u32,
+    identity: ReadIdentity,
+    chr_table: &Arc<[String]>,
+    config: &ResolvedConfig,
+    mbias_only_silence: bool,
+    mbias_only: bool,
+    mbias: &mut [MbiasTable; 2],
+    report: &mut SplittingReport,
+) -> Result<Vec<RoutedCall>, BismarkExtractorError> {
+    if (chr_id as usize) >= chr_table.len() {
+        return Err(BismarkExtractorError::InternalError {
+            message: format!(
+                "orphan chr_id {} out of range vs header (count {})",
+                chr_id,
+                chr_table.len()
+            ),
+        });
+    }
+
+    // R2 orphan uses R2 trims + M-bias slot 1; R1/Single use R1 trims + slot 0.
+    let (ignore_5p, ignore_3p, mbias_idx) = match identity {
+        ReadIdentity::R2 => (config.ignore_5p_r2, config.ignore_3p_r2, 1usize),
+        ReadIdentity::R1 | ReadIdentity::Single => {
+            (config.ignore_5p_r1, config.ignore_3p_r1, 0usize)
+        }
+    };
+
+    let strand = record.record_strand();
+    let calls = extract_calls(record, ignore_5p, ignore_3p, mbias_only_silence)?;
+
+    let mode = config.output_mode;
+    let qname_arc: Arc<[u8]> = qname_arc_for(record);
+    let mut routed_calls: Vec<RoutedCall> = if mbias_only {
+        Vec::new()
+    } else {
+        Vec::with_capacity(calls.len())
+    };
+
+    for call in calls {
+        if !config.mbias_off {
+            let pos_1based = call.read_pos.saturating_add(1);
+            mbias[mbias_idx].accumulate(call.context, pos_1based, call.methylated);
+        }
+        increment_counters(report, call);
+        if mbias_only {
+            continue;
+        }
+        let (yacht_col6, yacht_col7) = compute_yacht_columns(mode, record, strand)?;
+        routed_calls.push(RoutedCall {
+            call,
+            strand,
+            yacht_col6,
+            yacht_col7,
+            qname: Arc::clone(&qname_arc),
+            chr_id,
+        });
+    }
+
+    // An orphan is one read = one "line" = one call string.
+    report.records_processed = report.records_processed.saturating_add(1);
+    report.call_strings_processed = report.call_strings_processed.saturating_add(1);
+    report.orphan_reads_called = report.orphan_reads_called.saturating_add(1);
 
     Ok(routed_calls)
 }

--- a/rust/bismark/src/extractor/pipeline.rs
+++ b/rust/bismark/src/extractor/pipeline.rs
@@ -20,13 +20,17 @@
 
 use std::path::Path;
 
-use crate::io::{BismarkPair, ReadIdentity, open_reader, open_reader_without_sort_check};
+use crate::io::{
+    AnyReader, BismarkPair, BismarkRecord, ReadIdentity, open_reader,
+    open_reader_without_sort_check,
+};
 
 use crate::extractor::call::extract_calls;
 use crate::extractor::cli::ResolvedConfig;
 use crate::extractor::error::BismarkExtractorError;
 use crate::extractor::header::build_chr_name_table;
-use crate::extractor::overlap::drop_overlap;
+use crate::extractor::overlap::{drop_overlap, drop_overlap_generic};
+use crate::extractor::pair_class::{PairClass, classify_pair};
 use crate::extractor::route::route_call;
 use crate::extractor::state::ExtractState;
 
@@ -77,6 +81,14 @@ pub fn derive_basename(path: &Path) -> String {
 /// `parallel.rs::run_pipeline`.
 pub fn extract_se(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkExtractorError> {
     let mut reader = open_reader_without_sort_check(input, /*cram_ref=*/ None)?;
+    // `--allow_discordant` in SE mode enables only the io-layer 0x900 skip
+    // (a general aligner's SE output has supplementaries too). Default no-op.
+    if config.allow_discordant {
+        reader.set_filter(crate::io::RecordFilter {
+            drop_secondary: true,
+            drop_supplementary: true,
+        });
+    }
     // Rev 2: build chr_table from `&reader.header()` directly — no Header
     // clone (Reviewer B E2). The borrow is released before `reader.records()`
     // takes its own mutable borrow further down.
@@ -172,11 +184,24 @@ pub fn extract_se(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkEx
         state.report.call_strings_processed = state.report.call_strings_processed.saturating_add(1);
     }
 
+    // Fold the io-layer skip counts (secondary/supplementary) into the report
+    // before finalize. Zero unless `--allow_discordant` set the filter.
+    fold_skip_counts(&mut state, reader.skip_counts());
+
     // Post-loop: no `cleanup_partial_outputs` on finalize failure — the data
     // is already on disk, and the contract (state.rs::finalize doc) is that
     // post-finalize errors don't trigger cleanup.
     state.finalize(config)?;
     Ok(())
+}
+
+/// Fold io-layer [`crate::io::SkipCounts`] into a state's splitting report.
+fn fold_skip_counts(state: &mut ExtractState, sc: crate::io::SkipCounts) {
+    state.report.secondary_skipped = state.report.secondary_skipped.saturating_add(sc.secondary);
+    state.report.supplementary_skipped = state
+        .report
+        .supplementary_skipped
+        .saturating_add(sc.supplementary);
 }
 
 /// PE extraction main loop (Phase C).
@@ -226,10 +251,26 @@ pub fn extract_se(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkEx
 /// to remove all 12 partial files before propagating.
 pub fn extract_pe(input: &Path, config: &ResolvedConfig) -> Result<(), BismarkExtractorError> {
     let mut reader = open_reader(input, /*cram_ref=*/ None)?;
+    if config.allow_discordant {
+        reader.set_filter(crate::io::RecordFilter {
+            drop_secondary: true,
+            drop_supplementary: true,
+        });
+    }
     let chr_table = build_chr_name_table(reader.header())?;
 
     let input_basename = derive_basename(input);
     let mut state = ExtractState::new(config, input, &input_basename, /*is_paired=*/ true)?;
+
+    if config.allow_discordant {
+        if let Err(e) = extract_pe_discordant(&mut reader, &mut state, &chr_table, config) {
+            state.cleanup_partial_outputs();
+            return Err(e);
+        }
+        fold_skip_counts(&mut state, reader.skip_counts());
+        state.finalize(config)?;
+        return Ok(());
+    }
 
     let mut records = reader.records();
     loop {
@@ -370,5 +411,179 @@ fn handle_one_pair(
     for call in r2_calls {
         route_call(state, pair.r2(), chr, pair_strand, call, ReadIdentity::R2)?;
     }
+    Ok(())
+}
+
+/// `--allow_discordant` single-threaded PE driver (the byte-identity reference
+/// for `parallel.rs`'s discordant producer). Orphan-tolerant pairing (qname
+/// pre-compare + one-slot pushback) + geometric classification, dispatching to
+/// [`handle_one_pair`] (Concordant), [`handle_one_pair_independent`], or
+/// [`handle_one_orphan`]. Counter semantics mirror `parallel.rs`'s
+/// `process_pe` / `process_pe_independent` / `process_orphan` exactly.
+fn extract_pe_discordant(
+    reader: &mut AnyReader<std::io::BufReader<std::fs::File>, std::fs::File>,
+    state: &mut ExtractState,
+    chr_table: &[String],
+    config: &ResolvedConfig,
+) -> Result<(), BismarkExtractorError> {
+    let mut records = reader.records();
+    let mut pending: Option<BismarkRecord> = None;
+    loop {
+        // R1: a pushed-back record or the next read.
+        let r1 = match pending.take() {
+            Some(r) => r,
+            None => match records.next() {
+                Some(Ok(r)) => r,
+                Some(Err(e)) => return Err(e.into()),
+                None => break, // clean EOF
+            },
+        };
+        // R2.
+        let r2 = match records.next() {
+            Some(Ok(r)) => r,
+            Some(Err(e)) => {
+                // R1 is a valid mapped primary → call it as an orphan, then
+                // propagate the read error.
+                handle_one_orphan(&r1, state, chr_table, config)?;
+                return Err(e.into());
+            }
+            None => {
+                // EOF after R1: the historical `UnpairedFinalRecord` is now an
+                // orphan (its mate is simply absent).
+                handle_one_orphan(&r1, state, chr_table, config)?;
+                break;
+            }
+        };
+
+        // qname pre-compare via the shared pairing predicate (the same one
+        // `from_mates` uses). A mismatch → R1's mate was filtered/unmapped, so
+        // R1 is an orphan and R2 belongs to the next template.
+        if !BismarkPair::qnames_match(&r1, &r2) {
+            handle_one_orphan(&r1, state, chr_table, config)?;
+            pending = Some(r2);
+            continue;
+        }
+
+        let r1_refid = resolve_refid(r1.inner().reference_sequence_id(), "R1")?;
+        let r2_refid = resolve_refid(r2.inner().reference_sequence_id(), "R2")?;
+        let pair = BismarkPair::from_mates(r1, r2)?;
+        match classify_pair(&pair, r1_refid, r2_refid) {
+            PairClass::Concordant => {
+                handle_one_pair(&pair, state, chr_table, config)?;
+                state.report.records_processed = state.report.records_processed.saturating_add(1);
+                state.report.call_strings_processed =
+                    state.report.call_strings_processed.saturating_add(2);
+            }
+            PairClass::Independent => {
+                handle_one_pair_independent(&pair, state, chr_table, config, r1_refid, r2_refid)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a record's `reference_sequence_id` (`Option<usize>`) or fail with an
+/// `InternalError` (a mapped primary always has one).
+fn resolve_refid(refid: Option<usize>, mate: &str) -> Result<usize, BismarkExtractorError> {
+    refid.ok_or_else(|| BismarkExtractorError::InternalError {
+        message: format!("PE {mate} missing reference_sequence_id"),
+    })
+}
+
+/// Resolve a chromosome name from the table or fail with an `InternalError`.
+fn chr_name(chr_table: &[String], refid: usize) -> Result<&str, BismarkExtractorError> {
+    chr_table
+        .get(refid)
+        .map(String::as_str)
+        .ok_or_else(|| BismarkExtractorError::InternalError {
+            message: format!(
+                "refid {} out of range vs header (count {})",
+                refid,
+                chr_table.len()
+            ),
+        })
+}
+
+/// `--allow_discordant` Independent-pair handler (single-threaded reference for
+/// `parallel.rs::process_pe_independent`). Each mate called independently,
+/// routed by its own `record_strand`, against its own chromosome; same-chr
+/// overlaps deduped generically (keep R1) via [`drop_overlap_generic`].
+fn handle_one_pair_independent(
+    pair: &BismarkPair,
+    state: &mut ExtractState,
+    chr_table: &[String],
+    config: &ResolvedConfig,
+    r1_refid: usize,
+    r2_refid: usize,
+) -> Result<(), BismarkExtractorError> {
+    let r1_chr = chr_name(chr_table, r1_refid)?;
+    let r2_chr = chr_name(chr_table, r2_refid)?;
+    let r1_strand = pair.r1().record_strand();
+    let r2_strand = pair.r2().record_strand();
+    let mbias_only_silence = config.is_mbias_only();
+
+    let r1_calls = extract_calls(
+        pair.r1(),
+        config.ignore_5p_r1,
+        config.ignore_3p_r1,
+        mbias_only_silence,
+    )?;
+    let r2_calls_raw = extract_calls(
+        pair.r2(),
+        config.ignore_5p_r2,
+        config.ignore_3p_r2,
+        mbias_only_silence,
+    )?;
+    let r2_calls = if r1_refid == r2_refid && config.no_overlap {
+        drop_overlap_generic(&r1_calls, r2_calls_raw)
+    } else {
+        r2_calls_raw
+    };
+
+    for call in r1_calls {
+        route_call(state, pair.r1(), r1_chr, r1_strand, call, ReadIdentity::R1)?;
+    }
+    for call in r2_calls {
+        route_call(state, pair.r2(), r2_chr, r2_strand, call, ReadIdentity::R2)?;
+    }
+
+    state.report.records_processed = state.report.records_processed.saturating_add(1);
+    state.report.call_strings_processed = state.report.call_strings_processed.saturating_add(2);
+    if r1_refid == r2_refid {
+        state.report.pairs_same_chr_independent =
+            state.report.pairs_same_chr_independent.saturating_add(1);
+    } else {
+        state.report.pairs_cross_chr_independent =
+            state.report.pairs_cross_chr_independent.saturating_add(1);
+    }
+    Ok(())
+}
+
+/// `--allow_discordant` orphan handler (single-threaded reference for
+/// `parallel.rs::process_orphan`). Called single-end style: trims + M-bias slot
+/// by read identity, routed by the record's own `record_strand`.
+fn handle_one_orphan(
+    record: &BismarkRecord,
+    state: &mut ExtractState,
+    chr_table: &[String],
+    config: &ResolvedConfig,
+) -> Result<(), BismarkExtractorError> {
+    let identity = record.read_identity();
+    let refid = resolve_refid(record.inner().reference_sequence_id(), "orphan")?;
+    let chr = chr_name(chr_table, refid)?;
+    let strand = record.record_strand();
+    let (ignore_5p, ignore_3p) = match identity {
+        ReadIdentity::R2 => (config.ignore_5p_r2, config.ignore_3p_r2),
+        ReadIdentity::R1 | ReadIdentity::Single => (config.ignore_5p_r1, config.ignore_3p_r1),
+    };
+    let calls = extract_calls(record, ignore_5p, ignore_3p, config.is_mbias_only())?;
+    for call in calls {
+        // `route_call` selects the M-bias slot from `identity` (R2 → 1, else 0),
+        // matching `process_orphan`.
+        route_call(state, record, chr, strand, call, identity)?;
+    }
+    state.report.records_processed = state.report.records_processed.saturating_add(1);
+    state.report.call_strings_processed = state.report.call_strings_processed.saturating_add(1);
+    state.report.orphan_reads_called = state.report.orphan_reads_called.saturating_add(1);
     Ok(())
 }

--- a/rust/bismark/src/extractor/state.rs
+++ b/rust/bismark/src/extractor/state.rs
@@ -197,7 +197,22 @@ impl ExtractState {
         // Console final methylation summary (#882) — mirror of the
         // splitting-report numbers, Perl `warn`'d at :2480-:2521. Emitted
         // regardless of `--report` (Perl always warns it); gated by --quiet.
-        logger.final_summary(&self.report);
+        logger.final_summary(&self.report, config.allow_discordant);
+
+        // `--allow_discordant` guardrail: a massive orphan rate usually means
+        // the input is not name-grouped (so almost every read looks unpaired).
+        // Warn (a genuine warning, never gated by --quiet) without failing —
+        // opt-in tolerance shouldn't silently degrade a corrupted file.
+        if config.allow_discordant && self.report.records_processed > 0 {
+            // > 20% orphans: orphan_reads_called * 5 > records_processed.
+            if self.report.orphan_reads_called.saturating_mul(5) > self.report.records_processed {
+                eprintln!(
+                    "warning: --allow_discordant: {} of {} records are orphans (>20%); \
+                     input may not be name-grouped (query-sorted / name-collated)",
+                    self.report.orphan_reads_called, self.report.records_processed
+                );
+            }
+        }
         if !config.mbias_off {
             let mbias_path = mbias_txt_path(&config.output_dir, &self.input_path);
             write_mbias_txt(&mbias_path, &self.mbias, self.is_paired)?;
@@ -317,6 +332,7 @@ mod tests {
             parallel: 1,
             quiet: false,
             verbose: false,
+            allow_discordant: false,
         }
     }
 

--- a/rust/bismark/src/io/mod.rs
+++ b/rust/bismark/src/io/mod.rs
@@ -32,8 +32,8 @@ pub use error::BismarkIoError;
 pub use genome::{Genome, GenomeError};
 pub use pair::BismarkPair;
 pub use read::{
-    AlignmentKind, AnyReader, BamReader, CramReader, SamReader, ThreadedBamReader,
-    detect_paired_from_header, open_reader, open_reader_without_sort_check,
+    AlignmentKind, AnyReader, BamReader, CramReader, RecordFilter, SamReader, SkipCounts,
+    ThreadedBamReader, detect_paired_from_header, open_reader, open_reader_without_sort_check,
 };
 pub use record::{AlignedXmCall, BismarkRecord, ReadIdentity, Umi};
 pub use strand::BismarkStrand;

--- a/rust/bismark/src/io/pair.rs
+++ b/rust/bismark/src/io/pair.rs
@@ -63,11 +63,18 @@ impl BismarkPair {
         // is feeding us nameless reads, surfacing a MateMismatch here would
         // be misleading. Real corruption would manifest as one name set and
         // the other missing, which still triggers MateMismatch correctly.
-        let r1_name_opt = r1.inner().name();
-        let r2_name_opt = r2.inner().name();
-        let r1_bytes: &[u8] = r1_name_opt.as_ref().map_or(b"", |n| AsRef::as_ref(*n));
-        let r2_bytes: &[u8] = r2_name_opt.as_ref().map_or(b"", |n| AsRef::as_ref(*n));
-        if r1_bytes != r2_bytes {
+        if !Self::qnames_match(&r1, &r2) {
+            // Cold path: allocate the names only to build the error.
+            let r1_bytes: &[u8] = r1
+                .inner()
+                .name()
+                .as_ref()
+                .map_or(b"", |n| AsRef::as_ref(*n));
+            let r2_bytes: &[u8] = r2
+                .inner()
+                .name()
+                .as_ref()
+                .map_or(b"", |n| AsRef::as_ref(*n));
             return Err(BismarkIoError::MateMismatch {
                 r1_qname: r1_bytes.to_vec(),
                 r2_qname: r2_bytes.to_vec(),
@@ -80,6 +87,23 @@ impl BismarkPair {
             r2,
             pair_strand,
         })
+    }
+
+    /// The pairing predicate: `true` iff `r1` and `r2` carry the same query
+    /// name. Borrow-compare only (no allocation) — at 27M+ pairs per PE run the
+    /// cheap path matters. Both-nameless compares equal (treated as matching,
+    /// per [`Self::from_mates`]); exactly one nameless is a mismatch.
+    ///
+    /// This is the single source of truth for R1/R2 adjacency. `from_mates`
+    /// uses it, and `--allow_discordant`'s producers call it to pre-check
+    /// adjacency without constructing (and failing) a pair.
+    #[must_use]
+    pub fn qnames_match(r1: &BismarkRecord, r2: &BismarkRecord) -> bool {
+        let r1_name_opt = r1.inner().name();
+        let r2_name_opt = r2.inner().name();
+        let r1_bytes: &[u8] = r1_name_opt.as_ref().map_or(b"", |n| AsRef::as_ref(*n));
+        let r2_bytes: &[u8] = r2_name_opt.as_ref().map_or(b"", |n| AsRef::as_ref(*n));
+        r1_bytes == r2_bytes
     }
 
     /// Library-level strand classification, derived from R1.

--- a/rust/bismark/src/io/read.rs
+++ b/rust/bismark/src/io/read.rs
@@ -49,6 +49,34 @@ use noodles_sam::header::record::value::map::header::tag::SORT_ORDER;
 use crate::io::error::BismarkIoError;
 use crate::io::record::BismarkRecord;
 
+/// Per-record iterator filter: which record classes (beyond the always-on
+/// unmapped `0x4` drop) to silently skip + count.
+///
+/// [`RecordFilter::default()`] disables both flags, so the reader's iterator
+/// behaves bit-for-bit like the historical unmapped-only filter. Set via a
+/// reader's `set_filter`; used by `bismark-extractor`'s `--allow_discordant`
+/// mode to consume general-aligner output (which — unlike Bismark — emits
+/// secondary/supplementary alignments) without a `samtools view -F 0x900`
+/// pre-filter. The counts are surfaced afterwards via `skip_counts()`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RecordFilter {
+    /// Drop (and count) secondary alignments (SAM FLAG `0x100`).
+    pub drop_secondary: bool,
+    /// Drop (and count) supplementary alignments (SAM FLAG `0x800`).
+    pub drop_supplementary: bool,
+}
+
+/// Running counts of records dropped by a [`RecordFilter`]. Interior-mutable
+/// (`Cell`) inside each reader, single-threaded on the producer, read once at
+/// EOF via `skip_counts()`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SkipCounts {
+    /// Secondary alignments (FLAG `0x100`) dropped.
+    pub secondary: u64,
+    /// Supplementary alignments (FLAG `0x800`) dropped.
+    pub supplementary: u64,
+}
+
 /// Recognised input file kinds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AlignmentKind {
@@ -216,6 +244,8 @@ fn detect_cram_magic(
 pub struct BamReader<R: BufRead> {
     inner: noodles_bam::io::Reader<noodles_bgzf::io::Reader<R>>,
     header: Header,
+    filter: RecordFilter,
+    skip_counts: std::cell::Cell<SkipCounts>,
 }
 
 impl BamReader<BufReader<File>> {
@@ -247,7 +277,12 @@ impl<R: BufRead> BamReader<R> {
         let mut inner = noodles_bam::io::Reader::new(reader);
         let header = inner.read_header()?;
         check_not_coordinate_sorted(&header)?;
-        Ok(Self { inner, header })
+        Ok(Self {
+            inner,
+            header,
+            filter: RecordFilter::default(),
+            skip_counts: std::cell::Cell::default(),
+        })
     }
 
     /// Construct without rejecting coordinate-sorted input. For SE-only
@@ -256,7 +291,12 @@ impl<R: BufRead> BamReader<R> {
     pub fn without_sort_check(reader: R) -> Result<Self, BismarkIoError> {
         let mut inner = noodles_bam::io::Reader::new(reader);
         let header = inner.read_header()?;
-        Ok(Self { inner, header })
+        Ok(Self {
+            inner,
+            header,
+            filter: RecordFilter::default(),
+            skip_counts: std::cell::Cell::default(),
+        })
     }
 
     /// Header from the BAM file.
@@ -264,13 +304,29 @@ impl<R: BufRead> BamReader<R> {
         &self.header
     }
 
+    /// Set the per-record iterator [`RecordFilter`] (secondary/supplementary
+    /// skip). Default is a no-op filter; setting it is byte-neutral for all
+    /// records except the flagged classes.
+    pub fn set_filter(&mut self, filter: RecordFilter) {
+        self.filter = filter;
+    }
+
+    /// Records skipped by [`RecordFilter`] so far. Read once at EOF.
+    pub fn skip_counts(&self) -> SkipCounts {
+        self.skip_counts.get()
+    }
+
     /// Iterator yielding one [`BismarkRecord`] per mapped alignment.
-    /// Unmapped reads (SAM FLAG & 0x4) are silently filtered.
+    /// Unmapped reads (SAM FLAG & 0x4) are silently filtered; secondary
+    /// (`0x100`) / supplementary (`0x800`) are additionally skipped + counted
+    /// iff the [`RecordFilter`] enables it (default: no).
     pub fn records(&mut self) -> impl Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_ {
         let header = &self.header;
+        let filter = self.filter;
+        let counts = &self.skip_counts;
         self.inner
             .record_bufs(header)
-            .filter_map(filter_unmapped_then_classify)
+            .filter_map(move |item| filter_then_classify(item, filter, counts))
     }
 
     /// Iterator yielding one [`BismarkRecord`] per mapped alignment, with
@@ -317,6 +373,8 @@ impl<R: BufRead> BamReader<R> {
 pub struct ThreadedBamReader {
     inner: noodles_bam::io::Reader<noodles_bgzf::io::MultithreadedReader<File>>,
     header: Header,
+    filter: RecordFilter,
+    skip_counts: std::cell::Cell<SkipCounts>,
 }
 
 impl ThreadedBamReader {
@@ -336,7 +394,12 @@ impl ThreadedBamReader {
         let mut inner = noodles_bam::io::Reader::from(bgzf);
         let header = inner.read_header()?;
         check_not_coordinate_sorted(&header)?;
-        Ok(Self { inner, header })
+        Ok(Self {
+            inner,
+            header,
+            filter: RecordFilter::default(),
+            skip_counts: std::cell::Cell::default(),
+        })
     }
 
     /// Open a BAM file with `parallel` workers, without rejecting
@@ -349,7 +412,12 @@ impl ThreadedBamReader {
         let bgzf = noodles_bgzf::io::MultithreadedReader::with_worker_count(parallel, file);
         let mut inner = noodles_bam::io::Reader::from(bgzf);
         let header = inner.read_header()?;
-        Ok(Self { inner, header })
+        Ok(Self {
+            inner,
+            header,
+            filter: RecordFilter::default(),
+            skip_counts: std::cell::Cell::default(),
+        })
     }
 
     /// Header from the BAM file.
@@ -357,13 +425,26 @@ impl ThreadedBamReader {
         &self.header
     }
 
+    /// Set the per-record iterator [`RecordFilter`] (see [`BamReader::set_filter`]).
+    pub fn set_filter(&mut self, filter: RecordFilter) {
+        self.filter = filter;
+    }
+
+    /// Records skipped by [`RecordFilter`] so far. Read once at EOF.
+    pub fn skip_counts(&self) -> SkipCounts {
+        self.skip_counts.get()
+    }
+
     /// Iterator yielding one [`BismarkRecord`] per mapped alignment.
-    /// Unmapped reads (SAM FLAG & 0x4) are silently filtered.
+    /// Unmapped reads (SAM FLAG & 0x4) are silently filtered; secondary /
+    /// supplementary skipped + counted iff the [`RecordFilter`] enables it.
     pub fn records(&mut self) -> impl Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_ {
         let header = &self.header;
+        let filter = self.filter;
+        let counts = &self.skip_counts;
         self.inner
             .record_bufs(header)
-            .filter_map(filter_unmapped_then_classify)
+            .filter_map(move |item| filter_then_classify(item, filter, counts))
     }
 
     /// As [`Self::records`] but pre-extracts a UMI from each record's
@@ -384,6 +465,8 @@ impl ThreadedBamReader {
 pub struct SamReader<R: BufRead> {
     inner: noodles_sam::io::Reader<R>,
     header: Header,
+    filter: RecordFilter,
+    skip_counts: std::cell::Cell<SkipCounts>,
 }
 
 impl SamReader<BufReader<File>> {
@@ -411,14 +494,24 @@ impl<R: BufRead> SamReader<R> {
         let mut inner = noodles_sam::io::Reader::new(reader);
         let header = inner.read_header()?;
         check_not_coordinate_sorted(&header)?;
-        Ok(Self { inner, header })
+        Ok(Self {
+            inner,
+            header,
+            filter: RecordFilter::default(),
+            skip_counts: std::cell::Cell::default(),
+        })
     }
 
     /// Construct without rejecting coordinate-sorted input.
     pub fn without_sort_check(reader: R) -> Result<Self, BismarkIoError> {
         let mut inner = noodles_sam::io::Reader::new(reader);
         let header = inner.read_header()?;
-        Ok(Self { inner, header })
+        Ok(Self {
+            inner,
+            header,
+            filter: RecordFilter::default(),
+            skip_counts: std::cell::Cell::default(),
+        })
     }
 
     /// Header from the SAM file.
@@ -426,12 +519,24 @@ impl<R: BufRead> SamReader<R> {
         &self.header
     }
 
+    /// Set the per-record iterator [`RecordFilter`] (see [`BamReader::set_filter`]).
+    pub fn set_filter(&mut self, filter: RecordFilter) {
+        self.filter = filter;
+    }
+
+    /// Records skipped by [`RecordFilter`] so far. Read once at EOF.
+    pub fn skip_counts(&self) -> SkipCounts {
+        self.skip_counts.get()
+    }
+
     /// Iterator yielding one [`BismarkRecord`] per mapped alignment.
     pub fn records(&mut self) -> impl Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_ {
         let header = &self.header;
+        let filter = self.filter;
+        let counts = &self.skip_counts;
         self.inner
             .record_bufs(header)
-            .filter_map(filter_unmapped_then_classify)
+            .filter_map(move |item| filter_then_classify(item, filter, counts))
     }
 
     /// As [`Self::records`] but pre-extracts a UMI per record. See
@@ -457,6 +562,8 @@ impl<R: BufRead> SamReader<R> {
 pub struct CramReader<R: Read + Seek> {
     inner: noodles_cram::io::Reader<R>,
     header: Header,
+    filter: RecordFilter,
+    skip_counts: std::cell::Cell<SkipCounts>,
 }
 
 impl CramReader<File> {
@@ -469,7 +576,12 @@ impl CramReader<File> {
             .build_from_path(path)?;
         let header = inner.read_header()?;
         check_not_coordinate_sorted(&header)?;
-        Ok(Self { inner, header })
+        Ok(Self {
+            inner,
+            header,
+            filter: RecordFilter::default(),
+            skip_counts: std::cell::Cell::default(),
+        })
     }
 
     /// Open without the coordinate-sort check. For SE-only callers.
@@ -482,7 +594,12 @@ impl CramReader<File> {
             .set_reference_sequence_repository(repo)
             .build_from_path(path)?;
         let header = inner.read_header()?;
-        Ok(Self { inner, header })
+        Ok(Self {
+            inner,
+            header,
+            filter: RecordFilter::default(),
+            skip_counts: std::cell::Cell::default(),
+        })
     }
 }
 
@@ -492,13 +609,26 @@ impl<R: Read + Seek> CramReader<R> {
         &self.header
     }
 
+    /// Set the per-record iterator [`RecordFilter`] (see [`BamReader::set_filter`]).
+    pub fn set_filter(&mut self, filter: RecordFilter) {
+        self.filter = filter;
+    }
+
+    /// Records skipped by [`RecordFilter`] so far. Read once at EOF.
+    pub fn skip_counts(&self) -> SkipCounts {
+        self.skip_counts.get()
+    }
+
     /// Iterator yielding one [`BismarkRecord`] per mapped alignment.
-    /// Unmapped reads are silently filtered.
+    /// Unmapped reads are silently filtered; secondary / supplementary
+    /// skipped + counted iff the [`RecordFilter`] enables it.
     pub fn records(&mut self) -> impl Iterator<Item = Result<BismarkRecord, BismarkIoError>> + '_ {
         let header = &self.header;
+        let filter = self.filter;
+        let counts = &self.skip_counts;
         self.inner
             .records(header)
-            .filter_map(filter_unmapped_then_classify)
+            .filter_map(move |item| filter_then_classify(item, filter, counts))
     }
 
     /// As [`Self::records`] but pre-extracts a UMI per record. See
@@ -539,6 +669,25 @@ impl<R: BufRead, RC: Read + Seek> AnyReader<R, RC> {
             Self::Bam(r) => r.header(),
             Self::Sam(r) => r.header(),
             Self::Cram(r) => r.header(),
+        }
+    }
+
+    /// Set the per-record iterator [`RecordFilter`] on the underlying reader
+    /// (see [`BamReader::set_filter`]).
+    pub fn set_filter(&mut self, filter: RecordFilter) {
+        match self {
+            Self::Bam(r) => r.set_filter(filter),
+            Self::Sam(r) => r.set_filter(filter),
+            Self::Cram(r) => r.set_filter(filter),
+        }
+    }
+
+    /// Records skipped by [`RecordFilter`] so far. Read once at EOF.
+    pub fn skip_counts(&self) -> SkipCounts {
+        match self {
+            Self::Bam(r) => r.skip_counts(),
+            Self::Sam(r) => r.skip_counts(),
+            Self::Cram(r) => r.skip_counts(),
         }
     }
 
@@ -626,25 +775,49 @@ pub fn open_reader_without_sort_check(
 }
 
 /// Filter out unmapped records (FLAG & 0x4) and classify the rest as
-/// [`BismarkRecord`]. Surfaces noodles I/O errors and `BismarkIoError`
-/// from classification.
-fn filter_unmapped_then_classify(
+/// [`BismarkRecord`], honouring a [`RecordFilter`]: after the always-on
+/// unmapped (`0x4`) drop, secondary (`0x100`) and supplementary (`0x800`)
+/// records are skipped + counted into `counts` iff the corresponding filter
+/// flag is set. Surfaces noodles I/O errors and `BismarkIoError` from
+/// classification.
+///
+/// With [`RecordFilter::default()`] (both flags `false`) the two extra branches
+/// test constant `false` and are byte-for-byte identical to the historical
+/// unmapped-only filter — no record dropped, no count taken. This is the
+/// mechanism behind `--allow_discordant`'s off-by-default guarantee.
+fn filter_then_classify(
     item: std::io::Result<RecordBuf>,
+    filter: RecordFilter,
+    counts: &std::cell::Cell<SkipCounts>,
 ) -> Option<Result<BismarkRecord, BismarkIoError>> {
     match item {
         Ok(rec) => {
             let flags = u16::from(rec.flags());
             if (flags & 0x4) != 0 {
-                None // unmapped — silently drop
-            } else {
-                Some(BismarkRecord::from_noodles_record(rec))
+                return None; // unmapped — silently drop (always)
             }
+            // Each dropped record is counted exactly once. A record with BOTH
+            // 0x100 and 0x800 set (rare) is attributed to `secondary` by this
+            // check-order precedence; the total dropped is still correct.
+            if filter.drop_secondary && (flags & 0x100) != 0 {
+                let mut c = counts.get();
+                c.secondary = c.secondary.saturating_add(1);
+                counts.set(c);
+                return None;
+            }
+            if filter.drop_supplementary && (flags & 0x800) != 0 {
+                let mut c = counts.get();
+                c.supplementary = c.supplementary.saturating_add(1);
+                counts.set(c);
+                return None;
+            }
+            Some(BismarkRecord::from_noodles_record(rec))
         }
         Err(e) => Some(Err(BismarkIoError::Io(e))),
     }
 }
 
-/// Companion to [`filter_unmapped_then_classify`] that also pre-extracts
+/// Companion to [`filter_then_classify`] that also pre-extracts
 /// the UMI via `extractor`. Used by `records_with_umi` on all reader
 /// variants. Added in v1.0.0-beta.5 for Phase B of the v1.2 UMI epic.
 fn filter_unmapped_then_classify_with_umi(

--- a/rust/bismark/tests/extractor_allow_discordant.rs
+++ b/rust/bismark/tests/extractor_allow_discordant.rs
@@ -1,0 +1,763 @@
+//! End-to-end tests for the opt-in `--allow_discordant` mode, which lets the
+//! methylation extractor call methylation on records the Bismark aligner never
+//! emits (cross-chromosome / same-chromosome discordant pairs, orphans, and —
+//! skipped — secondary/supplementary alignments), so it can consume a
+//! general-purpose bisulfite aligner's Bismark-format output directly instead
+//! of requiring a `samtools view -f 0x2 -F 0x900` pre-filter.
+//!
+//! Each new-class row is run twice: with the flag (asserting calls emitted +
+//! correct counters) and without (asserting today's exact error / behaviour is
+//! unchanged). Plus a flag-on ≡ flag-off byte-identity lock on concordant-only
+//! input and a `--parallel` invariant on a mixed fixture.
+//!
+//! Harness style mirrors `tests/extractor_nondir_swapped_flags_1030.rs`.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use bismark::extractor::cli::Cli;
+use bismark::extractor::{extract_pe, extract_pe_parallel};
+use bismark::io::{BamWriter, BismarkRecord};
+use bstr::BString;
+use clap::Parser;
+use noodles_core::Position;
+use noodles_sam::Header;
+use noodles_sam::alignment::RecordBuf;
+use noodles_sam::alignment::record::Flags;
+use noodles_sam::alignment::record::cigar::Op;
+use noodles_sam::alignment::record::cigar::op::Kind;
+use noodles_sam::alignment::record::data::field::Tag;
+use noodles_sam::alignment::record_buf::data::field::Value;
+use noodles_sam::alignment::record_buf::{Cigar, Sequence};
+use noodles_sam::header::record::value::Map;
+use noodles_sam::header::record::value::map::ReferenceSequence;
+use std::num::NonZeroUsize;
+
+// ───────────────────────────── helpers ─────────────────────────────────
+
+fn header_two_chr() -> Header {
+    let mut header = Header::default();
+    for name in ["chr1", "chr2"] {
+        header.reference_sequences_mut().insert(
+            BString::from(name),
+            Map::<ReferenceSequence>::new(NonZeroUsize::try_from(1_000_000).unwrap()),
+        );
+    }
+    header
+}
+
+/// One record to write: a validated Bismark record, or a raw noodles record
+/// (for unmapped / SEQ-less secondary records that cannot construct a
+/// `BismarkRecord`).
+enum Rec {
+    Bism(BismarkRecord),
+    Raw(RecordBuf),
+}
+
+/// Build a Bismark-shaped record (`M`-only CIGAR) on the given `refid`.
+#[allow(clippy::too_many_arguments)]
+fn synth(
+    qname: &[u8],
+    xr: &[u8],
+    xg: &[u8],
+    xm: &[u8],
+    start: usize,
+    refid: usize,
+    flags: u16,
+) -> BismarkRecord {
+    let mut record = RecordBuf::default();
+    *record.name_mut() = Some(BString::from(qname.to_vec()));
+    *record.flags_mut() = Flags::from(flags);
+    *record.reference_sequence_id_mut() = Some(refid);
+    *record.alignment_start_mut() = Some(Position::try_from(start).unwrap());
+    *record.cigar_mut() = Cigar::from(vec![Op::new(Kind::Match, xm.len())]);
+    *record.sequence_mut() = Sequence::from(vec![b'A'; xm.len()]);
+    record
+        .data_mut()
+        .insert(Tag::from(*b"XR"), Value::String(BString::from(xr.to_vec())));
+    record
+        .data_mut()
+        .insert(Tag::from(*b"XG"), Value::String(BString::from(xg.to_vec())));
+    record
+        .data_mut()
+        .insert(Tag::from(*b"XM"), Value::String(BString::from(xm.to_vec())));
+    BismarkRecord::from_noodles_record(record).unwrap()
+}
+
+/// A raw unmapped mate (FLAG 0x4): no Bismark tags. The io filter drops it (via
+/// the always-on 0x4 check) before validation, leaving its mate an orphan.
+fn raw_unmapped(qname: &[u8], flags: u16) -> RecordBuf {
+    let mut record = RecordBuf::default();
+    *record.name_mut() = Some(BString::from(qname.to_vec()));
+    *record.flags_mut() = Flags::from(flags | 0x4);
+    *record.sequence_mut() = Sequence::from(vec![b'A'; 10]);
+    record
+}
+
+/// A raw secondary alignment (FLAG 0x100) with `SEQ='*'` and no XM — the bwa
+/// convention. Cannot construct a `BismarkRecord`; under the flag it is skipped
+/// at the io layer, without it, it hard-errors at record construction.
+fn raw_secondary(qname: &[u8], start: usize, refid: usize) -> RecordBuf {
+    let mut record = RecordBuf::default();
+    *record.name_mut() = Some(BString::from(qname.to_vec()));
+    *record.flags_mut() = Flags::from(0x1 | 0x100);
+    *record.reference_sequence_id_mut() = Some(refid);
+    *record.alignment_start_mut() = Some(Position::try_from(start).unwrap());
+    *record.cigar_mut() = Cigar::from(vec![Op::new(Kind::Match, 10)]);
+    // SEQ='*' → empty sequence, no XM/XR/XG.
+    record
+}
+
+fn write_bam(path: &Path, header: Header, records: Vec<Rec>) {
+    let mut writer = BamWriter::from_path(path, header).unwrap();
+    for r in records {
+        match r {
+            Rec::Bism(b) => writer.write_record(&b).unwrap(),
+            Rec::Raw(raw) => writer.write_raw_record(&raw).unwrap(),
+        }
+    }
+    writer.finish().unwrap();
+}
+
+fn run(bam: &Path, outdir: &Path, paired: bool, extra: &[&str]) -> assert_cmd::assert::Assert {
+    fs::create_dir_all(outdir).unwrap();
+    let mut cmd = Command::cargo_bin("bismark_methylation_extractor").unwrap();
+    cmd.arg(bam)
+        .arg(if paired {
+            "--paired-end"
+        } else {
+            "--single-end"
+        })
+        .arg("--comprehensive")
+        .arg("--output_dir")
+        .arg(outdir);
+    for a in extra {
+        cmd.arg(a);
+    }
+    cmd.assert()
+}
+
+fn dir_snapshot(dir: &Path) -> BTreeMap<String, Vec<u8>> {
+    let mut map = BTreeMap::new();
+    for entry in fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_type().unwrap().is_file() {
+            map.insert(
+                entry.file_name().to_string_lossy().into_owned(),
+                fs::read(entry.path()).unwrap(),
+            );
+        }
+    }
+    map
+}
+
+fn read_report(outdir: &Path, base: &str) -> String {
+    fs::read_to_string(outdir.join(format!("{base}_splitting_report.txt")))
+        .expect("splitting report produced")
+}
+
+/// Parse a `label:\t<u64>` line from the splitting report.
+fn report_value(report: &str, label: &str) -> u64 {
+    for line in report.lines() {
+        let Some(rest) = line.strip_prefix(label) else {
+            continue;
+        };
+        let value = rest
+            .trim_start_matches([':', '\t', ' '])
+            .split('\t')
+            .next()
+            .and_then(|v| v.trim().parse::<u64>().ok());
+        if let Some(n) = value {
+            return n;
+        }
+    }
+    panic!("label {label:?} not found in report:\n{report}");
+}
+
+/// Total methylation calls = "Total number of C's analysed".
+fn total_calls(report: &str) -> u64 {
+    report_value(report, "Total number of C's analysed:")
+}
+
+/// Concatenated bytes of the three comprehensive context files.
+fn context_blob(outdir: &Path, base: &str) -> String {
+    let mut s = String::new();
+    for ctx in ["CpG", "CHG", "CHH"] {
+        let p = outdir.join(format!("{ctx}_context_{base}.txt"));
+        if p.exists() {
+            s.push_str(&fs::read_to_string(&p).unwrap());
+        }
+    }
+    s
+}
+
+// ───────────────────────────── tests ───────────────────────────────────
+
+/// Cross-chromosome pair: R1 on chr1, R2 on chr2. With the flag both mates are
+/// called against their own chromosome and the pair is counted; without the
+/// flag the run dies with the cross-chromosome error.
+#[test]
+fn cross_chr_pair_called_independently() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("sample.bam");
+    // R1 OT on chr1 @100 (Z@100), R2 CTOT on chr2 @500 (reverse: Z@ its own ref).
+    let r1 = synth(b"x", b"CT", b"CT", b"Z.........", 100, 0, 0x1 | 0x40);
+    let r2 = synth(b"x", b"GA", b"CT", b"Z.........", 500, 1, 0x1 | 0x80);
+    write_bam(&bam, header_two_chr(), vec![Rec::Bism(r1), Rec::Bism(r2)]);
+
+    // Flag on.
+    let out = work.path().join("on");
+    run(&bam, &out, true, &["--allow_discordant"]).success();
+    let report = read_report(&out, "sample");
+    assert_eq!(
+        report_value(&report, "Cross-chromosome pairs called independently:"),
+        1
+    );
+    assert_eq!(
+        total_calls(&report),
+        2,
+        "both mates' single Z calls counted"
+    );
+    let blob = context_blob(&out, "sample");
+    assert!(blob.contains("\tchr1\t"), "R1 called on chr1: {blob}");
+    assert!(blob.contains("\tchr2\t"), "R2 called on chr2: {blob}");
+
+    // Flag off → cross-chromosome hard error.
+    let out_off = work.path().join("off");
+    run(&bam, &out_off, true, &[])
+        .failure()
+        .stderr(predicates::str::contains("different chromosomes"));
+}
+
+/// Same-chromosome, non-overlapping discordant pair (R2 far downstream of an
+/// OT-class R1 — but a same-orientation FF pair so it is NOT concordant). Both
+/// mates called; span-disjoint so no dedup.
+#[test]
+fn same_chr_disjoint_discordant_pair_called() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("sample.bam");
+    // Both forward-class (OT + CTOB) → same orientation → Independent. Disjoint.
+    let r1 = synth(b"x", b"CT", b"CT", b"ZZ........", 100, 0, 0x1 | 0x40); // Z@100,101
+    let r2 = synth(b"x", b"GA", b"GA", b"ZZ........", 500, 0, 0x1 | 0x80); // Z@500,501
+    write_bam(&bam, header_two_chr(), vec![Rec::Bism(r1), Rec::Bism(r2)]);
+
+    let out = work.path().join("on");
+    run(&bam, &out, true, &["--allow_discordant"]).success();
+    let report = read_report(&out, "sample");
+    assert_eq!(
+        report_value(
+            &report,
+            "Same-chromosome discordant pairs called independently:"
+        ),
+        1
+    );
+    assert_eq!(total_calls(&report), 4, "all 4 disjoint calls kept");
+}
+
+/// **The double-count guard.** A same-chromosome *overlapping* FF pair (both
+/// forward-class, spans overlapping, shared cytosine positions). The Independent
+/// path must dedup generically (keep R1, drop R2 at shared ref positions) — NOT
+/// reuse the FR-only half-plane `drop_overlap`, and NOT call both mates raw.
+#[test]
+fn same_chr_ff_overlapping_pair_not_double_counted() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("sample.bam");
+    // R1 OT @100, CpG Z at ref 100,101,102,103,104.
+    // R2 CTOB @102 (forward-class, forward iteration), Z at ref 102,103,104,105,106.
+    // Shared ref positions: 102,103,104. Independent (both forward). Overlapping.
+    let r1 = synth(b"ovl", b"CT", b"CT", b"ZZZZZ.....", 100, 0, 0x1 | 0x40);
+    let r2 = synth(b"ovl", b"GA", b"GA", b"ZZZZZ.....", 102, 0, 0x1 | 0x80);
+    write_bam(&bam, header_two_chr(), vec![Rec::Bism(r1), Rec::Bism(r2)]);
+
+    // Flag on: R1's 5 calls + R2's 2 unique calls (105,106); 102-104 deduped.
+    let out = work.path().join("on");
+    run(&bam, &out, true, &["--allow_discordant"]).success();
+    let report = read_report(&out, "sample");
+    assert_eq!(
+        total_calls(&report),
+        7,
+        "shared cytosines must be counted ONCE (5 + 2), not double-counted (would be 10)"
+    );
+    assert_eq!(
+        report_value(
+            &report,
+            "Same-chromosome discordant pairs called independently:"
+        ),
+        1
+    );
+    // Each reference position appears exactly once across the context files.
+    let blob = context_blob(&out, "sample");
+    for pos in ["100", "101", "102", "103", "104", "105", "106"] {
+        let needle = format!("\tchr1\t{pos}\t");
+        assert_eq!(
+            blob.matches(&needle).count(),
+            1,
+            "ref pos {pos} must appear exactly once (no double count):\n{blob}"
+        );
+    }
+
+    // Flag off (concordant path): the half-plane drop_overlap treats the pair as
+    // OT and drops ALL of R2 (the silent mis-drop the flag fixes) → only R1's 5.
+    let out_off = work.path().join("off");
+    run(&bam, &out_off, true, &[]).success();
+    let report_off = read_report(&out_off, "sample");
+    assert_eq!(
+        total_calls(&report_off),
+        5,
+        "flag-off pins today's behaviour (half-plane drops all of R2)"
+    );
+}
+
+/// Orphan (mate unmapped) — mid-file (pushback path) and final-record. With the
+/// flag R1 is called single-end style; without it the survivor mis-pairs
+/// (`MateMismatch`) or is the unpaired final record.
+#[test]
+fn orphan_midfile_and_final_called() {
+    let work = tempfile::tempdir().unwrap();
+
+    // Mid-file: A_R1, A_R2(unmapped→dropped), B_R1, B_R2.
+    let bam_mid = work.path().join("mid.bam");
+    write_bam(
+        &bam_mid,
+        header_two_chr(),
+        vec![
+            Rec::Bism(synth(b"A", b"CT", b"CT", b"Z.........", 100, 0, 0x1 | 0x40)),
+            Rec::Raw(raw_unmapped(b"A", 0x1 | 0x80)),
+            // B is a concordant, NON-overlapping FR pair (2 calls kept).
+            Rec::Bism(synth(b"B", b"CT", b"CT", b"Z.........", 200, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"B", b"GA", b"CT", b"Z.........", 300, 0, 0x1 | 0x80)),
+        ],
+    );
+    let out = work.path().join("mid_on");
+    run(&bam_mid, &out, true, &["--allow_discordant"]).success();
+    let report = read_report(&out, "mid");
+    assert_eq!(
+        report_value(&report, "Orphan reads (mate unmapped) called:"),
+        1
+    );
+    // A's orphan (1 call) + B's concordant pair (2 calls) = 3.
+    assert_eq!(total_calls(&report), 3);
+
+    // Flag off: after the unmapped mate vanishes, A_R1 mis-pairs with B_R1.
+    let out_off = work.path().join("mid_off");
+    run(&bam_mid, &out_off, true, &[])
+        .failure()
+        .stderr(predicates::str::contains("mate mismatch"));
+
+    // Final-record orphan: A_R1, A_R2(unmapped→dropped) → A_R1 is the last record.
+    let bam_fin = work.path().join("fin.bam");
+    write_bam(
+        &bam_fin,
+        header_two_chr(),
+        vec![
+            Rec::Bism(synth(b"A", b"CT", b"CT", b"Z.........", 100, 0, 0x1 | 0x40)),
+            Rec::Raw(raw_unmapped(b"A", 0x1 | 0x80)),
+        ],
+    );
+    let out_fin = work.path().join("fin_on");
+    run(&bam_fin, &out_fin, true, &["--allow_discordant"]).success();
+    assert_eq!(
+        report_value(
+            &read_report(&out_fin, "fin"),
+            "Orphan reads (mate unmapped) called:"
+        ),
+        1
+    );
+
+    // Flag off: the historical unpaired-final-record error.
+    let out_fin_off = work.path().join("fin_off");
+    run(&bam_fin, &out_fin_off, true, &[])
+        .failure()
+        .stderr(predicates::str::contains("unpaired final record"));
+}
+
+/// Secondary (`SEQ='*'`) interleaved between primary pairs: skipped + counted
+/// with the flag, pairing of the surrounding primaries unaffected. Without the
+/// flag it hard-errors at record construction (no XR tag).
+#[test]
+fn secondary_skipped_and_counted() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("sample.bam");
+    write_bam(
+        &bam,
+        header_two_chr(),
+        vec![
+            Rec::Bism(synth(b"P", b"CT", b"CT", b"Z.........", 100, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"P", b"GA", b"CT", b"Z.........", 200, 0, 0x1 | 0x80)),
+            Rec::Raw(raw_secondary(b"P", 500, 0)),
+            Rec::Bism(synth(b"Q", b"CT", b"CT", b"Z.........", 300, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"Q", b"GA", b"CT", b"Z.........", 400, 0, 0x1 | 0x80)),
+        ],
+    );
+
+    let out = work.path().join("on");
+    run(&bam, &out, true, &["--allow_discordant"]).success();
+    let report = read_report(&out, "sample");
+    assert_eq!(report_value(&report, "Secondary alignments skipped:"), 1);
+    // Two concordant pairs, 1 call each mate = 4; the secondary contributed none.
+    assert_eq!(total_calls(&report), 4);
+
+    // Flag off: the SEQ='*'/tag-less secondary is not dropped and fails record
+    // construction at the missing XR tag (pin the error identity, like the
+    // sibling flag-off checks).
+    let out_off = work.path().join("off");
+    run(&bam, &out_off, true, &[])
+        .failure()
+        .stderr(predicates::str::contains("missing required Bismark tag"));
+}
+
+/// Supplementary (FLAG 0x800, hard-clipped, WITH valid tags) interleaved between
+/// primary pairs: skipped + counted with the flag; without it, it breaks R1/R2
+/// adjacency → `MateMismatch`.
+#[test]
+fn supplementary_skipped_and_counted() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("sample.bam");
+    write_bam(
+        &bam,
+        header_two_chr(),
+        vec![
+            Rec::Bism(synth(b"P", b"CT", b"CT", b"Z.........", 100, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"P", b"GA", b"CT", b"Z.........", 200, 0, 0x1 | 0x80)),
+            // Supplementary carries valid tags (constructs fine) → flag-off it
+            // is NOT dropped and breaks adjacency.
+            Rec::Bism(synth(b"P", b"CT", b"CT", b"Zz...", 500, 0, 0x1 | 0x800)),
+            Rec::Bism(synth(b"Q", b"CT", b"CT", b"Z.........", 300, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"Q", b"GA", b"CT", b"Z.........", 400, 0, 0x1 | 0x80)),
+        ],
+    );
+
+    let out = work.path().join("on");
+    run(&bam, &out, true, &["--allow_discordant"]).success();
+    let report = read_report(&out, "sample");
+    assert_eq!(
+        report_value(&report, "Supplementary alignments skipped:"),
+        1
+    );
+    assert_eq!(
+        total_calls(&report),
+        4,
+        "supplementary contributed no calls"
+    );
+
+    let out_off = work.path().join("off");
+    run(&bam, &out_off, true, &[])
+        .failure()
+        .stderr(predicates::str::contains("mate mismatch"));
+}
+
+/// Byte-identity lock: on a concordant-only PE fixture, flag-on output equals
+/// flag-off output for every file EXCEPT the splitting report, which differs
+/// only by the appended (all-zero) `--allow_discordant` section.
+#[test]
+fn flag_on_equals_flag_off_on_concordant_input_modulo_report_section() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("sample.bam");
+    // Two proper FR (OT/CTOT, OB/CTOB) concordant pairs.
+    write_bam(
+        &bam,
+        header_two_chr(),
+        vec![
+            // OT pair: R1 (OT) upstream, R2 (CTOT) downstream.
+            Rec::Bism(synth(b"a", b"CT", b"CT", b"Zz.X.h....", 100, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"a", b"GA", b"CT", b"Zz.X.h....", 120, 0, 0x1 | 0x80)),
+            // OB pair: R1 (OB) downstream, R2 (CTOB) upstream — proper FR geometry.
+            Rec::Bism(synth(b"b", b"CT", b"GA", b"z.H.x.....", 320, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"b", b"GA", b"GA", b"z.H.x.....", 300, 0, 0x1 | 0x80)),
+        ],
+    );
+
+    let off = work.path().join("off");
+    let on = work.path().join("on");
+    run(&bam, &off, true, &[]).success();
+    run(&bam, &on, true, &["--allow_discordant"]).success();
+
+    let snap_off = dir_snapshot(&off);
+    let snap_on = dir_snapshot(&on);
+    // Same set of files.
+    assert_eq!(
+        snap_off.keys().collect::<Vec<_>>(),
+        snap_on.keys().collect::<Vec<_>>()
+    );
+    // Every file except the splitting report is byte-identical.
+    for (name, off_bytes) in &snap_off {
+        let on_bytes = &snap_on[name];
+        if name.ends_with("_splitting_report.txt") {
+            let off_s = String::from_utf8_lossy(off_bytes);
+            let on_s = String::from_utf8_lossy(on_bytes);
+            assert!(
+                on_s.starts_with(off_s.as_ref()),
+                "flag-off report must be a prefix of flag-on report"
+            );
+            let suffix = &on_s[off_s.len()..];
+            assert!(
+                suffix.contains("Discordant read handling (--allow_discordant)"),
+                "flag-on report appends the discordant section; got suffix: {suffix:?}"
+            );
+            assert!(
+                suffix.contains("Cross-chromosome pairs called independently:\t0"),
+                "section reports the (zero) policy counts"
+            );
+            assert!(
+                !off_s.contains("Discordant read handling"),
+                "flag-off report must NOT contain the section"
+            );
+        } else {
+            assert_eq!(
+                off_bytes, on_bytes,
+                "non-report file {name} must be byte-identical flag-on vs flag-off"
+            );
+        }
+    }
+}
+
+/// `--parallel N` byte-invariance with the flag on, over a mixed fixture
+/// exercising all classes (concordant, cross-chr, orphan, secondary): the
+/// producer's classification rides the same `(batch_seq, within_idx)` order, so
+/// `--parallel 1` and `--parallel 4` output must be byte-identical.
+#[test]
+fn parallel_invariant_with_flag_on_mixed_fixture() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("mixed.bam");
+    write_bam(
+        &bam,
+        header_two_chr(),
+        vec![
+            // concordant FR
+            Rec::Bism(synth(b"c", b"CT", b"CT", b"Zz.X.h....", 100, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"c", b"GA", b"CT", b"Zz.X.h....", 120, 0, 0x1 | 0x80)),
+            // orphan (mate unmapped)
+            Rec::Bism(synth(b"o", b"CT", b"CT", b"Z.H.x.....", 400, 0, 0x1 | 0x40)),
+            Rec::Raw(raw_unmapped(b"o", 0x1 | 0x80)),
+            // cross-chr
+            Rec::Bism(synth(b"x", b"CT", b"CT", b"Z.........", 500, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"x", b"GA", b"CT", b"Z.........", 700, 1, 0x1 | 0x80)),
+            // secondary (skipped)
+            Rec::Raw(raw_secondary(b"x", 900, 0)),
+            // another concordant FR
+            Rec::Bism(synth(b"d", b"CT", b"GA", b"z.H.x.....", 800, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"d", b"GA", b"GA", b"z.H.x.....", 820, 0, 0x1 | 0x80)),
+        ],
+    );
+
+    let p1 = work.path().join("p1");
+    let p4 = work.path().join("p4");
+    run(&bam, &p1, true, &["--allow_discordant", "--parallel", "1"]).success();
+    run(&bam, &p4, true, &["--allow_discordant", "--parallel", "4"]).success();
+    assert_eq!(
+        dir_snapshot(&p1),
+        dir_snapshot(&p4),
+        "--parallel 4 output must be byte-identical to --parallel 1 with the flag on"
+    );
+}
+
+/// Legacy single-threaded `extract_pe` ≡ parallel `extract_pe_parallel` on a
+/// mixed fixture with the flag on (the `mod.rs` PHASE-F oracle, extended to the
+/// new discordant classes). Keeps the "parallel ≡ single-threaded" invariant
+/// meaningful for `PeIndependent` / `Orphan`.
+#[test]
+fn legacy_equals_parallel_with_flag_on_mixed_fixture() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("mixed.bam");
+    write_bam(
+        &bam,
+        header_two_chr(),
+        vec![
+            Rec::Bism(synth(b"c", b"CT", b"CT", b"Zz.X.h....", 100, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"c", b"GA", b"CT", b"Zz.X.h....", 300, 0, 0x1 | 0x80)),
+            Rec::Bism(synth(b"o", b"CT", b"CT", b"Z.H.x.....", 400, 0, 0x1 | 0x40)),
+            Rec::Raw(raw_unmapped(b"o", 0x1 | 0x80)),
+            Rec::Bism(synth(b"x", b"CT", b"CT", b"Z.........", 500, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"x", b"GA", b"CT", b"Z.........", 700, 1, 0x1 | 0x80)),
+            Rec::Raw(raw_secondary(b"x", 900, 0)),
+            // same-chr FF overlapping (Independent + generic dedup)
+            Rec::Bism(synth(b"f", b"CT", b"CT", b"ZZZZZ.....", 100, 0, 0x1 | 0x40)),
+            Rec::Bism(synth(b"f", b"GA", b"GA", b"ZZZZZ.....", 102, 0, 0x1 | 0x80)),
+        ],
+    );
+
+    let cfg = |dir: &Path, parallel: &str| {
+        Cli::try_parse_from([
+            "bismark_methylation_extractor",
+            "--paired-end",
+            "--comprehensive",
+            "--allow_discordant",
+            "--parallel",
+            parallel,
+            "--output_dir",
+            dir.to_str().unwrap(),
+            bam.to_str().unwrap(),
+        ])
+        .unwrap()
+        .validate()
+        .unwrap()
+    };
+
+    let legacy = work.path().join("legacy");
+    let parallel = work.path().join("parallel");
+    fs::create_dir_all(&legacy).unwrap();
+    fs::create_dir_all(&parallel).unwrap();
+    extract_pe(&bam, &cfg(&legacy, "1")).unwrap();
+    extract_pe_parallel(&bam, &cfg(&parallel, "4")).unwrap();
+
+    assert_eq!(
+        dir_snapshot(&legacy),
+        dir_snapshot(&parallel),
+        "single-threaded extract_pe must equal extract_pe_parallel with --allow_discordant"
+    );
+}
+
+/// R2-orphan: the *R1* mate is unmapped (io-dropped), so the surviving primary
+/// is a read-2 record (FLAG 0x80). Its `read_identity()` is `R2`, driving the
+/// `ReadIdentity::R2` arm of `process_orphan` / `handle_one_orphan` (R2 trims +
+/// M-bias slot 1) — the branch every other orphan fixture (all R1 survivors)
+/// leaves uncovered. Asserts the read-2 survivor is called and counted.
+#[test]
+fn r2_orphan_r1_unmapped_called_via_r2_identity() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("sample.bam");
+    // R1 unmapped (0x40 | 0x4 via raw_unmapped) → dropped at the io layer; the
+    // mapped read-2 (0x80) survivor is the orphan.
+    write_bam(
+        &bam,
+        header_two_chr(),
+        vec![
+            Rec::Raw(raw_unmapped(b"A", 0x1 | 0x40)),
+            Rec::Bism(synth(b"A", b"GA", b"CT", b"Z.........", 100, 0, 0x1 | 0x80)),
+        ],
+    );
+
+    let out = work.path().join("on");
+    run(&bam, &out, true, &["--allow_discordant"]).success();
+    let report = read_report(&out, "sample");
+    assert_eq!(
+        report_value(&report, "Orphan reads (mate unmapped) called:"),
+        1
+    );
+    // The read-2 survivor's single Z call is emitted (proves the R2 arm ran and
+    // produced output, not just that it didn't panic).
+    assert_eq!(total_calls(&report), 1);
+    let blob = context_blob(&out, "sample");
+    assert!(
+        blob.contains("\tchr1\t"),
+        "read-2 orphan called on chr1: {blob}"
+    );
+}
+
+/// Cross-chromosome pair whose mates share the *same numeric* reference position
+/// on different chromosomes. Pins the `r1_chr_id == r2_chr_id` guard: cross-chr
+/// positions coincide numerically but denote different loci, so they must NOT be
+/// deduped. Both Z@100 calls (chr1 and chr2) must survive — a regression that
+/// dropped the guard and deduped by bare `ref_pos` would lose one.
+#[test]
+fn cross_chr_coincident_positions_not_deduped() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("sample.bam");
+    // R1 chr1 @100 (Z@100), R2 chr2 @100 (Z@100) — identical numeric position.
+    let r1 = synth(b"y", b"CT", b"CT", b"Z.........", 100, 0, 0x1 | 0x40);
+    let r2 = synth(b"y", b"GA", b"CT", b"Z.........", 100, 1, 0x1 | 0x80);
+    write_bam(&bam, header_two_chr(), vec![Rec::Bism(r1), Rec::Bism(r2)]);
+
+    let out = work.path().join("on");
+    run(&bam, &out, true, &["--allow_discordant"]).success();
+    let report = read_report(&out, "sample");
+    assert_eq!(
+        total_calls(&report),
+        2,
+        "coincident cross-chr positions denote different loci — both must be kept"
+    );
+    let blob = context_blob(&out, "sample");
+    assert!(
+        blob.contains("\tchr1\t100\t"),
+        "R1 called at chr1:100: {blob}"
+    );
+    assert!(
+        blob.contains("\tchr2\t100\t"),
+        "R2 called at chr2:100 (not deduped against chr1:100): {blob}"
+    );
+}
+
+/// **Opposite-strand-of-origin overlap guard.** A same-chromosome *overlapping*
+/// pair whose mates come from opposite original strands — R1 `OT` (top) + R2
+/// `OB` (bottom) — passes the complementary-orientation check but is NOT a
+/// genuine Bismark pair. It must route to `Independent` (each mate called
+/// against its own strand), NOT `Concordant`: on the concordant path the FR-only
+/// half-plane `drop_overlap` treats the pair as `OT`-forward and silently
+/// discards R2's bottom-strand overlap-region calls. The two strands' cytosines
+/// never share a reference position, so `drop_overlap_generic` keeps every call.
+#[test]
+fn opposite_origin_ot_ob_overlap_not_misdropped() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("sample.bam");
+    // R1 OT @100 [100,109], one Z (ref 100). R2 OB @102 [102,111], ten Z's
+    // (refs 102-111). Spans overlap (102-109); R1's single call never collides
+    // numerically with R2's (100 ∉ 102..111).
+    let r1 = synth(b"op", b"CT", b"CT", b"Z.........", 100, 0, 0x1 | 0x40); // OT
+    let r2 = synth(b"op", b"CT", b"GA", b"ZZZZZZZZZZ", 102, 0, 0x1 | 0x80); // OB
+    write_bam(&bam, header_two_chr(), vec![Rec::Bism(r1), Rec::Bism(r2)]);
+
+    // Flag on: OT+OB → Independent; opposite strands never collide, so all
+    // 1 + 10 = 11 calls are kept.
+    let out = work.path().join("on");
+    run(&bam, &out, true, &["--allow_discordant"]).success();
+    let report = read_report(&out, "sample");
+    assert_eq!(
+        report_value(
+            &report,
+            "Same-chromosome discordant pairs called independently:"
+        ),
+        1,
+        "OT+OB (opposite origin) is a same-chromosome discordant pair"
+    );
+    let on_total = total_calls(&report);
+    assert_eq!(
+        on_total, 11,
+        "all calls kept (opposite strands never collide)"
+    );
+
+    // Flag off: the pre-fix hazard — OT+OB accepted as Concordant, drop_overlap
+    // (as OT-forward) discards R2's overlap-region calls (ref ≤ 109). Fewer
+    // calls survive, proving the routing fix recovers real data.
+    let out_off = work.path().join("off");
+    run(&bam, &out_off, true, &[]).success();
+    let off_total = total_calls(&read_report(&out_off, "sample"));
+    assert!(
+        off_total < on_total,
+        "flag-off concordant path drops R2 overlap-region calls: off={off_total} on={on_total}"
+    );
+}
+
+/// SE-mode `--allow_discordant`: the flag enables only the io-layer 0x900
+/// skip-and-count (there is no pairing to make discordant). A secondary
+/// interleaved among single-end primaries is skipped + counted; the primaries
+/// are called. Every other test in this file is paired-end, so this is the SE
+/// path's only coverage.
+#[test]
+fn se_mode_secondary_skipped_and_counted() {
+    let work = tempfile::tempdir().unwrap();
+    let bam = work.path().join("sample.bam");
+    write_bam(
+        &bam,
+        header_two_chr(),
+        vec![
+            Rec::Bism(synth(b"a", b"CT", b"CT", b"Z.........", 100, 0, 0x0)),
+            Rec::Raw(raw_secondary(b"a", 500, 0)),
+            Rec::Bism(synth(b"b", b"CT", b"CT", b"Z.........", 200, 0, 0x0)),
+        ],
+    );
+
+    // Flag on (single-end): secondary dropped + counted, both primaries called.
+    let out = work.path().join("on");
+    run(&bam, &out, false, &["--allow_discordant"]).success();
+    let report = read_report(&out, "sample");
+    assert_eq!(report_value(&report, "Secondary alignments skipped:"), 1);
+    assert_eq!(total_calls(&report), 2, "both SE primaries' single Z calls");
+
+    // Flag off: the tag-less secondary is not dropped → record-construction error.
+    let out_off = work.path().join("off");
+    run(&bam, &out_off, false, &[])
+        .failure()
+        .stderr(predicates::str::contains("missing required Bismark tag"));
+}

--- a/rust/bismark/tests/extractor_se_phase_b.rs
+++ b/rust/bismark/tests/extractor_se_phase_b.rs
@@ -793,6 +793,7 @@ fn splitting_report_emits_per_context_counts() {
         calls_chg_unmeth: 0,
         calls_chh_meth: 0,
         calls_chh_unmeth: 400,
+        ..Default::default()
     };
     // Phase C.2 (#864): added `is_paired: bool` argument (SE here).
     write_splitting_report(&report_path, &input_path, &config, false, &report).unwrap();


### PR DESCRIPTION
## Summary

Adds an opt-in `--allow_discordant` flag to `bismark_methylation_extractor` so it can call methylation on BAMs from **any** bisulfite aligner that emits Bismark-format `XM`/`XR`/`XG` tags — not only the Bismark aligner. General-purpose aligners (e.g. bwa-mem3 `--meth`) emit records the Bismark aligner never does — cross-chromosome and discordant-orientation pairs, orphans whose mate is unmapped, and secondary/supplementary alignments — on which the current extractor hard-errors, forcing a `samtools view -f 0x2 -F 0x900` pre-filter. This flag lets those reads be extracted directly.

**Off by default, and byte-identical to current behaviour when off** (including today's cross-chromosome and unpaired-record errors) — every new code path is gated behind the flag.

## What the flag does

- **Skips + counts** secondary (`0x100`) / supplementary (`0x800`) alignments at the reader layer, before record validation and pairing.
- **Classifies** each adjacent primary pair by strand: a genuine Bismark concordant pair (same chromosome, complementary orientation, **same strand of origin** — `{OT,CTOT}` or `{OB,CTOB}`, order-agnostic so non-directional libraries still match — and consistent geometry) takes today's concordant path verbatim. Everything else — cross-chromosome, same-orientation (FF/RR), opposite-strand-of-origin, or annihilated-geometry pairs — is called **independently**, each mate by its own record strand against its own chromosome.
- **Tolerates orphans** (a mapped primary whose mate was unmapped) via a qname pre-compare + one-slot pushback, calling them single-end style.
- **Deduplicates** same-chromosome overlapping independent pairs by reference position (keeping R1's calls) rather than reusing the FR-only half-plane `drop_overlap`, so shared cytosines are counted exactly once and never mis-dropped.
- **Reports** every class in a dedicated splitting-report section, and warns (not gated by `--quiet`) when >20% of records are orphans — a sign the input is not name-grouped.

## Validation

New `tests/extractor_allow_discordant.rs` covers every class (cross-chr; same-chr disjoint and overlapping; opposite-strand-of-origin overlap; orphans with both R1- and R2-survivors; secondary/supplementary skips; SE mode), plus a **flag-on ≡ flag-off byte-identity lock** on concordant input, a `--parallel 1 ≡ 4` invariant, and a single-threaded ≡ parallel oracle. Parallel and single-threaded pipelines share one `classify_pair`, so both get the same behaviour from one implementation.

## Follow-up: docs (preview)

I've drafted the documentation update as a separate, **stacked preview PR** on my fork so it doesn't clutter this review: nh13/Bismark#1. It documents `--allow_discordant` in the options reference and adds an "Input from a non-Bismark aligner" section to the methylation-extraction guide, including the measured trade-off of aligning with a general-purpose bisulfite aligner ([bwa-mem3](https://github.com/fg-labs/bwa-mem3) `--meth`) and extracting through `bismark extract --allow_discordant`: ~6.5× faster alignment on a human WGBS slice, per-CpG methylation concordance _r_ ≈ 0.97 with matching specificity, with the Bismark aligner keeping a small per-read sensitivity edge and the general-purpose aligner reporting higher yield.

It's framed as a starting point rather than a blanket recommendation. Happy to open it as a proper PR here once the feature lands, or to reword/drop the recommendation if you'd rather keep aligner suggestions out of the docs.
